### PR TITLE
fix: always return default format when item doesn't have format property

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -770,6 +770,26 @@ describe('Formatting', () => {
                     new Date('2021-03-10T00:00:00.000Z'),
                 ),
             ).toEqual('2021-03-10, 00:00:00:000 (+00:00)');
+            expect(
+                formatItemValue(
+                    {
+                        ...metric,
+                        type: MetricType.NUMBER,
+                        round: 2,
+                    },
+                    '1.123456123123',
+                ),
+            ).toEqual('1.12');
+            expect(
+                formatItemValue(
+                    {
+                        ...metric,
+                        type: MetricType.NUMBER,
+                        compact: Compact.THOUSANDS,
+                    },
+                    1000,
+                ),
+            ).toEqual('1K');
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -276,16 +276,12 @@ export function getCustomFormat(
         return item.format;
     }
 
-    if ('format' in item && typeof item.format === 'string') {
-        // This converts legacy format type (which is Format), to CustomFormat
-        return getCustomFormatFromLegacy({
-            format: item.format,
-            compact: item.compact,
-            round: item.round,
-        });
-    }
-
-    return undefined;
+    // This converts legacy format type (which is Format), to CustomFormat
+    return getCustomFormatFromLegacy({
+        ...('format' in item && { format: item.format }),
+        ...('compact' in item && { compact: item.compact }),
+        ...('round' in item && { round: item.round }),
+    });
 }
 
 function applyCompact(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8851

### Description:
Previously when no `format` property was present on the yaml it would just call `applyDefaultFormat` on the value, thus ignoring `round` and `compact`. This makes sure that even if no `format` is present in the object, it will format with a default `customFormat` and keep both `round` and `compact`.

Tests run without the fix:

- Round
<img width="427" alt="image" src="https://github.com/lightdash/lightdash/assets/22939015/f253bb6c-8bc2-4de3-86e5-8210ecf61a88">
<img width="826" alt="image" src="https://github.com/lightdash/lightdash/assets/22939015/e66955ba-135d-46bf-bed3-62f9c5870102">

- Compact
<img width="441" alt="image" src="https://github.com/lightdash/lightdash/assets/22939015/ef8be566-e784-4dfd-af58-43fc87c8fbf6">
<img width="848" alt="image" src="https://github.com/lightdash/lightdash/assets/22939015/ad52856b-da97-42a1-8b66-f84182069ab6">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
