### PR TITLE
feat: unify legacy Format with CustomFormat functions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -156,6 +156,11 @@ models:
               round: 2
               filters:
                 - is_completed: "true"
+            total_completed_order_amount_eur:
+              type: sum
+              format: eur
+              filters:
+                - is_completed: "true"
             total_non_completed_order_amount:
               type: number
               format: usd

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3607,7 +3607,7 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { code: { dataType: 'string' } },
+            nestedProperties: { spec: { dataType: 'object' } },
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -646,7 +646,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CustomFormatType: {
         dataType: 'refEnum',
-        enums: ['default', 'percent', 'currency', 'number'],
+        enums: ['default', 'percent', 'currency', 'number', 'id'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     NumberSeparator: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -628,7 +628,7 @@
                 "type": "object"
             },
             "CustomFormatType": {
-                "enum": ["default", "percent", "currency", "number"],
+                "enum": ["default", "percent", "currency", "number", "id"],
                 "type": "string"
             },
             "NumberSeparator": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4057,8 +4057,9 @@
             },
             "CustomVis": {
                 "properties": {
-                    "code": {
-                        "type": "string"
+                    "spec": {
+                        "additionalProperties": false,
+                        "type": "object"
                     }
                 },
                 "type": "object"
@@ -6322,7 +6323,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.973.1",
+        "version": "0.974.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -120,6 +120,7 @@ export enum CustomFormatType {
     PERCENT = 'percent',
     CURRENCY = 'currency',
     NUMBER = 'number',
+    ID = 'id',
 }
 
 export type TableCalculation = {
@@ -139,7 +140,7 @@ export interface TableCalculationField extends Field {
     sql: string;
 }
 
-export const isTableCalculation = (item: Item): item is TableCalculation =>
+export const isTableCalculation = (item: any): item is TableCalculation =>
     item
         ? !('binType' in item) &&
           !!item.sql &&

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -140,7 +140,9 @@ export interface TableCalculationField extends Field {
     sql: string;
 }
 
-export const isTableCalculation = (item: any): item is TableCalculation =>
+export const isTableCalculation = (
+    item: Item | AdditionalMetric,
+): item is TableCalculation =>
     item
         ? !('binType' in item) &&
           !!item.sql &&

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -129,6 +129,7 @@ export const getFilterTypeFromItem = (item: FilterableItem): FilterType => {
         case MetricType.BOOLEAN:
             return FilterType.BOOLEAN;
         case CustomFormatType.DEFAULT:
+        case CustomFormatType.ID:
             return FilterType.STRING;
         case CustomFormatType.CURRENCY:
         case CustomFormatType.PERCENT:

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -526,6 +526,16 @@ describe('Formatting', () => {
 
                 expect(
                     applyCustomFormat(
+                        4000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$4.00K');
+
+                expect(
+                    applyCustomFormat(
                         5000000,
                         getCustomFormatFromLegacy({
                             compact: M,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -420,9 +420,6 @@ describe('Formatting', () => {
             test('it should return the right style', () => {
                 expect(applyCustomFormat(5, thousandsConfig)).toEqual('0.005K');
                 expect(applyCustomFormat(5, millionsConfig)).toEqual('0M');
-                expect(
-                    applyCustomFormat(5, { ...millionsConfig, round: 2 }),
-                ).toEqual('0.00M');
                 expect(applyCustomFormat(500000, billionsConfig)).toEqual(
                     '0.001B',
                 );
@@ -430,6 +427,21 @@ describe('Formatting', () => {
                 expect(applyCustomFormat(5000000000, trillionsConfig)).toEqual(
                     '0.005T',
                 );
+            });
+
+            test('when applying round it should return the right style', () => {
+                expect(
+                    applyCustomFormat(5, { ...millionsConfig, round: 2 }),
+                ).toEqual('0.00M');
+                expect(
+                    applyCustomFormat(5400000, { ...millionsConfig, round: 0 }),
+                ).toEqual('5M');
+                expect(
+                    applyCustomFormat(4956789123, {
+                        ...trillionsConfig,
+                        round: -1,
+                    }),
+                ).toEqual('0.005T');
             });
 
             test('with legacy distance format it should return the right format', () => {

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -68,244 +68,290 @@ describe('Formatting', () => {
     });
 
     describe('applying CustomFormat to value', () => {
-        test('applyCustomFormat should return the right format', () => {
-            const kilometerOptions = {
-                format: Format.KM,
-            };
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy(kilometerOptions),
-                ),
-            ).toEqual('5 km');
-            expect(
-                applyCustomFormat(
-                    '5',
-                    getCustomFormatFromLegacy(kilometerOptions),
-                ),
-            ).toEqual('5 km');
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.MI,
-                    }),
-                ),
-            ).toEqual('5 mi');
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({ format: Format.USD }),
-                ),
-            ).toEqual('$5.00');
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({ format: Format.GBP }),
-                ),
-            ).toEqual('£5.00');
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({ format: Format.EUR }),
-                ),
-            ).toEqual('€5.00');
+        describe('when using legacy format', () => {
+            describe('if Format is distance unit', () => {
+                test('it should return the right format', () => {
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy({ format: Format.KM }),
+                        ),
+                    ).toEqual('5 km');
 
-            const percentageOptions = {
-                format: Format.PERCENT,
-            };
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy(percentageOptions),
-                ),
-            ).toEqual('500%');
-            expect(
-                applyCustomFormat(
-                    0.05,
-                    getCustomFormatFromLegacy(percentageOptions),
-                ),
-            ).toEqual('5%');
-            expect(
-                applyCustomFormat(
-                    '5',
-                    getCustomFormatFromLegacy(percentageOptions),
-                ),
-            ).toEqual('500%');
-            expect(
-                applyCustomFormat(
-                    'foo',
-                    getCustomFormatFromLegacy(percentageOptions),
-                ),
-            ).toEqual('foo');
-            expect(
-                applyCustomFormat(
-                    false,
-                    getCustomFormatFromLegacy(percentageOptions),
-                ),
-            ).toEqual('false');
-            expect(applyCustomFormat(1103)).toEqual('1,103');
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy({
+                                format: Format.MI,
+                            }),
+                        ),
+                    ).toEqual('5 mi');
+                });
+            });
 
-            expect(applyCustomFormat(5)).toEqual('5');
+            describe('if Format is currency unit', () => {
+                test('it should return the right format', () => {
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy({ format: Format.USD }),
+                        ),
+                    ).toEqual('$5.00');
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy({ format: Format.GBP }),
+                        ),
+                    ).toEqual('£5.00');
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy({ format: Format.EUR }),
+                        ),
+                    ).toEqual('€5.00');
+                });
+            });
 
-            // Intl.NumberFormat rounds up after 3 decimals
-            expect(applyCustomFormat(5.9)).toEqual('5.9');
-            expect(applyCustomFormat(5.99)).toEqual('5.99');
-            expect(applyCustomFormat(5.999)).toEqual('5.999');
-            expect(applyCustomFormat(5.9999)).toEqual('6');
-            expect(applyCustomFormat(5.99999)).toEqual('6');
+            describe('if Format is percent', () => {
+                test('it should return the right format', () => {
+                    const percentageOptions = {
+                        format: Format.PERCENT,
+                    };
 
-            // ids are not comma separated
-            expect(
-                applyCustomFormat(
-                    1019,
-                    getCustomFormatFromLegacy({ format: Format.ID }),
-                ),
-            ).toEqual('1019');
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy(percentageOptions),
+                        ),
+                    ).toEqual('500%');
+                    expect(
+                        applyCustomFormat(
+                            0.05,
+                            getCustomFormatFromLegacy(percentageOptions),
+                        ),
+                    ).toEqual('5%');
+                    expect(
+                        applyCustomFormat(
+                            '5',
+                            getCustomFormatFromLegacy(percentageOptions),
+                        ),
+                    ).toEqual('500%');
+                    expect(
+                        applyCustomFormat(
+                            'foo',
+                            getCustomFormatFromLegacy(percentageOptions),
+                        ),
+                    ).toEqual('foo');
+                    expect(
+                        applyCustomFormat(
+                            false,
+                            getCustomFormatFromLegacy(percentageOptions),
+                        ),
+                    ).toEqual('false');
+                });
+            });
+
+            describe('if Format is undefined', () => {
+                test('it should return the right format', () => {
+                    expect(applyCustomFormat(1103)).toEqual('1,103');
+                    expect(applyCustomFormat(5)).toEqual('5');
+                });
+            });
+
+            describe('if Format is id', () => {
+                test('it should return the right format', () => {
+                    // ids are not comma separated
+                    expect(
+                        applyCustomFormat(
+                            1019,
+                            getCustomFormatFromLegacy({ format: Format.ID }),
+                        ),
+                    ).toEqual('1019');
+                });
+            });
         });
 
