### PR TITLE
feat: send once option for threshold alerts

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -29,6 +29,7 @@ export type SchedulerDb = {
     custom_viewport_width: number | null;
     thresholds: string | null;
     enabled: boolean;
+    notification_frequency: string | null;
 };
 
 export type ChartSchedulerDb = SchedulerDb & {
@@ -73,6 +74,7 @@ export type SchedulerTable = Knex.CompositeTableType<
           | 'filters'
           | 'custom_viewport_width'
           | 'thresholds'
+          | 'notification_frequency'
       >
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>
 >;

--- a/packages/backend/src/database/migrations/20240222164421_add_notification_frequency_to_alerts.ts
+++ b/packages/backend/src/database/migrations/20240222164421_add_notification_frequency_to_alerts.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('scheduler', (t) => {
+        t.string('notification_frequency').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('scheduler', (t) => {
+        t.dropColumn('notification_frequency');
+    });
+}

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -69,6 +69,7 @@ export class SchedulerModel {
             customViewportWidth: scheduler.custom_viewport_width,
             thresholds: scheduler.thresholds || undefined,
             enabled: scheduler.enabled,
+            notificationFrequency: scheduler.notification_frequency,
         } as Scheduler;
     }
 
@@ -230,6 +231,8 @@ export class SchedulerModel {
                         ? JSON.stringify(newScheduler.thresholds)
                         : null,
                     enabled: true,
+                    notification_frequency:
+                        newScheduler.notificationFrequency || null,
                 })
                 .returning('*');
             const targetPromises = newScheduler.targets.map(async (target) => {
@@ -292,6 +295,8 @@ export class SchedulerModel {
                     thresholds: scheduler.thresholds
                         ? JSON.stringify(scheduler.thresholds)
                         : null,
+                    notification_frequency:
+                        scheduler.notificationFrequency || null,
                 })
                 .where('scheduler_uuid', scheduler.schedulerUuid);
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -67,6 +67,12 @@ export enum ThresholdOperator {
     DECREASED_BY = 'decreasedBy',
     // HAS_CHANGED = '=',
 }
+
+export enum NotificationFrequency {
+    ALWAYS = 'always',
+    ONCE = 'once',
+    // DAILY = 'daily',
+}
 export const operatorAction = (operator: ThresholdOperator) => {
     switch (operator) {
         case ThresholdOperator.GREATER_THAN:
@@ -105,6 +111,7 @@ export type SchedulerBase = {
     options: SchedulerOptions;
     thresholds?: ThresholdOptions[]; // it can ben an array of AND conditions
     enabled: boolean;
+    notificationFrequency?: NotificationFrequency;
 };
 
 export type ChartScheduler = SchedulerBase & {
@@ -196,6 +203,7 @@ export type UpdateSchedulerAndTargets = Pick<
     | 'format'
     | 'options'
     | 'thresholds'
+    | 'notificationFrequency'
 > &
     Pick<DashboardScheduler, 'filters' | 'customViewportWidth'> & {
         targets: Array<

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -10,6 +10,7 @@ import {
     isSchedulerImageOptions,
     isSlackTarget,
     ItemsMap,
+    NotificationFrequency,
     SchedulerAndTargets,
     SchedulerFormat,
     ThresholdOperator,
@@ -109,6 +110,7 @@ const DEFAULT_VALUES_ALERT = {
             value: 0,
         },
     ],
+    notificationFrequency: NotificationFrequency.ONCE,
 };
 
 const thresholdOperatorOptions = [
@@ -164,6 +166,7 @@ const getFormValuesFromScheduler = (schedulerData: SchedulerAndTargets) => {
             customViewportWidth: schedulerData.customViewportWidth,
         }),
         thresholds: schedulerData.thresholds,
+        notificationFrequency: schedulerData.notificationFrequency,
     };
 };
 
@@ -257,7 +260,6 @@ const SchedulerForm: FC<Props> = ({
                     cronExpression,
                 );
             },
-            // TODO: validate thresholds
         },
 
         transformValues: (values): CreateSchedulerAndTargetsWithoutIds => {
@@ -304,6 +306,10 @@ const SchedulerForm: FC<Props> = ({
                 }),
                 thresholds: values.thresholds,
                 enabled: true,
+                notificationFrequency:
+                    'notificationFrequency' in values
+                        ? (values.notificationFrequency as NotificationFrequency)
+                        : undefined,
             };
         },
     });
