### PR TITLE
feat: show longer dbt descriptions for fields, including markdown support

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/docs.md
+++ b/examples/full-jaffle-shop-demo/dbt/models/docs.md
@@ -1,14 +1,15 @@
 {% docs orders_status %}
 
+# Order Status
+
 Orders can be one of the following statuses:
 
 | status         | description                                                                                                            |
-|----------------|------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | placed         | The order has been placed but has not yet left the warehouse                                                           |
 | shipped        | The order has ben shipped to the customer and is currently in transit                                                  |
 | completed      | The order has been received by the customer                                                                            |
 | return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |
 | returned       | The order has been returned by the customer and received at the warehouse                                              |
-
 
 {% enddocs %}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailContext.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailContext.tsx
@@ -1,0 +1,64 @@
+import { Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+    createContext,
+    FC,
+    PropsWithChildren,
+    useCallback,
+    useContext,
+    useState,
+} from 'react';
+
+interface ItemDetailProps {
+    header: JSX.Element;
+    detail: JSX.Element;
+}
+
+const ItemDetailContext = createContext<{
+    showItemDetail: (detail: ItemDetailProps) => void;
+} | null>(null);
+
+export const ItemDetailProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
+    const [itemDetail, setItemDetail] = useState<ItemDetailProps>();
+    const [opened, { open, close }] = useDisclosure();
+
+    const showItemDetail = useCallback(
+        (newItemDetail: ItemDetailProps) => {
+            setItemDetail(newItemDetail);
+            open();
+        },
+        [setItemDetail, open],
+    );
+
+    return (
+        <ItemDetailContext.Provider
+            value={{
+                showItemDetail,
+            }}
+        >
+            {itemDetail && opened && (
+                <Modal
+                    p="xl"
+                    size="lg"
+                    opened={opened}
+                    onClose={close}
+                    title={itemDetail.header}
+                >
+                    {itemDetail.detail}
+                </Modal>
+            )}
+
+            {children}
+        </ItemDetailContext.Provider>
+    );
+};
+
+export const useItemDetail = () => {
+    const ctx = useContext(ItemDetailContext);
+
+    if (ctx == null) {
+        throw new Error('useItemDetail must be used within ItemDetailProvider');
+    }
+
+    return ctx;
+};

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailContext.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailContext.tsx
@@ -9,6 +9,9 @@ import {
     useState,
 } from 'react';
 
