### PR TITLE
fix: hide dbt metric button

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -94,7 +94,7 @@ export class GitIntegrationService {
             );
         // todo: check if installation has access to the project repository
         return {
-            enabled: true,
+            enabled: !!installationId,
         };
     }
 


### PR DESCRIPTION
### Description:

Hide the add custom metric to project button. I did this the quick way but commenting out the UI for now. We should put it behind a feature flag

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
