### PR TITLE
fix: floating point values in alerts

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -46,6 +46,7 @@ import {
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import { FC, useCallback, useMemo, useState } from 'react';
 import FieldSelect from '../../../components/common/FieldSelect';
+import FilterNumberInput from '../../../components/common/Filters/FilterInputs/FilterNumberInput';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { TagInput } from '../../../components/common/TagInput/TagInput';
 import { CronInternalInputs } from '../../../components/ReactHookForm/CronInput';
@@ -492,11 +493,21 @@ const SchedulerForm: FC<Props> = ({
                                             `thresholds.0.operator`,
                                         )}
                                     />
-                                    <NumberInput
+                                    <FilterNumberInput
                                         label="Threshold"
+                                        size="sm"
                                         {...form.getInputProps(
                                             `thresholds.0.value`,
                                         )}
+                                        onChange={(value) => {
+                                            form.setFieldValue(
+                                                'thresholds.0.value',
+                                                value || '',
+                                            );
+                                        }}
+                                        value={
+                                            form.values.thresholds?.[0]?.value
+                                        }
                                     />
                                 </Group>
                             </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8944 

### Description:

Allow using decimal values in alerts.

I tested this a few ways and it all seems to work. There is one oddity with this component that 1.5 gets saved as 1,5 regardless of the system number format. We should fix that in the component, not here. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
