### PR TITLE
fix: filter configuration apply tooltip

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -356,7 +356,7 @@ const FilterConfiguration: FC<Props> = ({
 
                 <Tooltip
                     label="Filter field and value required"
-                    disabled={isApplyDisabled}
+                    disabled={!isApplyDisabled}
                 >
                     <Box>
                         <Button


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

show explanation tooltip when button is disabled not the opposite.

![CleanShot 2024-01-31 at 18 57 22@2x](https://github.com/lightdash/lightdash/assets/962095/78ad09dd-a751-420d-820a-a39625063810)
![CleanShot 2024-01-31 at 18 57 26@2x](https://github.com/lightdash/lightdash/assets/962095/09bce391-de01-46b8-8bcc-cf159b98f2dc)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