@@ -545,6 +551,45 @@ const SchedulerForm: FC<Props> = ({
                                 />
                             </Box>
                         </Input.Wrapper>
+                        {isThresholdAlert && (
+                            <Stack spacing="xs">
+                                <Checkbox
+                                    label="notify me only once"
+                                    {...{
+                                        ...form.getInputProps(
+                                            'notificationFrequency',
+                                        ),
+                                        checked:
+                                            'notificationFrequency' in
+                                                form.values &&
+                                            form.values
+                                                .notificationFrequency ===
+                                                NotificationFrequency.ONCE,
+                                        onChange: (e) => {
+                                            form.setFieldValue(
+                                                'notificationFrequency',
+                                                e.target.checked
+                                                    ? NotificationFrequency.ONCE
+                                                    : NotificationFrequency.ALWAYS,
+                                            );
+                                        },
+                                    }}
+                                />
+                                {'notificationFrequency' in form.values &&
+                                    form.values.notificationFrequency ===
+                                        NotificationFrequency.ALWAYS && (
+                                        <Text
+                                            size="xs"
+                                            color="gray.6"
+                                            fs="italic"
+                                        >
+                                            You will be notified at the
+                                            specified frequency whenever the
+                                            threshold conditions are met
+                                        </Text>
+                                    )}
+                            </Stack>
+                        )}
                         {!isThresholdAlert && (
                             <Stack spacing={0}>
                                 <Input.Label> Format </Input.Label>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -513,6 +513,44 @@ const SchedulerForm: FC<Props> = ({
                                         }
                                     />
                                 </Group>
+
+                                <Stack spacing="xs" mt="xs">
+                                    <Checkbox
+                                        label="notify me only once"
+                                        {...{
+                                            ...form.getInputProps(
+                                                'notificationFrequency',
+                                            ),
+                                            checked:
+                                                'notificationFrequency' in
+                                                    form.values &&
+                                                form.values
+                                                    .notificationFrequency ===
+                                                    NotificationFrequency.ONCE,
+                                            onChange: (e) => {
+                                                form.setFieldValue(
+                                                    'notificationFrequency',
+                                                    e.target.checked
+                                                        ? NotificationFrequency.ONCE
+                                                        : NotificationFrequency.ALWAYS,
+                                                );
+                                            },
+                                        }}
+                                    />
+                                    {'notificationFrequency' in form.values &&
+                                        form.values.notificationFrequency ===
+                                            NotificationFrequency.ALWAYS && (
+                                            <Text
+                                                size="xs"
+                                                color="gray.6"
+                                                fs="italic"
+                                            >
+                                                You will be notified at the
+                                                specified frequency whenever the
+                                                threshold conditions are met
+                                            </Text>
+                                        )}
+                                </Stack>
                             </Stack>
                         )}
                         <Input.Wrapper
@@ -551,45 +589,6 @@ const SchedulerForm: FC<Props> = ({
                                 />
                             </Box>
                         </Input.Wrapper>
-                        {isThresholdAlert && (
-                            <Stack spacing="xs">
-                                <Checkbox
-                                    label="notify me only once"
-                                    {...{
-                                        ...form.getInputProps(
-                                            'notificationFrequency',
-                                        ),
-                                        checked:
-                                            'notificationFrequency' in
-                                                form.values &&
-                                            form.values
-                                                .notificationFrequency ===
-                                                NotificationFrequency.ONCE,
-                                        onChange: (e) => {
-                                            form.setFieldValue(
-                                                'notificationFrequency',
-                                                e.target.checked
-                                                    ? NotificationFrequency.ONCE
-                                                    : NotificationFrequency.ALWAYS,
-                                            );
-                                        },
-                                    }}
-                                />
-                                {'notificationFrequency' in form.values &&
-                                    form.values.notificationFrequency ===
-                                        NotificationFrequency.ALWAYS && (
-                                        <Text
-                                            size="xs"
-                                            color="gray.6"
-                                            fs="italic"
-                                        >
-                                            You will be notified at the
-                                            specified frequency whenever the
-                                            threshold conditions are met
-                                        </Text>
-                                    )}
-                            </Stack>
-                        )}
                         {!isThresholdAlert && (
                             <Stack spacing={0}>
                                 <Input.Label> Format </Input.Label>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -516,7 +516,7 @@ const SchedulerForm: FC<Props> = ({
 
                                 <Stack spacing="xs" mt="xs">
                                     <Checkbox
-                                        label="notify me only once"
+                                        label="Notify me only once"
                                         {...{
                                             ...form.getInputProps(
                                                 'notificationFrequency',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9026 

### Description:

Note that this is a draft at the moment. It seems to work, but I'd like to test it more rigorously. 

Adds a checkbox to send scheduled alerts just once. This does this by disabling the alert once it's been sent. I added some helper text when the box is turned off. Should we add some text when it is on as well.

Send once state:
<img width="618" alt="Screenshot 2024-02-23 at 17 57 43" src="https://github.com/lightdash/lightdash/assets/1864179/60d2e180-9361-4281-b3aa-4af4f5d04923">

Send always state:
<img width="618" alt="Screenshot 2024-02-23 at 17 57 59" src="https://github.com/lightdash/lightdash/assets/1864179/7f6367ae-5c2b-41f2-a88e-1b9363776bb2">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