+/**
+ * These map directly to the modal's title and body:
+ */
 interface ItemDetailProps {
     header: JSX.Element;
     detail: JSX.Element;
@@ -16,8 +19,13 @@ interface ItemDetailProps {
 
 const ItemDetailContext = createContext<{
     showItemDetail: (detail: ItemDetailProps) => void;
+    isItemDetailOpen: boolean;
 } | null>(null);
 
+/**
+ * Exposes the necessary context for a shared modal to display details about
+ * a tree item - primarily its description.
+ */
 export const ItemDetailProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
     const [itemDetail, setItemDetail] = useState<ItemDetailProps>();
     const [opened, { open, close }] = useDisclosure();
@@ -34,6 +42,7 @@ export const ItemDetailProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
         <ItemDetailContext.Provider
             value={{
                 showItemDetail,
+                isItemDetailOpen: opened,
             }}
         >
             {itemDetail && opened && (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -16,14 +16,12 @@ import {
     Group,
     Highlight,
     HoverCard,
-    Modal,
     NavLink,
     Text,
     Title,
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import { IconAlertTriangle, IconFilter } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { darken, lighten } from 'polished';
@@ -33,6 +31,7 @@ import { getItemBgColor } from '../../../../../hooks/useColumns';
 import { useFilters } from '../../../../../hooks/useFilters';
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
+import { useItemDetail } from '../ItemDetailContext';
 import { Node, useTableTreeContext } from './TreeProvider';
 import TreeSingleNodeActions from './TreeSingleNodeActions';
 
@@ -135,10 +134,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         onItemClick,
     } = useTableTreeContext();
     const { isFilteredField } = useFilters();
-    const [
-        isDescriptionViewOpen,
-        { open: openDescriptionView, close: closeDescriptionView },
-    ] = useDisclosure();
+    const { showItemDetail } = useItemDetail();
 
     const [isHover, toggle] = useToggle(false);
     const [isMenuOpen, toggleMenu] = useToggle(false);
@@ -169,6 +165,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         missingCustomMetrics &&
         missingCustomMetrics.includes(item);
     const description = isField(item) ? item.description : undefined;
+
     const bgColor = getItemBgColor(item);
 
     // TODO: Add getFieldType function to common which should return FieldType enum (which should also have CUSTOM_METRIC, CUSTOM_DIMENSION, and TABLE_CALCULATION)
@@ -179,6 +176,28 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         if (isMetric(field)) return 'yellow.9';
 
         return 'yellow.9';
+    };
+
+    const onOpenDescriptionView = () => {
+        showItemDetail({
+            detail: (
+                <Group>
+                    <FieldIcon
+                        item={item}
+                        color={getFieldIconColor(item)}
+                        size="md"
+                    />
+                    <Text size="md">{label}</Text>
+                </Group>
+            ),
+            header: description ? (
+                <NodeDetailMarkdown
+                    source={description ?? ''}
+                ></NodeDetailMarkdown>
+            ) : (
+                <Text color="gray">No description available.</Text>
+            ),
+        });
     };
 
     return (
@@ -242,38 +261,12 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                                 `This field from '${item.table}' table is no longer available`
                             ) : (
                                 <TreeSingleNodeDetail
-                                    onViewDescription={openDescriptionView}
+                                    onViewDescription={onOpenDescriptionView}
                                     description={description}
                                 />
                             )}
                         </HoverCard.Dropdown>
                     </HoverCard>
-
-                    <Modal
-                        withinPortal
-                        p="xl"
-                        size="lg"
-                        opened={isDescriptionViewOpen}
-                        onClose={closeDescriptionView}
-                        title={
-                            <Group>
-                                <FieldIcon
-                                    item={item}
-                                    color={getFieldIconColor(item)}
-                                    size="md"
-                                />
-                                <Text size="md">{label}</Text>
-                            </Group>
-                        }
-                    >
-                        {description ? (
-                            <NodeDetailMarkdown
-                                source={description ?? ''}
-                            ></NodeDetailMarkdown>
-                        ) : (
-                            <Text color="gray">No description available.</Text>
-                        )}
-                    </Modal>
 
                     {isFiltered ? (
                         <Tooltip withinPortal label="This field is filtered">
@@ -306,7 +299,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     isSelected={isSelected}
                     isOpened={isMenuOpen}
                     hasDescription={description != null}
-                    onViewDescription={openDescriptionView}
+                    onViewDescription={onOpenDescriptionView}
                     onMenuChange={toggleMenu}
                 />
             }

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -180,7 +180,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
 
     const onOpenDescriptionView = () => {
         showItemDetail({
-            detail: (
+            header: (
                 <Group>
                     <FieldIcon
                         item={item}
@@ -190,7 +190,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     <Text size="md">{label}</Text>
                 </Group>
             ),
-            header: description ? (
+            detail: description ? (
                 <NodeDetailMarkdown
                     source={description ?? ''}
                 ></NodeDetailMarkdown>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -39,26 +39,6 @@ type Props = {
     node: Node;
 };
 
-const NodeDetailMarkdown: FC<{ source: string }> = ({ source }) => {
-    const theme = useMantineTheme();
-    return (
-        <MarkdownPreview
-            skipHtml
-            linkTarget="_blank"
-            components={{
-                h1: ({ children }) => <Title order={2}>{children}</Title>,
-                h2: ({ children }) => <Title order={3}>{children}</Title>,
-                h3: ({ children }) => <Title order={4}>{children}</Title>,
-            }}
-            source={source}
-            disallowedElements={['img']}
-            style={{
-                fontSize: theme.fontSizes.sm,
-            }}
-        />
-    );
-};
-
 /**
  * Truncate an item description by limiting to:
  *
@@ -87,7 +67,36 @@ const truncateDescription = (description: string) => {
     return truncatedLines.join('\n').substring(0, 256);
 };
 
-const TreeSingleNodeDetail: FC<{
+/**
+ * Renders markdown for an item's description, with additional constraints
+ * to avoid markdown styling from completely throwing its surroundings out
+ * of whack.
+ */
+const NodeDetailMarkdown: FC<{ source: string }> = ({ source }) => {
+    const theme = useMantineTheme();
+    return (
+        <MarkdownPreview
+            skipHtml
+            linkTarget="_blank"
+            components={{
+                h1: ({ children }) => <Title order={2}>{children}</Title>,
+                h2: ({ children }) => <Title order={3}>{children}</Title>,
+                h3: ({ children }) => <Title order={4}>{children}</Title>,
+            }}
+            source={source}
+            disallowedElements={['img']}
+            style={{
+                fontSize: theme.fontSizes.sm,
+            }}
+        />
+    );
+};
+
+/**
+ * Renders a truncated version of an item's description, with an option
+ * to read the full description if necessary.
+ */
+const NodeDetailPreview: FC<{
     description?: string;
     onViewDescription: () => void;
 }> = ({ description, onViewDescription }) => {
@@ -178,6 +187,10 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         return 'yellow.9';
     };
 
+    /**
+     * Handles putting together and opening the shared modal for a field's
+     * detailed description.
+     */
     const onOpenDescriptionView = () => {
         showItemDetail({
             header: (
@@ -260,7 +273,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             {isMissing ? (
                                 `This field from '${item.table}' table is no longer available`
                             ) : (
-                                <TreeSingleNodeDetail
+                                <NodeDetailPreview
                                     onViewDescription={onOpenDescriptionView}
                                     description={description}
                                 />

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -29,6 +29,7 @@ import { FC } from 'react';
 import { useToggle } from 'react-use';
 import { getItemBgColor } from '../../../../../hooks/useColumns';
 import { useFilters } from '../../../../../hooks/useFilters';
+import { rehypeRemoveHeaderLinks } from '../../../../../utils/markdownUtils';
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useItemDetail } from '../ItemDetailContext';
@@ -83,6 +84,7 @@ const NodeDetailMarkdown: FC<{ source: string }> = ({ source }) => {
                 h2: ({ children }) => <Title order={3}>{children}</Title>,
                 h3: ({ children }) => <Title order={4}>{children}</Title>,
             }}
+            rehypeRewrite={rehypeRemoveHeaderLinks}
             source={source}
             disallowedElements={['img']}
             style={{

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -311,7 +311,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     isHovered={isHover}
                     isSelected={isSelected}
                     isOpened={isMenuOpen}
-                    hasDescription={description != null}
+                    hasDescription={!!description}
                     onViewDescription={onOpenDescriptionView}
                     onMenuChange={toggleMenu}
                 />

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -15,8 +15,8 @@ import {
     Flex,
     Group,
     Highlight,
-    HoverCard,
     NavLink,
+    Popover,
     Text,
     Title,
     Tooltip,
@@ -145,7 +145,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
     const { isFilteredField } = useFilters();
     const { showItemDetail } = useItemDetail();
 
-    const [isHover, toggle] = useToggle(false);
+    const [isHover, toggleHover] = useToggle(false);
     const [isMenuOpen, toggleMenu] = useToggle(false);
 
     const isSelected = selectedItems.has(node.key);
@@ -192,6 +192,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
      * detailed description.
      */
     const onOpenDescriptionView = () => {
+        toggleHover(false);
+
         showItemDetail({
             header: (
                 <Group>
@@ -237,21 +239,20 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                 )
             }
             onClick={() => onItemClick(node.key, item)}
-            onMouseEnter={() => toggle(true)}
-            onMouseLeave={() => toggle(false)}
+            onMouseEnter={() => toggleHover(true)}
+            onMouseLeave={() => toggleHover(false)}
             label={
                 <Group noWrap>
-                    <HoverCard
+                    <Popover
+                        opened={isHover}
                         shadow="sm"
                         withinPortal
                         disabled={!description && !isMissing}
                         position="right"
-                        /** Stops larger popups from being annoying when scanning the list of items */
-                        openDelay={300}
                         /** Ensures the hover card does not overlap with the right-hand menu. */
                         offset={40}
                     >
-                        <HoverCard.Target>
+                        <Popover.Target>
                             <Highlight
                                 component={Text}
                                 truncate
@@ -260,8 +261,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             >
                                 {label}
                             </Highlight>
-                        </HoverCard.Target>
-                        <HoverCard.Dropdown
+                        </Popover.Target>
+                        <Popover.Dropdown
                             p="xs"
                             maw={380}
                             /**
@@ -278,8 +279,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                                     description={description}
                                 />
                             )}
-                        </HoverCard.Dropdown>
-                    </HoverCard>
+                        </Popover.Dropdown>
+                    </Popover>
 
                     {isFiltered ? (
                         <Tooltip withinPortal label="This field is filtered">

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -63,8 +63,10 @@ type Props = {
     item: Metric | Dimension | AdditionalMetric | CustomDimension;
     isHovered: boolean;
     isSelected: boolean;
+    hasDescription: boolean;
     isOpened: MenuProps['opened'];
     onMenuChange: MenuProps['onChange'];
+    onViewDescription: () => void;
 };
 
 const TreeSingleNodeActions: FC<Props> = ({
@@ -73,6 +75,8 @@ const TreeSingleNodeActions: FC<Props> = ({
     isSelected,
     isOpened,
     onMenuChange,
+    hasDescription,
+    onViewDescription,
 }) => {
     const { addFilter } = useFilters();
     const { track } = useTracking();
@@ -158,6 +162,19 @@ const TreeSingleNodeActions: FC<Props> = ({
                         </Menu.Item>
                     </>
                 ) : null}
+
+                {hasDescription && (
+                    <Menu.Item
+                        component="button"
+                        icon={<MantineIcon icon={IconDots} />}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onViewDescription();
+                        }}
+                    >
+                        View description
+                    </Menu.Item>
+                )}
 
                 {customMetrics.length > 0 && isDimension(item) ? (
                     <>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -5,13 +5,14 @@ import {
 } from '@lightdash/common';
 import { Group, MantineProvider, NavLink, Text, Tooltip } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
-import { FC } from 'react';
+import type { FC } from 'react';
 import { useToggle } from 'react-use';
 
 import { getMantineThemeOverride } from '../../../../mantineTheme';
 import { TrackSection } from '../../../../providers/TrackingProvider';
 import { SectionName } from '../../../../types/Events';
 import MantineIcon from '../../../common/MantineIcon';
+import { ItemDetailProvider } from './ItemDetailContext';
 import TableTreeSections from './TableTreeSections';
 
 type TableTreeWrapperProps = {
@@ -113,22 +114,24 @@ const TableTree: FC<Props> = ({
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <MantineProvider inherit theme={themeOverride}>
-                <Wrapper
-                    isOpen={isSearching || isOpen}
-                    toggle={toggle}
-                    table={table}
-                >
-                    <TableTreeSections
+                <ItemDetailProvider>
+                    <Wrapper
+                        isOpen={isSearching || isOpen}
+                        toggle={toggle}
                         table={table}
-                        searchQuery={searchQuery}
-                        additionalMetrics={additionalMetrics}
-                        customDimensions={customDimensions}
-                        missingCustomMetrics={missingCustomMetrics}
-                        missingFields={missingFields}
-                        selectedDimensions={selectedDimensions}
-                        {...rest}
-                    />
-                </Wrapper>
+                    >
+                        <TableTreeSections
+                            table={table}
+                            searchQuery={searchQuery}
+                            additionalMetrics={additionalMetrics}
+                            customDimensions={customDimensions}
+                            missingCustomMetrics={missingCustomMetrics}
+                            missingFields={missingFields}
+                            selectedDimensions={selectedDimensions}
+                            {...rest}
+                        />
+                    </Wrapper>
+                </ItemDetailProvider>
             </MantineProvider>
         </TrackSection>
     );

--- a/packages/frontend/src/utils/markdownUtils.ts
+++ b/packages/frontend/src/utils/markdownUtils.ts
@@ -1,0 +1,16 @@
+import type MarkdownPreview from '@uiw/react-markdown-preview';
+
+/**
+ * Removes header auto-linking when rendering markdown via ReactMarkdownPreview.
+ */
+export const rehypeRemoveHeaderLinks: React.ComponentProps<
+    typeof MarkdownPreview
+>['rehypeRewrite'] = (node, _, parent) => {
+    if (
+        node.tagName === 'a' &&
+        parent &&
+        /^h(1|2|3|4|5|6)/.test(parent.tagName as string)
+    ) {
+        parent.children = parent.children.slice(1);
+    }
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1174 

### Description:

Adds an improved UX for viewing dbt field descriptions:

<img width="478" alt="Screenshot 2024-02-20 at 22 15 58" src="https://github.com/lightdash/lightdash/assets/382538/c693492c-c47a-498f-80af-e955b06e39eb">
<img width="420" alt="Screenshot 2024-02-20 at 22 16 17" src="https://github.com/lightdash/lightdash/assets/382538/c60091e1-e419-43d4-b412-f996627c0688">
<img width="727" alt="Screenshot 2024-02-20 at 22 16 25" src="https://github.com/lightdash/lightdash/assets/382538/f8997942-198c-40ec-b115-ffbc78d25bc1">
<img width="700" alt="Screenshot 2024-02-20 at 22 17 16" src="https://github.com/lightdash/lightdash/assets/382538/68e25936-b58f-4720-b728-5bc47f396769">
<img width="713" alt="Screenshot 2024-02-20 at 22 17 09" src="https://github.com/lightdash/lightdash/assets/382538/e2149f29-1937-47fb-9f05-72e09ad6ce07">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
