### PR TITLE
fix: use dbt model package_name for lightdash generate

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -23,6 +23,7 @@ type CompiledModel = {
     database: string;
     originalFilePath: string;
     patchPath: string | null | undefined;
+    packageName: string;
     alias?: string;
 };
 
@@ -156,7 +157,7 @@ export const findAndUpdateModelYaml = async ({
         includeMeta,
     });
     const filenames = [];
-    const { patchPath } = model;
+    const { patchPath, packageName } = model;
     if (patchPath) {
         const { project: expectedYamlProject, path: expectedYamlSubPath } =
             patchPathParts(patchPath);
@@ -172,7 +173,7 @@ export const findAndUpdateModelYaml = async ({
         filenames.push(expectedYamlPath);
     }
     const defaultYmlPath = path.join(
-        path.dirname(path.join(projectDir, model.originalFilePath)),
+        path.dirname(path.join(packageName, model.originalFilePath)),
         `${model.name}.yml`,
     );
     filenames.push(defaultYmlPath);
@@ -377,5 +378,6 @@ export const getCompiledModels = async (
         originalFilePath: modelLookup[modelId].original_file_path,
         patchPath: modelLookup[modelId].patch_path,
         alias: modelLookup[modelId].alias,
+        packageName: modelLookup[modelId].package_name,
     }));
 };

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -173,7 +173,14 @@ export const findAndUpdateModelYaml = async ({
         filenames.push(expectedYamlPath);
     }
     const defaultYmlPath = path.join(
-        path.dirname(path.join(packageName, model.originalFilePath)),
+        path.dirname(
+            path.join(
+                packageName === projectName
+                    ? '.'
+                    : path.join('dbt_packages', packageName),
+                model.originalFilePath,
+            ),
+        ),
         `${model.name}.yml`,
     );
     filenames.push(defaultYmlPath);


### PR DESCRIPTION
### Problem

some dbt configurations are not listing out models in packages for example:

```
# this does not work
dbt ls -s other_package.model_in_other

# this does work
dbt ls -s model_in_other
```

In the first case `dbt` fails. In the second case `lightdash fails`. This fixes the second case, by checking for the `package_name` on the model metadata instead of relying on the `patch_path` to determine it (it seems sometimes the `patch_path` is missing)

Slack thread: https://lightdash.slack.com/archives/C0699FEJCR0/p1708003529824679?thread_ts=1705415250.660129&cid=C0699FEJCR0