### PR TITLE
feat: standardize editor actions across SqlForm and SqlRunnerInput

### DIFF
--- a/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
@@ -30,7 +30,7 @@ export const SqlEditorActions: FC<{
                 withArrow
                 position="left"
             >
-                <ActionIcon onClick={onToggleSoftWrap}>
+                <ActionIcon onClick={onToggleSoftWrap} color="gray">
                     {isSoftWrapEnabled ? (
                         <MantineIcon icon={IconTextWrapDisabled} />
                     ) : (

--- a/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
@@ -1,0 +1,64 @@
+import { ActionIcon, CopyButton, Flex, Tooltip } from '@mantine/core';
+import {
+    IconCheck,
+    IconClipboard,
+    IconTextWrap,
+    IconTextWrapDisabled,
+} from '@tabler/icons-react';
+import { FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+
+export const SqlEditorActions: FC<{
+    isSoftWrapEnabled: boolean;
+    clipboardContent?: string | undefined;
+    onToggleSoftWrap: () => void;
+}> = ({ isSoftWrapEnabled, onToggleSoftWrap, clipboardContent }) => {
+    return (
+        <Flex
+            pos="absolute"
+            bottom={0}
+            right={0}
+            // Avoids potential collision with ScrollArea scrollbar:
+            mr={5}
+        >
+            <Tooltip
+                label={
+                    isSoftWrapEnabled
+                        ? 'Disable editor soft-wrapping'
+                        : 'Enable editor soft-wrapping'
+                }
+                withArrow
+                position="left"
+            >
+                <ActionIcon onClick={onToggleSoftWrap}>
+                    {isSoftWrapEnabled ? (
+                        <MantineIcon icon={IconTextWrapDisabled} />
+                    ) : (
+                        <MantineIcon icon={IconTextWrap} />
+                    )}
+                </ActionIcon>
+            </Tooltip>
+            <CopyButton value={clipboardContent ?? ''} timeout={2000}>
+                {({ copied, copy }) => (
+                    <Tooltip
+                        label={copied ? 'Copied to clipboard!' : 'Copy'}
+                        withArrow
+                        position="right"
+                        color={copied ? 'green' : 'dark'}
+                    >
+                        <ActionIcon
+                            color={copied ? 'teal' : 'gray'}
+                            onClick={copy}
+                        >
+                            {copied ? (
+                                <IconCheck size="1rem" />
+                            ) : (
+                                <IconClipboard size="1rem" />
+                            )}
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+            </CopyButton>
+        </Flex>
+    );
+};

--- a/packages/frontend/src/components/SqlRunner/SqlRunnerInput.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlRunnerInput.tsx
@@ -1,11 +1,11 @@
 import { ProjectCatalog } from '@lightdash/common';
-import { ActionIcon, CopyButton, Tooltip } from '@mantine/core';
-import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
 import React, { FC } from 'react';
 import AceEditor from 'react-ace';
+import { useToggle } from 'react-use';
 import { useProjectCatalogAceEditorCompleter } from '../../hooks/useProjectCatalogAceEditorCompleter';
+import { SqlEditorActions } from './SqlEditorActions';
 
 const SqlRunnerInput: FC<{
     sql: string;
@@ -15,6 +15,8 @@ const SqlRunnerInput: FC<{
 }> = ({ sql, onChange, isDisabled, projectCatalog }) => {
     const { setAceEditor } =
         useProjectCatalogAceEditorCompleter(projectCatalog);
+
+    const [isSoftWrapEnabled, toggleSoftWrap] = useToggle(false);
 
     return (
         <div
@@ -37,36 +39,13 @@ const SqlRunnerInput: FC<{
                     onChange(value);
                 }}
                 onLoad={setAceEditor}
+                wrapEnabled={isSoftWrapEnabled}
             />
-            <div
-                style={{
-                    position: 'absolute',
-                    bottom: 0,
-                    right: 0,
-                }}
-            >
-                <CopyButton value={sql} timeout={2000}>
-                    {({ copied, copy }) => (
-                        <Tooltip
-                            label={copied ? 'Copied to clipboard!' : 'Copy'}
-                            withArrow
-                            position="right"
-                            color={copied ? 'green' : 'dark'}
-                        >
-                            <ActionIcon
-                                color={copied ? 'teal' : 'gray'}
-                                onClick={copy}
-                            >
-                                {copied ? (
-                                    <IconCheck size="1rem" />
-                                ) : (
-                                    <IconClipboard size="1rem" />
-                                )}
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </CopyButton>
-            </div>
+            <SqlEditorActions
+                isSoftWrapEnabled={isSoftWrapEnabled}
+                onToggleSoftWrap={toggleSoftWrap}
+                clipboardContent={sql}
+            />
         </div>
     );
 };

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -1,18 +1,11 @@
 import {
-    ActionIcon,
     Alert,
     Anchor,
-    Box,
     ScrollArea,
     Text,
-    Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import {
-    IconSparkles,
-    IconTextWrap,
-    IconTextWrapDisabled,
-} from '@tabler/icons-react';
+import { IconSparkles } from '@tabler/icons-react';
 import { FC } from 'react';
 import AceEditor, { IAceEditorProps } from 'react-ace';
 import styled, { css } from 'styled-components';
@@ -23,6 +16,7 @@ import { TableCalculationForm } from '../types';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
 import { useToggle } from 'react-use';
+import { SqlEditorActions } from '../../../components/SqlRunner/SqlEditorActions';
 
 const SQL_PLACEHOLDER = '${table_name.field_name} + ${table_name.metric_name}';
 
@@ -49,41 +43,11 @@ const SqlEditor = styled(AceEditor)<
               `}
 `;
 
-const SqlEditorActions: FC<{
-    isSoftWrapEnabled: boolean;
-    onToggleSoftWrap: () => void;
-}> = ({ isSoftWrapEnabled, onToggleSoftWrap }) => (
-    <Box
-        pos="absolute"
-        bottom={0}
-        right={0}
-        // Avoids potential collision with ScrollArea scrollbar:
-        mr={5}
-    >
-        <Tooltip
-            label={
-                isSoftWrapEnabled
-                    ? 'Disable editor soft-wrapping'
-                    : 'Enable editor soft-wrapping'
-            }
-            withArrow
-            position="left"
-        >
-            <ActionIcon onClick={onToggleSoftWrap}>
-                {isSoftWrapEnabled ? (
-                    <MantineIcon icon={IconTextWrapDisabled} />
-                ) : (
-                    <MantineIcon icon={IconTextWrap} />
-                )}
-            </ActionIcon>
-        </Tooltip>
-    </Box>
-);
-
 export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
     const theme = useMantineTheme();
     const [isSoftWrapEnabled, toggleSoftWrap] = useToggle(false);
     const { setAceEditor } = useExplorerAceEditorCompleter();
+
     return (
         <>
             <ScrollArea h={isFullScreen ? '95%' : '150px'}>
@@ -109,6 +73,7 @@ export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
                 <SqlEditorActions
                     isSoftWrapEnabled={isSoftWrapEnabled}
                     onToggleSoftWrap={toggleSoftWrap}
+                    clipboardContent={form.values.sql}
                 />
             </ScrollArea>
 

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -13,7 +13,6 @@ import {
     Stack,
     Tabs,
     TextInput,
-    Title,
     useMantineTheme,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -108,12 +107,16 @@ const TableCalculationModal: FC<Props> = ({
             onClose={() => onClose()}
             size="xl"
             title={
-                <Title order={5}>
-                    {tableCalculation
-                        ? 'Edit table calculation'
-                        : 'Add table calculation'}
-                </Title>
+                tableCalculation
+                    ? 'Edit table calculation'
+                    : 'Add table calculation'
             }
+            styles={{
+                title: {
+                    fontSize: theme.fontSizes.md,
+                    fontWeight: 700,
+                },
+            }}
             fullScreen={isFullscreen}
         >
             <form name="table_calculation" onSubmit={handleSubmit}>


### PR DESCRIPTION
### Description:

- Fixes an error on the table calculations modal where the modal title was an `h5` inside the Mantine-default `h2` title (which is not valid html, and throws an error)
- Made `SqlEditorActions` a shared component across `SqlRunnerInput` and `SqlForm`, with both editors now supporting soft wrapping and copying to clipboard:

#### Sql runner:
<img width="589" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/a6af65e3-9f0e-452f-af97-7823d4fe1f04">

#### Table calculations modal:
<img width="811" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/c1bf4512-afc6-4238-bcb8-f817ac2f02b3">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
