### PR TITLE
fix: return correct cast when type string

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -710,6 +710,12 @@ describe('Formatting', () => {
             ).toEqual('5');
             expect(
                 formatItemValue(
+                    { ...dimension, type: DimensionType.STRING },
+                    132323123,
+                ),
+            ).toEqual('132323123');
+            expect(
+                formatItemValue(
                     { ...dimension, type: DimensionType.BOOLEAN },
                     true,
                 ),

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -375,6 +375,9 @@ export function formatItemValue(
     if (item) {
         if ('type' in item) {
             switch (item.type) {
+                case DimensionType.STRING:
+                case MetricType.STRING:
+                    return `${value}`;
                 case DimensionType.BOOLEAN:
                 case MetricType.BOOLEAN:
                     return formatBoolean(value);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8869

### Description:

Cast numbers as strings when their `type` is set as `string`.

Where this was happening before: https://github.com/lightdash/lightdash/pull/8807#discussion_r1484326210

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
