### PR TITLE
feat: export png by default

### DIFF
--- a/packages/e2e/cypress/e2e/app/sqlrunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlrunner.cy.ts
@@ -14,13 +14,15 @@ describe('SQL Runner', () => {
     it('Should see results from customers by typing', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/sqlRunner`);
 
+        cy.contains('SQL');
+
         const customersTable = `"jaffle"."customers"`;
 
-        cy.get('.ace_content')
-            .type(
-                `SELECT * FROM ${customersTable} order by customer_id LIMIT 1`,
-            )
-            .type('{ctrl}{enter}');
+        cy.get('.ace_content').type(
+            `SELECT * FROM ${customersTable} order by customer_id LIMIT 1`,
+        );
+
+        cy.contains('Run query').click();
 
         const find = [
             'First name',
@@ -34,9 +36,13 @@ describe('SQL Runner', () => {
     it('Should autocomplete customer table', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/sqlRunner`);
 
-        cy.get('.ace_content')
-            .type(`SELECT * FROM cu{enter} order by customer_id`)
-            .type('{ctrl}{enter}');
+        cy.contains('SQL');
+
+        cy.get('.ace_content').type(
+            `SELECT * FROM cu{enter} order by customer_id`,
+        );
+
+        cy.contains('Run query').click();
 
         const find = [
             'First name',
@@ -59,6 +65,7 @@ describe('SQL Runner', () => {
     });
 
     it('Get error on invalid SQL', () => {
+        cy.contains('SQL');
         cy.get('.ace_content').type(`SELECT test`).type('{ctrl}{enter}');
 
         cy.findByText('Failed to run sql query');
@@ -66,6 +73,7 @@ describe('SQL Runner', () => {
     });
 
     it('Should see results with custom SQL ', () => {
+        cy.contains('SQL');
         const sql = `select a from ( values ('foo'), ('bar')) s(a);`;
 
         cy.get('.ace_content').type(sql).type('{ctrl}{enter}');

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -5,7 +5,14 @@ import {
     ChartType,
     getCustomLabelsFromColumnProperties,
 } from '@lightdash/common';
-import { Button, Popover, Select, Stack, Text } from '@mantine/core';
+import {
+    Button,
+    Popover,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+} from '@mantine/core';
 import { IconDownload, IconShare2 } from '@tabler/icons-react';
 import EChartsReact from 'echarts-for-react';
 import JsPDF from 'jspdf';
@@ -38,6 +45,7 @@ async function base64SvgToBase64Image(
     originalBase64: string,
     width: number,
     type: 'jpeg' | 'png' = 'png',
+    isBackgroundTransparent: boolean = false,
 ): Promise<string> {
     return new Promise((resolve, reject) => {
         const img = document.createElement('img');
@@ -50,7 +58,10 @@ async function base64SvgToBase64Image(
             canvas.height = width / ratio;
             const ctx = canvas.getContext('2d');
             if (ctx) {
-                if (type === 'jpeg') {
+                if (
+                    type === 'jpeg' ||
+                    (type === 'png' && !isBackgroundTransparent)
+                ) {
                     ctx.fillStyle = 'white';
                     ctx.fillRect(0, 0, canvas.width, canvas.height);
                 }
@@ -116,6 +127,9 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
     chartType,
 }) => {
     const [type, setType] = useState<DownloadType>(DownloadType.PNG);
+    const [isBackgroundTransparent, setIsBackgroundTransparent] =
+        useState(false);
+
     const isTable = chartType === ChartType.TABLE;
     const onDownload = useCallback(async () => {
         const echartsInstance = chartRef.current?.getEchartsInstance();
@@ -147,7 +161,12 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                     break;
                 case DownloadType.PNG:
                     downloadImage(
-                        await base64SvgToBase64Image(svgBase64, width),
+                        await base64SvgToBase64Image(
+                            svgBase64,
+                            width,
+                            'png',
+                            isBackgroundTransparent,
+                        ),
                     );
                     break;
                 case DownloadType.JSON:
@@ -163,7 +182,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
         } catch (e) {
             console.error(`Unable to download ${type} from chart ${e}`);
         }
-    }, [chartRef, type]);
+    }, [chartRef, type, isBackgroundTransparent]);
 
     return (
         <Stack>
@@ -179,6 +198,21 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                     label: downloadType,
                 }))}
             />
+
+            {type === DownloadType.PNG && (
+                <SegmentedControl
+                    size="xs"
+                    id="background-transparency"
+                    value={isBackgroundTransparent ? 'Transparent' : 'Opaque'}
+                    onChange={(value) =>
+                        setIsBackgroundTransparent(value === 'Transparent')
+                    }
+                    data={[
+                        { value: 'Opaque', label: 'Opaque' },
+                        { value: 'Transparent', label: 'Transparent' },
+                    ]}
+                />
+            )}
 
             {!isTable && (
                 <Button

--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -115,7 +115,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
     chartRef,
     chartType,
 }) => {
-    const [type, setType] = useState<DownloadType>(DownloadType.JPEG);
+    const [type, setType] = useState<DownloadType>(DownloadType.PNG);
     const isTable = chartType === ChartType.TABLE;
     const onDownload = useCallback(async () => {
         const echartsInstance = chartRef.current?.getEchartsInstance();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8906 

### Description:

- Set `png` as the default export option in charts
- Allow the toggling of background transparency in `png` - set transparent by default
- I have added select options `Transparent` and `Opaque` for png exports. We can change the values to whatever feels suitable. Can also create an enum for the transparency options similar to how its done for download type if need be.

Output - 

`bg-transparency option in png` - 

![image](https://github.com/lightdash/lightdash/assets/85165953/a4b3acab-eb0c-470b-84eb-a9eb5c953a1e)

Transparent PNG -

![image](https://github.com/lightdash/lightdash/assets/85165953/8c2c444e-526f-46a7-96b5-0a9cd7d84074)

Opaque PNG - 

![image](https://github.com/lightdash/lightdash/assets/85165953/e17b461a-c6fb-4676-9994-0e8d268d333f)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
