### PR TITLE
fix: dropColumn format_options on down in migration

### DIFF
--- a/packages/backend/src/database/migrations/20240130125623_add-custom-metrics-format-options.ts
+++ b/packages/backend/src/database/migrations/20240130125623_add-custom-metrics-format-options.ts
@@ -14,5 +14,6 @@ export async function down(knex: Knex): Promise<void> {
         tableBuilder.string('prefix').nullable();
         tableBuilder.string('suffix').nullable();
         tableBuilder.string('separator').nullable();
+        tableBuilder.dropColumn('format_options');
     });
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Edit missed `dropColumn` in down function for `format_options` -> custom metrics formatting

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
