### PR TITLE
chore: fix typo with step output

### DIFF
--- a/.github/workflows/duplicate-external-pr.yml
+++ b/.github/workflows/duplicate-external-pr.yml
@@ -32,10 +32,10 @@ jobs:
               run: |
                   if git ls-remote --heads origin duplicate-${{env.ISSUE_NUMBER}} ${{env.REF}} | grep duplicate-${{env.ISSUE_NUMBER}}; then
                       echo "Branch already exists."
-                      echo "branch_exists=true" >> $GITHUB_ENV
+                      echo "branch_exists=true" >> $GITHUB_OUTPUT
                   else
                       echo "Branch does not exist yet"
-                      echo "branch_exists=false" >> $GITHUB_ENV
+                      echo "branch_exists=false" >> $GITHUB_OUTPUT
                   fi
             - name: Update existing branch
               if: steps.check-branch.outputs.branch_exists == 'true'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:N/A

### Description:

Related to `duplicate-external-pr` github action

output should be set as `GITHUB_OUTPUT`
fixes typo where I had `GITHUB_ENV` 

team affiliation check works: https://github.com/lightdash/lightdash/actions/runs/7987560280

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
