### PR TITLE
fix: do not show create option for exact matches on filter input

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -161,7 +161,9 @@ const FilterStringAutoComplete: FC<Props> = ({
              * Opts out of Mantine's default condition and always allows adding, as long as not
              * an empty query.
              */
-            shouldCreate={(query) => query.trim().length > 0}
+            shouldCreate={(query) =>
+                query.trim().length > 0 && !values.includes(query)
+            }
             getCreateLabel={(query) => (
                 <Group spacing="xxs">
                     <MantineIcon icon={IconPlus} color="blue" size="sm" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Tightens the logic around filter matching/value creation by hiding the option for exact matches. Fixes failing e2e test.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
