### PR TITLE
fix: wrap sql_filter with ()

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -1259,7 +1259,7 @@ export const METRIC_QUERY_WITH_SQL_FILTER = `SELECT
   MAX("table1".number_column) AS "table1_metric1"
 FROM "db"."schema"."table1" AS "table1"
 
-WHERE 'EU' = 'US'
+WHERE ('EU' = 'US')
 GROUP BY 1
 ORDER BY "table1_metric1" DESC
 LIMIT 10`;

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -307,7 +307,7 @@ describe('replaceUserAttributes', () => {
 
     it('method should replace sqlFilter with user attribute', async () => {
         const userAttributes = { test: ['1'] };
-        const expected = "'1' > 1";
+        const expected = "('1' > 1)";
         expect(
             replaceUserAttributes(
                 '${lightdash.attribute.test} > 1',
@@ -325,14 +325,14 @@ describe('replaceUserAttributes', () => {
             replaceUserAttributes("'1' IN (${lightdash.attribute.test})", {
                 test: ['1', '2'],
             }),
-        ).toEqual("'1' IN ('1', '2')");
+        ).toEqual("('1' IN ('1', '2'))");
     });
 
     it('method should replace sqlFilter with multiple user attributes', async () => {
         const userAttributes = { test: ['1'], another: ['2'] };
         const sqlFilter =
             '${dimension} IS NOT NULL OR (${lightdash.attribute.test} > 1 AND ${lightdash.attribute.another} = 2)';
-        const expected = "${dimension} IS NOT NULL OR ('1' > 1 AND '2' = 2)";
+        const expected = "(${dimension} IS NOT NULL OR ('1' > 1 AND '2' = 2))";
         expect(replaceUserAttributes(sqlFilter, userAttributes)).toEqual(
             expected,
         );
@@ -340,7 +340,7 @@ describe('replaceUserAttributes', () => {
 
     it('method should replace sqlFilter using short aliases', async () => {
         const userAttributes = { test: ['1'], another: ['2'] };
-        const expected = "'1' > 1";
+        const expected = "('1' > 1)";
         expect(
             replaceUserAttributes('${ld.attribute.test} > 1', userAttributes),
         ).toEqual(expected);

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -106,31 +106,38 @@ export const replaceUserAttributes = (
         return sqlFilter;
     }
 
-    return sqlAttributes.reduce<string>((acc, sqlAttribute) => {
-        const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
-        const attributeValues: string[] | undefined = userAttributes[attribute];
+    const replacedUserAttributesSql = sqlAttributes.reduce<string>(
+        (acc, sqlAttribute) => {
+            const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
+            const attributeValues: string[] | undefined =
+                userAttributes[attribute];
 
-        if (attributeValues === undefined) {
-            throw new ForbiddenError(
-                `Missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
-            );
-        }
-        if (attributeValues.length === 0) {
-            throw new ForbiddenError(
-                `Invalid or missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
-            );
-        }
+            if (attributeValues === undefined) {
+                throw new ForbiddenError(
+                    `Missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
+                );
+            }
+            if (attributeValues.length === 0) {
+                throw new ForbiddenError(
+                    `Invalid or missing user attribute "${attribute}" on ${filter}: "${sqlFilter}"`,
+                );
+            }
 
-        return acc.replace(
-            sqlAttribute,
-            attributeValues
-                .map(
-                    (attributeValue) =>
-                        `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
-                )
-                .join(', '),
-        );
-    }, sqlFilter);
+            return acc.replace(
+                sqlAttribute,
+                attributeValues
+                    .map(
+                        (attributeValue) =>
+                            `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
+                    )
+                    .join(', '),
+            );
+        },
+        sqlFilter,
+    );
+
+    // NOTE: Wrap the replaced user attributes in parentheses to avoid issues with AND/OR operators
+    return `(${replacedUserAttributesSql})`;
 };
 
 export const assertValidDimensionRequiredAttribute = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-commercial/issues/73

### Description:

(See ticket from commercial on how to replicate ^)

When users set a `sql_filter` that is similar to this expression: 
```
${TABLE}.status = ${lightdash.attributes.order_status} or ${lightdash.attributes.order_status} = 'ALL'
```

And if the following statement is true: `${TABLE}.status = ${lightdash.attributes.order_status}`, then if the user sets extra filters on a chart, these will be ignored because there's a `( )` wrap missing. 

This will then affect charts and their generated SQL + where they're being used (dashboards, embedded dashboards)

This will then wrap the `replacedUserAttributesSQL` with a `()`

Question: should this be done somewhere else? I'm not sure... 



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
