### PR TITLE
fix: delete property of columnProperties object

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -332,12 +332,18 @@ const useTableConfig = (
     // Remove columnProperties from map if the column has been removed from results
     useEffect(() => {
         if (Object.keys(columnProperties).length > 0 && selectedItemIds) {
-            const columnsRemoved = Object.keys(columnProperties).filter(
-                (field) => !selectedItemIds.includes(field),
+            setColumnProperties(
+                Object.keys(columnProperties).reduce(
+                    (acc, field) =>
+                        selectedItemIds.includes(field)
+                            ? {
+                                  ...acc,
+                                  [field]: columnProperties[field],
+                              }
+                            : acc,
+                    {},
+                ),
             );
-            columnsRemoved.forEach((field) => delete columnProperties[field]);
-
-            setColumnProperties(columnProperties);
         }
     }, [selectedItemIds, columnProperties]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9027 

### Description:

I have utilized `cloneDeep` to create a fully independent copy of the `columnProperties` object, avoiding the direct mutation of state. 
Also each property is checked for configurability before deletion, to prevent deletion of non-configurable properties.

Had to create a test object to reproduce the issue,

Test code :

```
let properties = {};

Object.defineProperties(properties, {
    __1: {
        value: { visible: true, name: 'Column 1', frozen: false },
        configurable: false,
        enumerable: true,
    },
    column2: {
        value: { visible: true, name: 'Column 2', frozen: false },
        configurable: true, 
        enumerable: true,
    },
});
  
Object.keys(properties).forEach((field) => {
    try {
        console.log(`Attempting to delete property '${field}'`);
        delete properties[field]; // Attempt to delete - error here
        console.log('deleted', field);
        // eslint-disable-next-line @typescript-eslint/no-shadow
    } catch (error) {
        console.error(`Failed to delete property '${field}':`, error);
    }
});
 ```

-  Here, column2 is deleted without issues, but while deleting column __1, we get error - 

![image](https://github.com/lightdash/lightdash/assets/85165953/c24f351c-ec67-4f59-9c8a-351c6b8a502d)

- Adding a check for configurable properties solves this.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
