### PR TITLE
feat: Add additional attribute for # of table calculations in `ProjectService.runMetricQuery` trace

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1558,6 +1558,19 @@ export class ProjectService {
                         );
                     }
 
+                    const useNewTableCalculationsEngine =
+                        (await postHogClient?.isFeatureEnabled(
+                            'new-table-calculations-engine',
+                            user.userUuid,
+                            user.organizationUuid !== undefined
+                                ? {
+                                      groups: {
+                                          organization: user.organizationUuid,
+                                      },
+                                  }
+                                : {},
+                        )) ?? false;
+
                     const { organizationUuid } =
                         await this.projectModel.getSummary(projectUuid);
 
@@ -1680,6 +1693,13 @@ export class ProjectService {
 
                     Logger.debug(`Fetch query results from cache or warehouse`);
                     span.setAttribute('generatedSql', query);
+
+                    if (useNewTableCalculationsEngine) {
+                        span.setAttribute(
+                            'tableCalculationsNum',
+                            metricQuery.tableCalculations.length,
+                        );
+                    }
                     span.setAttribute('lightdash.projectUuid', projectUuid);
                     span.setAttribute(
                         'warehouse.type',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1699,10 +1699,11 @@ export class ProjectService {
                      * the impact of upcoming table calculation handling changes.
                      */
                     if (useNewTableCalculationsEngine) {
-                        span.setAttribute(
-                            'tableCalculationsNum',
-                            metricQuery.tableCalculations.length,
-                        );
+                        span.setAttributes({
+                            tableCalculationsNum:
+                                metricQuery.tableCalculations.length,
+                            newTableCalculations: useNewTableCalculationsEngine,
+                        });
                     }
                     span.setAttribute('lightdash.projectUuid', projectUuid);
                     span.setAttribute(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1694,6 +1694,10 @@ export class ProjectService {
                     Logger.debug(`Fetch query results from cache or warehouse`);
                     span.setAttribute('generatedSql', query);
 
+                    /**
+                     * If enabled, we include additional attributes for this span allowing us to measure
+                     * the impact of upcoming table calculation handling changes.
+                     */
                     if (useNewTableCalculationsEngine) {
                         span.setAttribute(
                             'tableCalculationsNum',


### PR DESCRIPTION
### Description:

- Includes support for a new `new-table-calculations-engine` feature flag
- When enabled, includes a new span attribute for `ProjectService.runMetricQuery`:
  - `tableCalculationsNum`: number of table calculations for this query

The goal is to measure the impact of upcoming table calculation changes on metrics queries. The span attribute will be moved outside the feature flag condition in a follow-up PR, to allow comparison testing (with/without new table calculations changes).

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
