### PR TITLE
feat: add full text search to charts

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -67,6 +67,7 @@ export type DbSavedChart = {
     last_version_chart_kind: ChartKind;
     last_version_updated_at: Date;
     last_version_updated_by_user_uuid: string | undefined;
+    search_vector: number[];
 };
 
 export type DbSavedChartVersion = {

--- a/packages/backend/src/database/migrations/20240214160420_add_search_vector_to_charts.ts
+++ b/packages/backend/src/database/migrations/20240214160420_add_search_vector_to_charts.ts
@@ -1,0 +1,40 @@
+import { Knex } from 'knex';
+import { SavedChartsTableName } from '../entities/savedCharts';
+
+export async function up(knex: Knex): Promise<void> {
+    // add search_vector column to savedCharts table
+    await knex.raw(`
+      ALTER TABLE ${SavedChartsTableName} ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+          setweight(to_tsvector('english', coalesce(description, '')), 'B')
+      ) STORED;
+    `);
+
+    // create index on search_vector column
+    await knex.schema.alterTable(SavedChartsTableName, (table) => {
+        table.index('search_vector', 'charts_search_vector_idx', 'GIN');
+    });
+
+    // backfilling the search_vector column
+    await knex
+        .update({
+            name: knex.raw('name'),
+            description: knex.raw('description'),
+        })
+        .into(SavedChartsTableName);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SavedChartsTableName, 'search_vector')) {
+        await knex.schema.alterTable(SavedChartsTableName, (table) => {
+            table.dropColumn('search_vector');
+        });
+    }
+
+    if (await knex.schema.hasTable('charts_search_vector_idx')) {
+        await knex.schema.alterTable(SavedChartsTableName, (table) => {
+            table.dropIndex('charts_search_vector_idx');
+        });
+    }
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -137,6 +137,7 @@ export const savedChartEntry: SavedChartTable['base'] = {
     last_version_updated_at: new Date(),
     last_version_updated_by_user_uuid: undefined,
     dashboard_uuid: null,
+    search_vector: [],
 };
 
 export const dashboardEntry: DashboardTable['base'] = {

--- a/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
+++ b/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-export function getFullTextSearchRankColumn(
+export function getFullTextSearchRankCalcSql(
     database: Knex,
     tableName: string,
     searchVectorColumnName: string,

--- a/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
+++ b/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export function getFullTextSearchRankColumn(
+    database: Knex,
+    tableName: string,
+    searchVectorColumnName: string,
+    query: string,
+    searchRankColumnName = 'search_rank',
+) {
+    const searchRankRawSql = database.raw(
+        `ts_rank(${tableName}.${searchVectorColumnName}, websearch_to_tsquery(?), 0) as ${searchRankColumnName}`,
+        [query],
+    );
+
+    return {
+        searchRankRawSql,
+        searchRankColumnName,
+    };
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #5631

### Description:

- Adds full text search to charts
- Makes search rank calc raw sql reusable

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
