### PR TITLE
chore: revert customers table alias

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/customers.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/customers.sql
@@ -1,4 +1,3 @@
-{{ config(alias='customers_alias') }}
 
 with customers as (
 

--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -1,8 +1,6 @@
 version: 2
 models:
   - name: customers
-    config:
-      alias: customers_alias
     meta:
       joins:
         - join: membership


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

E2E tests are failing because it expects a new table in the staging warehouses that doesn't exist. 
I reverted the jaffle project to not use the table alias anymore, restoring it as it was before.

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
