### PR TITLE
fix: using zero in conditional formatting

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -128,7 +128,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                     onChange={(newValue) => {
                         onChange({
                             ...rule,
-                            values: newValue ? [newValue] : [],
+                            values: newValue !== null ? [newValue] : [],
                         });
                     }}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Partially closes: #8873 

### Description:

This issue was also coming up in case of `greater than` as it was related to our `FilterNumberInput`
The check for the input value - `values: newValue ? [newValue] : []` evaluated to false for 0 and hence did not set the values correctly.

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/c7dc0348-c032-4b29-9f47-2262b5d44bac)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/5a8b3dc6-4782-4bc4-bf66-b137c61904d8)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