-        test('applyCustomFormat should return the right round', () => {
-            const roundZeroOptions = {
-                round: 0,
-            };
-            expect(
-                applyCustomFormat(
-                    1,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('1');
-            expect(
-                applyCustomFormat(
-                    10,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('10');
-            expect(
-                applyCustomFormat(
-                    100,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('100');
-            expect(
-                applyCustomFormat(
-                    1000,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('1,000');
-            expect(
-                applyCustomFormat(
-                    10000,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('10,000');
-            expect(
-                applyCustomFormat(
-                    100000,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('100,000');
-            expect(
-                applyCustomFormat(
-                    1000000,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('1,000,000');
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('5');
-            expect(
-                applyCustomFormat(
-                    5.001,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('5');
-            expect(
-                applyCustomFormat(
-                    5.9999999,
-                    getCustomFormatFromLegacy(roundZeroOptions),
-                ),
-            ).toEqual('6');
+        describe('when applying round', () => {
+            describe('if round is undefined', () => {
+                test('it should keep up to 3 decimal places', () => {
+                    expect(applyCustomFormat(5.9)).toEqual('5.9');
+                    expect(applyCustomFormat(5.99)).toEqual('5.99');
+                    expect(applyCustomFormat(5.999)).toEqual('5.999');
+                    expect(applyCustomFormat(5.9999)).toEqual('6');
+                    expect(applyCustomFormat(5.99999)).toEqual('6');
+                });
+            });
 
-            const roundTwoOptions = {
-                round: 2,
-            };
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('5.00');
-            expect(
-                applyCustomFormat(
-                    5.001,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('5.00');
-            expect(
-                applyCustomFormat(
-                    5.555,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('5.56');
-            expect(
-                applyCustomFormat(
-                    5.5555,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('5.56');
-            expect(
-                applyCustomFormat(
-                    5.9999999,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('6.00');
-            expect(
-                applyCustomFormat(
-                    'foo',
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('foo');
-            expect(
-                applyCustomFormat(
-                    false,
-                    getCustomFormatFromLegacy(roundTwoOptions),
-                ),
-            ).toEqual('false');
+            describe('when round zero', () => {
+                test('it should return the right round', () => {
+                    const roundZeroOptions = {
+                        round: 0,
+                    };
+                    expect(
+                        applyCustomFormat(
+                            1,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('1');
+                    expect(
+                        applyCustomFormat(
+                            10,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('10');
+                    expect(
+                        applyCustomFormat(
+                            100,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('100');
+                    expect(
+                        applyCustomFormat(
+                            1000,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('1,000');
+                    expect(
+                        applyCustomFormat(
+                            10000,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('10,000');
+                    expect(
+                        applyCustomFormat(
+                            100000,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('100,000');
+                    expect(
+                        applyCustomFormat(
+                            1000000,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('1,000,000');
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('5');
+                    expect(
+                        applyCustomFormat(
+                            5.001,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('5');
+                    expect(
+                        applyCustomFormat(
+                            5.9999999,
+                            getCustomFormatFromLegacy(roundZeroOptions),
+                        ),
+                    ).toEqual('6');
+                });
+            });
 
-            const roundTenOptions = {
-                round: 10,
-            };
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy(roundTenOptions),
-                ),
-            ).toEqual('5.0000000000');
-            expect(
-                applyCustomFormat(
-                    5.001,
-                    getCustomFormatFromLegacy(roundTenOptions),
-                ),
-            ).toEqual('5.0010000000');
-            expect(
-                applyCustomFormat(
-                    5.9999999,
-                    getCustomFormatFromLegacy(roundTenOptions),
-                ),
-            ).toEqual('5.9999999000');
+            describe('when round is positive number', () => {
+                test('it should return the right round', () => {
+                    const roundTwoOptions = {
+                        round: 2,
+                    };
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('5.00');
+                    expect(
+                        applyCustomFormat(
+                            5.001,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('5.00');
+                    expect(
+                        applyCustomFormat(
+                            5.555,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('5.56');
+                    expect(
+                        applyCustomFormat(
+                            5.5555,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('5.56');
+                    expect(
+                        applyCustomFormat(
+                            5.9999999,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('6.00');
+                    expect(
+                        applyCustomFormat(
+                            'foo',
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('foo');
+                    expect(
+                        applyCustomFormat(
+                            false,
+                            getCustomFormatFromLegacy(roundTwoOptions),
+                        ),
+                    ).toEqual('false');
 
-            // negative rounding not supported
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        round: -1,
-                    }),
-                ),
-            ).toEqual('5');
+                    const roundTenOptions = {
+                        round: 10,
+                    };
+                    expect(
+                        applyCustomFormat(
+                            5,
+                            getCustomFormatFromLegacy(roundTenOptions),
+                        ),
+                    ).toEqual('5.0000000000');
+                    expect(
+                        applyCustomFormat(
+                            5.001,
+                            getCustomFormatFromLegacy(roundTenOptions),
+                        ),
+                    ).toEqual('5.0010000000');
+                    expect(
+                        applyCustomFormat(
+                            5.9999999,
+                            getCustomFormatFromLegacy(roundTenOptions),
+                        ),
+                    ).toEqual('5.9999999000');
+                });
+            });
+
+            describe('when round is negative number', () => {
+                test('it should return the right round', () => {
+                    const number = 123456789.12345;
+
+                    expect(
+                        formatNumberValue(number, {
+                            type: CustomFormatType.DEFAULT,
+                            round: -1,
+                        }),
+                    ).toEqual('123,456,790');
+                    expect(
+                        formatNumberValue(number, {
+                            type: CustomFormatType.DEFAULT,
+                            round: -2,
+                        }),
+                    ).toEqual('123,456,800');
+                    expect(
+                        formatNumberValue(number, {
+                            type: CustomFormatType.DEFAULT,
+                            round: -3,
+                        }),
+                    ).toEqual('123,457,000');
+                    expect(
+                        formatNumberValue(number, {
+                            type: CustomFormatType.DEFAULT,
+                            round: -99,
+                        }),
+                    ).toEqual('100,000,000');
+                });
+            });
         });
 
         test('applyCustomFormat should return the right format and round', () => {
@@ -371,7 +417,7 @@ describe('Formatting', () => {
                         round: -2,
                     }),
                 ),
-            ).toEqual('$5.00');
+            ).toEqual('$5');
             expect(
                 applyCustomFormat(
                     5.25,
@@ -380,7 +426,7 @@ describe('Formatting', () => {
                         round: -1,
                     }),
                 ),
-            ).toEqual('$5.25');
+            ).toEqual('$5');
             expect(
                 applyCustomFormat(
                     '5.0000',
@@ -407,7 +453,7 @@ describe('Formatting', () => {
                         round: -2,
                     }),
                 ),
-            ).toEqual('£5.00');
+            ).toEqual('£5');
             expect(
                 applyCustomFormat(
                     5.25,
@@ -416,7 +462,7 @@ describe('Formatting', () => {
                         round: -2,
                     }),
                 ),
-            ).toEqual('£5.25');
+            ).toEqual('£5');
             expect(
                 applyCustomFormat(
                     5,
@@ -434,16 +480,16 @@ describe('Formatting', () => {
                         round: -2,
                     }),
                 ),
-            ).toEqual('€5.00');
+            ).toEqual('€5');
             expect(
                 applyCustomFormat(
                     5.25,
                     getCustomFormatFromLegacy({
                         format: Format.EUR,
-                        round: -2,
+                        round: -1,
                     }),
                 ),
-            ).toEqual('€5.25');
+            ).toEqual('€5');
             expect(
                 applyCustomFormat(
                     5,
@@ -527,259 +573,278 @@ describe('Formatting', () => {
             ).toEqual('500%');
         });
 
-        test('applyCustomFormat should return the right style', () => {
+        describe('when applying compact', () => {
             const K = Compact.THOUSANDS;
             const M = Compact.MILLIONS;
             const B = Compact.BILLIONS;
+            const T = Compact.TRILLIONS;
 
-            expect(
-                applyCustomFormat(5, getCustomFormatFromLegacy({ compact: K })),
-            ).toEqual('0.01K');
+            const thousandsConfig = {
+                type: CustomFormatType.NUMBER,
+                compact: K,
+            };
+            const millionsConfig = {
+                type: CustomFormatType.NUMBER,
+                compact: M,
+            };
+            const billionsConfig = {
+                type: CustomFormatType.NUMBER,
+                compact: B,
+            };
+            const trillionsConfig = {
+                type: CustomFormatType.NUMBER,
+                compact: T,
+            };
 
-            expect(
-                applyCustomFormat(5, getCustomFormatFromLegacy({ compact: M })),
-            ).toEqual('0.00M');
+            test('it should return the right style', () => {
+                expect(applyCustomFormat(5, thousandsConfig)).toEqual('0.005K');
+                expect(applyCustomFormat(5, millionsConfig)).toEqual('0M');
+                expect(
+                    applyCustomFormat(5, { ...millionsConfig, round: 2 }),
+                ).toEqual('0.00M');
+                expect(applyCustomFormat(500000, billionsConfig)).toEqual(
+                    '0.001B',
+                );
+                expect(applyCustomFormat(5, billionsConfig)).toEqual('0B');
+                expect(applyCustomFormat(5000000000, trillionsConfig)).toEqual(
+                    '0.005T',
+                );
+            });
 
-            expect(
-                applyCustomFormat(
-                    500000,
-                    getCustomFormatFromLegacy({ compact: B }),
-                ),
-            ).toEqual('0.00B');
+            describe('with legacy distance format', () => {
+                test('it should return the right format', () => {
+                    expect(
+                        applyCustomFormat(
+                            5000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.KM,
+                            }),
+                        ),
+                    ).toEqual('5.00K km');
 
-            expect(
-                applyCustomFormat(5, getCustomFormatFromLegacy({ compact: B })),
-            ).toEqual('0.00B');
+                    expect(
+                        applyCustomFormat(
+                            50000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 4,
+                                format: Format.MI,
+                            }),
+                        ),
+                    ).toEqual('50.0000K mi');
+                });
+            });
 
-            expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({ compact: M, round: 2 }),
-                ),
-            ).toEqual('0.00M');
+            describe('with legacy currency format', () => {
+                test('it should return the right format', () => {
+                    expect(
+                        applyCustomFormat(
+                            5000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5.00K');
 
-            expect(
-                applyCustomFormat(
-                    5000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.KM,
-                    }),
-                ),
-            ).toEqual('5.00K km');
+                    expect(
+                        applyCustomFormat(
+                            5000000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5,000.00K');
 
-            expect(
-                applyCustomFormat(
-                    50000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 4,
-                        format: Format.MI,
-                    }),
-                ),
-            ).toEqual('50.0000K mi');
+                    expect(
+                        applyCustomFormat(
+                            5000000,
+                            getCustomFormatFromLegacy({
+                                compact: M,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5.00M');
 
-            expect(
-                applyCustomFormat(
-                    5000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5.00K');
+                    expect(
+                        applyCustomFormat(
+                            4,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$0.00K');
 
-            expect(
-                applyCustomFormat(
-                    5000000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5,000.00K');
+                    expect(
+                        applyCustomFormat(
+                            4,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 3,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$0.004K');
 
-            expect(
-                applyCustomFormat(
-                    5000000,
-                    getCustomFormatFromLegacy({
-                        compact: M,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5.00M');
+                    expect(
+                        applyCustomFormat(
+                            5000000,
+                            getCustomFormatFromLegacy({
+                                compact: M,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5.00M');
 
-            expect(
-                applyCustomFormat(
-                    4,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$0.00K');
+                    expect(
+                        applyCustomFormat(
+                            5000000000,
+                            getCustomFormatFromLegacy({
+                                compact: M,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5,000.00M');
 
-            expect(
-                applyCustomFormat(
-                    4,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 3,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$0.004K');
+                    expect(
+                        applyCustomFormat(
+                            5000000000,
+                            getCustomFormatFromLegacy({
+                                compact: B,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5.00B');
 
-            expect(
-                applyCustomFormat(
-                    5000000,
-                    getCustomFormatFromLegacy({
-                        compact: M,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5.00M');
+                    expect(
+                        applyCustomFormat(
+                            5000.0,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 0,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5K');
 
-            expect(
-                applyCustomFormat(
-                    5000000000,
-                    getCustomFormatFromLegacy({
-                        compact: M,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5,000.00M');
+                    expect(
+                        applyCustomFormat(
+                            '5000',
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.USD,
+                            }),
+                        ),
+                    ).toEqual('$5.00K');
 
-            expect(
-                applyCustomFormat(
-                    5000000000,
-                    getCustomFormatFromLegacy({
-                        compact: B,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5.00B');
+                    expect(
+                        applyCustomFormat(
+                            5000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.GBP,
+                            }),
+                        ),
+                    ).toEqual('£5.00K');
 
-            expect(
-                applyCustomFormat(
-                    5000.0,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 0,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5K');
+                    expect(
+                        applyCustomFormat(
+                            5000,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.EUR,
+                            }),
+                        ),
+                    ).toEqual('€5.00K');
+                });
+            });
 
-            expect(
-                applyCustomFormat(
-                    '5000',
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.USD,
-                    }),
-                ),
-            ).toEqual('$5.00K');
+            describe('with legacy percent format', () => {
+                test('it should return the right format', () => {
+                    expect(
+                        applyCustomFormat(
+                            0.05,
+                            getCustomFormatFromLegacy({
+                                compact: K,
+                                round: 2,
+                                format: Format.PERCENT,
+                            }),
+                        ),
+                    ).toEqual('5.00%');
+                });
+            });
 
-            expect(
-                applyCustomFormat(
-                    5000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.GBP,
-                    }),
-                ),
-            ).toEqual('£5.00K');
+            test('suports compact alias', () => {
+                expect(
+                    applyCustomFormat(
+                        1000,
+                        getCustomFormatFromLegacy({ compact: 'K' }),
+                    ),
+                ).toEqual('1K');
 
-            expect(
-                applyCustomFormat(
-                    5000,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.EUR,
-                    }),
-                ),
-            ).toEqual('€5.00K');
+                expect(
+                    applyCustomFormat(
+                        1000,
+                        getCustomFormatFromLegacy({ compact: 'thousand' }),
+                    ),
+                ).toEqual('1K');
 
-            expect(
-                applyCustomFormat(
-                    0.05,
-                    getCustomFormatFromLegacy({
-                        compact: K,
-                        round: 2,
-                        format: Format.PERCENT,
-                    }),
-                ),
-            ).toEqual('5.00%'); // No affects percent
-        });
+                expect(
+                    applyCustomFormat(
+                        1000000,
+                        getCustomFormatFromLegacy({ compact: 'M' }),
+                    ),
+                ).toEqual('1M');
 
-        test('applyCustomFormat should support compact alias', () => {
-            expect(
-                applyCustomFormat(
-                    1000,
-                    getCustomFormatFromLegacy({ compact: 'K' }),
-                ),
-            ).toEqual('1.00K');
+                expect(
+                    applyCustomFormat(
+                        1000000,
+                        getCustomFormatFromLegacy({ compact: 'million' }),
+                    ),
+                ).toEqual('1M');
 
-            expect(
-                applyCustomFormat(
-                    1000,
-                    getCustomFormatFromLegacy({ compact: 'thousand' }),
-                ),
-            ).toEqual('1.00K');
+                expect(
+                    applyCustomFormat(
+                        1000000000,
+                        getCustomFormatFromLegacy({ compact: 'B' }),
+                    ),
+                ).toEqual('1B');
 
-            expect(
-                applyCustomFormat(
-                    1000000,
-                    getCustomFormatFromLegacy({ compact: 'M' }),
-                ),
-            ).toEqual('1.00M');
+                expect(
+                    applyCustomFormat(
+                        1000000000,
+                        getCustomFormatFromLegacy({ compact: 'billion' }),
+                    ),
+                ).toEqual('1B');
 
-            expect(
-                applyCustomFormat(
-                    1000000,
-                    getCustomFormatFromLegacy({ compact: 'million' }),
-                ),
-            ).toEqual('1.00M');
+                expect(
+                    applyCustomFormat(
+                        1000000000000,
+                        getCustomFormatFromLegacy({ compact: 'T' }),
+                    ),
+                ).toEqual('1T');
 
-            expect(
-                applyCustomFormat(
-                    1000000000,
-                    getCustomFormatFromLegacy({ compact: 'B' }),
-                ),
-            ).toEqual('1.00B');
-
-            expect(
-                applyCustomFormat(
-                    1000000000,
-                    getCustomFormatFromLegacy({ compact: 'billion' }),
-                ),
-            ).toEqual('1.00B');
-
-            expect(
-                applyCustomFormat(
-                    1000000000000,
-                    getCustomFormatFromLegacy({ compact: 'T' }),
-                ),
-            ).toEqual('1.00T');
-
-            expect(
-                applyCustomFormat(
-                    1000000000000,
-                    getCustomFormatFromLegacy({ compact: 'trillion' }),
-                ),
-            ).toEqual('1.00T');
+                expect(
+                    applyCustomFormat(
+                        1000000000000,
+                        getCustomFormatFromLegacy({ compact: 'trillion' }),
+                    ),
+                ).toEqual('1T');
+            });
         });
     });
 
@@ -924,7 +989,7 @@ describe('Formatting', () => {
             expect(formatItemValue(percentFormat, 0.05)).toEqual('5%');
             expect(formatItemValue(percentFormat, 1)).toEqual('100%');
             expect(formatItemValue(percentFormat, 5)).toEqual('500%');
-            expect(formatItemValue(percentFormat, '0.05123')).toEqual('5%');
+            expect(formatItemValue(percentFormat, '0.05123')).toEqual('5.123%');
         });
         test('table calculation with percent format and round', () => {
             const percentFormat = {
@@ -984,38 +1049,6 @@ describe('Formatting', () => {
                     separator: NumberSeparator.NO_SEPARATOR_PERIOD,
                 }),
             ).toEqual('123456789.12');
-        });
-
-        test.only('format negative round', () => {
-            const number = 123456789.12345;
-            expect(
-                formatNumberValue(number, {
-                    type: CustomFormatType.DEFAULT,
-                    round: -1,
-                    separator: NumberSeparator.COMMA_PERIOD,
-                }),
-            ).toEqual('123,456,790');
-            expect(
-                formatNumberValue(number, {
-                    type: CustomFormatType.DEFAULT,
-                    round: -2,
-                    separator: NumberSeparator.PERIOD_COMMA,
-                }),
-            ).toEqual('123.456.800');
-            expect(
-                formatNumberValue(number, {
-                    type: CustomFormatType.DEFAULT,
-                    round: -3,
-                    separator: NumberSeparator.SPACE_PERIOD,
-                }),
-            ).toEqual('123 457 000');
-            expect(
-                formatNumberValue(number, {
-                    type: CustomFormatType.DEFAULT,
-                    round: -99,
-                    separator: NumberSeparator.NO_SEPARATOR_PERIOD,
-                }),
-            ).toEqual('100000000');
         });
 
         test('available currencies', () => {
@@ -1145,7 +1178,7 @@ describe('Formatting', () => {
                 applyCustomFormat(12345.56789, {
                     type: CustomFormatType.NUMBER,
                 }),
-            ).toEqual('12,346');
+            ).toEqual('12,345.568');
             expect(
                 applyCustomFormat(12345.1235, {
                     type: CustomFormatType.NUMBER,
@@ -1163,13 +1196,10 @@ describe('Formatting', () => {
                     prefix: 'foo ',
                     suffix: ' bar',
                 }),
-            ).toEqual('foo 12,345 bar');
+            ).toEqual('foo 12,345.124 bar');
         });
         test('convert table calculation formats with invalid numbers', () => {
-            const formatTableCalculation = (value: any, format: CustomFormat) =>
-                applyCustomFormat(format, value);
             // This method should return the original value if the value is not a number
-
             const values = [
                 'this is a string',
                 '',
@@ -1188,7 +1218,7 @@ describe('Formatting', () => {
             ];
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.DEFAULT,
                     }),
                 ).toEqual(expectedValue[i]),
@@ -1196,7 +1226,7 @@ describe('Formatting', () => {
 
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.CURRENCY,
                         currency: Format.USD,
                     }),
@@ -1204,7 +1234,7 @@ describe('Formatting', () => {
             );
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.CURRENCY,
                         currency: Format.USD,
                         round: 2,
@@ -1216,14 +1246,14 @@ describe('Formatting', () => {
 
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.NUMBER,
                     }),
                 ).toEqual(expectedValue[i]),
             );
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.NUMBER,
                         prefix: 'foo',
                         suffix: 'bar',
@@ -1236,14 +1266,14 @@ describe('Formatting', () => {
 
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.PERCENT,
                     }),
                 ).toEqual(expectedValue[i]),
             );
             values.map((value, i) =>
                 expect(
-                    formatTableCalculation(value, {
+                    applyCustomFormat(value, {
                         type: CustomFormatType.PERCENT,
                         round: 2,
                         separator: NumberSeparator.PERIOD_COMMA,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1,5 +1,6 @@
 import {
     Compact,
+    CustomFormat,
     CustomFormatType,
     DimensionType,
     Format,
@@ -58,7 +59,7 @@ describe('Formatting', () => {
 
     describe('applying CustomFormat to value', () => {
         describe('when using legacy format', () => {
-            test('if Format is distance unit it should return the right format', () => {
+            test('if Format is legacy distance unit it should return the right format', () => {
                 expect(
                     applyCustomFormat(
                         5,
@@ -78,60 +79,37 @@ describe('Formatting', () => {
 
             test('if Format is currency unit it should return the right format', () => {
                 expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy({ format: Format.USD }),
-                    ),
+                    applyCustomFormat(5, {
+                        type: CustomFormatType.CURRENCY,
+                        currency: Format.USD,
+                    }),
                 ).toEqual('$5.00');
                 expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy({ format: Format.GBP }),
-                    ),
+                    applyCustomFormat(5, {
+                        type: CustomFormatType.CURRENCY,
+                        currency: Format.GBP,
+                    }),
                 ).toEqual('£5.00');
                 expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy({ format: Format.EUR }),
-                    ),
+                    applyCustomFormat(5, {
+                        type: CustomFormatType.CURRENCY,
+                        currency: Format.EUR,
+                    }),
                 ).toEqual('€5.00');
             });
 
             test('if Format is percent it should return the right format', () => {
-                const percentageOptions = {
-                    format: Format.PERCENT,
+                const percentFormat: CustomFormat = {
+                    type: CustomFormatType.PERCENT,
                 };
 
-                expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy(percentageOptions),
-                    ),
-                ).toEqual('500%');
-                expect(
-                    applyCustomFormat(
-                        0.05,
-                        getCustomFormatFromLegacy(percentageOptions),
-                    ),
-                ).toEqual('5%');
-                expect(
-                    applyCustomFormat(
-                        '5',
-                        getCustomFormatFromLegacy(percentageOptions),
-                    ),
-                ).toEqual('500%');
-                expect(
-                    applyCustomFormat(
-                        'foo',
-                        getCustomFormatFromLegacy(percentageOptions),
-                    ),
-                ).toEqual('foo');
-                expect(
-                    applyCustomFormat(
-                        false,
-                        getCustomFormatFromLegacy(percentageOptions),
-                    ),
-                ).toEqual('false');
+                expect(applyCustomFormat(5, percentFormat)).toEqual('500%');
+                expect(applyCustomFormat(0.05, percentFormat)).toEqual('5%');
+                expect(applyCustomFormat('5', percentFormat)).toEqual('500%');
+                expect(applyCustomFormat('foo', percentFormat)).toEqual('foo');
+                expect(applyCustomFormat(false, percentFormat)).toEqual(
+                    'false',
+                );
             });
 
             test('if Format is undefined it should return the right format', () => {
@@ -142,10 +120,7 @@ describe('Formatting', () => {
             test('if Format is id it should return the right format', () => {
                 // ids are not comma separated
                 expect(
-                    applyCustomFormat(
-                        1019,
-                        getCustomFormatFromLegacy({ format: Format.ID }),
-                    ),
+                    applyCustomFormat(1019, { type: CustomFormatType.ID }),
                 ).toEqual('1019');
             });
         });
@@ -160,139 +135,71 @@ describe('Formatting', () => {
             });
 
             test('when round zero it should return the right round', () => {
-                const roundZeroOptions = {
+                const roundZeroFormat: CustomFormat = {
+                    type: CustomFormatType.NUMBER,
                     round: 0,
                 };
-                expect(
-                    applyCustomFormat(
-                        1,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('1');
-                expect(
-                    applyCustomFormat(
-                        10,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('10');
-                expect(
-                    applyCustomFormat(
-                        100,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('100');
-                expect(
-                    applyCustomFormat(
-                        1000,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('1,000');
-                expect(
-                    applyCustomFormat(
-                        10000,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('10,000');
-                expect(
-                    applyCustomFormat(
-                        100000,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('100,000');
-                expect(
-                    applyCustomFormat(
-                        1000000,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('1,000,000');
-                expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('5');
-                expect(
-                    applyCustomFormat(
-                        5.001,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('5');
-                expect(
-                    applyCustomFormat(
-                        5.9999999,
-                        getCustomFormatFromLegacy(roundZeroOptions),
-                    ),
-                ).toEqual('6');
+
+                expect(applyCustomFormat(1, roundZeroFormat)).toEqual('1');
+                expect(applyCustomFormat(10, roundZeroFormat)).toEqual('10');
+                expect(applyCustomFormat(100, roundZeroFormat)).toEqual('100');
+                expect(applyCustomFormat(5, roundZeroFormat)).toEqual('5');
+                expect(applyCustomFormat(5.001, roundZeroFormat)).toEqual('5');
+                expect(applyCustomFormat(1000, roundZeroFormat)).toEqual(
+                    '1,000',
+                );
+                expect(applyCustomFormat(10000, roundZeroFormat)).toEqual(
+                    '10,000',
+                );
+                expect(applyCustomFormat(100000, roundZeroFormat)).toEqual(
+                    '100,000',
+                );
+                expect(applyCustomFormat(1000000, roundZeroFormat)).toEqual(
+                    '1,000,000',
+                );
+                expect(applyCustomFormat(5.9999999, roundZeroFormat)).toEqual(
+                    '6',
+                );
             });
 
             test('when round is positive number it should return the right round', () => {
-                const roundTwoOptions = {
+                const roundTwoFormat: CustomFormat = {
+                    type: CustomFormatType.NUMBER,
                     round: 2,
                 };
-                expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('5.00');
-                expect(
-                    applyCustomFormat(
-                        5.001,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('5.00');
-                expect(
-                    applyCustomFormat(
-                        5.555,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('5.56');
-                expect(
-                    applyCustomFormat(
-                        5.5555,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('5.56');
-                expect(
-                    applyCustomFormat(
-                        5.9999999,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('6.00');
-                expect(
-                    applyCustomFormat(
-                        'foo',
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('foo');
-                expect(
-                    applyCustomFormat(
-                        false,
-                        getCustomFormatFromLegacy(roundTwoOptions),
-                    ),
-                ).toEqual('false');
 
-                const roundTenOptions = {
+                expect(applyCustomFormat(5, roundTwoFormat)).toEqual('5.00');
+                expect(applyCustomFormat('foo', roundTwoFormat)).toEqual('foo');
+                expect(applyCustomFormat(5.001, roundTwoFormat)).toEqual(
+                    '5.00',
+                );
+                expect(applyCustomFormat(5.555, roundTwoFormat)).toEqual(
+                    '5.56',
+                );
+                expect(applyCustomFormat(5.5555, roundTwoFormat)).toEqual(
+                    '5.56',
+                );
+                expect(applyCustomFormat(5.9999999, roundTwoFormat)).toEqual(
+                    '6.00',
+                );
+                expect(applyCustomFormat(false, roundTwoFormat)).toEqual(
+                    'false',
+                );
+
+                const roundTenFormat: CustomFormat = {
+                    type: CustomFormatType.NUMBER,
                     round: 10,
                 };
-                expect(
-                    applyCustomFormat(
-                        5,
-                        getCustomFormatFromLegacy(roundTenOptions),
-                    ),
-                ).toEqual('5.0000000000');
-                expect(
-                    applyCustomFormat(
-                        5.001,
-                        getCustomFormatFromLegacy(roundTenOptions),
-                    ),
-                ).toEqual('5.0010000000');
-                expect(
-                    applyCustomFormat(
-                        5.9999999,
-                        getCustomFormatFromLegacy(roundTenOptions),
-                    ),
-                ).toEqual('5.9999999000');
+
+                expect(applyCustomFormat(5, roundTenFormat)).toEqual(
+                    '5.0000000000',
+                );
+                expect(applyCustomFormat(5.001, roundTenFormat)).toEqual(
+                    '5.0010000000',
+                );
+                expect(applyCustomFormat(5.9999999, roundTenFormat)).toEqual(
+                    '5.9999999000',
+                );
             });
 
             test('when round is negative number it should return the right round', () => {
@@ -327,220 +234,163 @@ describe('Formatting', () => {
 
         test('applyCustomFormat should return the right format and round', () => {
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.KM,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.NUMBER,
+                    suffix: ` ${Format.KM}`,
+                    round: 2,
+                }),
             ).toEqual('5.00 km');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.KM,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.NUMBER,
+                    suffix: ` ${Format.KM}`,
+                    round: -2,
+                }),
             ).toEqual('5 km');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.MI,
-                        round: 4,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.NUMBER,
+                    suffix: ` ${Format.MI}`,
+                    round: 4,
+                }),
             ).toEqual('5.0000 mi');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.MI,
-                        round: -4,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.NUMBER,
+                    suffix: ` ${Format.MI}`,
+                    round: -4,
+                }),
             ).toEqual('5 mi');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.USD,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    round: 2,
+                }),
             ).toEqual('$5.00');
             expect(
-                applyCustomFormat(
-                    5.0,
-                    getCustomFormatFromLegacy({
-                        format: Format.USD,
-                        round: 0,
-                    }),
-                ),
+                applyCustomFormat(5.0, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    round: 0,
+                }),
             ).toEqual('$5');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.USD,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    round: -2,
+                }),
             ).toEqual('$5');
             expect(
-                applyCustomFormat(
-                    5.25,
-                    getCustomFormatFromLegacy({
-                        format: Format.USD,
-                        round: -1,
-                    }),
-                ),
+                applyCustomFormat(5.25, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    round: -1,
+                }),
             ).toEqual('$5');
             expect(
-                applyCustomFormat(
-                    '5.0000',
-                    getCustomFormatFromLegacy({
-                        format: Format.USD,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat('5.0000', {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    round: 2,
+                }),
             ).toEqual('$5.00');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.GBP,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.GBP,
+                    round: 2,
+                }),
             ).toEqual('£5.00');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.GBP,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.GBP,
+                    round: -2,
+                }),
             ).toEqual('£5');
             expect(
-                applyCustomFormat(
-                    5.25,
-                    getCustomFormatFromLegacy({
-                        format: Format.GBP,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(5.25, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.GBP,
+                    round: -2,
+                }),
             ).toEqual('£5');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.EUR,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.EUR,
+                    round: 2,
+                }),
             ).toEqual('€5.00');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.EUR,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.EUR,
+                    round: -2,
+                }),
             ).toEqual('€5');
             expect(
-                applyCustomFormat(
-                    5.25,
-                    getCustomFormatFromLegacy({
-                        format: Format.EUR,
-                        round: -1,
-                    }),
-                ),
+                applyCustomFormat(5.25, {
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.EUR,
+                    round: -1,
+                }),
             ).toEqual('€5');
             expect(
-                applyCustomFormat(
-                    5,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(5, {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('500.00%');
             expect(
-                applyCustomFormat(
-                    0.05,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(0.05, {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('5.00%');
             expect(
-                applyCustomFormat(
-                    '5',
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat('5', {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('500.00%');
             expect(
-                applyCustomFormat(
-                    0.0511,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(0.0511, {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('5.11%');
             expect(
-                applyCustomFormat(
-                    0.0511,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 4,
-                    }),
-                ),
+                applyCustomFormat(0.0511, {
+                    type: CustomFormatType.PERCENT,
+                    round: 4,
+                }),
             ).toEqual('5.1100%');
             expect(
-                applyCustomFormat(
-                    'foo',
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat('foo', {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('foo');
             expect(
-                applyCustomFormat(
-                    false,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: 2,
-                    }),
-                ),
+                applyCustomFormat(false, {
+                    type: CustomFormatType.PERCENT,
+                    round: 2,
+                }),
             ).toEqual('false');
             expect(
-                applyCustomFormat(
-                    0.05,
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat(0.05, {
+                    type: CustomFormatType.PERCENT,
+                    round: -2,
+                }),
             ).toEqual('5%');
             expect(
-                applyCustomFormat(
-                    '5',
-                    getCustomFormatFromLegacy({
-                        format: Format.PERCENT,
-                        round: -2,
-                    }),
-                ),
+                applyCustomFormat('5', {
+                    type: CustomFormatType.PERCENT,
+                    round: -2,
+                }),
             ).toEqual('500%');
         });
 
@@ -755,59 +605,59 @@ describe('Formatting', () => {
 
             test('suports compact alias', () => {
                 expect(
-                    applyCustomFormat(
-                        1000,
-                        getCustomFormatFromLegacy({ compact: 'K' }),
-                    ),
+                    applyCustomFormat(1000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'K',
+                    }),
                 ).toEqual('1K');
 
                 expect(
-                    applyCustomFormat(
-                        1000,
-                        getCustomFormatFromLegacy({ compact: 'thousand' }),
-                    ),
+                    applyCustomFormat(1000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'thousand',
+                    }),
                 ).toEqual('1K');
 
                 expect(
-                    applyCustomFormat(
-                        1000000,
-                        getCustomFormatFromLegacy({ compact: 'M' }),
-                    ),
+                    applyCustomFormat(1000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'M',
+                    }),
                 ).toEqual('1M');
 
                 expect(
-                    applyCustomFormat(
-                        1000000,
-                        getCustomFormatFromLegacy({ compact: 'million' }),
-                    ),
+                    applyCustomFormat(1000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'million',
+                    }),
                 ).toEqual('1M');
 
                 expect(
-                    applyCustomFormat(
-                        1000000000,
-                        getCustomFormatFromLegacy({ compact: 'B' }),
-                    ),
+                    applyCustomFormat(1000000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'B',
+                    }),
                 ).toEqual('1B');
 
                 expect(
-                    applyCustomFormat(
-                        1000000000,
-                        getCustomFormatFromLegacy({ compact: 'billion' }),
-                    ),
+                    applyCustomFormat(1000000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'billion',
+                    }),
                 ).toEqual('1B');
 
                 expect(
-                    applyCustomFormat(
-                        1000000000000,
-                        getCustomFormatFromLegacy({ compact: 'T' }),
-                    ),
+                    applyCustomFormat(1000000000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'T',
+                    }),
                 ).toEqual('1T');
 
                 expect(
-                    applyCustomFormat(
-                        1000000000000,
-                        getCustomFormatFromLegacy({ compact: 'trillion' }),
-                    ),
+                    applyCustomFormat(1000000000000, {
+                        type: CustomFormatType.NUMBER,
+                        compact: 'trillion',
+                    }),
                 ).toEqual('1T');
             });
         });
@@ -1163,6 +1013,7 @@ describe('Formatting', () => {
                 }),
             ).toEqual('foo 12,345.124 bar');
         });
+
         test('convert table calculation formats with invalid numbers', () => {
             // This method should return the original value if the value is not a number
             const values = [

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1,6 +1,5 @@
 import {
     Compact,
-    CustomFormat,
     CustomFormatType,
     DimensionType,
     Format,

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -18,338 +18,310 @@ import { dimension, metric, tableCalculation } from './formatting.mock';
 describe('Formatting', () => {
     describe('convert legacy Format type', () => {
         [Format.KM, Format.MI].forEach((format) => {
-            describe(`when it is ${format.toUpperCase()}`, () => {
-                test('getCustomFormatFromLegacy should return the correct CustomFormat options', () => {
-                    expect(getCustomFormatFromLegacy({ format })).toEqual({
-                        type: CustomFormatType.NUMBER,
-                        suffix: ` ${format}`,
-                        compact: undefined,
-                        round: undefined,
-                    });
-                });
-            });
-        });
-
-        [Format.EUR, Format.GBP, Format.USD].forEach((format) => {
-            describe(`when it is ${format.toUpperCase()}`, () => {
-                test('getCustomFormatFromLegacy should return the correct CustomFormat options', () => {
-                    expect(getCustomFormatFromLegacy({ format })).toEqual({
-                        type: CustomFormatType.CURRENCY,
-                        currency: format.toUpperCase(),
-                        compact: undefined,
-                        round: undefined,
-                    });
-                });
-            });
-        });
-
-        describe(`when it is ${Format.PERCENT.toUpperCase()}`, () => {
-            test('getCustomFormatFromLegacy should return the correct CustomFormat options', () => {
-                expect(
-                    getCustomFormatFromLegacy({ format: Format.PERCENT }),
-                ).toEqual({
-                    type: CustomFormatType.PERCENT,
+            test(`when it is ${format.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {
+                expect(getCustomFormatFromLegacy({ format })).toEqual({
+                    type: CustomFormatType.NUMBER,
+                    suffix: ` ${format}`,
                     compact: undefined,
                     round: undefined,
                 });
             });
         });
 
-        describe(`when it is ${Format.ID.toUpperCase()}`, () => {
-            test('getCustomFormatFromLegacy should return the correct CustomFormat options', () => {
-                expect(
-                    getCustomFormatFromLegacy({ format: Format.ID }),
-                ).toEqual({
-                    type: CustomFormatType.ID,
+        [Format.EUR, Format.GBP, Format.USD].forEach((format) => {
+            test(`when it is ${format.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {
+                expect(getCustomFormatFromLegacy({ format })).toEqual({
+                    type: CustomFormatType.CURRENCY,
+                    currency: format.toUpperCase(),
+                    compact: undefined,
+                    round: undefined,
                 });
+            });
+        });
+
+        test(`when it is ${Format.PERCENT.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {
+            expect(
+                getCustomFormatFromLegacy({ format: Format.PERCENT }),
+            ).toEqual({
+                type: CustomFormatType.PERCENT,
+                compact: undefined,
+                round: undefined,
+            });
+        });
+
+        test(`when it is ${Format.ID.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {
+            expect(getCustomFormatFromLegacy({ format: Format.ID })).toEqual({
+                type: CustomFormatType.ID,
             });
         });
     });
 
     describe('applying CustomFormat to value', () => {
         describe('when using legacy format', () => {
-            describe('if Format is distance unit', () => {
-                test('it should return the right format', () => {
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy({ format: Format.KM }),
-                        ),
-                    ).toEqual('5 km');
+            test('if Format is distance unit it should return the right format', () => {
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy({ format: Format.KM }),
+                    ),
+                ).toEqual('5 km');
 
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy({
-                                format: Format.MI,
-                            }),
-                        ),
-                    ).toEqual('5 mi');
-                });
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy({
+                            format: Format.MI,
+                        }),
+                    ),
+                ).toEqual('5 mi');
             });
 
-            describe('if Format is currency unit', () => {
-                test('it should return the right format', () => {
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy({ format: Format.USD }),
-                        ),
-                    ).toEqual('$5.00');
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy({ format: Format.GBP }),
-                        ),
-                    ).toEqual('£5.00');
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy({ format: Format.EUR }),
-                        ),
-                    ).toEqual('€5.00');
-                });
+            test('if Format is currency unit it should return the right format', () => {
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy({ format: Format.USD }),
+                    ),
+                ).toEqual('$5.00');
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy({ format: Format.GBP }),
+                    ),
+                ).toEqual('£5.00');
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy({ format: Format.EUR }),
+                    ),
+                ).toEqual('€5.00');
             });
 
-            describe('if Format is percent', () => {
-                test('it should return the right format', () => {
-                    const percentageOptions = {
-                        format: Format.PERCENT,
-                    };
+            test('if Format is percent it should return the right format', () => {
+                const percentageOptions = {
+                    format: Format.PERCENT,
+                };
 
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy(percentageOptions),
-                        ),
-                    ).toEqual('500%');
-                    expect(
-                        applyCustomFormat(
-                            0.05,
-                            getCustomFormatFromLegacy(percentageOptions),
-                        ),
-                    ).toEqual('5%');
-                    expect(
-                        applyCustomFormat(
-                            '5',
-                            getCustomFormatFromLegacy(percentageOptions),
-                        ),
-                    ).toEqual('500%');
-                    expect(
-                        applyCustomFormat(
-                            'foo',
-                            getCustomFormatFromLegacy(percentageOptions),
-                        ),
-                    ).toEqual('foo');
-                    expect(
-                        applyCustomFormat(
-                            false,
-                            getCustomFormatFromLegacy(percentageOptions),
-                        ),
-                    ).toEqual('false');
-                });
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy(percentageOptions),
+                    ),
+                ).toEqual('500%');
+                expect(
+                    applyCustomFormat(
+                        0.05,
+                        getCustomFormatFromLegacy(percentageOptions),
+                    ),
+                ).toEqual('5%');
+                expect(
+                    applyCustomFormat(
+                        '5',
+                        getCustomFormatFromLegacy(percentageOptions),
+                    ),
+                ).toEqual('500%');
+                expect(
+                    applyCustomFormat(
+                        'foo',
+                        getCustomFormatFromLegacy(percentageOptions),
+                    ),
+                ).toEqual('foo');
+                expect(
+                    applyCustomFormat(
+                        false,
+                        getCustomFormatFromLegacy(percentageOptions),
+                    ),
+                ).toEqual('false');
             });
 
-            describe('if Format is undefined', () => {
-                test('it should return the right format', () => {
-                    expect(applyCustomFormat(1103)).toEqual('1,103');
-                    expect(applyCustomFormat(5)).toEqual('5');
-                });
+            test('if Format is undefined it should return the right format', () => {
+                expect(applyCustomFormat(1103)).toEqual('1,103');
+                expect(applyCustomFormat(5)).toEqual('5');
             });
 
-            describe('if Format is id', () => {
-                test('it should return the right format', () => {
-                    // ids are not comma separated
-                    expect(
-                        applyCustomFormat(
-                            1019,
-                            getCustomFormatFromLegacy({ format: Format.ID }),
-                        ),
-                    ).toEqual('1019');
-                });
+            test('if Format is id it should return the right format', () => {
+                // ids are not comma separated
+                expect(
+                    applyCustomFormat(
+                        1019,
+                        getCustomFormatFromLegacy({ format: Format.ID }),
+                    ),
+                ).toEqual('1019');
             });
         });
 
         describe('when applying round', () => {
-            describe('if round is undefined', () => {
-                test('it should keep up to 3 decimal places', () => {
-                    expect(applyCustomFormat(5.9)).toEqual('5.9');
-                    expect(applyCustomFormat(5.99)).toEqual('5.99');
-                    expect(applyCustomFormat(5.999)).toEqual('5.999');
-                    expect(applyCustomFormat(5.9999)).toEqual('6');
-                    expect(applyCustomFormat(5.99999)).toEqual('6');
-                });
+            test('if round is undefined it should keep up to 3 decimal places', () => {
+                expect(applyCustomFormat(5.9)).toEqual('5.9');
+                expect(applyCustomFormat(5.99)).toEqual('5.99');
+                expect(applyCustomFormat(5.999)).toEqual('5.999');
+                expect(applyCustomFormat(5.9999)).toEqual('6');
+                expect(applyCustomFormat(5.99999)).toEqual('6');
             });
 
-            describe('when round zero', () => {
-                test('it should return the right round', () => {
-                    const roundZeroOptions = {
-                        round: 0,
-                    };
-                    expect(
-                        applyCustomFormat(
-                            1,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('1');
-                    expect(
-                        applyCustomFormat(
-                            10,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('10');
-                    expect(
-                        applyCustomFormat(
-                            100,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('100');
-                    expect(
-                        applyCustomFormat(
-                            1000,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('1,000');
-                    expect(
-                        applyCustomFormat(
-                            10000,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('10,000');
-                    expect(
-                        applyCustomFormat(
-                            100000,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('100,000');
-                    expect(
-                        applyCustomFormat(
-                            1000000,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('1,000,000');
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('5');
-                    expect(
-                        applyCustomFormat(
-                            5.001,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('5');
-                    expect(
-                        applyCustomFormat(
-                            5.9999999,
-                            getCustomFormatFromLegacy(roundZeroOptions),
-                        ),
-                    ).toEqual('6');
-                });
+            test('when round zero it should return the right round', () => {
+                const roundZeroOptions = {
+                    round: 0,
+                };
+                expect(
+                    applyCustomFormat(
+                        1,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('1');
+                expect(
+                    applyCustomFormat(
+                        10,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('10');
+                expect(
+                    applyCustomFormat(
+                        100,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('100');
+                expect(
+                    applyCustomFormat(
+                        1000,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('1,000');
+                expect(
+                    applyCustomFormat(
+                        10000,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('10,000');
+                expect(
+                    applyCustomFormat(
+                        100000,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('100,000');
+                expect(
+                    applyCustomFormat(
+                        1000000,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('1,000,000');
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('5');
+                expect(
+                    applyCustomFormat(
+                        5.001,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('5');
+                expect(
+                    applyCustomFormat(
+                        5.9999999,
+                        getCustomFormatFromLegacy(roundZeroOptions),
+                    ),
+                ).toEqual('6');
             });
 
-            describe('when round is positive number', () => {
-                test('it should return the right round', () => {
-                    const roundTwoOptions = {
-                        round: 2,
-                    };
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('5.00');
-                    expect(
-                        applyCustomFormat(
-                            5.001,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('5.00');
-                    expect(
-                        applyCustomFormat(
-                            5.555,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('5.56');
-                    expect(
-                        applyCustomFormat(
-                            5.5555,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('5.56');
-                    expect(
-                        applyCustomFormat(
-                            5.9999999,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('6.00');
-                    expect(
-                        applyCustomFormat(
-                            'foo',
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('foo');
-                    expect(
-                        applyCustomFormat(
-                            false,
-                            getCustomFormatFromLegacy(roundTwoOptions),
-                        ),
-                    ).toEqual('false');
+            test('when round is positive number it should return the right round', () => {
+                const roundTwoOptions = {
+                    round: 2,
+                };
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('5.00');
+                expect(
+                    applyCustomFormat(
+                        5.001,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('5.00');
+                expect(
+                    applyCustomFormat(
+                        5.555,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('5.56');
+                expect(
+                    applyCustomFormat(
+                        5.5555,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('5.56');
+                expect(
+                    applyCustomFormat(
+                        5.9999999,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('6.00');
+                expect(
+                    applyCustomFormat(
+                        'foo',
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('foo');
+                expect(
+                    applyCustomFormat(
+                        false,
+                        getCustomFormatFromLegacy(roundTwoOptions),
+                    ),
+                ).toEqual('false');
 
-                    const roundTenOptions = {
-                        round: 10,
-                    };
-                    expect(
-                        applyCustomFormat(
-                            5,
-                            getCustomFormatFromLegacy(roundTenOptions),
-                        ),
-                    ).toEqual('5.0000000000');
-                    expect(
-                        applyCustomFormat(
-                            5.001,
-                            getCustomFormatFromLegacy(roundTenOptions),
-                        ),
-                    ).toEqual('5.0010000000');
-                    expect(
-                        applyCustomFormat(
-                            5.9999999,
-                            getCustomFormatFromLegacy(roundTenOptions),
-                        ),
-                    ).toEqual('5.9999999000');
-                });
+                const roundTenOptions = {
+                    round: 10,
+                };
+                expect(
+                    applyCustomFormat(
+                        5,
+                        getCustomFormatFromLegacy(roundTenOptions),
+                    ),
+                ).toEqual('5.0000000000');
+                expect(
+                    applyCustomFormat(
+                        5.001,
+                        getCustomFormatFromLegacy(roundTenOptions),
+                    ),
+                ).toEqual('5.0010000000');
+                expect(
+                    applyCustomFormat(
+                        5.9999999,
+                        getCustomFormatFromLegacy(roundTenOptions),
+                    ),
+                ).toEqual('5.9999999000');
             });
 
-            describe('when round is negative number', () => {
-                test('it should return the right round', () => {
-                    const number = 123456789.12345;
+            test('when round is negative number it should return the right round', () => {
+                const number = 123456789.12345;
 
-                    expect(
-                        formatNumberValue(number, {
-                            type: CustomFormatType.DEFAULT,
-                            round: -1,
-                        }),
-                    ).toEqual('123,456,790');
-                    expect(
-                        formatNumberValue(number, {
-                            type: CustomFormatType.DEFAULT,
-                            round: -2,
-                        }),
-                    ).toEqual('123,456,800');
-                    expect(
-                        formatNumberValue(number, {
-                            type: CustomFormatType.DEFAULT,
-                            round: -3,
-                        }),
-                    ).toEqual('123,457,000');
-                    expect(
-                        formatNumberValue(number, {
-                            type: CustomFormatType.DEFAULT,
-                            round: -99,
-                        }),
-                    ).toEqual('100,000,000');
-                });
+                expect(
+                    formatNumberValue(number, {
+                        type: CustomFormatType.DEFAULT,
+                        round: -1,
+                    }),
+                ).toEqual('123,456,790');
+                expect(
+                    formatNumberValue(number, {
+                        type: CustomFormatType.DEFAULT,
+                        round: -2,
+                    }),
+                ).toEqual('123,456,800');
+                expect(
+                    formatNumberValue(number, {
+                        type: CustomFormatType.DEFAULT,
+                        round: -3,
+                    }),
+                ).toEqual('123,457,000');
+                expect(
+                    formatNumberValue(number, {
+                        type: CustomFormatType.DEFAULT,
+                        round: -99,
+                    }),
+                ).toEqual('100,000,000');
             });
         });
 
@@ -610,181 +582,175 @@ describe('Formatting', () => {
                 );
             });
 
-            describe('with legacy distance format', () => {
-                test('it should return the right format', () => {
-                    expect(
-                        applyCustomFormat(
-                            5000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.KM,
-                            }),
-                        ),
-                    ).toEqual('5.00K km');
+            test('with legacy distance format it should return the right format', () => {
+                expect(
+                    applyCustomFormat(
+                        5000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.KM,
+                        }),
+                    ),
+                ).toEqual('5.00K km');
 
-                    expect(
-                        applyCustomFormat(
-                            50000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 4,
-                                format: Format.MI,
-                            }),
-                        ),
-                    ).toEqual('50.0000K mi');
-                });
+                expect(
+                    applyCustomFormat(
+                        50000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 4,
+                            format: Format.MI,
+                        }),
+                    ),
+                ).toEqual('50.0000K mi');
             });
 
-            describe('with legacy currency format', () => {
-                test('it should return the right format', () => {
-                    expect(
-                        applyCustomFormat(
-                            5000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5.00K');
+            test('with legacy currency format it should return the right format', () => {
+                expect(
+                    applyCustomFormat(
+                        5000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5.00K');
 
-                    expect(
-                        applyCustomFormat(
-                            5000000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5,000.00K');
+                expect(
+                    applyCustomFormat(
+                        5000000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5,000.00K');
 
-                    expect(
-                        applyCustomFormat(
-                            5000000,
-                            getCustomFormatFromLegacy({
-                                compact: M,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5.00M');
+                expect(
+                    applyCustomFormat(
+                        5000000,
+                        getCustomFormatFromLegacy({
+                            compact: M,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5.00M');
 
-                    expect(
-                        applyCustomFormat(
-                            4,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$0.00K');
+                expect(
+                    applyCustomFormat(
+                        4,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$0.00K');
 
-                    expect(
-                        applyCustomFormat(
-                            4,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 3,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$0.004K');
+                expect(
+                    applyCustomFormat(
+                        4,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 3,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$0.004K');
 
-                    expect(
-                        applyCustomFormat(
-                            5000000,
-                            getCustomFormatFromLegacy({
-                                compact: M,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5.00M');
+                expect(
+                    applyCustomFormat(
+                        5000000,
+                        getCustomFormatFromLegacy({
+                            compact: M,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5.00M');
 
-                    expect(
-                        applyCustomFormat(
-                            5000000000,
-                            getCustomFormatFromLegacy({
-                                compact: M,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5,000.00M');
+                expect(
+                    applyCustomFormat(
+                        5000000000,
+                        getCustomFormatFromLegacy({
+                            compact: M,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5,000.00M');
 
-                    expect(
-                        applyCustomFormat(
-                            5000000000,
-                            getCustomFormatFromLegacy({
-                                compact: B,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5.00B');
+                expect(
+                    applyCustomFormat(
+                        5000000000,
+                        getCustomFormatFromLegacy({
+                            compact: B,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5.00B');
 
-                    expect(
-                        applyCustomFormat(
-                            5000.0,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 0,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5K');
+                expect(
+                    applyCustomFormat(
+                        5000.0,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 0,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5K');
 
-                    expect(
-                        applyCustomFormat(
-                            '5000',
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.USD,
-                            }),
-                        ),
-                    ).toEqual('$5.00K');
+                expect(
+                    applyCustomFormat(
+                        '5000',
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.USD,
+                        }),
+                    ),
+                ).toEqual('$5.00K');
 
-                    expect(
-                        applyCustomFormat(
-                            5000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.GBP,
-                            }),
-                        ),
-                    ).toEqual('£5.00K');
+                expect(
+                    applyCustomFormat(
+                        5000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.GBP,
+                        }),
+                    ),
+                ).toEqual('£5.00K');
 
-                    expect(
-                        applyCustomFormat(
-                            5000,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.EUR,
-                            }),
-                        ),
-                    ).toEqual('€5.00K');
-                });
+                expect(
+                    applyCustomFormat(
+                        5000,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.EUR,
+                        }),
+                    ),
+                ).toEqual('€5.00K');
             });
 
-            describe('with legacy percent format', () => {
-                test('it should return the right format', () => {
-                    expect(
-                        applyCustomFormat(
-                            0.05,
-                            getCustomFormatFromLegacy({
-                                compact: K,
-                                round: 2,
-                                format: Format.PERCENT,
-                            }),
-                        ),
-                    ).toEqual('5.00%');
-                });
+            test('with legacy percent format it should return the right format', () => {
+                expect(
+                    applyCustomFormat(
+                        0.05,
+                        getCustomFormatFromLegacy({
+                            compact: K,
+                            round: 2,
+                            format: Format.PERCENT,
+                        }),
+                    ),
+                ).toEqual('5.00%');
             });
 
             test('suports compact alias', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -202,7 +202,7 @@ export function formatNumberValue(
     }
 }
 
-function formatValue(value: unknown) {
+function defaultFormat(value: unknown) {
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (!isNumber(value)) {
@@ -292,7 +292,7 @@ export function applyCustomFormat(
     value: unknown,
     format?: CustomFormat | undefined,
 ): string {
-    if (format?.type === undefined) return formatValue(value);
+    if (format?.type === undefined) return defaultFormat(value);
 
     const applyCompact = (): {
         compactValue: number;
@@ -320,14 +320,14 @@ export function applyCustomFormat(
     }
 
     if (valueIsNaN(value) || value === null) {
-        return formatValue(value);
+        return defaultFormat(value);
     }
 
     switch (format.type) {
         case CustomFormatType.ID:
             return `${value}`;
         case CustomFormatType.DEFAULT:
-            return formatValue(value);
+            return defaultFormat(value);
 
         case CustomFormatType.PERCENT:
             const formatted = formatNumberValue(Number(value) * 100, format);
@@ -415,5 +415,5 @@ export function formatItemValue(
         return applyCustomFormat(value, customFormat);
     }
 
-    return formatValue(value);
+    return defaultFormat(value);
 }

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -9,17 +9,12 @@ import {
     findCompactConfig,
     Format,
     isDimension,
-    isField,
     isTableCalculation,
     MetricType,
     NumberSeparator,
     TableCalculation,
 } from '../types/field';
-import {
-    AdditionalMetric,
-    hasFormatOptions,
-    isAdditionalMetric,
-} from '../types/metricQuery';
+import { AdditionalMetric, hasFormatOptions } from '../types/metricQuery';
 import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 
@@ -81,26 +76,6 @@ export const getDateFormat = (
     }
 };
 
-export const isMomentInput = (value: unknown): value is MomentInput =>
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    value instanceof Date ||
-    value instanceof moment;
-
-export function formatDate(
-    date: MomentInput,
-    timeInterval: TimeFrames | undefined = TimeFrames.DAY,
-    convertToUTC: boolean = false,
-): string {
-    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
-    return momentDate.format(getDateFormat(timeInterval));
-}
-
-export const parseDate = (
-    str: string,
-    timeInterval: TimeFrames | undefined = TimeFrames.DAY,
-): Date => moment(str, getDateFormat(timeInterval)).toDate();
-
 const getTimeFormat = (
     timeInterval: TimeFrames | undefined = TimeFrames.DAY,
 ): string => {
@@ -122,6 +97,21 @@ const getTimeFormat = (
     return `YYYY-MM-DD, ${timeFormat} (Z)`;
 };
 
+export const isMomentInput = (value: unknown): value is MomentInput =>
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    value instanceof Date ||
+    value instanceof moment;
+
+export function formatDate(
+    date: MomentInput,
+    timeInterval: TimeFrames = TimeFrames.DAY,
+    convertToUTC: boolean = false,
+): string {
+    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
+    return momentDate.format(getDateFormat(timeInterval));
+}
+
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,
@@ -130,6 +120,11 @@ export function formatTimestamp(
     const momentDate = convertToUTC ? moment(value).utc() : moment(value);
     return momentDate.format(getTimeFormat(timeInterval));
 }
+
+export const parseDate = (
+    str: string,
+    timeInterval: TimeFrames | undefined = TimeFrames.DAY,
+): Date => moment(str, getDateFormat(timeInterval)).toDate();
 
 export const parseTimestamp = (
     str: string,
@@ -146,211 +141,53 @@ export function isNumber(value: unknown): value is number {
     return !valueIsNaN(value);
 }
 
-function roundNumber(
+export function formatNumberValue(
     value: number,
-    options?: {
-        format?: Format;
-        round?: number;
-        compact?: CompactOrAlias;
-    },
-): string {
-    const { format, round, compact } = options || {};
-
-    const invalidRound = round === undefined || round < 0;
-    if (invalidRound && !format) {
-        return compact && !Number.isInteger(value)
-            ? `${value}`
-            : new Intl.NumberFormat('en-US').format(Number(value));
-    }
-
-    const isValidCurrencyFormat =
-        !!format && currencies.includes(format.toUpperCase());
-
-    const validFractionDigits = invalidRound
-        ? {}
-        : { maximumFractionDigits: round, minimumFractionDigits: round };
-
-    if (isValidCurrencyFormat) {
-        return new Intl.NumberFormat('en-US', {
-            style: 'currency',
-            currency: format?.toUpperCase(),
-            ...validFractionDigits,
-        }).format(Number(value));
-    }
-
-    return new Intl.NumberFormat('en-US', validFractionDigits).format(
-        Number(value),
-    );
-}
-
-function styleNumber(
-    value: number,
-    options?: {
-        format?: Format;
-        round?: number;
-        compact?: CompactOrAlias;
-    },
-): string {
-    const { format, round, compact } = options || {};
-    if (compact) {
-        const compactRound =
-            compact && round === undefined && format === undefined ? 2 : round;
-        const compactConfig = findCompactConfig(compact);
-        if (compactConfig) {
-            return `${roundNumber(compactConfig.convertFn(Number(value)), {
-                format,
-                round: compactRound,
-                compact,
-            })}${compactConfig.suffix}`;
-        }
-    }
-    return `${new Intl.NumberFormat('en-US').format(Number(value))}`;
-}
-
-export function formatValue(
-    value: unknown,
-    options?: {
-        format?: Format;
-        round?: number;
-        compact?: CompactOrAlias;
-    },
-): string {
-    if (value === null) return '∅';
-    if (value === undefined) return '-';
-    if (!isNumber(value)) {
-        return `${value}`;
-    }
-    const { format, round, compact } = options || {};
-
-    const styledValue = compact
-        ? styleNumber(value, options)
-        : roundNumber(value, { round, format });
-    switch (format) {
-        case Format.KM:
-        case Format.MI:
-            return `${styledValue} ${format}`;
-        case Format.USD:
-        case Format.GBP:
-        case Format.EUR:
-            return `${styledValue}`;
-        case Format.ID:
-            return `${value}`;
-        case Format.PERCENT:
-            if (valueIsNaN(value)) {
-                return `${value}`;
-            }
-
-            const invalidRound = round === undefined || round < 0;
-            const roundBy = invalidRound ? 0 : round;
-            // Fix rounding issue
-            return `${(Number(value) * 100).toFixed(roundBy)}%`;
-        default:
-            // unrecognized format
-            return styledValue;
-    }
-}
-
-export function formatFieldValue(
-    field: Field | AdditionalMetric | undefined,
-    value: unknown,
-    convertToUTC?: boolean,
-): string {
-    if (value === null) return '∅';
-    if (value === undefined) return '-';
-    if (!field) {
-        return `${value}`;
-    }
-    const { type, round, format, compact } = field;
-
-    switch (type) {
-        case DimensionType.STRING:
-        case MetricType.STRING:
-            return `${value}`;
-        case DimensionType.NUMBER:
-        case MetricType.NUMBER:
-        case MetricType.PERCENTILE:
-        case MetricType.MEDIAN:
-        case MetricType.AVERAGE:
-        case MetricType.COUNT:
-        case MetricType.COUNT_DISTINCT:
-        case MetricType.SUM:
-            return formatValue(value, { format, round, compact });
-        case DimensionType.BOOLEAN:
-        case MetricType.BOOLEAN:
-            return formatBoolean(value);
-        case DimensionType.DATE:
-        case MetricType.DATE:
-            return isMomentInput(value)
-                ? formatDate(
-                      value,
-                      isDimension(field) ? field.timeInterval : undefined,
-                      convertToUTC,
-                  )
-                : 'NaT';
-        case DimensionType.TIMESTAMP:
-        case MetricType.TIMESTAMP:
-            return isMomentInput(value)
-                ? formatTimestamp(
-                      value,
-                      isDimension(field) ? field.timeInterval : undefined,
-                      convertToUTC,
-                  )
-                : 'NaT';
-        case MetricType.MAX:
-        case MetricType.MIN: {
-            if (value instanceof Date) {
-                return formatTimestamp(
-                    value,
-                    isDimension(field) ? field.timeInterval : undefined,
-                    convertToUTC,
-                );
-            }
-            return formatValue(value, { format, round, compact });
-        }
-        default: {
-            return `${value}`;
-        }
-    }
-}
-
-export function formatTableCalculationNumber(
-    value: number,
-    format: CustomFormat,
+    format?: CustomFormat,
 ): string {
     const getFormatOptions = () => {
-        const currencyOptions =
-            format.type === CustomFormatType.CURRENCY &&
-            format.currency !== undefined
-                ? { style: 'currency', currency: format.currency }
-                : {};
+        const hasCurrency =
+            format?.type === CustomFormatType.CURRENCY && format?.currency;
+        const currencyOptions = hasCurrency
+            ? { style: 'currency', currency: format.currency }
+            : {};
 
-        if (
-            format.round === undefined &&
-            format.type === CustomFormatType.CURRENCY &&
-            format.currency !== undefined
-        ) {
-            // We apply the default round and separator from the currency
-            return currencyOptions;
+        let round = format?.round;
+
+        if (format?.compact && round === undefined) {
+            round = 2;
         }
-        const round = format.round || 0;
-        return round <= 0
-            ? {
-                  maximumSignificantDigits: Math.max(
-                      Math.floor(value).toString().length + round,
-                      1,
-                  ),
-                  maximumFractionDigits: 0,
-                  ...currencyOptions,
-              }
-            : {
-                  maximumFractionDigits: Math.min(round, 20),
-                  minimumFractionDigits: Math.min(round, 20),
-                  ...currencyOptions,
-              };
+
+        if (format?.type === CustomFormatType.PERCENT && round === undefined) {
+            round = 0;
+        }
+
+        if (round === undefined || round < 0) {
+            return hasCurrency ? currencyOptions : {};
+        }
+
+        if (round === 0) {
+            return {
+                maximumSignificantDigits: Math.max(
+                    Math.floor(value).toString().length + round,
+                    1,
+                ),
+                maximumFractionDigits: 0,
+                ...currencyOptions,
+            };
+        }
+
+        const fractionDigits = Math.min(round, 20);
+        return {
+            maximumFractionDigits: fractionDigits,
+            minimumFractionDigits: fractionDigits,
+            ...currencyOptions,
+        };
     };
 
     const options = getFormatOptions();
-    const separator = format.separator || NumberSeparator.DEFAULT;
+    const separator = format?.separator || NumberSeparator.DEFAULT;
+
     switch (separator) {
         case NumberSeparator.COMMA_PERIOD:
             return value.toLocaleString('en-US', options);
@@ -372,9 +209,95 @@ export function formatTableCalculationNumber(
     }
 }
 
-export function formatTableCalculationValue(
-    format: CustomFormat | undefined,
+function formatValue(value: unknown) {
+    if (value === null) return '∅';
+    if (value === undefined) return '-';
+    if (!isNumber(value)) {
+        return `${value}`;
+    }
+
+    return formatNumberValue(value);
+}
+
+export function getCustomFormatFromLegacy({
+    format,
+    compact,
+    round,
+}: {
+    format?: Format;
+    compact?: CompactOrAlias;
+    round?: number;
+}): CustomFormat {
+    switch (format) {
+        case Format.EUR:
+        case Format.GBP:
+        case Format.USD:
+            return {
+                type: CustomFormatType.CURRENCY,
+                currency: format.toUpperCase(),
+                compact,
+                round,
+            };
+        case Format.KM:
+        case Format.MI:
+            return {
+                type: CustomFormatType.NUMBER,
+                suffix: ` ${format}`,
+                compact,
+                round,
+            };
+        case Format.PERCENT:
+            return {
+                type: CustomFormatType.PERCENT,
+                compact,
+                round,
+            };
+        case Format.ID:
+            return {
+                type: CustomFormatType.ID,
+            };
+        default:
+            return {
+                type: CustomFormatType.NUMBER,
+                round,
+                compact,
+            };
+    }
+}
+
+export function getCustomFormat(
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomDimension
+        | undefined,
+) {
+    if (!item) return undefined;
+
+    if (hasFormatOptions(item)) {
+        return item.formatOptions;
+    }
+
+    if (isTableCalculation(item)) {
+        return item.format;
+    }
+
+    if ('format' in item && typeof item.format === 'string') {
+        // This converts legacy format type (which is Format), to CustomFormat
+        return getCustomFormatFromLegacy({
+            format: item.format,
+            compact: item.compact,
+            round: item.round,
+        });
+    }
+
+    return undefined;
+}
+
+export function applyCustomFormat(
     value: unknown,
+    format?: CustomFormat | undefined,
 ): string {
     if (format?.type === undefined) return formatValue(value);
 
@@ -396,27 +319,30 @@ export function formatTableCalculationValue(
 
         return { compactValue: Number(value), compactSuffix: '' };
     };
+
     if (value === '') return '';
+
     if (value instanceof Date) {
         return formatTimestamp(value, undefined, false);
     }
+
     if (valueIsNaN(value) || value === null) {
         return formatValue(value);
     }
+
     switch (format.type) {
+        case CustomFormatType.ID:
+            return `${value}`;
         case CustomFormatType.DEFAULT:
             return formatValue(value);
 
         case CustomFormatType.PERCENT:
-            const formatted = formatTableCalculationNumber(
-                Number(value) * 100,
-                format,
-            );
+            const formatted = formatNumberValue(Number(value) * 100, format);
             return `${formatted}%`;
         case CustomFormatType.CURRENCY:
             const { compactValue, compactSuffix } = applyCompact();
 
-            const currencyFormatted = formatTableCalculationNumber(
+            const currencyFormatted = formatNumberValue(
                 compactValue,
                 format,
             ).replace(/\u00A0/, ' ');
@@ -430,10 +356,7 @@ export function formatTableCalculationValue(
                 compactSuffix: compactNumberSuffix,
             } = applyCompact();
 
-            const numberFormatted = formatTableCalculationNumber(
-                compactNumber,
-                format,
-            );
+            const numberFormatted = formatNumberValue(compactNumber, format);
 
             return `${prefix}${numberFormatted}${compactNumberSuffix}${suffix}`;
         default:
@@ -458,17 +381,46 @@ export function formatItemValue(
     if (value === undefined) return '-';
 
     if (item) {
-        if (hasFormatOptions(item)) {
-            return formatTableCalculationValue(item.formatOptions, value);
+        if ('type' in item) {
+            switch (item.type) {
+                case DimensionType.BOOLEAN:
+                case MetricType.BOOLEAN:
+                    return formatBoolean(value);
+                case DimensionType.DATE:
+                case MetricType.DATE:
+                    return isMomentInput(value)
+                        ? formatDate(
+                              value,
+                              isDimension(item) ? item.timeInterval : undefined,
+                              convertToUTC,
+                          )
+                        : 'NaT';
+                case DimensionType.TIMESTAMP:
+                case MetricType.TIMESTAMP:
+                    return isMomentInput(value)
+                        ? formatTimestamp(
+                              value,
+                              isDimension(item) ? item.timeInterval : undefined,
+                              convertToUTC,
+                          )
+                        : 'NaT';
+                case MetricType.MAX:
+                case MetricType.MIN:
+                    if (value instanceof Date) {
+                        return formatTimestamp(
+                            value,
+                            isDimension(item) ? item.timeInterval : undefined,
+                            convertToUTC,
+                        );
+                    }
+                    break;
+                default:
+            }
         }
 
-        if (isField(item) || isAdditionalMetric(item)) {
-            return formatFieldValue(item, value, convertToUTC);
-        }
-
-        if (isTableCalculation(item)) {
-            return formatTableCalculationValue(item.format, value);
-        }
+        const customFormat = getCustomFormat(item);
+        return applyCustomFormat(value, customFormat);
     }
+
     return formatValue(value);
 }

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -131,6 +131,39 @@ export const parseTimestamp = (
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,
 ): Date => moment(str, getTimeFormat(timeInterval)).toDate();
 
+function getFormatOptions(value: number, format?: CustomFormat) {
+    const hasCurrency =
+        format?.type === CustomFormatType.CURRENCY && format?.currency;
+    const currencyOptions = hasCurrency
+        ? { style: 'currency', currency: format.currency }
+        : {};
+
+    const round = format?.round;
+
+    if (round === undefined) {
+        // When round is not defined, keep up to 3 decimal places
+        return hasCurrency ? currencyOptions : {};
+    }
+
+    if (round <= 0) {
+        return {
+            maximumSignificantDigits: Math.max(
+                Math.floor(value).toString().length + round,
+                1,
+            ),
+            maximumFractionDigits: 0,
+            ...currencyOptions,
+        };
+    }
+
+    const fractionDigits = Math.min(round, 20);
+    return {
+        maximumFractionDigits: fractionDigits,
+        minimumFractionDigits: fractionDigits,
+        ...currencyOptions,
+    };
+}
+
 export function valueIsNaN(value: unknown) {
     if (typeof value === 'boolean') return true;
 
@@ -145,40 +178,7 @@ export function formatNumberValue(
     value: number,
     format?: CustomFormat,
 ): string {
-    const getFormatOptions = () => {
-        const hasCurrency =
-            format?.type === CustomFormatType.CURRENCY && format?.currency;
-        const currencyOptions = hasCurrency
-            ? { style: 'currency', currency: format.currency }
-            : {};
-
-        const round = format?.round;
-
-        if (round === undefined) {
-            // When round is not defined, keep up to 3 decimal places
-            return hasCurrency ? currencyOptions : {};
-        }
-
-        if (round <= 0) {
-            return {
-                maximumSignificantDigits: Math.max(
-                    Math.floor(value).toString().length + round,
-                    1,
-                ),
-                maximumFractionDigits: 0,
-                ...currencyOptions,
-            };
-        }
-
-        const fractionDigits = Math.min(round, 20);
-        return {
-            maximumFractionDigits: fractionDigits,
-            minimumFractionDigits: fractionDigits,
-            ...currencyOptions,
-        };
-    };
-
-    const options = getFormatOptions();
+    const options = getFormatOptions(value, format);
     const separator = format?.separator || NumberSeparator.DEFAULT;
 
     switch (separator) {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -202,7 +202,7 @@ export function formatNumberValue(
     }
 }
 
-function defaultFormat(value: unknown) {
+function applyDefaultFormat(value: unknown) {
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (!isNumber(value)) {
@@ -292,7 +292,7 @@ export function applyCustomFormat(
     value: unknown,
     format?: CustomFormat | undefined,
 ): string {
-    if (format?.type === undefined) return defaultFormat(value);
+    if (format?.type === undefined) return applyDefaultFormat(value);
 
     const applyCompact = (): {
         compactValue: number;
@@ -320,14 +320,14 @@ export function applyCustomFormat(
     }
 
     if (valueIsNaN(value) || value === null) {
-        return defaultFormat(value);
+        return applyDefaultFormat(value);
     }
 
     switch (format.type) {
         case CustomFormatType.ID:
             return `${value}`;
         case CustomFormatType.DEFAULT:
-            return defaultFormat(value);
+            return applyDefaultFormat(value);
 
         case CustomFormatType.PERCENT:
             const formatted = formatNumberValue(Number(value) * 100, format);
@@ -415,5 +415,5 @@ export function formatItemValue(
         return applyCustomFormat(value, customFormat);
     }
 
-    return defaultFormat(value);
+    return applyDefaultFormat(value);
 }

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -152,21 +152,14 @@ export function formatNumberValue(
             ? { style: 'currency', currency: format.currency }
             : {};
 
-        let round = format?.round;
+        const round = format?.round;
 
-        if (format?.compact && round === undefined) {
-            round = 2;
-        }
-
-        if (format?.type === CustomFormatType.PERCENT && round === undefined) {
-            round = 0;
-        }
-
-        if (round === undefined || round < 0) {
+        if (round === undefined) {
+            // When round is not defined, keep up to 3 decimal places
             return hasCurrency ? currencyOptions : {};
         }
 
-        if (round === 0) {
+        if (round <= 0) {
             return {
                 maximumSignificantDigits: Math.max(
                     Math.floor(value).toString().length + round,

--- a/packages/e2e/cypress/e2e/app/formats.cy.ts
+++ b/packages/e2e/cypress/e2e/app/formats.cy.ts
@@ -98,7 +98,7 @@ describe('Explore', () => {
             '£1,999,000',
             '1,999,000 km',
             '1,999,000 mi',
-            '199900000%',
+            '199,900,000%',
         ];
         body.forEach((field, i) => {
             cy.get(`tbody > tr > :nth-child(${i + 2})`).contains(field);

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -1,10 +1,10 @@
 import {
+    applyCustomFormat,
     Compact,
     CompactConfigMap,
     currencies,
     CustomFormat,
     CustomFormatType,
-    formatTableCalculationValue,
     NumberSeparator,
 } from '@lightdash/common';
 import {
@@ -95,11 +95,11 @@ export const FormatForm: FC<Props> = ({
                 {formatType !== CustomFormatType.DEFAULT && (
                     <Text ml="md" mt={30} color="gray.6">
                         {'Looks like: '}
-                        {formatTableCalculationValue(
-                            format,
+                        {applyCustomFormat(
                             CustomFormatType.PERCENT === formatType
                                 ? '0.75'
                                 : '1234.56',
+                            format,
                         )}
                     </Text>
                 )}

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1,13 +1,13 @@
 import {
     ApiQueryResults,
+    applyCustomFormat,
     CartesianChart,
     CartesianSeriesType,
     DimensionType,
     formatItemValue,
-    formatTableCalculationValue,
-    formatValue,
     friendlyName,
     getAxisName,
+    getCustomFormatFromLegacy,
     getDateGroupLabel,
     getDefaultSeriesColor,
     getItemLabelWithoutTableName,
@@ -601,16 +601,19 @@ const getPivotSeries = ({
                                 return value;
                             }
                             if (isTableCalculation(field)) {
-                                return formatTableCalculationValue(
-                                    field.format,
+                                return formatItemValue(
+                                    field,
                                     value?.value?.[yFieldHash],
                                 );
                             } else {
-                                return formatValue(value?.value?.[yFieldHash], {
-                                    format: field.format,
-                                    round: field.round,
-                                    compact: field.compact,
-                                });
+                                return applyCustomFormat(
+                                    value?.value?.[yFieldHash],
+                                    getCustomFormatFromLegacy({
+                                        format: field.format,
+                                        round: field.round,
+                                        compact: field.compact,
+                                    }),
+                                );
                             }
                         },
                     }),
@@ -676,16 +679,19 @@ const getSimpleSeries = ({
                             return value;
                         }
                         if (isTableCalculation(field)) {
-                            return formatTableCalculationValue(
-                                field.format,
+                            return formatItemValue(
+                                field,
                                 value?.value?.[yFieldHash],
                             );
                         } else {
-                            return formatValue(value?.value?.[yFieldHash], {
-                                format: field.format,
-                                round: field.round,
-                                compact: field.compact,
-                            });
+                            return applyCustomFormat(
+                                value?.value?.[yFieldHash],
+                                getCustomFormatFromLegacy({
+                                    format: field.format,
+                                    round: field.round,
+                                    compact: field.compact,
+                                }),
+                            );
                         }
                     },
                 }),
@@ -872,16 +878,13 @@ const getEchartAxes = ({
         } else if (axisItem !== undefined && isTableCalculation(axisItem)) {
             axisConfig.axisLabel = {
                 formatter: (value: any) => {
-                    return formatTableCalculationValue(axisItem.format, value);
+                    return formatItemValue(axisItem, value);
                 },
             };
             axisConfig.axisPointer = {
                 label: {
                     formatter: (value: any) => {
-                        return formatTableCalculationValue(
-                            axisItem.format,
-                            value.value,
-                        );
+                        return formatItemValue(axisItem, value.value);
                     },
                 },
             };
@@ -1571,8 +1574,8 @@ const useEchartsCartesianConfig = (
                 if (dimensionId !== undefined) {
                     const field = itemsMap[dimensionId];
                     if (isTableCalculation(field)) {
-                        const tooltipHeader = formatTableCalculationValue(
-                            field.format,
+                        const tooltipHeader = formatItemValue(
+                            field,
                             params[0].axisValueLabel,
                         );
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -1,13 +1,14 @@
 import {
     ApiQueryResults,
+    applyCustomFormat,
     BigNumber,
     CompactOrAlias,
     ComparisonDiffTypes,
     ComparisonFormatTypes,
-    Format,
-    formatTableCalculationValue,
-    formatValue,
+    CustomFormatType,
+    formatItemValue,
     friendlyName,
+    getCustomFormatFromLegacy,
     getItemId,
     getItemLabel,
     isField,
@@ -54,39 +55,42 @@ const formatComparisonValue = (
     }
     switch (format) {
         case ComparisonFormatTypes.PERCENTAGE:
-            return `${prefix}${formatValue(value, {
-                format: Format.PERCENT,
+            return `${prefix}${applyCustomFormat(value, {
                 round: 0,
+                type: CustomFormatType.PERCENT,
             })}`;
         case ComparisonFormatTypes.RAW:
             if (item !== undefined && isTableCalculation(item)) {
-                return `${prefix}${formatTableCalculationValue(
-                    item.format,
-                    value,
-                )}`;
+                return `${prefix}${formatItemValue(item, value)}`;
             }
-            return `${prefix}${formatValue(value, {
-                format: isField(item) ? item.format : undefined,
-                round: bigNumberComparisonStyle
-                    ? 2
-                    : isField(item)
-                    ? item.round
-                    : undefined,
-                compact: bigNumberComparisonStyle,
-            })}`;
+            return `${prefix}${applyCustomFormat(
+                value,
+                getCustomFormatFromLegacy({
+                    format: isField(item) ? item.format : undefined,
+                    round: bigNumberComparisonStyle
+                        ? 2
+                        : isField(item)
+                        ? item.round
+                        : undefined,
+                    compact: bigNumberComparisonStyle,
+                }),
+            )}`;
         default:
             if (item !== undefined && isTableCalculation(item)) {
-                return formatTableCalculationValue(item.format, value);
+                return formatItemValue(item, value);
             }
-            return formatValue(value, {
-                format: isField(item) ? item.format : undefined,
-                round: bigNumberComparisonStyle
-                    ? 2
-                    : isField(item)
-                    ? item.round
-                    : undefined,
-                compact: bigNumberComparisonStyle,
-            });
+            return applyCustomFormat(
+                value,
+                getCustomFormatFromLegacy({
+                    format: isField(item) ? item.format : undefined,
+                    round: bigNumberComparisonStyle
+                        ? 2
+                        : isField(item)
+                        ? item.round
+                        : undefined,
+                    compact: bigNumberComparisonStyle,
+                }),
+            );
     }
 };
 
@@ -224,17 +228,20 @@ const useBigNumberConfig = (
                 resultsData?.rows?.[0]?.[selectedField]?.value.formatted
             );
         } else if (item !== undefined && isTableCalculation(item)) {
-            return formatTableCalculationValue(item.format, firstRowValueRaw);
+            return formatItemValue(item, firstRowValueRaw);
         } else {
-            return formatValue(firstRowValueRaw, {
-                format: isField(item) ? item.format : undefined,
-                round: bigNumberStyle
-                    ? 2
-                    : isField(item)
-                    ? item.round
-                    : undefined,
-                compact: bigNumberStyle,
-            });
+            return applyCustomFormat(
+                firstRowValueRaw,
+                getCustomFormatFromLegacy({
+                    format: isField(item) ? item.format : undefined,
+                    round: bigNumberStyle
+                        ? 2
+                        : isField(item)
+                        ? item.round
+                        : undefined,
+                    compact: bigNumberStyle,
+                }),
+            );
         }
     }, [item, firstRowValueRaw, selectedField, bigNumberStyle, resultsData]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8767 

### Description:

- Unifies the legacy formatting functions used for Metrics and Dimensions with the TableCalculation ones adhering to CustomFormat type
- Adds a convert function from legacy Format to CustomFormat
- Standardises rounding so that when round is undefined, then up to 3 decimal places are kept
- Adds support for negative rounding to Metrics and Dimensions. Previously it was just available for TableCalculations
- Fixes the tests

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
