### PR TITLE
chore: add duplicate-external-PR GH action

### DIFF
--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -60,4 +60,4 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git checkout -b duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
                   git push origin duplicate-${{env.ISSUE_NUMBER}}
-                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}} --title "${{env.PR_TITLE}}" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}
+                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}} --title "chore: ${{env.ISSUE_NUMBER}} [DUPLICATE]" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -15,7 +15,7 @@ jobs:
                   organization: lightdash
                   team: engineering
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Stop workflow if user is no member
+            - name: Stop workflow if user isn't a member
               if: steps.check-user-for-team-affiliation.outputs.isTeamMember == 'false'
               run: |
                   echo "You have no rights to trigger this job."
@@ -24,7 +24,31 @@ jobs:
               uses: actions/checkout@v2
               with:
                   ref: ${{ github.event.issue.pull_request.head.ref }}
-            - name: Duplicate external PR
+            - name: Check if duplicate branch exists
+              id: check-branch
+              env:
+                  ISSUE_NUMBER: ${{ github.event.issue.number }}
+              run: |
+                  if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}} | grep duplicate-${{env.ISSUE_NUMBER}}; then
+                      echo "Branch exists."
+                      echo "::set-output name=branch_exists::true"
+                  else
+                      echo "Branch does not exist."
+                      echo "::set-output name=branch_exists::false"
+                  fi
+            - name: Update existing branch
+              if: steps.check_branch.outputs.branch_exists == 'true'
+              env:
+                  ISSUE_NUMBER: ${{ github.event.issue.number }}
+                  REF: ${{ github.event.issue.pull_request.head.ref }}
+              run: |
+                  git fetch origin duplicate-${{env.ISSUE_NUMBER}}
+                  git checkout duplicate-${{env.ISSUE_NUMBER}}
+                  git pull origin ${{env.REF}} --rebase
+                  git push origin duplicate-${{env.ISSUE_NUMBER}}
+              continue-on-error: true
+            - name: Create new branch and PR
+              if: steps.check_branch.outputs.branch_exists == 'false'
               env:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   PR_TITLE: ${{ github.event.issue.title }}
@@ -34,6 +58,6 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git checkout -b duplicate-${{ env.ISSUE_NUMBER }} ${{ env.REF }}
-                  git push origin duplicate-${{ env.ISSUE_NUMBER }}
-                  gh pr create --base ${{ env.DEFAULT_BRANCH }} --head duplicate-${{ env.ISSUE_NUMBER }} --title "$PR_TITLE" --body "This is a duplicated PR for running E2E tests." --assignee ${{ env.ASSIGNEE }}
+                  git checkout -b duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
+                  git push origin duplicate-${{env.ISSUE_NUMBER}}
+                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}} --title "${{env.PR_TITLE}}" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -28,12 +28,13 @@ jobs:
               id: check-branch
               env:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
+                  REF: ${{ github.event.issue.pull_request.head.ref }}
               run: |
-                  if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}} | grep duplicate-${{env.ISSUE_NUMBER}}; then
-                      echo "Branch exists."
+                  if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}} | grep duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}; then
+                      echo "Branch already exists."
                       echo "::set-output name=branch_exists::true"
                   else
-                      echo "Branch does not exist."
+                      echo "Branch does not exist yet"
                       echo "::set-output name=branch_exists::false"
                   fi
             - name: Update existing branch
@@ -60,4 +61,4 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git checkout -b duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
                   git push origin duplicate-${{env.ISSUE_NUMBER}}
-                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}} --title "chore: ${{env.ISSUE_NUMBER}} [DUPLICATE]" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}
+                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}}${{env.REF}} --title "chore: ${{env.ISSUE_NUMBER}} [DUPLICATE]" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -42,10 +42,10 @@ jobs:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   REF: ${{ github.event.issue.pull_request.head.ref }}
               run: |
-                  git fetch origin duplicate-${{env.ISSUE_NUMBER}}
-                  git checkout duplicate-${{env.ISSUE_NUMBER}}
+                  git fetch origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
+                  git checkout duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
                   git pull origin ${{env.REF}} --rebase
