### PR TITLE
feat: add shared chart color support under feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -10,4 +10,11 @@ export enum FeatureFlags {
      * See  ProjectService for example usage.
      */
     UseDbtLs = 'use-dbt-ls',
+
+    /**
+     * Use shared color assignments for cartesian-type charts, when possible. This
+     * essentially means we try to have the same dimension translate into the same
+     * color in the org's color palette every time.
+     */
+    UseSharedColorAssignment = 'use-shared-color-assignment',
 }

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
@@ -29,6 +29,7 @@ type VisualizationCartesianConfigProps =
         setPivotDimensions: React.Dispatch<
             React.SetStateAction<string[] | undefined>
         >;
+        colorPalette: string[];
     };
 
 const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
@@ -41,6 +42,7 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
     onChartConfigChange,
     stacking,
     cartesianType,
+    colorPalette,
     children,
 }) => {
     const cartesianConfig = useCartesianChartConfig({
@@ -52,6 +54,7 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
         itemsMap,
         stacking,
         cartesianType,
+        colorPalette,
     });
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -230,6 +230,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
                     cartesianType={cartesianType}
                     setPivotDimensions={setPivotDimensions}
                     onChartConfigChange={handleChartConfigChange}
+                    colorPalette={colorPalette}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider


### PR DESCRIPTION
### Description:
Taken from the method comment:

```ts
    /**
     * Given the org's color palette, and a dimension identifier, return the color
     * in the palette assigned to that identifier.
     *
     * This works by hashing the identifier into an integer value, and then projecting
     * that value into the org's color space - effectivelly getting a number from 0 to
     * <number of colors in palette>.
     *
     * This is a straight-forward way to handle hashing dimensions into colors, with
     * two major caveats:
     *
     * - We're no longer cycling over colors in the palette, potentially not following
     *   an intentionally-designed best-neighbor-color approach.
     * - We have no guarantee different dimensions won't be assigned the same color due
     *   to the narrow color space - we can fix this by shifting colors aside when
     *   compiling the chart config.
     */
```

tl;dr: Hooks into `useCartesianChartConfig` to add initial support for mapping colors in a predictable manner, based on dimensions. This is likely to require additional adjustments and support for different chart configurations, but this PR allows testing against real data via a feature flag.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
