### PR TITLE
fix: remove mantine default filtering

### DIFF
--- a/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
@@ -1,10 +1,24 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
+// Search requests are debounced, so take that into account when waiting for the search request to complete
+const SEARCHED_QUERIES = new Set<string>();
+
 function search(query: string) {
+    const hasPerformedSearch = SEARCHED_QUERIES.has(query);
     cy.findByRole('search').click();
+
+    if (!hasPerformedSearch) {
+        SEARCHED_QUERIES.add(query);
+        cy.intercept('**/search/**').as('search');
+    }
+
     cy.findByPlaceholderText(/Search Jaffle shop/gi)
         .clear()
         .type(query);
+
+    if (!hasPerformedSearch) {
+        cy.wait('@search');
+    }
 }
 
 describe('Global search', () => {

--- a/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
+++ b/packages/frontend/src/components/NavBar/GlobalSearch/index.tsx
@@ -287,6 +287,7 @@ const GlobalSearch: FC<GlobalSearchProps> = ({ projectUuid }) => {
                             },
                         });
                     }}
+                    filter={(_query, actions) => actions} // always display all actions, remove any default mantine filtering
                 />
             </MantineProvider>
         </>

--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 previewsEnabled: true
 
 databases:
-  - name: jaffle_db
+  - name: jaffle_db_recreate_test
     ipAllowList: []
     postgresMajorVersion: 13
 

--- a/render.yaml
+++ b/render.yaml
@@ -21,23 +21,23 @@ services:
       - fromGroup: pr-settings
       - key: PGHOST
         fromDatabase:
-          name: jaffle_db
+          name: jaffle_db_recreate_test
           property: host
       - key: PGPORT
         fromDatabase:
-          name: jaffle_db
+          name: jaffle_db_recreate_test
           property: port
       - key: PGDATABASE
         fromDatabase:
-          name: jaffle_db
+          name: jaffle_db_recreate_test
           property: database
       - key: PGUSER
         fromDatabase:
-          name: jaffle_db
+          name: jaffle_db_recreate_test
           property: user
       - key: PGPASSWORD
         fromDatabase:
-          name: jaffle_db
+          name: jaffle_db_recreate_test
           property: password
       - key: LIGHTDASH_SECRET
         generateValue: true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8926 

### Description:

- Makes sure that the filtering of results is done in the backend (for dashboards for now)
- Removes all default mantine filtering

Before:
![image](https://github.com/lightdash/lightdash/assets/22939015/428171a9-a48a-43c1-be65-71fe84692cb8)

After:
![image](https://github.com/lightdash/lightdash/assets/22939015/7dbf289e-163e-4c2d-867d-5272e451d9ac)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
