### PR TITLE
feat: button inactive until change

### DIFF
--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -110,9 +110,9 @@ export const AllowedEmailDomainProjectRoles: Array<AllowedEmailDomainProjectsRol
     ];
 
 export function isAllowedEmailDomainProjectRole(
-    role: ProjectMemberRole,
+    role: ProjectMemberRole | OrganizationMemberRole,
 ): role is AllowedEmailDomainProjectsRole {
-    return AllowedEmailDomainProjectRoles.includes(role as any);
+    return (AllowedEmailDomainProjectRoles as unknown[]).includes(role);
 }
 
 export type AllowedEmailDomains = {

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export const getEmailDomain = (email: string): string => {
     if (/\s/.test(email)) {
         throw new Error(`Invalid email, contains whitespace: ${email}`);
@@ -62,6 +64,10 @@ const EMAIL_PROVIDER_LIST = [
 
 const isEmailProviderDomain = (domain: string): boolean =>
     EMAIL_PROVIDER_LIST.includes(domain);
+
+const VALID_EMAIL_DOMAIN_REGEX = /^[a-zA-Z0-9][\w.-]+\.\w{2,4}/g;
+export const isValidEmailDomain = (value: string) =>
+    value.match(VALID_EMAIL_DOMAIN_REGEX);
 
 export const validateOrganizationEmailDomains = (domains: string[]) => {
     const invalidDomains = domains.filter((domain) =>

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-
 export const getEmailDomain = (email: string): string => {
     if (/\s/.test(email)) {
         throw new Error(`Invalid email, contains whitespace: ${email}`);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -33,7 +33,7 @@
         "@lightdash/common": "^0.993.0",
         "@mantine/core": "^6.0.21",
         "@mantine/dates": "^6.0.21",
-        "@mantine/form": "^6.0.21",
+        "@mantine/form": "^7.5.2",
         "@mantine/hooks": "^6.0.21",
         "@mantine/notifications": "^6.0.20",
         "@mantine/prism": "^6.0.21",

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -144,6 +144,45 @@ const ProjectTablesConfiguration: FC<{
         }
     }, [isSuccess, onSuccess]);
 
+    const setFormValuesFromData = useCallback(() => {
+        if (data) {
+            form.setValues({
+                type: data.tableSelection.type,
+                tags:
+                    data.tableSelection.type === TableSelectionType.WITH_TAGS &&
+                    data.tableSelection.value
+                        ? data.tableSelection.value
+                        : [],
+                names:
+                    data.tableSelection.type ===
+                        TableSelectionType.WITH_NAMES &&
+                    data.tableSelection.value
+                        ? data.tableSelection.value
+                        : [],
+            });
+
+            form.resetDirty({
+                type: data.tableSelection.type,
+                tags:
+                    data.tableSelection.type === TableSelectionType.WITH_TAGS &&
+                    data.tableSelection.value
+                        ? data.tableSelection.value
+                        : [],
+                names:
+                    data.tableSelection.type ===
+                        TableSelectionType.WITH_NAMES &&
+                    data.tableSelection.value
+                        ? data.tableSelection.value
+                        : [],
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
+
     const handleSubmit = form.onSubmit(async (formData: FormData) => {
         track({
             name: EventName.UPDATE_PROJECT_TABLES_CONFIGURATION_BUTTON_CLICKED,
@@ -354,15 +393,28 @@ const ProjectTablesConfiguration: FC<{
                     </Radio.Group>
 
                     {canUpdateTableConfiguration && (
-                        <Button
-                            mt={'xl'}
-                            type="submit"
-                            loading={isSaving}
-                            disabled={disabled}
-                            sx={{ float: 'right' }}
-                        >
-                            Save changes
-                        </Button>
+                        <Flex justify="flex-end" gap="sm">
+                            {form.isDirty() && (
+                                <Button
+                                    mt={'xl'}
+                                    variant="outline"
+                                    onClick={() => {
+                                        setFormValuesFromData();
+                                    }}
+                                >
+                                    Cancel
+                                </Button>
+                            )}
+                            <Button
+                                mt={'xl'}
+                                type="submit"
+                                loading={isSaving}
+                                disabled={disabled || !form.isDirty()}
+                                sx={{ float: 'right' }}
+                            >
+                                Save changes
+                            </Button>
+                        </Flex>
                     )}
                 </div>
             </SettingsGridCard>

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -5,6 +5,7 @@ import {
     Box,
     Button,
     Collapse,
+    Flex,
     Highlight,
     Loader,
     MultiSelect,
@@ -146,35 +147,19 @@ const ProjectTablesConfiguration: FC<{
 
     const setFormValuesFromData = useCallback(() => {
         if (data) {
-            form.setValues({
-                type: data.tableSelection.type,
-                tags:
-                    data.tableSelection.type === TableSelectionType.WITH_TAGS &&
-                    data.tableSelection.value
-                        ? data.tableSelection.value
-                        : [],
-                names:
-                    data.tableSelection.type ===
-                        TableSelectionType.WITH_NAMES &&
-                    data.tableSelection.value
-                        ? data.tableSelection.value
-                        : [],
-            });
+            const { type, value } = data.tableSelection;
 
-            form.resetDirty({
-                type: data.tableSelection.type,
-                tags:
-                    data.tableSelection.type === TableSelectionType.WITH_TAGS &&
-                    data.tableSelection.value
-                        ? data.tableSelection.value
-                        : [],
-                names:
-                    data.tableSelection.type ===
-                        TableSelectionType.WITH_NAMES &&
-                    data.tableSelection.value
-                        ? data.tableSelection.value
-                        : [],
-            });
+            const getValueBasedOnType = (selectionType: TableSelectionType) =>
+                type === selectionType && value ? value : [];
+
+            const formValues = {
+                type: type,
+                tags: getValueBasedOnType(TableSelectionType.WITH_TAGS),
+                names: getValueBasedOnType(TableSelectionType.WITH_NAMES),
+            };
+
+            form.setValues(formValues);
+            form.resetDirty(formValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -37,7 +37,7 @@ const validationSchema = z.object({
     names: z.array(z.string()),
 });
 
-type FormData = z.infer<typeof validationSchema>;
+type FormValues = z.infer<typeof validationSchema>;
 
 type Props = {
     projectUuid: string;
@@ -76,7 +76,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
         isLoadingExplores ||
         !canUpdateTableConfiguration;
 
-    const form = useForm<FormData>({
+    const form = useForm<FormValues>({
         initialValues: {
             type: TableSelectionType.ALL,
             tags: [],
@@ -154,7 +154,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
         }
     }, [isSuccess, onSuccess]);
 
-    const handleSubmit = form.onSubmit(async (formData: FormData) => {
+    const handleSubmit = form.onSubmit(async (formData) => {
         if (!form.isValid()) return;
 
         track({

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -18,7 +18,14 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconHelpCircle, IconPlus, IconX } from '@tabler/icons-react';
-import { FC, ForwardedRef, forwardRef, useEffect, useMemo } from 'react';
+import {
+    FC,
+    ForwardedRef,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useMemo,
+} from 'react';
 import {
     useAllowedEmailDomains,
     useUpdateAllowedEmailDomains,
@@ -116,6 +123,26 @@ const AllowedDomainsPanel: FC = () => {
             setFieldValue('projects', allowedEmailDomainsData.projects);
         }
     }, [allowedEmailDomainsData, projectOptions, setFieldValue]);
+
+    const setFormValuesFromData = useCallback(() => {
+        if (allowedEmailDomainsData) {
+            form.setValues({
+                emailDomains: allowedEmailDomainsData.emailDomains,
+                role: allowedEmailDomainsData.role,
+                projects: allowedEmailDomainsData.projects,
+            });
+            form.resetDirty({
+                emailDomains: allowedEmailDomainsData.emailDomains,
+                role: allowedEmailDomainsData.role,
+                projects: allowedEmailDomainsData.projects,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [allowedEmailDomainsData]);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
 
     const handleOnSubmit = form.onSubmit((values) => {
         const role =
@@ -386,14 +413,27 @@ const AllowedDomainsPanel: FC = () => {
                         ) : null}
                     </>
                 )}
-                <Button
-                    type="submit"
-                    display="block"
-                    ml="auto"
-                    loading={isLoading}
-                >
-                    Update
-                </Button>
+
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && (
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setFormValuesFromData();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    )}
+                    <Button
+                        type="submit"
+                        display="block"
+                        loading={isLoading}
+                        disabled={!form.isDirty()}
+                    >
+                        Update
+                    </Button>
+                </Flex>
             </Stack>
         </form>
     ) : null;

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -88,10 +88,10 @@ const validationSchema = z.object({
     ),
 });
 
-type FormDataType = z.infer<typeof validationSchema>;
+type FormValues = z.infer<typeof validationSchema>;
 
 const AllowedDomainsPanel: FC = () => {
-    const form = useForm<FormDataType>({
+    const form = useForm<FormValues>({
         initialValues: {
             emailDomains: [],
             role: OrganizationMemberRole.VIEWER,

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -126,16 +126,14 @@ const AllowedDomainsPanel: FC = () => {
 
     const setFormValuesFromData = useCallback(() => {
         if (allowedEmailDomainsData) {
-            form.setValues({
+            const formValues = {
                 emailDomains: allowedEmailDomainsData.emailDomains,
                 role: allowedEmailDomainsData.role,
                 projects: allowedEmailDomainsData.projects,
-            });
-            form.resetDirty({
-                emailDomains: allowedEmailDomainsData.emailDomains,
-                role: allowedEmailDomainsData.role,
-                projects: allowedEmailDomainsData.projects,
-            });
+            };
+
+            form.setValues(formValues);
+            form.resetDirty(formValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [allowedEmailDomainsData]);

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -1,5 +1,6 @@
 import {
     AllowedEmailDomains,
+    isValidEmailDomain,
     OrganizationMemberRole,
     ProjectMemberRole,
     ProjectType,
@@ -16,22 +17,15 @@ import {
     Title,
     Tooltip,
 } from '@mantine/core';
-import { useForm } from '@mantine/form';
-import { IconHelpCircle, IconPlus, IconX } from '@tabler/icons-react';
-import {
-    FC,
-    ForwardedRef,
-    forwardRef,
-    useCallback,
-    useEffect,
-    useMemo,
-} from 'react';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
+import { FC, ForwardedRef, forwardRef, useEffect, useMemo } from 'react';
+import { z } from 'zod';
 import {
     useAllowedEmailDomains,
     useUpdateAllowedEmailDomains,
 } from '../../../hooks/organization/useAllowedDomains';
 import { useProjects } from '../../../hooks/useProjects';
-import { isValidEmailDomain } from '../../../utils/fieldValidators';
 import MantineIcon from '../../common/MantineIcon';
 
 const roleOptions: Array<{
@@ -83,76 +77,87 @@ const projectRoleOptions: Array<{
     },
 ];
 
-const AllowedDomainsPanel: FC = () => {
-    const form = useForm({
-        initialValues: {
-            emailDomains: [] as string[],
-            role: OrganizationMemberRole.VIEWER as AllowedEmailDomains['role'],
-            projects: [] as AllowedEmailDomains['projects'],
-        },
-    });
-    const { setFieldValue } = form;
+const validationSchema = z.object({
+    emailDomains: z.array(z.string().nonempty()),
+    role: z.nativeEnum(OrganizationMemberRole),
+    projects: z.array(
+        z.object({
+            projectUuid: z.string().nonempty(),
+            role: z.nativeEnum(ProjectMemberRole),
+        }),
+    ),
+});
 
-    const { data: projects, isInitialLoading: isLoadingProjects } =
-        useProjects();
+type FormDataType = z.infer<typeof validationSchema>;
+
+const AllowedDomainsPanel: FC = () => {
+    const form = useForm<FormDataType>({
+        initialValues: {
+            emailDomains: [],
+            role: OrganizationMemberRole.VIEWER,
+            projects: [],
+        },
+        validate: zodResolver(validationSchema),
+    });
+
+    const { data: projects, isLoading: isLoadingProjects } = useProjects();
+
     const {
         data: allowedEmailDomainsData,
-        isInitialLoading: emailDomainsLoading,
+        isLoading: isAllowedEmailDomainsDataLoading,
         isSuccess,
     } = useAllowedEmailDomains();
-    const { mutate, isLoading: updateEmailDomainsLoading } =
+
+    const { mutate, isLoading: isUpdateAllowedEmailDomainsLoading } =
         useUpdateAllowedEmailDomains();
+
     const isLoading =
-        updateEmailDomainsLoading || emailDomainsLoading || isLoadingProjects;
-
-    const projectOptions = useMemo(
-        () =>
-            (projects || [])
-                .filter(({ type }) => type !== ProjectType.PREVIEW)
-                .map((item) => ({
-                    value: item.projectUuid,
-                    label: item.name,
-                })),
-        [projects],
-    );
+        isUpdateAllowedEmailDomainsLoading ||
+        isAllowedEmailDomainsDataLoading ||
+        isLoadingProjects;
 
     useEffect(() => {
-        if (allowedEmailDomainsData) {
-            setFieldValue('emailDomains', allowedEmailDomainsData.emailDomains);
-            setFieldValue('role', allowedEmailDomainsData.role);
-            setFieldValue('projects', allowedEmailDomainsData.projects);
-        }
-    }, [allowedEmailDomainsData, projectOptions, setFieldValue]);
+        if (isAllowedEmailDomainsDataLoading || !allowedEmailDomainsData)
+            return;
 
-    const setFormValuesFromData = useCallback(() => {
-        if (allowedEmailDomainsData) {
-            const formValues = {
-                emailDomains: allowedEmailDomainsData.emailDomains,
-                role: allowedEmailDomainsData.role,
-                projects: allowedEmailDomainsData.projects,
-            };
+        const initialValues = {
+            emailDomains: allowedEmailDomainsData.emailDomains,
+            role: allowedEmailDomainsData.role,
+            projects: allowedEmailDomainsData.projects,
+        };
 
-            form.setValues(formValues);
-            form.resetDirty(formValues);
-        }
+        form.setInitialValues(initialValues);
+        form.setValues(initialValues);
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [allowedEmailDomainsData]);
+    }, [allowedEmailDomainsData, isAllowedEmailDomainsDataLoading]);
 
-    useEffect(() => {
-        setFormValuesFromData();
-    }, [setFormValuesFromData]);
+    const projectOptions = useMemo(() => {
+        if (!projects) return [];
 
-    const handleOnSubmit = form.onSubmit((values) => {
+        return projects
+            .filter(({ type }) => type !== ProjectType.PREVIEW)
+            .map((item) => ({
+                value: item.projectUuid,
+                label: item.name,
+            }));
+    }, [projects]);
+
+    const handleSubmit = form.onSubmit((values) => {
+        if (!form.isValid()) return;
+
         const role =
             values.emailDomains.length > 0
                 ? values.role
                 : OrganizationMemberRole.VIEWER;
+
         const newProjects =
             role === OrganizationMemberRole.MEMBER ? values.projects : [];
+
         mutate({
             emailDomains: values.emailDomains,
-            role,
-            projects: newProjects,
+            role: role as AllowedEmailDomains['role'],
+            projects: newProjects as AllowedEmailDomains['projects'],
         });
     });
 
@@ -177,9 +182,11 @@ const AllowedDomainsPanel: FC = () => {
     };
 
     return isSuccess ? (
-        <form name="allowedEmailDomains" onSubmit={handleOnSubmit}>
+        <form name="allowedEmailDomains" onSubmit={handleSubmit}>
             <Stack>
                 <MultiSelect
+                    creatable
+                    searchable
                     name="emailDomains"
                     label="Allowed email domains"
                     placeholder="E.g. lightdash.com"
@@ -188,10 +195,6 @@ const AllowedDomainsPanel: FC = () => {
                         value: emailDomain,
                         label: emailDomain,
                     }))}
-                    searchable
-                    creatable
-                    getCreateLabel={(query: string) => `+ Add ${query} domain`}
-                    defaultValue={form.values.emailDomains}
                     onCreate={(value) => {
                         if (!isValidEmailDomain(value)) {
                             form.setFieldError(
@@ -216,6 +219,8 @@ const AllowedDomainsPanel: FC = () => {
 
                         return value;
                     }}
+                    getCreateLabel={(query: string) => `+ Add ${query} domain`}
+                    defaultValue={form.values.emailDomains}
                     {...form.getInputProps('emailDomains')}
                 />
 
@@ -268,158 +273,168 @@ const AllowedDomainsPanel: FC = () => {
                                 <Title order={5} mb="md">
                                     Project access
                                 </Title>
-                                {form.values.projects.map(
-                                    ({ projectUuid }, index) => (
-                                        <Flex
-                                            key={projectUuid}
-                                            align="flex-end"
-                                            gap="xs"
-                                            mb="xs"
-                                        >
-                                            <Select
-                                                label={
-                                                    index === 0
-                                                        ? 'Project name'
-                                                        : undefined
-                                                }
-                                                data={projectOptions.filter(
-                                                    ({ value }) => {
-                                                        const isCurrentValue =
-                                                            value ===
-                                                            form.values
-                                                                .projects[index]
-                                                                .projectUuid;
-                                                        if (isCurrentValue) {
-                                                            return true;
-                                                        }
-                                                        const isSelected =
-                                                            form.values.projects.find(
-                                                                (project) =>
-                                                                    project.projectUuid ===
-                                                                    value,
-                                                            );
-                                                        return !isSelected;
-                                                    },
-                                                )}
-                                                {...form.getInputProps(
-                                                    `projects.${index}.projectUuid`,
-                                                )}
-                                            />
-                                            <Select
-                                                label={
-                                                    index === 0
-                                                        ? 'Project role'
-                                                        : undefined
-                                                }
-                                                disabled={isLoading}
-                                                data={projectRoleOptions}
-                                                itemComponent={forwardRef(
-                                                    (
-                                                        {
-                                                            selected,
-                                                            subLabel,
-                                                            label,
-                                                            ...others
-                                                        }: any,
-                                                        ref: ForwardedRef<HTMLDivElement>,
-                                                    ) => {
-                                                        return (
-                                                            <Flex
-                                                                ref={ref}
-                                                                gap="xs"
-                                                                justify="space-between"
-                                                                align="center"
-                                                                {...others}
-                                                            >
-                                                                <Text size="sm">
-                                                                    {label}
-                                                                </Text>
-                                                                <Tooltip
-                                                                    withinPortal
-                                                                    multiline
-                                                                    label={
-                                                                        subLabel
-                                                                    }
-                                                                >
-                                                                    <MantineIcon
-                                                                        color={
-                                                                            selected
-                                                                                ? 'white'
-                                                                                : 'grey'
-                                                                        }
-                                                                        icon={
-                                                                            IconHelpCircle
-                                                                        }
-                                                                    />
-                                                                </Tooltip>
-                                                            </Flex>
-                                                        );
-                                                    },
-                                                )}
-                                                defaultValue={
-                                                    ProjectMemberRole.VIEWER
-                                                }
-                                                {...form.getInputProps(
-                                                    `projects.${index}.role`,
-                                                )}
-                                            />
-                                            <ActionIcon
-                                                color="red"
-                                                variant="outline"
-                                                size="35px"
-                                                onClick={() =>
-                                                    form.removeListItem(
-                                                        'projects',
-                                                        index,
-                                                    )
-                                                }
+
+                                <Stack spacing="sm" align="flex-start">
+                                    {form.values.projects.map(
+                                        ({ projectUuid }, index) => (
+                                            <Flex
+                                                key={projectUuid}
+                                                align="flex-end"
+                                                gap="xs"
                                             >
-                                                <MantineIcon
-                                                    icon={IconX}
-                                                    color="red"
+                                                <Select
+                                                    size="xs"
+                                                    disabled={isLoading}
+                                                    label={
+                                                        index === 0
+                                                            ? 'Project name'
+                                                            : undefined
+                                                    }
+                                                    data={projectOptions.filter(
+                                                        ({ value }) => {
+                                                            const isCurrentValue =
+                                                                value ===
+                                                                form.values
+                                                                    .projects[
+                                                                    index
+                                                                ].projectUuid;
+                                                            if (
+                                                                isCurrentValue
+                                                            ) {
+                                                                return true;
+                                                            }
+                                                            const isSelected =
+                                                                form.values.projects.find(
+                                                                    (project) =>
+                                                                        project.projectUuid ===
+                                                                        value,
+                                                                );
+                                                            return !isSelected;
+                                                        },
+                                                    )}
+                                                    {...form.getInputProps(
+                                                        `projects.${index}.projectUuid`,
+                                                    )}
                                                 />
-                                            </ActionIcon>
-                                        </Flex>
-                                    ),
-                                )}
-                                <Tooltip
-                                    withinPortal
-                                    multiline
-                                    disabled={canAddMoreProjects}
-                                    label={'There are no other projects to add'}
-                                >
-                                    <Button
-                                        {...(!canAddMoreProjects && {
-                                            'data-disabled': true,
-                                        })}
-                                        sx={{
-                                            '&[data-disabled="true"]': {
-                                                pointerEvents: 'all',
-                                            },
-                                        }}
-                                        onClick={handleAddProject}
-                                        variant="outline"
-                                        size="xs"
-                                        leftIcon={
-                                            <MantineIcon icon={IconPlus} />
+
+                                                <Select
+                                                    label={
+                                                        index === 0
+                                                            ? 'Project role'
+                                                            : undefined
+                                                    }
+                                                    disabled={isLoading}
+                                                    size="xs"
+                                                    data={projectRoleOptions}
+                                                    itemComponent={forwardRef(
+                                                        (
+                                                            {
+                                                                selected,
+                                                                subLabel,
+                                                                label,
+                                                                ...others
+                                                            }: any,
+                                                            ref: ForwardedRef<HTMLDivElement>,
+                                                        ) => {
+                                                            return (
+                                                                <Flex
+                                                                    ref={ref}
+                                                                    gap="xs"
+                                                                    justify="space-between"
+                                                                    align="center"
+                                                                    {...others}
+                                                                >
+                                                                    <Text size="xs">
+                                                                        {label}
+                                                                    </Text>
+
+                                                                    <Tooltip
+                                                                        withinPortal
+                                                                        multiline
+                                                                        label={
+                                                                            subLabel
+                                                                        }
+                                                                    >
+                                                                        <MantineIcon
+                                                                            color={
+                                                                                selected
+                                                                                    ? 'white'
+                                                                                    : 'grey'
+                                                                            }
+                                                                            icon={
+                                                                                IconHelpCircle
+                                                                            }
+                                                                        />
+                                                                    </Tooltip>
+                                                                </Flex>
+                                                            );
+                                                        },
+                                                    )}
+                                                    defaultValue={
+                                                        ProjectMemberRole.VIEWER
+                                                    }
+                                                    {...form.getInputProps(
+                                                        `projects.${index}.role`,
+                                                    )}
+                                                />
+
+                                                <ActionIcon
+                                                    color="red"
+                                                    variant="outline"
+                                                    size={30}
+                                                    disabled={isLoading}
+                                                    onClick={() =>
+                                                        form.removeListItem(
+                                                            'projects',
+                                                            index,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                        size="sm"
+                                                    />
+                                                </ActionIcon>
+                                            </Flex>
+                                        ),
+                                    )}
+
+                                    <Tooltip
+                                        withinPortal
+                                        multiline
+                                        disabled={canAddMoreProjects}
+                                        label={
+                                            'There are no other projects to add'
                                         }
                                     >
-                                        Add project
-                                    </Button>
-                                </Tooltip>
+                                        <Button
+                                            {...(!canAddMoreProjects && {
+                                                'data-disabled': true,
+                                            })}
+                                            sx={{
+                                                '&[data-disabled="true"]': {
+                                                    pointerEvents: 'all',
+                                                },
+                                            }}
+                                            onClick={handleAddProject}
+                                            variant="outline"
+                                            size="xs"
+                                            leftIcon={
+                                                <MantineIcon icon={IconPlus} />
+                                            }
+                                        >
+                                            Add project
+                                        </Button>
+                                    </Tooltip>
+                                </Stack>
                             </div>
                         ) : null}
                     </>
                 )}
 
                 <Flex justify="flex-end" gap="sm">
-                    {form.isDirty() && (
-                        <Button
-                            variant="outline"
-                            onClick={() => {
-                                setFormValuesFromData();
-                            }}
-                        >
+                    {form.isDirty() && !isUpdateAllowedEmailDomainsLoading && (
+                        <Button variant="outline" onClick={() => form.reset()}>
                             Cancel
                         </Button>
                     )}

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -1,7 +1,7 @@
 import { ProjectType } from '@lightdash/common';
-import { Button, Select, Stack } from '@mantine/core';
+import { Button, Flex, Select, Stack } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
 import { useProjects } from '../../../hooks/useProjects';
@@ -33,6 +33,22 @@ const DefaultProjectPanel: FC = () => {
         }
     }, [data, data?.defaultProjectUuid, setFieldValue]);
 
+    const setFormValuesFromData = useCallback(() => {
+        if (data) {
+            form.setValues({
+                defaultProjectUuid: data?.defaultProjectUuid,
+            });
+            form.resetDirty({
+                defaultProjectUuid: data?.defaultProjectUuid,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
+
     const handleOnSubmit = form.onSubmit(({ defaultProjectUuid }) => {
         updateOrganization({ defaultProjectUuid: defaultProjectUuid });
     });
@@ -41,6 +57,7 @@ const DefaultProjectPanel: FC = () => {
         <form onSubmit={handleOnSubmit}>
             <Stack>
                 <Select
+                    key={form.values.defaultProjectUuid}
                     label="Project name"
                     data={projects
                         .filter(({ type }) => type !== ProjectType.PREVIEW)
@@ -54,15 +71,27 @@ const DefaultProjectPanel: FC = () => {
                     dropdownPosition="bottom"
                     {...form.getInputProps('defaultProjectUuid')}
                 />
-                <Button
-                    display="block"
-                    ml="auto"
-                    type="submit"
-                    disabled={isLoading}
-                    loading={isLoading}
-                >
-                    Update
-                </Button>
+
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && (
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setFormValuesFromData();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    )}
+                    <Button
+                        display="block"
+                        type="submit"
+                        disabled={isLoading || !form.isDirty()}
+                        loading={isLoading}
+                    >
+                        Update
+                    </Button>
+                </Flex>
             </Stack>
         </form>
     );

--- a/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
@@ -1,8 +1,15 @@
 import { Button, Flex, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { FC, useEffect } from 'react';
+import { z } from 'zod';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
+
+const validationSchema = z.object({
+    organizationName: z.string().nonempty(),
+});
+
+type FormValues = z.infer<typeof validationSchema>;
 
 const OrganizationPanel: FC = () => {
     const { isLoading: isOrganizationLoading, data: organizationData } =
@@ -15,7 +22,7 @@ const OrganizationPanel: FC = () => {
 
     const isLoading = isOrganizationUpdateLoading || isOrganizationLoading;
 
-    const form = useForm({
+    const form = useForm<FormValues>({
         initialValues: {
             organizationName: '',
         },
@@ -56,6 +63,7 @@ const OrganizationPanel: FC = () => {
                             Cancel
                         </Button>
                     )}
+
                     <Button
                         display="block"
                         type="submit"

--- a/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
@@ -1,47 +1,41 @@
 import { Button, Flex, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
 
 const OrganizationPanel: FC = () => {
-    const { isInitialLoading: isOrganizationLoading, data } = useOrganization();
+    const { isLoading: isOrganizationLoading, data: organizationData } =
+        useOrganization();
+
     const {
         isLoading: isOrganizationUpdateLoading,
         mutate: updateOrganization,
     } = useOrganizationUpdateMutation();
+
     const isLoading = isOrganizationUpdateLoading || isOrganizationLoading;
+
     const form = useForm({
         initialValues: {
             organizationName: '',
         },
     });
 
-    const { setFieldValue } = form;
-
     useEffect(() => {
-        if (data) {
-            setFieldValue('organizationName', data?.name);
-        }
-    }, [data, data?.name, setFieldValue]);
+        if (isOrganizationLoading || !organizationData) return;
 
-    const setFormValuesFromData = useCallback(() => {
-        if (data?.name) {
-            form.setValues({
-                organizationName: data?.name,
-            });
-            form.resetDirty({
-                organizationName: data?.name,
-            });
-        }
+        const initialData = {
+            organizationName: organizationData.name,
+        };
+
+        form.setInitialValues(initialData);
+        form.setValues(initialData);
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data?.name]);
-
-    useEffect(() => {
-        setFormValuesFromData();
-    }, [setFormValuesFromData]);
+    }, [isOrganizationLoading, organizationData]);
 
     const handleOnSubmit = form.onSubmit(({ organizationName }) => {
+        if (!form.isValid()) return;
         updateOrganization({ name: organizationName });
     });
 
@@ -57,13 +51,8 @@ const OrganizationPanel: FC = () => {
                 />
 
                 <Flex justify="flex-end" gap="sm">
-                    {form.isDirty() && (
-                        <Button
-                            variant="outline"
-                            onClick={() => {
-                                setFormValuesFromData();
-                            }}
-                        >
+                    {form.isDirty() && !isOrganizationUpdateLoading && (
+                        <Button variant="outline" onClick={() => form.reset()}>
                             Cancel
                         </Button>
                     )}

--- a/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
@@ -1,6 +1,6 @@
-import { Button, Stack, TextInput } from '@mantine/core';
+import { Button, Flex, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { FC, useEffect } from 'react';
+import { FC, useCallback, useEffect } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUpdateMutation } from '../../../hooks/organization/useOrganizationUpdateMutation';
 
@@ -25,6 +25,22 @@ const OrganizationPanel: FC = () => {
         }
     }, [data, data?.name, setFieldValue]);
 
+    const setFormValuesFromData = useCallback(() => {
+        if (data?.name) {
+            form.setValues({
+                organizationName: data?.name,
+            });
+            form.resetDirty({
+                organizationName: data?.name,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data?.name]);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
+
     const handleOnSubmit = form.onSubmit(({ organizationName }) => {
         updateOrganization({ name: organizationName });
     });
@@ -40,15 +56,26 @@ const OrganizationPanel: FC = () => {
                     {...form.getInputProps('organizationName')}
                 />
 
-                <Button
-                    display="block"
-                    ml="auto"
-                    type="submit"
-                    disabled={isLoading}
-                    loading={isLoading}
-                >
-                    Update
-                </Button>
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && (
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setFormValuesFromData();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    )}
+                    <Button
+                        display="block"
+                        type="submit"
+                        disabled={isLoading || !form.isDirty()}
+                        loading={isLoading}
+                    >
+                        Update
+                    </Button>
+                </Flex>
             </Stack>
         </form>
     );

--- a/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
@@ -53,21 +53,20 @@ const PasswordPanel: FC = () => {
             },
         });
 
-    const setFormValuesFromData = useCallback(() => {
-        form.setValues({
+    const handleFormReset = useCallback(() => {
+        const resetValues = {
             currentPassword: '',
             newPassword: '',
-        });
-        form.resetDirty({
-            currentPassword: '',
-            newPassword: '',
-        });
+        };
+
+        form.setValues(resetValues);
+        form.resetDirty(resetValues);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
-        setFormValuesFromData();
-    }, [setFormValuesFromData]);
+        handleFormReset();
+    }, [handleFormReset]);
 
     const handleOnSubmit = form.onSubmit(({ currentPassword, newPassword }) => {
         if (hasPassword) {
@@ -107,7 +106,7 @@ const PasswordPanel: FC = () => {
                         <Button
                             variant="outline"
                             onClick={() => {
-                                setFormValuesFromData();
+                                handleFormReset();
                             }}
                         >
                             Cancel

--- a/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
@@ -1,7 +1,7 @@
 import { getPasswordSchema } from '@lightdash/common';
-import { Button, PasswordInput, Stack } from '@mantine/core';
+import { Button, Flex, PasswordInput, Stack } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { FC } from 'react';
+import { FC, useCallback, useEffect } from 'react';
 import { z } from 'zod';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
@@ -53,6 +53,22 @@ const PasswordPanel: FC = () => {
             },
         });
 
+    const setFormValuesFromData = useCallback(() => {
+        form.setValues({
+            currentPassword: '',
+            newPassword: '',
+        });
+        form.resetDirty({
+            currentPassword: '',
+            newPassword: '',
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
+
     const handleOnSubmit = form.onSubmit(({ currentPassword, newPassword }) => {
         if (hasPassword) {
             updateUserPassword({
@@ -85,15 +101,27 @@ const PasswordPanel: FC = () => {
                         {...form.getInputProps('newPassword')}
                     />
                 </PasswordTextInput>
-                <Button
-                    type="submit"
-                    ml="auto"
-                    display="block"
-                    loading={isLoading}
-                    disabled={isLoading}
-                >
-                    Update
-                </Button>
+
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && (
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setFormValuesFromData();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    )}
+                    <Button
+                        type="submit"
+                        display="block"
+                        loading={isLoading}
+                        disabled={isLoading || !form.isDirty()}
+                    >
+                        Update
+                    </Button>
+                </Flex>
             </Stack>
         </form>
     );

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -95,16 +95,14 @@ const ProfilePanel: FC = () => {
 
     const setFormValuesFromData = useCallback(() => {
         if (user.data?.firstName || user.data?.lastName || user.data?.email) {
-            form.setValues({
+            const formValues = {
                 firstName: user.data?.firstName,
                 lastName: user.data?.lastName,
                 email: user.data?.email,
-            });
-            form.resetDirty({
-                firstName: user.data?.firstName,
-                lastName: user.data?.lastName,
-                email: user.data?.email,
-            });
+            };
+
+            form.setValues(formValues);
+            form.resetDirty(formValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [user.data?.firstName, user.data?.lastName, user.data?.email]);

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -57,6 +57,7 @@ const ProfilePanel: FC = () => {
 
         form.setInitialValues(initialValues);
         form.setValues(initialValues);
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isLoadingUser, userData]);
 

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -4,7 +4,15 @@ import {
     UpdateUserArgs,
     validateEmail,
 } from '@lightdash/common';
-import { Anchor, Button, Stack, Text, TextInput, Tooltip } from '@mantine/core';
+import {
+    Anchor,
+    Button,
+    Flex,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconAlertCircle, IconCircleCheck } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -84,6 +92,26 @@ const ProfilePanel: FC = () => {
             setShowVerifyEmailModal(false);
         }
     }, [data?.isVerified, isEmailServerConfigured, sendVerificationEmailError]);
+
+    const setFormValuesFromData = useCallback(() => {
+        if (user.data?.firstName || user.data?.lastName || user.data?.email) {
+            form.setValues({
+                firstName: user.data?.firstName,
+                lastName: user.data?.lastName,
+                email: user.data?.email,
+            });
+            form.resetDirty({
+                firstName: user.data?.firstName,
+                lastName: user.data?.lastName,
+                email: user.data?.email,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [user.data?.firstName, user.data?.lastName, user.data?.email]);
+
+    useEffect(() => {
+        setFormValuesFromData();
+    }, [setFormValuesFromData]);
 
     const handleOnSubmit = form.onSubmit(({ firstName, lastName, email }) => {
         if (firstName && lastName && email && validateEmail(email)) {
@@ -182,15 +210,27 @@ const ProfilePanel: FC = () => {
                     }
                 />
 
-                <Button
-                    type="submit"
-                    display="block"
-                    ml="auto"
-                    loading={isUpdateUserLoading}
-                    data-cy="update-profile-settings"
-                >
-                    Update
-                </Button>
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && (
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setFormValuesFromData();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    )}
+                    <Button
+                        type="submit"
+                        display="block"
+                        loading={isUpdateUserLoading}
+                        data-cy="update-profile-settings"
+                        disabled={!form.isDirty()}
+                    >
+                        Update
+                    </Button>
+                </Flex>
                 <VerifyEmailModal
                     opened={showVerifyEmailModal}
                     onClose={() => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -513,6 +513,7 @@ const SchedulerForm: FC<Props> = ({
                                     <CronInternalInputs
                                         disabled={disabled}
                                         {...form.getInputProps('cron')}
+                                        value={form.values.cron}
                                         name="cron"
                                     />
                                 </Box>

--- a/packages/frontend/src/hooks/user/useUserUpdateMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserUpdateMutation.ts
@@ -1,0 +1,35 @@
+import { ApiError, LightdashUser, UpdateUserArgs } from '@lightdash/common';
+import {
+    useMutation,
+    UseMutationOptions,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const updateUserQuery = async (data: Partial<UpdateUserArgs>) =>
+    lightdashApi<LightdashUser>({
+        url: `/user/me`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUserUpdateMutation = (
+    useMutationOptions?: UseMutationOptions<
+        LightdashUser,
+        ApiError,
+        Partial<UpdateUserArgs>
+    >,
+) => {
+    const queryClient = useQueryClient();
+    return useMutation<LightdashUser, ApiError, Partial<UpdateUserArgs>>({
+        mutationKey: ['user_update'],
+        mutationFn: updateUserQuery,
+        ...useMutationOptions,
+        onSuccess: async (data, variables, context) => {
+            await queryClient.refetchQueries(['user']);
+            await queryClient.refetchQueries(['email_status']);
+
+            useMutationOptions?.onSuccess?.(data, variables, context);
+        },
+    });
+};

--- a/packages/frontend/src/utils/fieldValidators.ts
+++ b/packages/frontend/src/utils/fieldValidators.ts
@@ -58,7 +58,3 @@ export const isInvalidCronExpression: FieldValidator<string> =
                 : undefined;
         }
     };
-
-const VALID_EMAIL_DOMAIN_REGEX = /^[a-zA-Z0-9][\w\.-]+\.\w{2,4}/g;
-export const isValidEmailDomain = (value: string) =>
-    value.match(VALID_EMAIL_DOMAIN_REGEX);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3655,13 +3655,13 @@
   dependencies:
     "@mantine/utils" "6.0.21"
 
-"@mantine/form@^6.0.21":
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/@mantine/form/-/form-6.0.21.tgz#0d717631aa90b9cce834a479f4c8d7e9c0e1969b"
-  integrity sha512-d4tlxyZic7MSDnaPx/WliCX1sRFDkUd2nxx4MxxO2T4OSek0YDqTlSBCxeoveu60P+vrQQN5rbbsVsaOJBe4SQ==
+"@mantine/form@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@mantine/form/-/form-7.5.2.tgz#cfe66a62aa4b0aadd16e8a1ace2c2edd512e5800"
+  integrity sha512-Kz4UNLvAvxB1utKflt4gr5Uzt1Dxj17thcnlLzB2JX6unzV3OkvC36b5XoXAtuoFxt/RzEyUrp5M38jZLwCLEA==
   dependencies:
     fast-deep-equal "^3.1.3"
-    klona "^2.0.5"
+    klona "^2.0.6"
 
 "@mantine/hooks@^6.0.21":
   version "6.0.21"
@@ -13517,9 +13517,9 @@ kleur@^4.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz"
   integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
-klona@^2.0.5:
+klona@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
   integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
 
 knex-mock-client@^1.11.0:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8738 

### Description:

Added code to keep save/update buttons inactive until a change is made. Also includes cancel button to revert back to original state.

- [x] The Save Button should be disabled until a change has been made
- [x]  Once a change has been made, there should be an option to cancel that change. When I click on this, the changes revert and the Save button goes back to being disabled

Areas of impact in the form settings
- [x] User settings - Profile form
- [x] User settings - Password form
- [x] Project - Tables Configuration form
- [x] Organizations - General form
- [ ]  Organizations - Embedding configuration form

Just wanted to check on the `Organizations - Embedding configuration form`.
I do see it in the docs - https://docs.lightdash.com/references/embedding/. Is the code for this closed-source for now?

Output:

Profile Form -
Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/f1dc10e9-a8a9-40c0-921a-ccfed52d677e)

On Change:

![image](https://github.com/lightdash/lightdash/assets/85165953/91b04bde-d0a0-437e-a0db-e8f3d94c5ee2)

Table Configuration Form-
Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/06f82c99-71c6-4720-ab5a-2233b9444c0b)

On Change:

![image](https://github.com/lightdash/lightdash/assets/85165953/a3025c8a-18a9-4be7-a47b-72d7b38cb9d7)

General Form-
Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/e7e44397-5344-444f-906c-9ad2fad338b4)

On Change:

![image](https://github.com/lightdash/lightdash/assets/85165953/ede4c1f0-5e6b-47ea-8405-fefa40babcf6)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
