### PR TITLE
fix: use --quiet flag for dbt version >= 1.6.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
         "nunjucks": "^3.2.3",
         "ora": "5.4.1",
         "parse-node-version": "^2.0.0",
+        "semver": "^7.6.0",
         "unique-names-generator": "^4.7.1",
         "uuid": "^8.3.2"
     },

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -1,5 +1,6 @@
 import { ParseError } from '@lightdash/common';
 import execa from 'execa';
+import { gte } from 'semver';
 import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
 
@@ -80,13 +81,8 @@ export const dbtList = async (
             'unique_id',
         ];
         const version = await getDbtVersion();
-        // older dbt versions don't support --quiet flag - only use it if the version is 1.6.6 or higher
-        if (
-            version.localeCompare('1.6.6', undefined, {
-                numeric: true,
-                sensitivity: 'base',
-            }) >= 0
-        ) {
+        // Only use --quiet flag for dbt versions >= 1.6.6
+        if (gte(version, '1.6.6')) {
             args.push('--quiet');
         }
         GlobalState.debug(`> Running: dbt ls ${args.join(' ')}`);

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -80,8 +80,13 @@ export const dbtList = async (
             'unique_id',
         ];
         const version = await getDbtVersion();
-        // older dbt versions don't support --quiet flag
-        if (!version.startsWith('1.3.') && !version.startsWith('1.4.')) {
+        // older dbt versions don't support --quiet flag - only use it if the version is 1.6.6 or higher
+        if (
+            version.localeCompare('1.6.6', undefined, {
+                numeric: true,
+                sensitivity: 'base',
+            }) >= 0
+        ) {
             args.push('--quiet');
         }
         GlobalState.debug(`> Running: dbt ls ${args.join(' ')}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -18107,6 +18107,13 @@ semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.2:
   version "0.17.2"
   resolved "https://registry.npmjs.org/send/-/send-0.17.2.tgz"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8928 

### Description:

Used `localeCompare` to push `--quiet` flag only for dbt version >= 1.6.6.
This does have a limitation in case of pre-release versions or versions with build metadata. But as dbt uses normal semantic versioning, this should work fine. 
Reference - https://docs.getdbt.com/docs/dbt-versions/core#how-dbt-core-uses-semantic-versioning

We can add custom logic for this or use some package like semver as well if needed.

Example - For dbt version 1.6.0

Before:
![image](https://github.com/lightdash/lightdash/assets/85165953/2b705585-78bf-47d5-8862-4de76ed6ce17)

After:
![image](https://github.com/lightdash/lightdash/assets/85165953/ef8848cb-7f83-42db-aaa7-5de90cc53814)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
