### PR TITLE
fix: add and use dictionary with no stop-words

### DIFF
--- a/packages/backend/src/database/migrations/20240207133121_add-english-dictionary-with-custom-stop-words.ts
+++ b/packages/backend/src/database/migrations/20240207133121_add-english-dictionary-with-custom-stop-words.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    // Create custom text search dictionary
+    await knex.schema.raw(`
+        CREATE TEXT SEARCH DICTIONARY lightdash_english_dict (
+            template = snowball,
+            language = english
+        )
+    `);
+
+    // Create a configuration file for stopwords
+    await knex.raw(`
+        CREATE TEXT SEARCH CONFIGURATION lightdash_english_config (
+            copy = english
+        )
+    `);
+
+    // Add the stopwords to the configuration file
+    await knex.raw(`
+        ALTER TEXT SEARCH CONFIGURATION lightdash_english_config
+            ALTER MAPPING FOR asciiword, asciihword, hword_asciipart, hword, hword_part
+            WITH lightdash_english_dict
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.raw(`
+        DROP TEXT SEARCH CONFIGURATION IF EXISTS lightdash_english_config;
+    `);
+
+    await knex.schema.raw(`
+        DROP TEXT SEARCH DICTIONARY IF EXISTS lightdash_english_dict;
+    `);
+}

--- a/packages/backend/src/database/migrations/20240207133122_add_search_vector_to_dashboards.ts
+++ b/packages/backend/src/database/migrations/20240207133122_add_search_vector_to_dashboards.ts
@@ -5,8 +5,8 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
       ALTER TABLE dashboards ADD COLUMN search_vector tsvector
         GENERATED ALWAYS AS (
-          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-          setweight(to_tsvector('english', coalesce(description, '')), 'B')
+          setweight(to_tsvector('lightdash_english_config', coalesce(name, '')), 'A') ||
+          setweight(to_tsvector('lightdash_english_config', coalesce(description, '')), 'B')
       ) STORED;
     `);
 

--- a/packages/backend/src/database/migrations/20240214160420_add_search_vector_to_charts.ts
+++ b/packages/backend/src/database/migrations/20240214160420_add_search_vector_to_charts.ts
@@ -6,8 +6,8 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
       ALTER TABLE ${SavedChartsTableName} ADD COLUMN search_vector tsvector
         GENERATED ALWAYS AS (
-          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-          setweight(to_tsvector('english', coalesce(description, '')), 'B')
+          setweight(to_tsvector('lightdash_english_config', coalesce(name, '')), 'A') ||
+          setweight(to_tsvector('lightdash_english_config', coalesce(description, '')), 'B')
       ) STORED;
     `);
 

--- a/packages/backend/src/database/migrations/20240215091924_add_search_vector_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20240215091924_add_search_vector_to_spaces.ts
@@ -6,7 +6,7 @@ export async function up(knex: Knex): Promise<void> {
     await knex.raw(`
       ALTER TABLE ${SpaceTableName} ADD COLUMN search_vector tsvector
         GENERATED ALWAYS AS (
-          to_tsvector('english', coalesce(name, ''))
+          to_tsvector('lightdash_english_config', coalesce(name, ''))
       ) STORED;
     `);
 

--- a/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
+++ b/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
@@ -8,7 +8,7 @@ export function getFullTextSearchRankCalcSql(
     searchRankColumnName = 'search_rank',
 ) {
     const searchRankRawSql = database.raw(
-        `ts_rank(${tableName}.${searchVectorColumnName}, websearch_to_tsquery(?), 0) as ${searchRankColumnName}`,
+        `ts_rank(${tableName}.${searchVectorColumnName}, websearch_to_tsquery('lightdash_english_config', ?), 0) as ${searchRankColumnName}`,
         [query],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#5631](https://github.com/lightdash/lightdash/issues/5631)

### Description:

Default dictionary uses stop words which would impact our search results, this removes those stop words.

Before:
![image](https://github.com/lightdash/lightdash/assets/22939015/26cacfd6-3c6f-40db-b090-8b740eb3ca24)

After:
![image](https://github.com/lightdash/lightdash/assets/22939015/43103f08-ae97-4e7e-813b-667aa7bfca9d)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
