### PR TITLE
fix: number strings in filter by value

### DIFF
--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -85,6 +85,24 @@ describe('Common index', () => {
                 ).values,
             ).toEqual(['test1', 'test2']);
         });
+        test('should parse numbers to strings in type string', async () => {
+            expect(
+                getFilterRuleWithDefaultValue(
+                    stringDimension,
+                    emptyValueFilter,
+                    [102],
+                ).values,
+            ).toEqual(['102']);
+        });
+        test('should parse numbers/strings to strings in type string', async () => {
+            expect(
+                getFilterRuleWithDefaultValue(
+                    stringDimension,
+                    emptyValueFilter,
+                    [102, 'test2'],
+                ).values,
+            ).toEqual(['102', 'test2']);
+        });
     });
 });
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -227,6 +227,10 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                     values !== undefined ? values : [false];
                 break;
             }
+            case FilterType.STRING: {
+                filterRuleDefaults.values = values?.map(String) ?? [];
+                break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8955 

### Description:

The `number strings` were getting passed as `integers` in `getFilterRuleWithDefaultValue`. Added code to convert all values to strings in case of `FilterType.STRING`.

Example - 

Configured `Customers - Customer Id` to be of type `string`.

- Select Field

![image](https://github.com/lightdash/lightdash/assets/85165953/2cb7e390-2372-4702-b482-dfd9e20fd6a3)

- Filter by value

![image](https://github.com/lightdash/lightdash/assets/85165953/811656f1-49dc-44ad-ad1e-6ff3c1c274c4)

- Filter tab -

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/86894dbf-09d9-4820-8daf-162d4f82cbe4)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/858fd990-2a8a-48f7-96a3-69ea83bf10a7)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
