### PR TITLE
fix: change name to 'Alerts' in chart context menus

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -777,7 +777,7 @@ const SavedChartsHeader: FC = () => {
                                                 toggleThresholdAlertsModal(true)
                                             }
                                         >
-                                            Threshold alerts
+                                            Alerts
                                         </Menu.Item>
                                     )}
                                 {userCanManageCharts &&

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -33,7 +33,7 @@ const SchedulersModal: FC<
                 isThresholdAlert ? (
                     <Group spacing="xs">
                         <MantineIcon icon={IconBell} size="lg" color="gray.7" />
-                        <Text fw={600}>Threshold alerts</Text>
+                        <Text fw={600}>Alerts</Text>
                     </Group>
                 ) : (
                     <Group spacing="xs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8980

### Description:
This PR changes name from `Threshold Alerts` to `Alerts` in Chart Context Menus and also for the Threshold Alert Modal as shown in the following screenshots.

Please let me know if there are any other changes to be made, I will be happy to make them as desired :)

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2024-02-20 05-06-13](https://github.com/lightdash/lightdash/assets/111004544/6fb8001d-f38f-4a4a-b520-5a8dec0d0cda)
![Screenshot from 2024-02-20 05-08-43](https://github.com/lightdash/lightdash/assets/111004544/7360e94b-dd71-4191-b82b-f7fece227571)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
