### PR TITLE
feat: automatically assign individual reviewer from team assignment

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -11,7 +11,103 @@ jobs:
             - uses: actions/github-script@v7
               env:
                   SHA: '${{env.parentSHA}}'
+                  # Comma-separated list of team slugs to consider for auto-assignment
+                  TEAM_SLUGS: 'engineering'
+                  # Comma-separated list of user logins that always skip assignment
+                  SKIPPED_LOGINS: ''
               with:
                   script: |
-                      const reviewer = context.requested_reviewer;
-                      console.log(JSON.stringify(context, null, 2))
+                      const existingReviewers = context.requested_reviewers;
+                      const teams = context.requested_teams;
+                      const prNumber = context.number;
+
+                      // Team slugs for which this auto-assignment will be triggered:
+                      const teamSlugs = (process.env.TEAM_SLUGS ?? "").split(",");
+
+                      // User logins which will never be auto-assigned:
+                      const skippedLogins = (process.env.SKIPPED_LOGINS ?? "").split(",");
+
+                      // No action taken if there's already a reviewer, if the request review is for more than a
+                      // single team, or if the selected team doesn't match one of the valid team slugs:
+                      if (
+                        existingReviewers.length > 0 ||
+                        teams.length !== 1 ||
+                        !teamSlugs.includes(teams[0].slug)
+                      ) {
+                        console.log(
+                          `Skipping - more than one team assigned, already have a reviewer, or not one of ${teamSlugs}`
+                        );
+                        return;
+                      }
+
+                      const {
+                        organization: { login: repoOwner },
+                        pull_request: {
+                          base: {
+                            repo: { name: repoName },
+                          },
+                        },
+                      } = context;
+
+                      const { slug } = teams[0];
+
+                      const teamMembers = await github.rest.teams.listMembersInOrg({
+                        org: repoOwner,
+                        team_slug: slug,
+                        per_page: 100,
+                      });
+
+                      // Get a set of recent pull requests and look at assignments:
+                      const lookback = await github.rest.pulls.list({
+                        state: "all",
+                        owner: repoOwner,
+                        repo: repoName,
+                        per_page: 20,
+                      });
+
+                      // Count how many times we've seen each reviewer over a period, starting
+                      // with a list of all known users for this team sitting at 0 recent reviews:
+                      const reviewerTotals = lookback.reduce((acc, pr) => {
+                        pr.requested_reviewers.map((reviewer) => {
+                          const currentTotal = acc[reviewer.login] ?? 0;
+                          acc[reviewer.login] = currentTotal + 1;
+                        });
+
+                        return acc;
+                      }, Object.fromEntries(teamMembers.map((member) => [member.login, 0])));
+
+                      // Sort from least to most busy, extract just the user logins, and filter out
+                      // any skipped users:
+                      const sortedReviewers = Object.entries(reviewerTotals)
+                        .sort((a, b) => a[1] - b[1])
+                        .map((reviewer) => reviewer[0])
+                        .filter((reviewerLogin) => !skippedLogins.includes(reviewerLogin));
+
+                      // Finally, if we have someone to pick, get the person right at the top of the list,
+                      // and assign them as reviewer. We also remove the team assignment.
+                      if (sortedReviewers.length > 0) {
+                        const assignedLogin = sortedReviewers[0];
+
+                        console.log(
+                          `Assigning reviewer. Picked: ${assignedLogin} from (${sortedReviewers.join(
+                            ", "
+                          )}), low to high`
+                        );
+
+                        // Remove the team assignment:
+                        await github.rest.pulls.removeRequestedReviewers({
+                          owner: repoOwner,
+                          repo: repoName,
+                          pull_number: prNumber,
+                          team_reviewers: [slug],
+                          reviewers: [],
+                        });
+
+                        // Assign the new reviewer:
+                        await github.rest.pulls.requestReviewers({
+                          owner: repoOwner,
+                          repo: repoName,
+                          pull_number: prNumber,
+                          reviewers: [assignedLogin],
+                        });
+                      }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,18 @@
+name: Round-robin assign reviewer
+on:
+    pull_request:
+        types:
+            - review_requested
+jobs:
+    assign-reviewer:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/github-script@v7
+              env:
+                  SHA: '${{env.parentSHA}}'
+              with:
+                  script: |
+                      const reviewer = context.requested_reviewer;
+
+                      console.log(reviewer)

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -27,6 +27,8 @@ jobs:
                       // User logins which will never be auto-assigned:
                       const skippedLogins = (process.env.SKIPPED_LOGINS ?? "").split(",");
 
