### PR TITLE
feat: drill menus table names as headers

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -213,6 +213,7 @@ export const DrillDownModal: FC = () => {
                     item={selectedDimension}
                     items={dimensionsAvailable}
                     onChange={setSelectedDimension}
+                    hasGrouping
                 />
                 <Group position="right">
                     <Button variant="outline" onClick={onClose}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #8868

### Description:
The drill menus will now have table names as headers.
Passing the `hasGrouping` prop to `FieldSection` component has made this possible.

<!-- Even better add a screenshot / gif / loom -->
![Screenshot](https://github.com/lightdash/lightdash/assets/111004544/d204b680-9d30-4233-93ce-54b2ee59c497)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
