### PR TITLE
chore: fix dom nesting warning in create dashboard

### DIFF
--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -1,6 +1,7 @@
 import { Dashboard, Space } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     Button,
     Group,
     MantineProvider,
@@ -133,7 +134,11 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     return (
         <MantineProvider inherit theme={{ colorScheme: 'light' }}>
             <Modal
-                title={<Title order={5}>Create dashboard</Title>}
+                title={
+                    <Box>
+                        <Title order={4}>Create Dashboard</Title>
+                    </Box>
+                }
                 onClose={() => handleClose()}
                 {...modalProps}
             >


### PR DESCRIPTION
### Description:

Opening the Create Dashboard modal causes a console error about nesting that can be annoying. Wrapping the modal title in a Box seems to fix the error. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
