### PR TITLE
chore: change name of thresholdAlert to alert in code

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -711,7 +711,7 @@ export type SchedulerJobEvent = BaseTrack & {
         jobId: string;
         schedulerId: string | undefined;
         sendNow?: boolean;
-        isThresholdAlert?: boolean;
+        isAlert?: boolean;
     };
 };
 
@@ -730,7 +730,7 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
         format?: SchedulerFormat;
         withPdf?: boolean;
         sendNow: boolean;
-        isThresholdAlert?: boolean;
+        isAlert?: boolean;
     };
 };
 

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -1,8 +1,4 @@
-import {
-    friendlyName,
-    LightdashPage,
-    ThresholdOptions,
-} from '@lightdash/common';
+import { AlertOptions, friendlyName, LightdashPage } from '@lightdash/common';
 import { KnownBlock, LinkUnfurls, SectionBlock } from '@slack/bolt';
 import { Unfurl } from '../../services/UnfurlService/UnfurlService';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
@@ -183,7 +179,7 @@ export const getChartCsvResultsBlocks = ({
             : undefined,
     ]);
 
-type GetChartThresholdBlocksArgs = {
+type GetChartAlertBlocksArgs = {
     name: string;
 
     title: string;
@@ -192,28 +188,28 @@ type GetChartThresholdBlocksArgs = {
     ctaUrl: string;
     imageUrl?: string;
     footerMarkdown?: string;
-    thresholds: ThresholdOptions[];
+    alerts: AlertOptions[];
 };
-export const getChartThresholdAlertBlocks = ({
+export const getChartAlertBlocks = ({
     name,
     title,
     message,
     description,
     imageUrl,
     ctaUrl,
-    thresholds,
+    alerts,
     footerMarkdown,
-}: GetChartThresholdBlocksArgs): KnownBlock[] => {
-    // TODO only pass threshold conditions met
+}: GetChartAlertBlocksArgs): KnownBlock[] => {
+    // TODO only pass alert conditions met
     // TODO send field name from explore or results (instead of friendly name)
-    // TODO better threshold.operator namign (instead of friendly name)
-    const thresholdBlocks: KnownBlock[] = thresholds.map((threshold) => ({
+    // TODO better alert.operator naming (instead of friendly name)
+    const alertBlocks: KnownBlock[] = alerts.map((alert) => ({
         type: 'section',
         text: {
             type: 'mrkdwn',
-            text: `• \`${friendlyName(threshold.fieldId)}\` is *${friendlyName(
-                threshold.operator,
-            )}* \`${threshold.value}\` `,
+            text: `• \`${friendlyName(alert.fieldId)}\` is *${friendlyName(
+                alert.operator,
+            )}* \`${alert.value}\` `,
         },
     }));
     return getBlocks([
@@ -251,7 +247,7 @@ export const getChartThresholdAlertBlocks = ({
                 action_id: 'button-action',
             },
         },
-        ...thresholdBlocks,
+        ...alertBlocks,
         imageUrl
             ? {
                   type: 'image',

--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -27,7 +27,7 @@ export type SchedulerDb = {
     options: Record<string, any>;
     filters: string | null;
     custom_viewport_width: number | null;
-    thresholds: string | null;
+    alerts: string | null;
     enabled: boolean;
 };
 
@@ -72,7 +72,7 @@ export type SchedulerTable = Knex.CompositeTableType<
           | 'options'
           | 'filters'
           | 'custom_viewport_width'
-          | 'thresholds'
+          | 'alerts'
       >
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>
 >;

--- a/packages/backend/src/database/migrations/20240220173913_change_threshold_name.ts
+++ b/packages/backend/src/database/migrations/20240220173913_change_threshold_name.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('scheduler', (t) => {
+        t.renameColumn('thresholds', 'alerts');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('scheduler', (t) => {
+        t.renameColumn('alerts', 'thresholds');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4086,7 +4086,7 @@ const models: TsoaRoute.Models = {
         enums: ['greaterThan', 'lessThan', 'increasedBy', 'decreasedBy'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ThresholdOptions: {
+    AlertOptions: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -4105,9 +4105,9 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 enabled: { dataType: 'boolean', required: true },
-                thresholds: {
+                alerts: {
                     dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ThresholdOptions' },
+                    array: { dataType: 'refAlias', ref: 'AlertOptions' },
                 },
                 options: { ref: 'SchedulerOptions', required: true },
                 dashboardUuid: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4584,7 +4584,7 @@
                 ],
                 "type": "string"
             },
-            "ThresholdOptions": {
+            "AlertOptions": {
                 "properties": {
                     "value": {
                         "type": "number",
@@ -4605,9 +4605,9 @@
                     "enabled": {
                         "type": "boolean"
                     },
-                    "thresholds": {
+                    "alerts": {
                         "items": {
-                            "$ref": "#/components/schemas/ThresholdOptions"
+                            "$ref": "#/components/schemas/AlertOptions"
                         },
                         "type": "array"
                     },
@@ -6364,7 +6364,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.998.5",
+        "version": "0.999.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -67,7 +67,7 @@ export class SchedulerModel {
             options: scheduler.options,
             filters: scheduler.filters,
             customViewportWidth: scheduler.custom_viewport_width,
-            thresholds: scheduler.thresholds || undefined,
+            alerts: scheduler.alerts || undefined,
             enabled: scheduler.enabled,
         } as Scheduler;
     }
@@ -226,8 +226,8 @@ export class SchedulerModel {
                         newScheduler.customViewportWidth
                             ? newScheduler.customViewportWidth
                             : null,
-                    thresholds: newScheduler.thresholds
-                        ? JSON.stringify(newScheduler.thresholds)
+                    alerts: newScheduler.alerts
+                        ? JSON.stringify(newScheduler.alerts)
                         : null,
                     enabled: true,
                 })
@@ -289,8 +289,8 @@ export class SchedulerModel {
                         scheduler.customViewportWidth
                             ? scheduler.customViewportWidth
                             : null,
-                    thresholds: scheduler.thresholds
-                        ? JSON.stringify(scheduler.thresholds)
+                    alerts: scheduler.alerts
+                        ? JSON.stringify(scheduler.alerts)
                         : null,
                 })
                 .where('scheduler_uuid', scheduler.schedulerUuid);

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -66,7 +66,7 @@ export enum ThresoldOperator {
     DECREASED_BY = 'decreasedBy',
     // HAS_CHANGED = '=',
 }
-export type ThresholdOptions = {
+export type AlertOptions = {
     operator: ThresoldOperator;
     fieldId: string;
     value: number;
@@ -84,7 +84,7 @@ export type SchedulerBase = {
     savedChartUuid: string | null;
     dashboardUuid: string | null;
     options: SchedulerOptions;
-    thresholds?: ThresholdOptions[]; // it can ben an array of AND conditions
+    alerts?: AlertOptions[]; // it can ben an array of AND conditions
     enabled: boolean;
 };
 
@@ -176,7 +176,7 @@ export type UpdateSchedulerAndTargets = Pick<
     | 'cron'
     | 'format'
     | 'options'
-    | 'thresholds'
+    | 'alerts'
 > &
     Pick<DashboardScheduler, 'filters' | 'customViewportWidth'> & {
         targets: Array<

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -203,8 +203,7 @@ const SavedChartsHeader: FC = () => {
     const [isMovingChart, setIsMovingChart] = useState(false);
     const [isScheduledDeliveriesModalOpen, toggleScheduledDeliveriesModal] =
         useToggle(false);
-    const [isThresholdAlertsModalOpen, toggleThresholdAlertsModal] =
-        useToggle(false);
+    const [isAlertsModalOpen, toggleAlertsModal] = useToggle(false);
     const [
         isSyncWithGoogleSheetsModalOpen,
         toggleSyncWithGoogleSheetsModalOpen,
@@ -774,7 +773,7 @@ const SavedChartsHeader: FC = () => {
                                                 <MantineIcon icon={IconBell} />
                                             }
                                             onClick={() =>
-                                                toggleThresholdAlertsModal(true)
+                                                toggleAlertsModal(true)
                                             }
                                         >
                                             Alerts
@@ -910,14 +909,14 @@ const SavedChartsHeader: FC = () => {
                     onClose={() => toggleScheduledDeliveriesModal(false)}
                 />
             )}
-            {isThresholdAlertsModalOpen && savedChart?.uuid && (
+            {isAlertsModalOpen && savedChart?.uuid && (
                 <ChartSchedulersModal
                     chartUuid={savedChart.uuid}
                     name={savedChart.name}
-                    isThresholdAlert
+                    isAlert
                     itemsMap={itemsMap}
-                    isOpen={isThresholdAlertsModalOpen}
-                    onClose={() => toggleThresholdAlertsModal(false)}
+                    isOpen={isAlertsModalOpen}
+                    onClose={() => toggleAlertsModal(false)}
                 />
             )}
             {savedChart && (

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -10,7 +10,7 @@ const SchedulersModal: FC<
         name: string;
         onClose?: () => void;
         isOpen?: boolean;
-        isThresholdAlert?: boolean;
+        isAlert?: boolean;
         itemsMap?: ItemsMap;
     }
 > = ({
@@ -19,7 +19,7 @@ const SchedulersModal: FC<
     createMutation,
     isOpen = false,
     isChart,
-    isThresholdAlert,
+    isAlert,
     itemsMap,
     onClose = () => {},
 }) => {
@@ -30,7 +30,7 @@ const SchedulersModal: FC<
             size="lg"
             yOffset={65}
             title={
-                isThresholdAlert ? (
+                isAlert ? (
                     <Group spacing="xs">
                         <MantineIcon icon={IconBell} size="lg" color="gray.7" />
                         <Text fw={600}>Alerts</Text>
@@ -53,7 +53,7 @@ const SchedulersModal: FC<
                 createMutation={createMutation}
                 onClose={onClose}
                 isChart={isChart}
-                isThresholdAlert={isThresholdAlert}
+                isAlert={isAlert}
                 itemsMap={itemsMap}
             />
         </Modal>

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -29,17 +29,11 @@ enum States {
 
 const ListStateContent: FC<{
     schedulersQuery: UseQueryResult<SchedulerAndTargets[], ApiError>;
-    isThresholdAlertList?: boolean;
+    isAlertList?: boolean;
     onClose: () => void;
     onConfirm: () => void;
     onEdit: (schedulerUuid: string) => void;
-}> = ({
-    schedulersQuery,
-    isThresholdAlertList,
-    onClose,
-    onConfirm,
-    onEdit,
-}) => {
+}> = ({ schedulersQuery, isAlertList, onClose, onConfirm, onEdit }) => {
     return (
         <>
             <Box
@@ -50,7 +44,7 @@ const ListStateContent: FC<{
             >
                 <SchedulersList
                     schedulersQuery={schedulersQuery}
-                    isThresholdAlertList={isThresholdAlertList}
+                    isAlertList={isAlertList}
                     onEdit={onEdit}
                 />
             </Box>
@@ -71,17 +65,10 @@ const CreateStateContent: FC<{
         { resourceUuid: string; data: CreateSchedulerAndTargetsWithoutIds }
     >;
     isChart: boolean;
-    isThresholdAlert?: boolean;
+    isAlert?: boolean;
     itemsMap?: ItemsMap;
     onBack: () => void;
-}> = ({
-    resourceUuid,
-    createMutation,
-    isChart,
-    isThresholdAlert,
-    itemsMap,
-    onBack,
-}) => {
+}> = ({ resourceUuid, createMutation, isChart, isAlert, itemsMap, onBack }) => {
     useEffect(() => {
         if (createMutation.isSuccess) {
             createMutation.reset();
@@ -139,13 +126,11 @@ const CreateStateContent: FC<{
                           }
                 }
                 onSubmit={handleSubmit}
-                confirmText={
-                    isThresholdAlert ? 'Create alert' : 'Create schedule'
-                }
+                confirmText={isAlert ? 'Create alert' : 'Create schedule'}
                 onBack={onBack}
                 onSendNow={handleSendNow}
                 loading={createMutation.isLoading}
-                isThresholdAlert={isThresholdAlert}
+                isAlert={isAlert}
                 itemsMap={itemsMap}
             />
         </>
@@ -156,8 +141,8 @@ const UpdateStateContent: FC<{
     schedulerUuid: string;
     itemsMap?: ItemsMap;
     onBack: () => void;
-    isThresholdAlert?: boolean;
-}> = ({ schedulerUuid, itemsMap, onBack, isThresholdAlert }) => {
+    isAlert?: boolean;
+}> = ({ schedulerUuid, itemsMap, onBack, isAlert }) => {
     const scheduler = useScheduler(schedulerUuid);
 
     const mutation = useSchedulersUpdateMutation(schedulerUuid);
@@ -234,7 +219,7 @@ const UpdateStateContent: FC<{
                 }
                 disabled={mutation.isLoading}
                 savedSchedulerData={scheduler.data}
-                isThresholdAlert={isThresholdAlert}
+                isAlert={isAlert}
                 onSubmit={handleSubmit}
                 confirmText="Save"
                 onBack={onBack}
@@ -256,7 +241,7 @@ interface Props {
     >;
     onClose: () => void;
     isChart: boolean;
-    isThresholdAlert?: boolean;
+    isAlert?: boolean;
     itemsMap?: ItemsMap;
 }
 
@@ -265,7 +250,7 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
     schedulersQuery,
     createMutation,
     isChart,
-    isThresholdAlert,
+    isAlert,
     itemsMap,
     onClose = () => {},
 }) => {
@@ -302,7 +287,7 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
                         setState(States.EDIT);
                         setSchedulerUuid(schedulerUuidToUpdate);
                     }}
-                    isThresholdAlertList={isThresholdAlert}
+                    isAlertList={isAlert}
                 />
             )}
             {state === States.CREATE && (
@@ -312,7 +297,7 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
                     isChart={isChart}
                     itemsMap={itemsMap}
                     onBack={() => setState(States.LIST)}
-                    isThresholdAlert={isThresholdAlert}
+                    isAlert={isAlert}
                 />
             )}
             {state === States.EDIT && schedulerUuid && (
@@ -320,7 +305,7 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
                     schedulerUuid={schedulerUuid}
                     itemsMap={itemsMap}
                     onBack={() => setState(States.LIST)}
-                    isThresholdAlert={isThresholdAlert}
+                    isAlert={isAlert}
                 />
             )}
         </>

--- a/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
@@ -41,7 +41,7 @@ interface ChartSchedulersProps {
     chartUuid: string;
     name: string;
     isOpen: boolean;
-    isThresholdAlert?: boolean;
+    isAlert?: boolean;
     itemsMap?: ItemsMap;
     onClose: () => void;
 }

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -12,14 +12,14 @@ import SchedulersListItem from './SchedulersListItem';
 
 type Props = {
     schedulersQuery: UseQueryResult<SchedulerAndTargets[], ApiError>;
-    isThresholdAlertList?: boolean;
+    isAlertList?: boolean;
     onEdit: (schedulerUuid: string) => void;
 };
 
 const SchedulersList: FC<Props> = ({
     schedulersQuery,
     onEdit,
-    isThresholdAlertList,
+    isAlertList,
 }) => {
     const { data: schedulers, isInitialLoading, error } = schedulersQuery;
     const [schedulerUuid, setSchedulerUuid] = useState<string>();
@@ -29,7 +29,7 @@ const SchedulersList: FC<Props> = ({
         alertSchedulers: SchedulerAndTargets[];
     }>(
         (acc, scheduler) => {
-            if (scheduler.thresholds && scheduler.thresholds.length > 0) {
+            if (scheduler.alerts && scheduler.alerts.length > 0) {
                 acc.alertSchedulers.push(scheduler);
             } else {
                 acc.deliverySchedulers.push(scheduler);
@@ -51,14 +51,14 @@ const SchedulersList: FC<Props> = ({
         return <ErrorState error={error.error} />;
     }
     if (
-        (!isThresholdAlertList && deliverySchedulers.length <= 0) ||
-        (isThresholdAlertList && alertSchedulers.length <= 0)
+        (!isAlertList && deliverySchedulers.length <= 0) ||
+        (isAlertList && alertSchedulers.length <= 0)
     ) {
         return (
             <Stack color="gray" align="center" mt="xxl">
                 <Title order={4} color="gray.6">
                     {`There are no existing ${
-                        isThresholdAlertList ? 'alerts' : 'scheduled deliveries'
+                        isAlertList ? 'alerts' : 'scheduled deliveries'
                     }`}
                 </Title>
                 <Text color="gray.6">
@@ -69,7 +69,7 @@ const SchedulersList: FC<Props> = ({
     }
     return (
         <div>
-            {isThresholdAlertList
+            {isAlertList
                 ? alertSchedulers?.map((alertScheduler) => (
                       <SchedulersListItem
                           key={alertScheduler.schedulerUuid}


### PR DESCRIPTION
### Description:

We decided to make the name of threshold alerts more generic and just call them alerts. This changes the code (not the display strings) to reflect that. 

@rephus I put this together, but let me know if you don't think it's worth doing. In general it seems like a good idea to have the names match, but since this contains a migration maybe it's overkill? 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
