### PR TITLE
feat: add entity type filter backend for global search

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -54,10 +54,12 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
+            const { type } = req.query;
             const results = await searchService.getSearchResults(
                 req.user!,
                 req.params.projectUuid,
                 req.params.query,
+                { type: type?.toString() },
             );
             res.json({ status: 'ok', results });
         } catch (e) {

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -5,6 +5,7 @@ import {
     ForbiddenError,
     isTableErrorSearchResult,
     SavedChartSearchResult,
+    SearchFilters,
     SearchResults,
     SessionUser,
     SpaceSearchResult,
@@ -46,6 +47,7 @@ export class SearchService {
         user: SessionUser,
         projectUuid: string,
         query: string,
+        filters: SearchFilters,
     ): Promise<SearchResults> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -62,7 +64,13 @@ export class SearchService {
         ) {
             throw new ForbiddenError();
         }
-        const results = await this.searchModel.search(projectUuid, query);
+
+        const results = await this.searchModel.search(
+            projectUuid,
+            query,
+            filters,
+        );
+
         const spaceUuids = [
             ...new Set([
                 ...results.dashboards.map((dashboard) => dashboard.spaceUuid),

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -47,7 +47,7 @@ export class SearchService {
         user: SessionUser,
         projectUuid: string,
         query: string,
-        filters: SearchFilters,
+        filters?: SearchFilters,
     ): Promise<SearchResults> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -119,3 +119,8 @@ export const getSearchResultId = (meta: SearchResult | undefined) => {
     }
     return meta.uuid;
 };
+
+export type EntityType = 'dashboards' | 'charts' | 'spaces' | 'explores';
+export interface SearchFilters {
+    type?: string; // the type filter can be any string, but it should be one of the EntityType to be valid, see shouldSearchForType function
+}

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -120,7 +120,7 @@ export const getSearchResultId = (meta: SearchResult | undefined) => {
     return meta.uuid;
 };
 
-export type EntityType = 'dashboards' | 'charts' | 'spaces' | 'explores';
+export type EntityType = 'dashboards' | 'charts' | 'spaces' | 'tables_fields';
 export interface SearchFilters {
     type?: string; // the type filter can be any string, but it should be one of the EntityType to be valid, see shouldSearchForType function
 }

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -120,7 +120,12 @@ export const getSearchResultId = (meta: SearchResult | undefined) => {
     return meta.uuid;
 };
 
-export type EntityType = 'dashboards' | 'charts' | 'spaces' | 'tables_fields';
+export type EntityType =
+    | 'dashboards'
+    | 'charts'
+    | 'spaces'
+    | 'tables'
+    | 'fields';
 export interface SearchFilters {
     type?: string; // the type filter can be any string, but it should be one of the EntityType to be valid, see shouldSearchForType function
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #5266 

### Description:

- Adds backend to allow for entity type filter in global search. The types supported are:
    - charts
    - dashboards
    - tables
    - fields
    - spaces

Examples:

- search for `jaffle`

- with no filter: `http://localhost:3000/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/search/jaffle`

```json
{"status":"ok","results":{"spaces":[{"uuid":"156de9a5-9db6-4c71-8bf2-aa7fe981cfeb","name":"Jaffle shop","search_rank":0.6079271}],"dashboards":[{"uuid":"fb03a6dd-66b2-4445-9d4e-a4b4f039259e","name":"Jaffle dashboard","description":null,"spaceUuid":"156de9a5-9db6-4c71-8bf2-aa7fe981cfeb","search_rank":0.6079271,"validationErrors":[]}],"savedCharts":[],"tables":[],"fields":[],"pages":[]}}
```

- with type dashboards filter: `http://localhost:3000/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/search/jaffle?type=dashboards`

```json
{"status":"ok","results":{"spaces":[],"dashboards":[{"uuid":"fb03a6dd-66b2-4445-9d4e-a4b4f039259e","name":"Jaffle dashboard","description":null,"spaceUuid":"156de9a5-9db6-4c71-8bf2-aa7fe981cfeb","search_rank":0.6079271,"validationErrors":[]}],"savedCharts":[],"tables":[],"fields":[],"pages":[]}}
```

- with type spaces filter: `http://localhost:3000/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/search/jaffle?type=spaces`

```json
{"status":"ok","results":{"spaces":[{"uuid":"156de9a5-9db6-4c71-8bf2-aa7fe981cfeb","name":"Jaffle shop","search_rank":0.6079271}],"dashboards":[],"savedCharts":[],"tables":[],"fields":[],"pages":[]}}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
