### PR TITLE
fix: disable chart download in custom viz

### DIFF
--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -22,6 +22,7 @@ import ExportSelector from './ExportSelector';
 import { isBigNumberVisualizationConfig } from './LightdashVisualization/VisualizationBigNumberConfig';
 import { isCartesianVisualizationConfig } from './LightdashVisualization/VisualizationConfigCartesian';
 import { isTableVisualizationConfig } from './LightdashVisualization/VisualizationConfigTable';
+import { isCustomVisualizationConfig } from './LightdashVisualization/VisualizationCustomConfig';
 import { useVisualizationContext } from './LightdashVisualization/VisualizationProvider';
 
 const FILE_NAME = 'lightdash_chart';
@@ -225,7 +226,8 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             !resultsData?.metricQuery ||
             isBigNumberVisualizationConfig(visualizationConfig) ||
             (isCartesianVisualizationConfig(visualizationConfig) &&
-                !eChartsOptions);
+                !eChartsOptions) ||
+            isCustomVisualizationConfig(visualizationConfig);
 
         const { user } = useApp();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8914 

### Description:

Disabled chart download for custom viz. https://github.com/lightdash/lightdash/issues/8914#issuecomment-1941869268

![image](https://github.com/lightdash/lightdash/assets/85165953/e4806568-ab6f-4ecd-a214-cfb3fc48540e)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
