### PR TITLE
feat: Do not apply shared colors to non-group series

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -24,6 +24,7 @@ import {
 import { CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { EChartSeries } from '../../hooks/echarts/useEchartsCartesianConfig';
 import {
+    isGroupedSeries,
     SeriesLike,
     useChartColorConfig,
 } from '../../hooks/useChartColorConfig';
@@ -235,7 +236,13 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
         (seriesLike: SeriesLike, seriesIndex: number) => {
             if (seriesLike.color) return seriesLike.color;
 
-            return useSharedColors
+            /**
+             * If shared colors are enabled AND this series is grouped, figure out a shared
+             * color assignment from the series.
+             *
+             * Otherwise, use the default behavior of picking a series color from the palette.
+             */
+            return useSharedColors && isGroupedSeries(seriesLike)
                 ? calculateSeriesColorAssignment(seriesLike)
                 : colorPalette[seriesIndex % colorPalette.length] ??
                       getDefaultSeriesColor(seriesIndex);

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { ECHARTS_DEFAULT_COLORS } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -47,15 +48,8 @@ const defaultColorPalettes: ColorPalette[] = [
         name: 'Default Colors',
         icon: IconColorFilter,
         colors: [
-            '#ff5733',
-            '#ff8933',
-            '#ffbd33',
-            '#ffe133',
-            '#e8ff33',
-            '#b4ff33',
-            '#80ff33',
-            '#4cff33',
-            '#33ff49',
+            // Use the initial 9 colors directly from ECHARTS to keep them in sync:
+            ...ECHARTS_DEFAULT_COLORS,
             '#33ff7d',
             '#33ffb1',
             '#33ffe6',

--- a/packages/frontend/src/hooks/useChartColorConfig.ts
+++ b/packages/frontend/src/hooks/useChartColorConfig.ts
@@ -5,6 +5,13 @@ import { EChartSeries } from './echarts/useEchartsCartesianConfig';
 
 export type SeriesLike = EChartSeries | Series;
 
+export const isGroupedSeries = (series: SeriesLike) => {
+    return (
+        (series as EChartSeries)?.pivotReference?.pivotValues != null ||
+        (series as Series)?.encode.yRef.pivotValues != null
+    );
+};
+
 export const useChartColorConfig = ({
     colorPalette,
 }: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8978 

### Description:

Skips the shared color assignment logic for non-group series, instead using the default behavior that applies color from the palette in order.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