-                  git push origin duplicate-${{env.ISSUE_NUMBER}}
+                  git push origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
               continue-on-error: true
             - name: Create new branch and PR
               if: steps.check_branch.outputs.branch_exists == 'false'

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -24,15 +24,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   ref: ${{ github.event.issue.pull_request.head.ref }}
-            - name: Set PR title to environment variable
-              run: |
-                  echo "PR_TITLE<<EOF" >> $GITHUB_ENV
-                  echo "${{ github.event.issue.title }}" >> $GITHUB_ENV
-                  echo "EOF" >> $GITHUB_ENV
             - name: Duplicate external PR
+              env:
+                  ISSUE_NUMBER: ${{ github.event.issue.number }}
+                  PR_TITLE: ${{ github.event.issue.title }}
+                  REF: ${{ github.event.issue.pull_request.head.ref }}
+                  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+                  ASSIGNEE: ${{ github.event.comment.user.login }}
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git checkout -b duplicate-${{ github.event.issue.number }} ${{ github.event.issue.pull_request.head.ref }}
-                  git push origin duplicate-${{ github.event.issue.number }}
-                  gh pr create --base ${{ github.event.repository.default_branch }} --head duplicate-${{ github.event.issue.number }} --title "$PR_TITLE" --body "This is a duplicated PR for running E2E tests." --assignee ${{ github.event.comment.user.login }}
+                  git checkout -b duplicate-${{ env.ISSUE_NUMBER }} ${{ env.REF }}
+                  git push origin duplicate-${{ env.ISSUE_NUMBER }}
+                  gh pr create --base ${{ env.DEFAULT_BRANCH }} --head duplicate-${{ env.ISSUE_NUMBER }} --title "$PR_TITLE" --body "This is a duplicated PR for running E2E tests." --assignee ${{ env.ASSIGNEE }}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -32,10 +32,10 @@ jobs:
               run: |
                   if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}} ${{env.REF}} | grep duplicate-${{env.ISSUE_NUMBER}}; then
                       echo "Branch already exists."
-                      echo "::set-output name=branch_exists::true"
+                      echo "branch_exists=true" >> $GITHUB_ENV
                   else
                       echo "Branch does not exist yet"
-                      echo "::set-output name=branch_exists::false"
+                      echo "branch_exists=false" >> $GITHUB_ENV
                   fi
             - name: Update existing branch
               if: steps.check-branch.outputs.branch_exists == 'true'

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -1,0 +1,33 @@
+name: Duplicate External PR and Run E2E Tests
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  duplicate-and-test:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/duplicate-external-pr')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check user for team affiliation
+      id: check-user-for-team-affiliation
+      uses: tspascoal/get-user-teams-membership@v3
+      with:
+        username: ${{ github.event.comment.user.login }}
+        organization: lightdash
+        team: engineering
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Stop workflow if user is no member
+      if: steps.check-user-for-team-affiliation.outputs.isTeamMember == 'false'
+      run: |
+          echo "You have no rights to trigger this job."
+          exit 1
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.issue.pull_request.head.ref }}
+    - name: Duplicate external PR
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -b duplicate-${{ github.event.issue.number }} ${{ github.event.issue.pull_request.head.ref }}
+        git push origin duplicate-${{ github.event.issue.number }}
+        gh pr create --base ${{ github.event.repository.default_branch }} --head duplicate-${{ github.event.issue.number }} --title "[Duplicate] ${{ github.event.issue.title }}" --body "This is a duplicated PR for running E2E tests." --assignee ${{ github.event.comment.user.login }}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -30,7 +30,7 @@ jobs:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   REF: ${{ github.event.issue.pull_request.head.ref }}
               run: |
-                  if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}} | grep duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}; then
+                  if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}} ${{env.REF}} | grep duplicate-${{env.ISSUE_NUMBER}}; then
                       echo "Branch already exists."
                       echo "::set-output name=branch_exists::true"
                   else
@@ -43,10 +43,10 @@ jobs:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   REF: ${{ github.event.issue.pull_request.head.ref }}
               run: |
-                  git fetch origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
-                  git checkout duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
+                  git fetch origin duplicate-${{env.ISSUE_NUMBER}}
+                  git checkout duplicate-${{env.ISSUE_NUMBER}}
                   git pull origin ${{env.REF}} --rebase
-                  git push origin duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
+                  git push origin duplicate-${{env.ISSUE_NUMBER}}
               continue-on-error: true
             - name: Create new branch and PR
               if: steps.check_branch.outputs.branch_exists == 'false'
