### PR TITLE
chore: update dbt compile error message

### DIFF
--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -95,7 +95,7 @@ export const dbtList = async (
         return models;
     } catch (e: any) {
         throw new ParseError(
-            `Error executing 'dbt ls':\n  ${e.message}\nEnsure you're on the latest patch version of dbt.`,
+            `Error executing 'dbt ls':\n  ${e.message}\nEnsure you're on the latest patch version. '--use-dbt-list' is true by default; if you encounter issues, try using '--use-dbt-list=false`,
         );
     }
 };

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -94,6 +94,8 @@ export const dbtList = async (
         console.error(stderr);
         return models;
     } catch (e: any) {
-        throw new ParseError(`Failed to run dbt ls:\n  ${e.message}`);
+        throw new ParseError(
+            `Error executing 'dbt ls':\n  ${e.message}\nEnsure you're on the latest patch version of dbt.`,
+        );
     }
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #8928 

### Description:

`dbt ls` supports the `--quiet` flag for dbt `1.5.5` but fails for other patch versions like: `1.5.4`. For `1.6.x`, `dbt ls` doesn't support this flag for >`1.6.0` and <`1.6.6`

Instead of providing a very explicit range of versions before pushing arg `--quiet` in:
```ts
if (!version.startsWith('1.3.') && !version.startsWith('1.4.')) {
            args.push('--quiet');
        }
```
Let's add a workaround and more detailed error message to our users when logging the error, to: 
* advise on upgrading to latest patch version of `dbt`
* provide a potential alternative to the command they're using (that uses `dbt ls`) to disable it by setting `--use-dbt-list=false`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
