### PR TITLE
fix: add new useFeatureFlagEnabled hook, migrate existing frontend feature flags

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -17,4 +17,12 @@ export enum FeatureFlags {
      * color in the org's color palette every time.
      */
     UseSharedColorAssignment = 'use-shared-color-assignment',
+
+    /**/
+    PassthroughLogin = 'passthrough-login',
+
+    /**
+     * Enables custom visualizations when the environment variable is also enabled
+     */
+    CustomVisualizationsEnabled = 'custom-visualizations-enabled',
 }

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     CartesianSeriesType,
     ChartType,
+    FeatureFlags,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
@@ -17,8 +18,8 @@ import {
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { FC, memo, useMemo } from 'react';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useApp } from '../../../providers/AppProvider';
 import {
     COLLAPSABLE_CARD_BUTTON_PROPS,
@@ -34,9 +35,8 @@ import { useVisualizationContext } from '../../LightdashVisualization/Visualizat
 
 const VisualizationCardOptions: FC = memo(() => {
     const { health } = useApp();
-    // FEATURE FLAG: custom-visualizations-enabled
     const customVizEnabled = useFeatureFlagEnabled(
-        'custom-visualizations-enabled',
+        FeatureFlags.CustomVisualizationsEnabled,
     );
 
     const {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,4 +1,4 @@
-import { WarehouseTypes } from '@lightdash/common';
+import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -12,10 +12,10 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import React, { FC } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { hasNoWhiteSpaces } from '../../../utils/fieldValidators';
 import MantineIcon from '../../common/MantineIcon';
 import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
@@ -73,8 +73,9 @@ const PostgresForm: FC<{
             setValue('warehouse.sshTunnelPublicKey', data.publicKey);
         },
     });
-    const isPassthroughLoginFeatureEnabled =
-        useFeatureFlagEnabled('passthrough-login');
+    const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
+        FeatureFlags.PassthroughLogin,
+    );
     return (
         <>
             <Stack style={{ marginTop: '8px' }}>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,4 +1,4 @@
-import { WarehouseTypes } from '@lightdash/common';
+import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -14,10 +14,10 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import React, { FC } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { hasNoWhiteSpaces } from '../../../utils/fieldValidators';
 import MantineIcon from '../../common/MantineIcon';
 import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
@@ -74,8 +74,9 @@ const RedshiftForm: FC<{
             setValue('warehouse.sshTunnelPublicKey', data.publicKey);
         },
     });
-    const isPassthroughLoginFeatureEnabled =
-        useFeatureFlagEnabled('passthrough-login');
+    const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
+        FeatureFlags.PassthroughLogin,
+    );
     return (
         <>
             <Stack style={{ marginTop: '8px' }}>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -1,4 +1,4 @@
-import { WarehouseTypes } from '@lightdash/common';
+import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
 import {
     Anchor,
     Group,
@@ -7,10 +7,11 @@ import {
     Switch,
     TextInput,
 } from '@mantine/core';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
+
 import React, { FC } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import {
     hasNoWhiteSpaces,
     isUppercase,
@@ -50,8 +51,9 @@ const SnowflakeForm: FC<{
 
     const requireSecrets: boolean =
         savedProject?.warehouseConnection?.type !== WarehouseTypes.SNOWFLAKE;
-    const isPassthroughLoginFeatureEnabled =
-        useFeatureFlagEnabled('passthrough-login');
+    const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
+        FeatureFlags.PassthroughLogin,
+    );
     return (
         <>
             <Stack style={{ marginTop: '8px' }}>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
@@ -1,4 +1,4 @@
-import { WarehouseTypes } from '@lightdash/common';
+import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
 import {
     Anchor,
     NumberInput,
@@ -7,10 +7,10 @@ import {
     Stack,
     TextInput,
 } from '@mantine/core';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import React, { FC } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useToggle } from 'react-use';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { hasNoWhiteSpaces } from '../../../utils/fieldValidators';
 import BooleanSwitch from '../../ReactHookForm/BooleanSwitch';
 import FormSection from '../../ReactHookForm/FormSection';
@@ -46,8 +46,9 @@ const TrinoForm: FC<{
     const requireSecrets: boolean =
         savedProject?.warehouseConnection?.type !== WarehouseTypes.TRINO;
     const { register } = useFormContext();
-    const isPassthroughLoginFeatureEnabled =
-        useFeatureFlagEnabled('passthrough-login');
+    const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
+        FeatureFlags.PassthroughLogin,
+    );
     return (
         <>
             <Stack style={{ marginTop: '8px' }}>

--- a/packages/frontend/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/frontend/src/hooks/useFeatureFlagEnabled.ts
@@ -1,0 +1,9 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useFeatureFlagEnabled as useFeatureFlagEnabledPosthog } from 'posthog-js/react';
+
+/**
+ * Thin wrapper around posthog's useFeatureFlagEnabled hook that is aware
+ * of our FeatureFlags enum.
+ */
+export const useFeatureFlagEnabled = (featureFlag: FeatureFlags) =>
+    useFeatureFlagEnabledPosthog(featureFlag) === true;

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { FeatureFlags } from '@lightdash/common';
 import { Box, Stack, Text, Title } from '@mantine/core';
 import {
     IconBuildingSkyscraper,
@@ -19,7 +20,6 @@ import {
     IconUsers,
     IconUserShield,
 } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { FC } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { Can } from '../components/common/Authorization';
@@ -47,6 +47,7 @@ import UserAttributesPanel from '../components/UserSettings/UserAttributesPanel'
 import UsersAndGroupsPanel from '../components/UserSettings/UsersAndGroupsPanel';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
+import { useFeatureFlagEnabled } from '../hooks/useFeatureFlagEnabled';
 import { useProject } from '../hooks/useProject';
 import { useApp } from '../providers/AppProvider';
 import { TrackPage, useTracking } from '../providers/TrackingProvider';
@@ -54,8 +55,9 @@ import { EventName, PageName } from '../types/Events';
 import ProjectSettings from './ProjectSettings';
 
 const Settings: FC = () => {
-    const isPassthroughLoginFeatureEnabled =
-        useFeatureFlagEnabled('passthrough-login');
+    const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
+        FeatureFlags.PassthroughLogin,
+    );
 
     const {
         health: {


### PR DESCRIPTION
### Description:

Follow-up on #8795

- Adds a new `useFeatureFlagEnabled` hook that shadows posthog's, with stricter typing to require a member of the `FeatureFlags` enum
- Update existing uses of posthog's `useFeatureFlagEnabled` to use this new hook.

Note: intentionally avoided any type-level trickery (e.g overriding the external type definition for posthog's hook); technically would be a lower surface area, but could introduce maintainability issues down the road.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