@@ -59,6 +59,6 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git checkout -b duplicate-${{env.ISSUE_NUMBER}}${{env.REF}}
+                  git checkout -b duplicate-${{env.ISSUE_NUMBER}} ${{env.REF}}
                   git push origin duplicate-${{env.ISSUE_NUMBER}}
-                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}}${{env.REF}} --title "chore: ${{env.ISSUE_NUMBER}} [DUPLICATE]" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}
+                  gh pr create --base ${{env.DEFAULT_BRANCH}} --head duplicate-${{env.ISSUE_NUMBER}} --title "chore: ${{env.ISSUE_NUMBER}} [DUPLICATE]" --body "This is a duplicated PR for running E2E tests." --assignee ${{env.ASSIGNEE}}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -38,7 +38,7 @@ jobs:
                       echo "::set-output name=branch_exists::false"
                   fi
             - name: Update existing branch
-              if: steps.check_branch.outputs.branch_exists == 'true'
+              if: steps.check-branch.outputs.branch_exists == 'true'
               env:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   REF: ${{ github.event.issue.pull_request.head.ref }}
@@ -49,7 +49,7 @@ jobs:
                   git push origin duplicate-${{env.ISSUE_NUMBER}}
               continue-on-error: true
             - name: Create new branch and PR
-              if: steps.check_branch.outputs.branch_exists == 'false'
+              if: steps.check-branch.outputs.branch_exists == 'false'
               env:
                   ISSUE_NUMBER: ${{ github.event.issue.number }}
                   PR_TITLE: ${{ github.event.issue.title }}

--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -1,33 +1,38 @@
 name: Duplicate External PR and Run E2E Tests
 on:
-  issue_comment:
-    types: [created]
+    issue_comment:
+        types: [created]
 jobs:
-  duplicate-and-test:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/duplicate-external-pr')
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check user for team affiliation
-      id: check-user-for-team-affiliation
-      uses: tspascoal/get-user-teams-membership@v3
-      with:
-        username: ${{ github.event.comment.user.login }}
-        organization: lightdash
-        team: engineering
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Stop workflow if user is no member
-      if: steps.check-user-for-team-affiliation.outputs.isTeamMember == 'false'
-      run: |
-          echo "You have no rights to trigger this job."
-          exit 1
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.issue.pull_request.head.ref }}
-    - name: Duplicate external PR
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git checkout -b duplicate-${{ github.event.issue.number }} ${{ github.event.issue.pull_request.head.ref }}
-        git push origin duplicate-${{ github.event.issue.number }}
-        gh pr create --base ${{ github.event.repository.default_branch }} --head duplicate-${{ github.event.issue.number }} --title "[Duplicate] ${{ github.event.issue.title }}" --body "This is a duplicated PR for running E2E tests." --assignee ${{ github.event.comment.user.login }}
+    duplicate-and-test:
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '/duplicate-external-pr')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check user for team affiliation
+              id: check-user-for-team-affiliation
+              uses: tspascoal/get-user-teams-membership@v3
+              with:
+                  username: ${{ github.event.comment.user.login }}
+                  organization: lightdash
+                  team: engineering
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Stop workflow if user is no member
+              if: steps.check-user-for-team-affiliation.outputs.isTeamMember == 'false'
+              run: |
+                  echo "You have no rights to trigger this job."
+                  exit 1
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event.issue.pull_request.head.ref }}
+            - name: Set PR title to environment variable
+              run: |
+                  echo "PR_TITLE<<EOF" >> $GITHUB_ENV
+                  echo "${{ github.event.issue.title }}" >> $GITHUB_ENV
+                  echo "EOF" >> $GITHUB_ENV
+            - name: Duplicate external PR
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git checkout -b duplicate-${{ github.event.issue.number }} ${{ github.event.issue.pull_request.head.ref }}
+                  git push origin duplicate-${{ github.event.issue.number }}
+                  gh pr create --base ${{ github.event.repository.default_branch }} --head duplicate-${{ github.event.issue.number }} --title "$PR_TITLE" --body "This is a duplicated PR for running E2E tests." --assignee ${{ github.event.comment.user.login }}


### PR DESCRIPTION
### Description:

Adds `Duplicate External PR` by commenting on PR with `/duplicate-external-pr`

Before doing so, it checks if user belongs to `lightdash/engineering` team

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
