### PR TITLE
chore: reenable api e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/api/api.cy.ts
+++ b/packages/e2e/cypress/e2e/api/api.cy.ts
@@ -244,7 +244,7 @@ describe('Lightdash API', () => {
         );
     });
 
-    it.only('Should get metric filters from events', () => {
+    it('Should get metric filters from events', () => {
         cy.request({
             url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/explores/events`,
             headers: { 'Content-type': 'application/json' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-internal-work/issues/1435

### Description:

Not sure why they were disabled, probably we added `.only` for testing, and merged by mistake. 

<!-- Add a description of the changes proposed in the pull request. -->
![image](https://github.com/lightdash/lightdash/assets/1983672/c93c2820-537c-40de-b9ce-bc0e3bac9606)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
