### PR TITLE
fix: generate valid urls based on site url

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -477,7 +477,10 @@ export class CsvService {
             DownloadFileType.CSV,
         );
 
-        const localUrl = `${this.lightdashConfig.siteUrl}/api/v1/projects/${chart.projectUuid}/csv/${downloadFileId}`;
+        const localUrl = new URL(
+            `/api/v1/projects/${chart.projectUuid}/csv/${downloadFileId}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
         return {
             filename: `${chart.name}`,
             path: localUrl,
@@ -593,7 +596,10 @@ export class CsvService {
                     filePath,
                     DownloadFileType.CSV,
                 );
-                fileUrl = `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/csv/${downloadFileId}`;
+                fileUrl = new URL(
+                    `/api/v1/projects/${projectUuid}/csv/${downloadFileId}`,
+                    this.lightdashConfig.siteUrl,
+                ).href;
             }
 
             analytics.track({
@@ -771,8 +777,10 @@ export class CsvService {
                     filePath,
                     DownloadFileType.CSV,
                 );
-
-                fileUrl = `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/csv/${downloadFileId}`;
+                fileUrl = new URL(
+                    `/api/v1/projects/${projectUuid}/csv/${downloadFileId}`,
+                    this.lightdashConfig.siteUrl,
+                ).href;
             }
 
             analytics.track({

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -178,7 +178,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         const chartDetails = chart
             ? `
 Affected charts: 
-- [${chart.name}](${this.lightdashConfig.siteUrl}/projects/${projectUuid}/charts/${chart.uuid})
+- [${chart.name}](${
+                  new URL(
+                      `/projects/${projectUuid}/charts/${chart.uuid}`,
+                      this.lightdashConfig.siteUrl,
+                  ).href
+              })
         `
             : ``;
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -293,7 +293,10 @@ export class UnfurlService {
                     DownloadFileType.IMAGE,
                 );
 
-                imageUrl = `${this.lightdashConfig.siteUrl}/api/v1/slack/image/${downloadFileId}`;
+                imageUrl = new URL(
+                    `/api/v1/slack/image/${downloadFileId}`,
+                    this.lightdashConfig.siteUrl,
+                ).href;
             }
         }
 
@@ -311,7 +314,10 @@ export class UnfurlService {
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
             name: dashboard.name,
-            minimalUrl: `${this.lightdashConfig.siteUrl}/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}${queryFilters}`,
+            minimalUrl: new URL(
+                `/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}${queryFilters}`,
+                this.lightdashConfig.siteUrl,
+            ).href,
             pageType: LightdashPage.DASHBOARD,
         };
         if (
@@ -637,7 +643,10 @@ export class UnfurlService {
 
         const shareUrl = await this.shareModel.getSharedUrl(shareId);
 
-        const fullUrl = `${this.lightdashConfig.siteUrl}${shareUrl.path}${shareUrl.params}`;
+        const fullUrl = new URL(
+            `${shareUrl.path}${shareUrl.params}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
         Logger.debug(`Shared url ${shareId}: ${fullUrl}`);
 
         return fullUrl;
@@ -675,7 +684,10 @@ export class UnfurlService {
                 isValid: true,
                 lightdashPage: LightdashPage.CHART,
                 url,
-                minimalUrl: `${this.lightdashConfig.siteUrl}/minimal/projects/${projectUuid}/saved/${chartUuid}`,
+                minimalUrl: new URL(
+                    `/minimal/projects/${projectUuid}/saved/${chartUuid}`,
+                    this.lightdashConfig.siteUrl,
+                ).href,
                 projectUuid,
                 chartUuid,
             };
@@ -708,7 +720,10 @@ export class UnfurlService {
         const token = getAuthenticationToken(userUuid);
 
         const response = await fetch(
-            `${this.lightdashConfig.siteUrl}/api/v1/headless-browser/login/${userUuid}`,
+            new URL(
+                `/api/v1/headless-browser/login/${userUuid}`,
+                this.lightdashConfig.siteUrl,
+            ).href,
             {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ --

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

If the SITE_URL variable ends with a `/` we generate invalid URLs. Example:

> Cannot POST //api/v1/headless-browser/login/ff2a9f1d-08bd-49df-8ce5-540e8a06197f

Change updates all the cases where we were concatenating the SITE_URL to use [URL constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).

This should also fix any security issues related to path traversing. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