+                      console.log(JSON.stringify(context, null, 2), existingReviewers, teams, teamSlugs);
+
                       // No action taken if there's already a reviewer, if the request review is for more than a
                       // single team, or if the selected team doesn't match one of the valid team slugs:
                       if (
@@ -82,6 +84,8 @@ jobs:
                         .sort((a, b) => a[1] - b[1])
                         .map((reviewer) => reviewer[0])
                         .filter((reviewerLogin) => !skippedLogins.includes(reviewerLogin));
+
+                      console.log('sorted reviewers', sortedReviewers);
 
                       // Finally, if we have someone to pick, get the person right at the top of the list,
                       // and assign them as reviewer. We also remove the team assignment.

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -52,6 +52,14 @@ jobs:
                         return;
                       }
 
+                      const oneDay = 24 * 60 * 60 * 1000;
+                      const daysBetweenTwoDates = (date1, date2) => {
+                        const firstDate = new Date(date1);
+                        const secondDate = new Date(date2);
+
+                        return Math.round(Math.abs((firstDate - secondDate) / oneDay));
+                      };
+
                       const {
                         organization: { login: repoOwner },
                         pull_request: {
@@ -87,6 +95,31 @@ jobs:
 
                         return acc;
                       }, Object.fromEntries(teamMembers.map((member) => [member.login, 0])));
