### PR TITLE
feat: version auto updater

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Helmet } from 'react-helmet';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AbilityContext } from './components/common/Authorization';
+import VersionAutoUpdater from './components/VersionAutoUpdater/VersionAutoUpdater';
 import MobileRoutes from './MobileRoutes';
 import { ActiveJobProvider } from './providers/ActiveJobProvider';
 import { AppProvider } from './providers/AppProvider';
@@ -34,6 +35,7 @@ const App = () => (
             <MantineProvider>
                 <AppProvider>
                     <Router>
+                        <VersionAutoUpdater />
                         <ThirdPartyProvider
                             enabled={isMobile || !isMinimalPage}
                         >

--- a/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
+++ b/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
@@ -12,9 +12,9 @@ const routesThatCantBeAutoRefreshed = [
 ];
 const VersionAutoUpdater: FC = () => {
     const [version, setVersion] = useState<string>();
-    const { showToastInfo } = useToaster();
+    const { showToastPrimary } = useToaster();
     const { data: healthData } = useHealth({
-        refetchInterval: 600000, // 10 minutes in milliseconds
+        refetchInterval: 1200000, // 20 minutes in milliseconds
     });
     const isRouteThatCantBeAutoRefreshed = useRouteMatch({
         path: routesThatCantBeAutoRefreshed,
@@ -26,12 +26,10 @@ const VersionAutoUpdater: FC = () => {
                 setVersion(healthData.version);
             } else if (version !== healthData.version) {
                 if (isRouteThatCantBeAutoRefreshed) {
-                    showToastInfo({
+                    showToastPrimary({
                         key: 'new-version-available',
                         autoClose: false,
-                        title: 'New version available',
-                        subtitle:
-                            'A new version of Lightdash is ready for you!',
+                        title: 'A new version of Lightdash is ready for you!',
                         action: {
                             children: 'Use new version',
                             icon: IconReload,
@@ -43,7 +41,7 @@ const VersionAutoUpdater: FC = () => {
                 }
             }
         }
-    }, [version, isRouteThatCantBeAutoRefreshed, healthData, showToastInfo]);
+    }, [version, isRouteThatCantBeAutoRefreshed, healthData, showToastPrimary]);
 
     return null;
 };

--- a/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
+++ b/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
@@ -30,7 +30,8 @@ const VersionAutoUpdater: FC = () => {
                         key: 'new-version-available',
                         autoClose: false,
                         title: 'New version available',
-                        subtitle: 'A new version is ready for you to use.',
+                        subtitle:
+                            'A new version of Lightdash is ready for you!',
                         action: {
                             children: 'Use new version',
                             icon: IconReload,

--- a/packages/frontend/src/hooks/health/useHealth.tsx
+++ b/packages/frontend/src/hooks/health/useHealth.tsx
@@ -1,5 +1,5 @@
 import { ApiError, ApiHealthResults, HealthState } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
@@ -11,10 +11,13 @@ const getHealthState = async () =>
         body: undefined,
     });
 
-const useHealth = () => {
+const useHealth = (
+    useQueryOptions?: UseQueryOptions<HealthState, ApiError>,
+) => {
     const health = useQuery<HealthState, ApiError>({
         queryKey: ['health'],
         queryFn: getHealthState,
+        ...useQueryOptions,
     });
 
     const { showToastError } = useToaster();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8806<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Every 10 minutes the FE checks the server version.

If there is a new version and the user is creating/editing a chart/dashboard it shows a toast otherwise it refreshes the page.

<img width="476" alt="Screenshot 2024-02-02 at 16 19 29" src="https://github.com/lightdash/lightdash/assets/9117144/a53ad644-a244-410d-91d1-5774ee4a0aba">


Auto refresh page when version updates:

https://github.com/lightdash/lightdash/assets/9117144/e3faeedb-5fc4-44fc-b628-6e379ce75d89

Shows toast when version updates:

https://github.com/lightdash/lightdash/assets/9117144/fb3988ca-32cc-4762-ab1d-da339c7226ca



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
