### PR TITLE
fix: move to space menu click handling

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -614,6 +614,9 @@ const SavedChartsHeader: FC = () => {
                                                     <Flex
                                                         justify="space-between"
                                                         align="center"
+                                                        onClick={(e) =>
+                                                            e.stopPropagation()
+                                                        }
                                                     >
                                                         Move to space
                                                         <MantineIcon
@@ -623,7 +626,11 @@ const SavedChartsHeader: FC = () => {
                                                         />
                                                     </Flex>
                                                 </Menu.Target>
-                                                <Menu.Dropdown>
+                                                <Menu.Dropdown
+                                                    onClick={(e) =>
+                                                        e.stopPropagation()
+                                                    }
+                                                >
                                                     {[
                                                         SpaceType.SharedWithMe,
                                                         SpaceType.AdminContentView,
@@ -662,6 +669,9 @@ const SavedChartsHeader: FC = () => {
                                                                         spaceToMove.uuid;
                                                                     return (
                                                                         <Menu.Item
+                                                                            disabled={
+                                                                                isDisabled
+                                                                            }
                                                                             key={
                                                                                 spaceToMove.uuid
                                                                             }


### PR DESCRIPTION
### Description:

The chart move to space menu was clickable where it shouldnt be and also showed an incorrect popup about charts in dashboards when clicked. This makes it so:
- You can't click disabled items in the sub menu
- You can't click the "move to space menu header"

Before:
![Kapture 2024-02-15 at 16 37 42](https://github.com/lightdash/lightdash/assets/1864179/6f25ea15-671d-4b83-8ed5-becd0f2af054)

After (fixed)

![Kapture 2024-02-15 at 16 38 42](https://github.com/lightdash/lightdash/assets/1864179/6dbaa0f9-ed21-45c6-b0b6-92ae00443226)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
