### PR TITLE
feat: set user id to null in share URL when user deleted

### DIFF
--- a/packages/backend/src/database/migrations/20240220173325_remove-share-user-id-cascade-deletion.ts
+++ b/packages/backend/src/database/migrations/20240220173325_remove-share-user-id-cascade-deletion.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('share', (tableBuilder) => {
+        tableBuilder.dropForeign('created_by_user_id');
+
+        tableBuilder.integer('created_by_user_id').nullable().alter();
+
+        tableBuilder
+            .foreign('created_by_user_id')
+            .references('user_id')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex('share').delete().whereNull('created_by_user_id');
+
+    await knex.schema.alterTable('share', (tableBuilder) => {
+        tableBuilder.dropForeign('created_by_user_id');
+
+        tableBuilder.integer('created_by_user_id').notNullable().alter();
+
+        tableBuilder
+            .foreign('created_by_user_id')
+            .references('user_id')
+            .inTable('users')
+            .onDelete('CASCADE');
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8981 

### Description:

- When a user is deleted, the `current_user_id` in share URLs is set to null. Currently we have the `ON DELETE CASCADE` for the foreign key `current_user_id` in the `shares` table. Due to this, when a user is deleted, any share URL created by him are broken. 

- Added a migration file to update this to `ON DELETE SET NULL` instead (also removed the `NOT NULL` constraint). Verified the changes in postgres database as well. (also checked the rollback command)

Share URL initially - 

![image](https://github.com/lightdash/lightdash/assets/85165953/2f9a9605-53ed-408d-a325-e4126b95cdaa)

When a user is deleted :

Before: 

![image](https://github.com/lightdash/lightdash/assets/85165953/1329881f-5e83-4fc5-b24e-b9bcd7635daf)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/db69a374-9b13-4ace-ad54-bfc2593809d8)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
