### PR TITLE
fix: use GITHUB_CI_TOKEN to check team in org

### DIFF
--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -14,7 +14,7 @@ jobs:
                   username: ${{ github.event.comment.user.login }}
                   organization: lightdash
                   team: engineering
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
             - name: Stop workflow if user isn't a member
               if: steps.check-user-for-team-affiliation.outputs.isTeamMember == 'false'
               run: |


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Utilises `GITHUB_CI_TOKEN` to check if user is part of lightdash engineering team

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
