### PR TITLE
feat: set --use-dbt-list as default in cli

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt: ['1.3', '1.4', '1.5', '1.6', '1.7']
+        dbt: ['1.4', '1.5', '1.6', '1.7']
     name: dbt ${{ matrix.dbt }}
     steps:
       - name: Checkout

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ function parseStartOfWeekArgument(value: string) {
     return number;
 }
 
-function parseUseDbtListOption(value: string | undefined) {
+function parseUseDbtListOption(value: string | undefined): boolean {
     if (value === undefined) {
         return true;
     }
@@ -341,7 +341,7 @@ program
         false,
     )
     .option(
-        '--use-dbt-list [use dbt list]',
+        '--use-dbt-list [true|false]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
         parseUseDbtListOption,
         true,
@@ -403,7 +403,7 @@ program
         false,
     )
     .option(
-        '--use-dbt-list [use dbt list]',
+        '--use-dbt-list [true|false]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
         parseUseDbtListOption,
         true,
@@ -478,7 +478,7 @@ program
         false,
     )
     .option(
-        '--use-dbt-list [use dbt list]',
+        '--use-dbt-list [true|false]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
         parseUseDbtListOption,
         true,
@@ -549,7 +549,7 @@ program
         false,
     )
     .option(
-        '--use-dbt-list [use dbt list]',
+        '--use-dbt-list [true|false]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
         parseUseDbtListOption,
         true,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,13 @@ function parseStartOfWeekArgument(value: string) {
     return number;
 }
 
+function parseUseDbtListOption(value: string | undefined) {
+    if (value === undefined) {
+        return true;
+    }
+    return value.toLowerCase() !== 'false';
+}
+
 program
     .version(VERSION)
     .name(styles.title('⚡️lightdash'))
@@ -334,9 +341,10 @@ program
         false,
     )
     .option(
-        '--use-dbt-list',
+        '--use-dbt-list [use dbt list]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
-        false,
+        parseUseDbtListOption,
+        true,
     )
     .action(previewHandler);
 
@@ -395,9 +403,10 @@ program
         false,
     )
     .option(
-        '--use-dbt-list',
+        '--use-dbt-list [use dbt list]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
-        false,
+        parseUseDbtListOption,
+        true,
     )
     .action(startPreviewHandler);
 
@@ -469,9 +478,10 @@ program
         false,
     )
     .option(
-        '--use-dbt-list',
+        '--use-dbt-list [use dbt list]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
-        false,
+        parseUseDbtListOption,
+        true,
     )
     .action(deployHandler);
 
@@ -539,9 +549,10 @@ program
         false,
     )
     .option(
-        '--use-dbt-list',
+        '--use-dbt-list [use dbt list]',
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
-        false,
+        parseUseDbtListOption,
+        true,
     )
     .action(validateHandler);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8773 

### Description:

- Set -`-use-dbt-list` option true as default in cli
- Allow the user to use `--use-dbt-list=false` in case they need to use dbt compile
- Setting it to any value other than `true` or `false` would set it back to true

Example - 

The following commands will consider --use-dbt-list to true.
```
node <index.js path> deploy --create --profiles-dir .
node <index.js path> deploy --create --profiles-dir . --use-dbt-list
node <index.js path> deploy --create --profiles-dir . --use-dbt-list=true
node <index.js path> deploy --create --profiles-dir . --use-dbt-list true
```

Output - 

![image](https://github.com/lightdash/lightdash/assets/85165953/bce2b6ac-14ea-4aa4-8527-9d5f43f24d93)

For setting it to false, we can use -
```
node <index.js path> deploy --create --profiles-dir . --use-dbt-list=false
node <index.js path> deploy --create --profiles-dir . --use-dbt-list false
```

Output -

![image](https://github.com/lightdash/lightdash/assets/85165953/2abb00ea-126e-419a-8398-1d2a360d9049)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
