### PR TITLE
feat: enable soft-wrapping by default, store user choice locally

### DIFF
--- a/packages/frontend/src/components/SqlRunner/SqlRunnerInput.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlRunnerInput.tsx
@@ -1,11 +1,13 @@
 import { ProjectCatalog } from '@lightdash/common';
+import { useLocalStorage } from '@mantine/hooks';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
 import React, { FC } from 'react';
 import AceEditor from 'react-ace';
-import { useToggle } from 'react-use';
 import { useProjectCatalogAceEditorCompleter } from '../../hooks/useProjectCatalogAceEditorCompleter';
 import { SqlEditorActions } from './SqlEditorActions';
+
+const SOFT_WRAP_LOCAL_STORAGE_KEY = 'lightdash-sql-runner-soft-wrap';
 
 const SqlRunnerInput: FC<{
     sql: string;
@@ -16,7 +18,10 @@ const SqlRunnerInput: FC<{
     const { setAceEditor } =
         useProjectCatalogAceEditorCompleter(projectCatalog);
 
-    const [isSoftWrapEnabled, toggleSoftWrap] = useToggle(false);
+    const [isSoftWrapEnabled, setSoftWrapEnabled] = useLocalStorage({
+        key: SOFT_WRAP_LOCAL_STORAGE_KEY,
+        defaultValue: true,
+    });
 
     return (
         <div
@@ -43,7 +48,7 @@ const SqlRunnerInput: FC<{
             />
             <SqlEditorActions
                 isSoftWrapEnabled={isSoftWrapEnabled}
-                onToggleSoftWrap={toggleSoftWrap}
+                onToggleSoftWrap={() => setSoftWrapEnabled(!isSoftWrapEnabled)}
                 clipboardContent={sql}
             />
         </div>

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -13,12 +13,13 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useExplorerAceEditorCompleter } from '../../../hooks/useExplorerAceEditorCompleter';
 import { TableCalculationForm } from '../types';
 
+import { useLocalStorage } from '@mantine/hooks';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
-import { useToggle } from 'react-use';
 import { SqlEditorActions } from '../../../components/SqlRunner/SqlEditorActions';
 
 const SQL_PLACEHOLDER = '${table_name.field_name} + ${table_name.metric_name}';
+const SOFT_WRAP_LOCAL_STORAGE_KEY = 'lightdash-sql-form-soft-wrap';
 
 type Props = {
     form: TableCalculationForm;
@@ -45,7 +46,11 @@ const SqlEditor = styled(AceEditor)<
 
 export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
     const theme = useMantineTheme();
-    const [isSoftWrapEnabled, toggleSoftWrap] = useToggle(false);
+    const [isSoftWrapEnabled, setSoftWrapEnabled] = useLocalStorage({
+        key: SOFT_WRAP_LOCAL_STORAGE_KEY,
+        defaultValue: true,
+    });
+
     const { setAceEditor } = useExplorerAceEditorCompleter();
 
     return (
@@ -72,7 +77,9 @@ export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
                 />
                 <SqlEditorActions
                     isSoftWrapEnabled={isSoftWrapEnabled}
-                    onToggleSoftWrap={toggleSoftWrap}
+                    onToggleSoftWrap={() =>
+                        setSoftWrapEnabled(!isSoftWrapEnabled)
+                    }
                     clipboardContent={form.values.sql}
                 />
             </ScrollArea>


### PR DESCRIPTION
### Description:

Follow-up to: #8771 

- Enables soft-wrapping by default
- Saves the user's selection locally using local storage

Note: this implementation tracks sql runner and the table calculations sql form separately; there's likely a good case for reusing the same state between both, but given the different dimensions & context for either, there's potentially good reasoning for keeping them separate, too.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