+
+                      // Factor in review recency into the totals, ensuring users with recent
+                      // reviews get weighted less strongly.
+                      const now = new Date();
+                      const reviewerTotalsWithRecencyBias = Object.keys(reviewerTotals).reduce(
+                        (acc, reviewerLogin) => {
+                          const lastReviewDate = new Date(
+                            Math.max(
+                              ...lookback
+                                .filter((lookbackPr) =>
+                                  lookbackPr.requested_reviewers.some(
+                                    (r) => r.login === reviewerLogin
+                                  )
+                                )
+                                .map((lookbackPr) => new Date(lookbackPr.created_at))
+                            )
+                          );
+
+                          const daysSinceLastReview = daysBetweenTwoDates(lastReviewDate, now);
+
+                          acc[reviewerLogin] /= daysSinceLastReview + 1;
+                          return acc;
+                        },
+                        reviewerTotals
+                      );
 
                       // Sort from least to most busy, extract just the user logins, and filter out
                       // any skipped users:

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -98,10 +98,7 @@ jobs:
                       // Finally, if we have someone to pick, get the person right at the top of the list,
                       // and assign them as reviewer. We also remove the team assignment.
                       if (sortedReviewers.length > 0) {
-                        // Pick up to 3 of the users at the bottom of the list, and from that pick
-                        // a random option:
-                        const candidates = sortedReviewers.slice(0, 3);
-                        const assignedLogin = candidates[Math.floor(Math.random() * candidates.length)];
+                        const assignedLogin = sortedReviewers[0];
 
                         console.log(
                           `Assigning reviewer. Picked: ${assignedLogin} from (${sortedReviewers.join(

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -98,7 +98,10 @@ jobs:
                       // Finally, if we have someone to pick, get the person right at the top of the list,
                       // and assign them as reviewer. We also remove the team assignment.
                       if (sortedReviewers.length > 0) {
-                        const assignedLogin = sortedReviewers[0];
+                        // Pick up to 3 of the users at the bottom of the list, and from that pick
+                        // a random option:
+                        const candidates = sortedReviewers.slice(0, 3);
+                        const assignedLogin = candidates[Math.floor(Math.random() * candidates.length)];
 
                         console.log(
                           `Assigning reviewer. Picked: ${assignedLogin} from (${sortedReviewers.join(

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -17,8 +17,9 @@ jobs:
                   SKIPPED_LOGINS: ''
               with:
                   script: |
-                      const existingReviewers = context.requested_reviewers;
-                      const teams = context.requested_teams;
+                      const pr = context.pull_request;
+                      const existingReviewers = pr.requested_reviewers;
+                      const teams = pr.requested_teams;
                       const prNumber = context.number;
 
                       // Team slugs for which this auto-assignment will be triggered:

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -15,12 +15,23 @@ jobs:
                   TEAM_SLUGS: 'engineering'
                   # Comma-separated list of user logins that always skip assignment
                   SKIPPED_LOGINS: ''
+                  # Comma-separated list of user logins that will not trigger this action by assigning a team
+                  IGNORE_ACTORS: ''
               with:
                   script: |
                       const pr = context.payload.pull_request;
                       const existingReviewers = pr.requested_reviewers;
                       const teams = pr.requested_teams;
                       const prNumber = context.payload.number;
+                      const actorLogin = context.payload.actor;
+
+                      // Users in this list assigning a reviewer do not trigger this behavior:
+                      const ignoredActors = (process.env.IGNORE_ACTORS ?? "").split(",");
+
+                      if (ignoredActors.includes(actorLogin)) {
+                        console.log(`Skipping: ${actorLogin} is in ignored actors list.`);
+                        return;
+                      }
 
                       // Team slugs for which this auto-assignment will be triggered:
                       const teamSlugs = (process.env.TEAM_SLUGS ?? "").split(",");

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -14,5 +14,4 @@ jobs:
               with:
                   script: |
                       const reviewer = context.requested_reviewer;
-
-                      console.log(reviewer)
+                      console.log(JSON.stringify(context, null, 2))

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -17,18 +17,16 @@ jobs:
                   SKIPPED_LOGINS: ''
               with:
                   script: |
-                      const pr = context.pull_request;
+                      const pr = context.payload.pull_request;
                       const existingReviewers = pr.requested_reviewers;
                       const teams = pr.requested_teams;
-                      const prNumber = context.number;
+                      const prNumber = context.payload.number;
 
                       // Team slugs for which this auto-assignment will be triggered:
                       const teamSlugs = (process.env.TEAM_SLUGS ?? "").split(",");
 
                       // User logins which will never be auto-assigned:
                       const skippedLogins = (process.env.SKIPPED_LOGINS ?? "").split(",");
-
-                      console.log(JSON.stringify(context, null, 2), existingReviewers, teams, teamSlugs);
 
                       // No action taken if there's already a reviewer, if the request review is for more than a
                       // single team, or if the selected team doesn't match one of the valid team slugs:
@@ -50,7 +48,7 @@ jobs:
                             repo: { name: repoName },
                           },
                         },
-                      } = context;
+                      } = context.payload;
 
                       const { slug } = teams[0];
 
@@ -85,8 +83,6 @@ jobs:
                         .sort((a, b) => a[1] - b[1])
                         .map((reviewer) => reviewer[0])
                         .filter((reviewerLogin) => !skippedLogins.includes(reviewerLogin));
-
-                      console.log('sorted reviewers', sortedReviewers);
 
                       // Finally, if we have someone to pick, get the person right at the top of the list,
                       // and assign them as reviewer. We also remove the team assignment.


### PR DESCRIPTION
### Description:

- Assigning a team as a reviewer, for specific teams, automatically changes the assignment to an individual team member (e.g assigning 'Engineering' picks out a person from that team)
- Looks at history of recent open and closed PRs, and sorts reviewers based on activity
- Picks out engineers with the least recent reviews, weighted based on amount + recency
- Ignores assignments if individual engineers are already assigned, more than one team is assigned, or the team is not part of a list
- Supports skipping individuals (e.g if out on vacation); currently by editing a skip var.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
