### PR TITLE
fix: search type filter for page wasn't being applied

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -532,7 +532,7 @@ export class SearchModel {
         );
 
         const tablesAndErrors = [...tables, ...tableErrors];
-        const pages = SearchModel.searchPages(projectUuid, query);
+        const pages = SearchModel.searchPages(projectUuid, query, filters);
 
         return {
             spaces,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Search filter for pages wasn't being applied so it always returned pages

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
