### PR TITLE
fix: allow 0 to be added to filter values

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -128,7 +128,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                     onChange={(newValue) => {
                         onChange({
                             ...rule,
-                            values: newValue ? [newValue] : [],
+                            values: [newValue ?? undefined],
                         });
                     }}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes half of: #8873

### Description:

Allows using 0 as a filter value.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
