### PR TITLE
fix: require threshold field in alerts

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -440,14 +440,8 @@ const SchedulerForm: FC<Props> = ({
                         {isThresholdAlert && (
                             <Stack spacing="xs">
                                 <FieldSelect
-                                    label={
-                                        <Text>
-                                            Alert field{' '}
-                                            <Text color="red" span>
-                                                *
-                                            </Text>{' '}
-                                        </Text>
-                                    }
+                                    label="Alert field"
+                                    required
                                     disabled={isThresholdAlertWithNoFields}
                                     withinPortal
                                     hasGrouping
@@ -487,7 +481,6 @@ const SchedulerForm: FC<Props> = ({
                                 )}
                                 <Group noWrap grow>
                                     <Select
-                                        required
                                         label="Condition"
                                         data={thresholdOperatorOptions}
                                         {...form.getInputProps(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8945 

### Description:

This just makes the field for alerting required. I thought there would be other validation that made sense, but I think this is sufficient for now. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
