### PR TITLE
feat: TV/Fullscreen mode for dashboards

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -32,8 +32,8 @@ const App = () => (
 
         <ReactQueryProvider>
             <MantineProvider>
-                <AppProvider>
-                    <Router>
+                <Router>
+                    <AppProvider>
                         <VersionAutoUpdater />
                         <ThirdPartyProvider
                             enabled={isMobile || !isMinimalPage}
@@ -52,8 +52,8 @@ const App = () => (
                                 </AbilityContext.Provider>
                             </TrackingProvider>
                         </ThirdPartyProvider>
-                    </Router>
-                </AppProvider>
+                    </AppProvider>
+                </Router>
             </MantineProvider>
 
             <ReactQueryDevtools initialIsOpen={false} />

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -18,6 +18,7 @@ import { Link, useHistory, useParams } from 'react-router-dom';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProjects } from '../../hooks/useProjects';
+import { useApp } from '../../providers/AppProvider';
 import Logo from '../../svgs/logo-icon.svg?react';
 import MantineIcon from '../common/MantineIcon';
 import BrowseMenu from './BrowseMenu';
@@ -112,6 +113,8 @@ const NavBar = memo(() => {
         clearDashboardStorage,
     } = useDashboardStorage();
 
+    const { isFullscreen } = useApp();
+
     const dashboardInfo = getEditingDashboardInfo();
 
     const homeUrl = activeProjectUuid
@@ -140,21 +143,19 @@ const NavBar = memo(() => {
         );
     }
 
+    const headerContainerHeight =
+        NAVBAR_HEIGHT + (isCurrentProjectPreview ? BANNER_HEIGHT : 0);
+
     return (
         <MantineProvider inherit theme={{ colorScheme: 'dark' }}>
             {isCurrentProjectPreview ? <PreviewBanner /> : null}
             {/* hack to make navbar fixed and maintain space */}
-            <Box
-                h={
-                    NAVBAR_HEIGHT +
-                    (isCurrentProjectPreview ? BANNER_HEIGHT : 0)
-                }
-            />
+            <Box h={!isFullscreen ? headerContainerHeight : 0} />
             <Header
                 height={NAVBAR_HEIGHT}
                 fixed
                 mt={isCurrentProjectPreview ? BANNER_HEIGHT : 'none'}
-                display="flex"
+                display={isFullscreen ? 'none' : 'flex'}
                 px="md"
                 zIndex={getDefaultZIndex('app')}
                 sx={{

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -14,6 +14,8 @@ import {
     Tooltip,
 } from '@mantine/core';
 import {
+    IconArrowsMaximize,
+    IconArrowsMinimize,
     IconCheck,
     IconChevronRight,
     IconCopy,
@@ -66,6 +68,7 @@ type DashboardHeaderProps = {
     hasDashboardChanged: boolean;
     isEditMode: boolean;
     isSaving: boolean;
+    isFullscreen: boolean;
     oldestCacheTime?: Date;
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     onCancel: () => void;
@@ -74,6 +77,7 @@ type DashboardHeaderProps = {
     onDuplicate: () => void;
     onMoveToSpace: (spaceUuid: string) => void;
     onExport: () => void;
+    onToggleFullscreen: () => void;
 };
 
 const DashboardHeader = ({
@@ -90,6 +94,7 @@ const DashboardHeader = ({
     hasDashboardChanged,
     isEditMode,
     isSaving,
+    isFullscreen,
     oldestCacheTime,
     onAddTiles,
     onCancel,
@@ -98,6 +103,7 @@ const DashboardHeader = ({
     onDuplicate,
     onMoveToSpace,
     onExport,
+    onToggleFullscreen,
 }: DashboardHeaderProps) => {
     const { search } = useLocation();
     const { projectUuid, dashboardUuid } = useParams<{
@@ -267,7 +273,32 @@ const DashboardHeader = ({
                 <PageActionsContainer>
                     {userCanExportData && <DashboardRefreshButton />}
 
-                    {!!userCanManageDashboard && (
+                    {!isEditMode && document.fullscreenEnabled && (
+                        <Tooltip
+                            label={
+                                isFullscreen
+                                    ? 'Exit Fullscreen Mode'
+                                    : 'Enter Fullscreen Mode'
+                            }
+                            withinPortal
+                            position="bottom"
+                        >
+                            <ActionIcon
+                                variant="default"
+                                onClick={onToggleFullscreen}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isFullscreen
+                                            ? IconArrowsMinimize
+                                            : IconArrowsMaximize
+                                    }
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+
+                    {!!userCanManageDashboard && !isFullscreen && (
                         <Tooltip
                             label="Edit dashboard"
                             withinPortal
@@ -286,166 +317,186 @@ const DashboardHeader = ({
                         </Tooltip>
                     )}
 
-                    {userCanExportData && (
+                    {userCanExportData && !isFullscreen && (
                         <ShareLinkButton url={`${window.location.href}`} />
                     )}
-                    <Menu
-                        position="bottom"
-                        withArrow
-                        withinPortal
-                        shadow="md"
-                        disabled={!userCanManageDashboard && !userCanExportData}
-                    >
-                        <Menu.Target>
-                            <ActionIcon variant="default">
-                                <MantineIcon icon={IconDots} />
-                            </ActionIcon>
-                        </Menu.Target>
 
-                        <Menu.Dropdown>
-                            {!!userCanManageDashboard && (
-                                <>
-                                    <Menu.Item
-                                        icon={<MantineIcon icon={IconCopy} />}
-                                        onClick={onDuplicate}
-                                    >
-                                        Duplicate
-                                    </Menu.Item>
+                    {!isFullscreen && (
+                        <Menu
+                            position="bottom"
+                            withArrow
+                            withinPortal
+                            shadow="md"
+                            disabled={
+                                !userCanManageDashboard && !userCanExportData
+                            }
+                        >
+                            <Menu.Target>
+                                <ActionIcon variant="default">
+                                    <MantineIcon icon={IconDots} />
+                                </ActionIcon>
+                            </Menu.Target>
 
+                            <Menu.Dropdown>
+                                {!!userCanManageDashboard && (
+                                    <>
+                                        <Menu.Item
+                                            icon={
+                                                <MantineIcon icon={IconCopy} />
+                                            }
+                                            onClick={onDuplicate}
+                                        >
+                                            Duplicate
+                                        </Menu.Item>
+
+                                        <Menu.Item
+                                            icon={
+                                                <MantineIcon
+                                                    icon={IconFolders}
+                                                />
+                                            }
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                            }}
+                                        >
+                                            <Menu
+                                                width={250}
+                                                withArrow
+                                                position="left-start"
+                                                shadow="md"
+                                                offset={40}
+                                                trigger="hover"
+                                            >
+                                                <Menu.Target>
+                                                    <Flex
+                                                        justify="space-between"
+                                                        align="center"
+                                                    >
+                                                        Move to space
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconChevronRight
+                                                            }
+                                                        />
+                                                    </Flex>
+                                                </Menu.Target>
+                                                <Menu.Dropdown>
+                                                    {spaces?.map(
+                                                        (spaceToMove) => {
+                                                            const isDisabled =
+                                                                dashboardSpaceUuid ===
+                                                                spaceToMove.uuid;
+
+                                                            return (
+                                                                <Menu.Item
+                                                                    icon={
+                                                                        <MantineIcon
+                                                                            icon={
+                                                                                isDisabled
+                                                                                    ? IconCheck
+                                                                                    : IconFolder
+                                                                            }
+                                                                        />
+                                                                    }
+                                                                    color={
+                                                                        isDisabled
+                                                                            ? 'gray.5'
+                                                                            : ''
+                                                                    }
+                                                                    onClick={(
+                                                                        e,
+                                                                    ) => {
+                                                                        e.preventDefault();
+                                                                        e.stopPropagation();
+                                                                        if (
+                                                                            dashboardSpaceUuid !==
+                                                                            spaceToMove.uuid
+                                                                        ) {
+                                                                            onMoveToSpace(
+                                                                                spaceToMove.uuid,
+                                                                            );
+                                                                        }
+                                                                    }}
+                                                                    key={
+                                                                        spaceToMove.uuid
+                                                                    }
+                                                                >
+                                                                    {
+                                                                        spaceToMove.name
+                                                                    }
+                                                                </Menu.Item>
+                                                            );
+                                                        },
+                                                    )}
+
+                                                    <Menu.Divider />
+
+                                                    <Menu.Item
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconPlus}
+                                                            />
+                                                        }
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            e.stopPropagation();
+                                                            setIsCreatingNewSpace(
+                                                                true,
+                                                            );
+                                                        }}
+                                                    >
+                                                        Create new space
+                                                    </Menu.Item>
+                                                </Menu.Dropdown>
+                                            </Menu>
+                                        </Menu.Item>
+                                    </>
+                                )}
+
+                                {!!userCanCreateDeliveries && (
                                     <Menu.Item
-                                        icon={
-                                            <MantineIcon icon={IconFolders} />
-                                        }
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
+                                        icon={<MantineIcon icon={IconSend} />}
+                                        onClick={() => {
+                                            toggleScheduledDeliveriesModal(
+                                                true,
+                                            );
                                         }}
                                     >
-                                        <Menu
-                                            width={250}
-                                            withArrow
-                                            position="left-start"
-                                            shadow="md"
-                                            offset={40}
-                                            trigger="hover"
-                                        >
-                                            <Menu.Target>
-                                                <Flex
-                                                    justify="space-between"
-                                                    align="center"
-                                                >
-                                                    Move to space
-                                                    <MantineIcon
-                                                        icon={IconChevronRight}
-                                                    />
-                                                </Flex>
-                                            </Menu.Target>
-                                            <Menu.Dropdown>
-                                                {spaces?.map((spaceToMove) => {
-                                                    const isDisabled =
-                                                        dashboardSpaceUuid ===
-                                                        spaceToMove.uuid;
-
-                                                    return (
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        isDisabled
-                                                                            ? IconCheck
-                                                                            : IconFolder
-                                                                    }
-                                                                />
-                                                            }
-                                                            color={
-                                                                isDisabled
-                                                                    ? 'gray.5'
-                                                                    : ''
-                                                            }
-                                                            onClick={(e) => {
-                                                                e.preventDefault();
-                                                                e.stopPropagation();
-                                                                if (
-                                                                    dashboardSpaceUuid !==
-                                                                    spaceToMove.uuid
-                                                                ) {
-                                                                    onMoveToSpace(
-                                                                        spaceToMove.uuid,
-                                                                    );
-                                                                }
-                                                            }}
-                                                            key={
-                                                                spaceToMove.uuid
-                                                            }
-                                                        >
-                                                            {spaceToMove.name}
-                                                        </Menu.Item>
-                                                    );
-                                                })}
-
-                                                <Menu.Divider />
-
-                                                <Menu.Item
-                                                    icon={
-                                                        <MantineIcon
-                                                            icon={IconPlus}
-                                                        />
-                                                    }
-                                                    onClick={(e) => {
-                                                        e.preventDefault();
-                                                        e.stopPropagation();
-                                                        setIsCreatingNewSpace(
-                                                            true,
-                                                        );
-                                                    }}
-                                                >
-                                                    Create new space
-                                                </Menu.Item>
-                                            </Menu.Dropdown>
-                                        </Menu>
+                                        Scheduled deliveries
                                     </Menu.Item>
-                                </>
-                            )}
+                                )}
 
-                            {!!userCanCreateDeliveries && (
-                                <Menu.Item
-                                    icon={<MantineIcon icon={IconSend} />}
-                                    onClick={() => {
-                                        toggleScheduledDeliveriesModal(true);
-                                    }}
-                                >
-                                    Scheduled deliveries
-                                </Menu.Item>
-                            )}
-
-                            {(userCanExportData || userCanManageDashboard) && (
-                                <Menu.Item
-                                    icon={<MantineIcon icon={IconUpload} />}
-                                    onClick={onExport}
-                                >
-                                    Export dashboard{' '}
-                                </Menu.Item>
-                            )}
-
-                            {userCanManageDashboard && (
-                                <>
-                                    <Menu.Divider />
+                                {(userCanExportData ||
+                                    userCanManageDashboard) && (
                                     <Menu.Item
-                                        icon={
-                                            <MantineIcon
-                                                icon={IconTrash}
-                                                color="red"
-                                            />
-                                        }
-                                        onClick={onDelete}
-                                        color="red"
+                                        icon={<MantineIcon icon={IconUpload} />}
+                                        onClick={onExport}
                                     >
-                                        Delete
-                                    </Menu.Item>{' '}
-                                </>
-                            )}
-                        </Menu.Dropdown>
-                    </Menu>
+                                        Export dashboard{' '}
+                                    </Menu.Item>
+                                )}
+
+                                {userCanManageDashboard && (
+                                    <>
+                                        <Menu.Divider />
+                                        <Menu.Item
+                                            icon={
+                                                <MantineIcon
+                                                    icon={IconTrash}
+                                                    color="red"
+                                                />
+                                            }
+                                            onClick={onDelete}
+                                            color="red"
+                                        >
+                                            Delete
+                                        </Menu.Item>{' '}
+                                    </>
+                                )}
+                            </Menu.Dropdown>
+                        </Menu>
+                    )}
 
                     {isCreatingNewSpace && (
                         <SpaceActionModal

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ import React, {
 } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
 import { useHistory, useParams } from 'react-router-dom';
-import { useIntersection, useToggle } from 'react-use';
+import { useIntersection } from 'react-use';
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -46,6 +46,7 @@ import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
+import { useApp } from '../providers/AppProvider';
 import {
     DashboardProvider,
     useDashboardContext,
@@ -169,7 +170,7 @@ const Dashboard: FC = () => {
     );
     const oldestCacheTime = useDashboardContext((c) => c.oldestCacheTime);
 
-    const [isFullscreen, toggleFullscreen] = useToggle(false);
+    const { isFullscreen, toggleFullscreen } = useApp();
     const { showToastError } = useToaster();
 
     const { data: organization } = useOrganization();

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -1,12 +1,15 @@
 import { ApiError, HealthState } from '@lightdash/common';
 import { UseQueryResult } from '@tanstack/react-query';
 import { createContext, FC, useContext } from 'react';
+import { useToggle } from 'react-use';
 import useHealth from '../hooks/health/useHealth';
 import useUser, { UserWithAbility } from '../hooks/user/useUser';
 
 interface AppContext {
     health: UseQueryResult<HealthState, ApiError>;
     user: UseQueryResult<UserWithAbility, ApiError>;
+    isFullscreen: boolean;
+    toggleFullscreen: (nextValue?: boolean) => void;
 }
 
 // used in test mocks
@@ -16,10 +19,13 @@ export const AppProviderContext = createContext<AppContext>(undefined as any);
 export const AppProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const health = useHealth();
     const user = useUser(!!health?.data?.isAuthenticated);
+    const [isFullscreen, toggleFullscreen] = useToggle(false);
 
     const value = {
         health,
         user,
+        isFullscreen,
+        toggleFullscreen,
     };
 
     return (

--- a/packages/frontend/src/providers/AppProvider.tsx
+++ b/packages/frontend/src/providers/AppProvider.tsx
@@ -1,6 +1,7 @@
 import { ApiError, HealthState } from '@lightdash/common';
 import { UseQueryResult } from '@tanstack/react-query';
-import { createContext, FC, useContext } from 'react';
+import { createContext, FC, useContext, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useToggle } from 'react-use';
 import useHealth from '../hooks/health/useHealth';
 import useUser, { UserWithAbility } from '../hooks/user/useUser';
@@ -20,6 +21,7 @@ export const AppProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const health = useHealth();
     const user = useUser(!!health?.data?.isAuthenticated);
     const [isFullscreen, toggleFullscreen] = useToggle(false);
+    const location = useLocation();
 
     const value = {
         health,
@@ -27,6 +29,10 @@ export const AppProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
         isFullscreen,
         toggleFullscreen,
     };
+
+    useEffect(() => {
+        toggleFullscreen(false);
+    }, [location, toggleFullscreen]);
 
     return (
         <AppProviderContext.Provider value={value}>

--- a/packages/frontend/src/testing/__mocks__/providers/AppProvider.mock.tsx
+++ b/packages/frontend/src/testing/__mocks__/providers/AppProvider.mock.tsx
@@ -41,7 +41,14 @@ const AppProviderMock: FC<PropsWithChildren<AppProviderMockProps>> = ({
     });
 
     return (
-        <AppProviderContext.Provider value={{ health, user }}>
+        <AppProviderContext.Provider
+            value={{
+                health,
+                user,
+                isFullscreen: false,
+                toggleFullscreen: () => {},
+            }}
+        >
             {children}
         </AppProviderContext.Provider>
     );


### PR DESCRIPTION
### Description:
- closes: #3195 
- Adds a TV/Fullscreen mode for dashboards:

<img width="344" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/a83b04aa-25da-4d66-bd84-6e95c63a92ff">

- Hides navbar when in fullscreen mode:
<img width="1512" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/5fb6d127-bab0-4e21-a53f-33762a0c9f9e">

Additionally, correctly handles browser-native fullscreen controls (e.g if the user exits fullscreen manually, we also disable TV mode in Lightdash).


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
