### PR TITLE
fix: prevent filter autocomplete from disallowing adding custom values

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -157,6 +157,11 @@ const FilterStringAutoComplete: FC<Props> = ({
             }
             disabled={disabled}
             creatable
+            /**
+             * Opts out of Mantine's default condition and always allows adding, as long as not
+             * an empty query.
+             */
+            shouldCreate={(query) => query.trim().length > 0}
             getCreateLabel={(query) => (
                 <Group spacing="xxs">
                     <MantineIcon icon={IconPlus} color="blue" size="sm" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Attempts to fix #8840 

### Description:

Opts-out of Mantine's multi-select condition for `shouldCreate`, which hides the option under some conditions:

- Missing query - which I tweaked to also exclude fully empty strings
- value exists in list of items even if casing doesn't match)
  - There's some existing uniqueness logic in Lightdash's filter string autocomplete component that was causing some weirdness when paired with Mantine's condition.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
