### PR TITLE
fix: dashboard filter label inside modal

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -298,7 +298,14 @@ const FilterConfiguration: FC<Props> = ({
                             selectedField && (
                                 <Group spacing="xs">
                                     <FieldIcon item={selectedField} />
-                                    <FieldLabel item={selectedField} />
+                                    {originalFilterRule?.label &&
+                                    !isEditMode ? (
+                                        <Text span fw={500}>
+                                            {originalFilterRule.label}
+                                        </Text>
+                                    ) : (
+                                        <FieldLabel item={selectedField} />
+                                    )}
                                 </Group>
                             )
                         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9062 

### Description:

Moved `filterLabel` state from `FilterSettings` to `FilterConfiguration` to use it in `FieldLabel`.

Example - 
Set field label of `Order Date Year` to `Year of order date`

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/dc7be2ae-05b4-4fb7-9e6e-69e2ac6d47a4)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/096d312e-0ae0-4a40-9a50-134b601f0e8b)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
