### PR TITLE
fix: support model alias

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/customers.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/customers.sql
@@ -1,3 +1,5 @@
+{{ config(alias='customers_alias') }}
+
 with customers as (
 
     select * from {{ ref('stg_customers') }}

--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -1,6 +1,8 @@
 version: 2
 models:
   - name: customers
+    config:
+      alias: customers_alias
     meta:
       joins:
         - join: membership

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -199,7 +199,7 @@ const COLUMN_WITH_CUSTOM_TIME_INTERVALS: Record<string, DbtModelColumn> = {
 };
 
 export const model: DbtModelNode & { relation_name: string } = {
-    alias: '',
+    alias: 'myTable',
     checksum: { name: '', checksum: '' },
     fqn: [],
     language: '',

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -620,9 +620,10 @@ export const attachTypesToModels = (
     });
 
     const getType = (
-        { database, schema, alias }: DbtModelNode,
+        { database, schema, name, alias }: DbtModelNode,
         columnName: string,
     ): DimensionType | undefined => {
+        const tableName = alias || name;
         const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
             caseSensitiveMatching
                 ? db === database
@@ -641,8 +642,8 @@ export const attachTypesToModels = (
             Object.keys(warehouseCatalog[databaseMatch][schemaMatch]).find(
                 (t) =>
                     caseSensitiveMatching
-                        ? t === alias
-                        : t.toLowerCase() === alias.toLowerCase(),
+                        ? t === tableName
+                        : t.toLowerCase() === tableName.toLowerCase(),
             );
         const columnMatch =
             databaseMatch &&
@@ -662,7 +663,7 @@ export const attachTypesToModels = (
         }
         if (throwOnMissingCatalogEntry) {
             throw new MissingCatalogEntryError(
-                `Column "${columnName}" from model "${alias}" does not exist.\n "${alias}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${alias}. Try rerunning dbt to update your warehouse.`,
+                `Column "${columnName}" from model "${tableName}" does not exist.\n "${tableName}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${tableName}. Try rerunning dbt to update your warehouse.`,
                 {},
             );
         }
@@ -684,8 +685,8 @@ export const attachTypesToModels = (
 export const getSchemaStructureFromDbtModels = (
     dbtModels: DbtModelNode[],
 ): { database: string; schema: string; table: string }[] =>
-    dbtModels.map(({ database, schema, alias }) => ({
+    dbtModels.map(({ database, schema, name, alias }) => ({
         database,
         schema,
-        table: alias,
+        table: alias || name,
     }));

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -620,7 +620,7 @@ export const attachTypesToModels = (
     });
 
     const getType = (
-        { database, schema, name }: DbtModelNode,
+        { database, schema, alias }: DbtModelNode,
         columnName: string,
     ): DimensionType | undefined => {
         const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
@@ -641,8 +641,8 @@ export const attachTypesToModels = (
             Object.keys(warehouseCatalog[databaseMatch][schemaMatch]).find(
                 (t) =>
                     caseSensitiveMatching
-                        ? t === name
-                        : t.toLowerCase() === name.toLowerCase(),
+                        ? t === alias
+                        : t.toLowerCase() === alias.toLowerCase(),
             );
         const columnMatch =
             databaseMatch &&
@@ -662,7 +662,7 @@ export const attachTypesToModels = (
         }
         if (throwOnMissingCatalogEntry) {
             throw new MissingCatalogEntryError(
-                `Column "${columnName}" from model "${name}" does not exist.\n "${name}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${name}. Try rerunning dbt to update your warehouse.`,
+                `Column "${columnName}" from model "${alias}" does not exist.\n "${alias}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${alias}. Try rerunning dbt to update your warehouse.`,
                 {},
             );
         }
@@ -684,8 +684,8 @@ export const attachTypesToModels = (
 export const getSchemaStructureFromDbtModels = (
     dbtModels: DbtModelNode[],
 ): { database: string; schema: string; table: string }[] =>
-    dbtModels.map(({ database, schema, name }) => ({
+    dbtModels.map(({ database, schema, alias }) => ({
         database,
         schema,
-        table: name,
+        table: alias,
     }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8963<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

dbt models have the table name under `alias` property. This property is also populated when the developer didn't set a alias in the yml.


Before: all dimensions are marked as strings

<img width="1292" alt="Screenshot 2024-02-19 at 14 35 09" src="https://github.com/lightdash/lightdash/assets/9117144/135efdb9-9567-46bc-ab89-6b78c5e29d20">

After: dimensions have correct type

<img width="1292" alt="Screenshot 2024-02-19 at 14 28 43" src="https://github.com/lightdash/lightdash/assets/9117144/b7ecdfdf-631d-4630-a3a7-2ea254d00c00">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
