### PR TITLE
fix: round with no decimals in table calculations

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -145,6 +145,7 @@ describe('Formatting', () => {
                 expect(applyCustomFormat(100, roundZeroFormat)).toEqual('100');
                 expect(applyCustomFormat(5, roundZeroFormat)).toEqual('5');
                 expect(applyCustomFormat(5.001, roundZeroFormat)).toEqual('5');
+                expect(applyCustomFormat(0.001, roundZeroFormat)).toEqual('0');
                 expect(applyCustomFormat(1000, roundZeroFormat)).toEqual(
                     '1,000',
                 );

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -145,7 +145,7 @@ function getFormatNumberOptions(value: number, format?: CustomFormat) {
         return hasCurrency ? currencyOptions : {};
     }
 
-    if (round <= 0) {
+    if (round < 0) {
         return {
             maximumSignificantDigits: Math.max(
                 Math.floor(value).toString().length + round,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8855 

### Description:

The issue was due to the `maximumSignificantDigits` that we had set for case `round <= 0.`
When `round = 0`, `maximumSignificantDigits` was set to 1. This worked fine for numbers greater than 1.
But for cases like 0.001, the only significant digit ie. 1 is being taken into account and we get 0.001 as output even if round was set to 0.

Fixed by removing the = from the if condition. Added a test for the same.

![image](https://github.com/lightdash/lightdash/assets/85165953/7268f0bd-c252-49da-812c-1bbf2dbb947f)

![image](https://github.com/lightdash/lightdash/assets/85165953/e2087a3a-5c5b-4376-aea6-f20c102ca9e8)

![image](https://github.com/lightdash/lightdash/assets/85165953/9d432fcf-dea2-4d47-9754-027dbde2493b)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
