### PR TITLE
feat: add search createdBy filter

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -63,7 +63,7 @@ export class SearchModel {
                 query,
             );
 
-        const subquery = this.database(SpaceTableName)
+        let subquery = this.database(SpaceTableName)
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -73,8 +73,8 @@ export class SearchModel {
             .where('projects.project_uuid', projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        filterByCreatedAt(SpaceTableName, subquery, filters);
-        filterByCreatedByUuid(
+        subquery = filterByCreatedAt(SpaceTableName, subquery, filters);
+        subquery = filterByCreatedByUuid(
             subquery,
             {
                 join: {
@@ -112,7 +112,7 @@ export class SearchModel {
                 query,
             );
 
-        const subquery = this.database(DashboardsTableName)
+        let subquery = this.database(DashboardsTableName)
             .leftJoin(
                 SpaceTableName,
                 `${DashboardsTableName}.space_id`,
@@ -133,8 +133,8 @@ export class SearchModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        filterByCreatedAt(DashboardsTableName, subquery, filters);
-        filterByCreatedByUuid(
+        subquery = filterByCreatedAt(DashboardsTableName, subquery, filters);
+        subquery = filterByCreatedByUuid(
             subquery,
             {
                 join: {
@@ -201,7 +201,7 @@ export class SearchModel {
             );
 
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results
-        const subquery = this.database(SavedChartsTableName)
+        let subquery = this.database(SavedChartsTableName)
             .leftJoin(
                 SpaceTableName,
                 `${SavedChartsTableName}.space_id`,
@@ -226,8 +226,8 @@ export class SearchModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        filterByCreatedAt(SavedChartsTableName, subquery, filters);
-        filterByCreatedByUuid(
+        subquery = filterByCreatedAt(SavedChartsTableName, subquery, filters);
+        subquery = filterByCreatedByUuid(
             subquery,
             {
                 tableName: SavedChartsTableName,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -7,7 +7,6 @@ import {
     isDimension,
     isExploreError,
     NotExistsError,
-    ParameterError,
     SavedChartSearchResult,
     SearchFilters,
     SearchItemType,
@@ -18,14 +17,22 @@ import {
     TableSelectionType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import moment from 'moment';
-import { DashboardsTableName } from '../../database/entities/dashboards';
+import {
+    DashboardsTableName,
+    DashboardVersionsTableName,
+} from '../../database/entities/dashboards';
 import {
     CachedExploresTableName,
     ProjectTableName,
 } from '../../database/entities/projects';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { SpaceTableName } from '../../database/entities/spaces';
+import { UserTableName } from '../../database/entities/users';
+import {
+    filterByCreatedAt,
+    filterByCreatedByUuid,
+    shouldSearchForType,
+} from './utils/filters';
 import { getFullTextSearchRankCalcSql } from './utils/fullTextSearch';
 
 type ModelDependencies = {
@@ -39,72 +46,12 @@ export class SearchModel {
         this.database = deps.database;
     }
 
-    private static shouldSearchForType(
-        entityType: SearchItemType,
-        queryTypeFilter?: string,
-    ) {
-        // if there is no filter or if the filter is the same as the entityType
-        return !queryTypeFilter || queryTypeFilter === entityType;
-    }
-
-    private static filterByCreatedAt<T extends {}, R>(
-        tableName: string,
-        query: Knex.QueryBuilder<T, R>,
-        filters: SearchFilters = {},
-    ) {
-        const { fromDate, toDate } = filters;
-        const fromDateObj = fromDate ? moment(fromDate).utc() : undefined;
-        const toDateObj = toDate ? moment(toDate).utc() : undefined;
-        const now = moment();
-
-        if (fromDateObj?.isAfter(toDateObj)) {
-            throw new ParameterError('fromDate cannot be after toDate');
-        }
-
-        if (fromDateObj) {
-            if (!fromDateObj.isValid()) {
-                throw new ParameterError('fromDate is not valid');
-            }
-
-            if (fromDateObj.isAfter(now)) {
-                throw new ParameterError('fromDate cannot be in the future');
-            }
-
-            query.whereRaw(
-                `Date(${tableName}.created_at) >= ?`,
-                fromDateObj.startOf('day').toDate(),
-            );
-        }
-
-        if (toDateObj) {
-            if (!toDateObj.isValid()) {
-                throw new ParameterError('toDate is not valid');
-            }
-
-            if (toDateObj.isAfter(now)) {
-                throw new ParameterError('toDate cannot be in the future');
-            }
-
-            query.whereRaw(
-                `Date(${tableName}.created_at) <= ?`,
-                toDateObj.endOf('day').toDate(),
-            );
-        }
-
-        return query;
-    }
-
     private async searchSpaces(
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
     ): Promise<SpaceSearchResult[]> {
-        if (
-            !SearchModel.shouldSearchForType(
-                SearchItemType.SPACE,
-                filters?.type,
-            )
-        ) {
+        if (!shouldSearchForType(SearchItemType.SPACE, filters?.type)) {
             return [];
         }
 
@@ -116,7 +63,7 @@ export class SearchModel {
                 query,
             );
 
-        const baseSubquery = this.database(SpaceTableName)
+        const subquery = this.database(SpaceTableName)
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -126,9 +73,18 @@ export class SearchModel {
             .where('projects.project_uuid', projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        const subquery = SearchModel.filterByCreatedAt(
-            SpaceTableName,
-            baseSubquery,
+        filterByCreatedAt(SpaceTableName, subquery, filters);
+        filterByCreatedByUuid(
+            subquery,
+            {
+                join: {
+                    joinTableName: UserTableName,
+                    joinTableIdColumnName: 'user_id',
+                    joinTableUserUuidColumnName: 'user_uuid',
+                    tableIdColumnName: 'created_by_user_id',
+                },
+                tableName: SpaceTableName,
+            },
             filters,
         );
 
@@ -144,12 +100,7 @@ export class SearchModel {
         query: string,
         filters?: SearchFilters,
     ): Promise<DashboardSearchResult[]> {
-        if (
-            !SearchModel.shouldSearchForType(
-                SearchItemType.DASHBOARD,
-                filters?.type,
-            )
-        ) {
+        if (!shouldSearchForType(SearchItemType.DASHBOARD, filters?.type)) {
             return [];
         }
 
@@ -161,7 +112,7 @@ export class SearchModel {
                 query,
             );
 
-        const baseSubquery = this.database(DashboardsTableName)
+        const subquery = this.database(DashboardsTableName)
             .leftJoin(
                 SpaceTableName,
                 `${DashboardsTableName}.space_id`,
@@ -182,9 +133,19 @@ export class SearchModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        const subquery = SearchModel.filterByCreatedAt(
-            DashboardsTableName,
-            baseSubquery,
+        filterByCreatedAt(DashboardsTableName, subquery, filters);
+        filterByCreatedByUuid(
+            subquery,
+            {
+                join: {
+                    isVersioned: true,
+                    joinTableName: DashboardVersionsTableName,
+                    joinTableIdColumnName: 'dashboard_id',
+                    joinTableUserUuidColumnName: 'updated_by_user_uuid',
+                    tableIdColumnName: 'dashboard_id',
+                },
+                tableName: DashboardsTableName,
+            },
             filters,
         );
 
@@ -227,12 +188,7 @@ export class SearchModel {
         query: string,
         filters?: SearchFilters,
     ): Promise<SavedChartSearchResult[]> {
-        if (
-            !SearchModel.shouldSearchForType(
-                SearchItemType.CHART,
-                filters?.type,
-            )
-        ) {
+        if (!shouldSearchForType(SearchItemType.CHART, filters?.type)) {
             return [];
         }
 
@@ -245,7 +201,7 @@ export class SearchModel {
             );
 
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results
-        const baseSubquery = this.database(SavedChartsTableName)
+        const subquery = this.database(SavedChartsTableName)
             .leftJoin(
                 SpaceTableName,
                 `${SavedChartsTableName}.space_id`,
@@ -270,15 +226,19 @@ export class SearchModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .orderBy(searchRankColumnName, 'desc');
 
-        const subQuery = SearchModel.filterByCreatedAt(
-            SavedChartsTableName,
-            baseSubquery,
+        filterByCreatedAt(SavedChartsTableName, subquery, filters);
+        filterByCreatedByUuid(
+            subquery,
+            {
+                tableName: SavedChartsTableName,
+                tableUserUuidColumnName: 'last_version_updated_by_user_uuid',
+            },
             filters,
         );
 
         const savedCharts = await this.database(SavedChartsTableName)
             .select()
-            .from(subQuery.as('saved_charts_with_rank'))
+            .from(subquery.as('saved_charts_with_rank'))
             .where(searchRankColumnName, '>', 0)
             .limit(10);
 
@@ -356,12 +316,12 @@ export class SearchModel {
         explores: Explore[],
         filters?: SearchFilters,
     ) {
-        const shouldSearchForTables = SearchModel.shouldSearchForType(
+        const shouldSearchForTables = shouldSearchForType(
             SearchItemType.TABLE,
             filters?.type,
         );
 
-        const shouldSearchForFields = SearchModel.shouldSearchForType(
+        const shouldSearchForFields = shouldSearchForType(
             SearchItemType.FIELD,
             filters?.type,
         );
@@ -483,9 +443,7 @@ export class SearchModel {
         query: string,
         filters?: SearchFilters,
     ) {
-        if (
-            !SearchModel.shouldSearchForType(SearchItemType.PAGE, filters?.type)
-        ) {
+        if (!shouldSearchForType(SearchItemType.PAGE, filters?.type)) {
             return [];
         }
 

--- a/packages/backend/src/models/SearchModel/utils/filters.ts
+++ b/packages/backend/src/models/SearchModel/utils/filters.ts
@@ -1,0 +1,115 @@
+import {
+    ParameterError,
+    SearchFilters,
+    SearchItemType,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import moment from 'moment';
+
+export function shouldSearchForType(
+    entityType: SearchItemType,
+    queryTypeFilter?: string,
+) {
+    // if there is no filter or if the filter is the same as the entityType
+    return !queryTypeFilter || queryTypeFilter === entityType;
+}
+
+export function filterByCreatedAt<T extends {}, R>(
+    tableName: string,
+    query: Knex.QueryBuilder<T, R>,
+    filters: SearchFilters = {},
+) {
+    const { fromDate, toDate } = filters;
+    const fromDateObj = fromDate ? moment(fromDate).utc() : undefined;
+    const toDateObj = toDate ? moment(toDate).utc() : undefined;
+    const now = moment();
+
+    if (fromDateObj?.isAfter(toDateObj)) {
+        throw new ParameterError('fromDate cannot be after toDate');
+    }
+
+    if (fromDateObj) {
+        if (!fromDateObj.isValid()) {
+            throw new ParameterError('fromDate is not valid');
+        }
+
+        if (fromDateObj.isAfter(now)) {
+            throw new ParameterError('fromDate cannot be in the future');
+        }
+
+        query.whereRaw(
+            `Date(${tableName}.created_at) >= ?`,
+            fromDateObj.startOf('day').toDate(),
+        );
+    }
+
+    if (toDateObj) {
+        if (!toDateObj.isValid()) {
+            throw new ParameterError('toDate is not valid');
+        }
+
+        if (toDateObj.isAfter(now)) {
+            throw new ParameterError('toDate cannot be in the future');
+        }
+
+        query.whereRaw(
+            `Date(${tableName}.created_at) <= ?`,
+            toDateObj.endOf('day').toDate(),
+        );
+    }
+
+    return query;
+}
+
+export function filterByCreatedByUuid<T extends {}, R>(
+    query: Knex.QueryBuilder<T, R>,
+    opts: {
+        join?: {
+            isVersioned?: boolean;
+            joinTableName: string;
+            joinTableIdColumnName: string;
+            joinTableUserUuidColumnName: string;
+            tableIdColumnName: string;
+        };
+        tableName: string;
+        tableUserUuidColumnName?: string;
+    },
+    filters: SearchFilters = {},
+) {
+    const { createdByUuid } = filters;
+
+    if (createdByUuid) {
+        // if entity doesn't have a user uuid, we need to join with the table that has it
+        if (opts.join) {
+            const filterQuery = query
+                .innerJoin(
+                    opts.join.joinTableName,
+                    `${opts.join.joinTableName}.${opts.join.joinTableIdColumnName}`,
+                    `${opts.tableName}.${opts.join.tableIdColumnName}`,
+                )
+                .where(
+                    `${opts.join.joinTableName}.${opts.join.joinTableUserUuidColumnName}`,
+                    createdByUuid,
+                );
+
+            // if entity is versioned, we need to filter by the latest version
+            if (opts.join.isVersioned) {
+                return filterQuery
+                    .orderBy(`${opts.join.joinTableName}.created_at`, 'desc')
+                    .limit(1);
+            }
+
+            return filterQuery;
+        }
+
+        // if entity has a user uuid, we can filter directly
+        if (opts.tableUserUuidColumnName) {
+            return query.where(
+                `${opts.tableName}.${opts.tableUserUuidColumnName}`,
+                createdByUuid,
+            );
+        }
+    }
+
+    return query;
+}

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -54,7 +54,7 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const { type, fromDate, toDate } = req.query;
+            const { type, fromDate, toDate, createdByUuid } = req.query;
             const results = await searchService.getSearchResults(
                 req.user!,
                 req.params.projectUuid,
@@ -63,6 +63,7 @@ projectRouter.get(
                     type: type?.toString(),
                     fromDate: fromDate?.toString(),
                     toDate: toDate?.toString(),
+                    createdByUuid: createdByUuid?.toString(),
                 },
             );
             res.json({ status: 'ok', results });

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -133,4 +133,5 @@ export type SearchFilters = {
     type?: string; // the type filter can be any string, but it should be one of the EntityType to be valid, see shouldSearchForType function
     fromDate?: string;
     toDate?: string;
+    createdByUuid?: string;
 };

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -1,9 +1,10 @@
 import {
     assertUnreachable,
+    OrganizationMemberProfile,
     SearchFilters,
     SearchItemType,
 } from '@lightdash/common';
-import { Button, Flex, Group, Menu } from '@mantine/core';
+import { Button, Flex, Group, Menu, Select } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -16,9 +17,11 @@ import {
     IconLayoutDashboard,
     IconRectangle,
     IconTable,
+    IconUser,
 } from '@tabler/icons-react';
 import { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { allSearchItemTypes } from '../types/searchItem';
 import { getDateFilterLabel } from '../utils/getDateFilterLabel';
 import { getSearchItemLabel } from '../utils/getSearchItemLabel';
@@ -51,8 +54,19 @@ type Props = {
     onSearchFilterChange: (searchFilters?: SearchFilters) => void;
 };
 
+function findUserName(
+    userUuid: string,
+    userList: OrganizationMemberProfile[] = [],
+) {
+    const user = userList.find((u) => u.userUuid === userUuid);
+
+    return user ? `${user.firstName} ${user.lastName}` : '';
+}
+
 const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
     const [isDateMenuOpen, dateMenuHandlers] = useDisclosure(false);
+    const [isCreatedByMenuOpen, createdByMenuHelpers] = useDisclosure(false);
+    const { data: organizationUsers } = useOrganizationUsers();
 
     return (
         <Group px="md" py="sm">
@@ -106,7 +120,7 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                 </Menu.Dropdown>
             </Menu>
             <Menu
-                position="bottom-start"
+                position="bottom-end"
                 withArrow
                 withinPortal
                 shadow="md"
@@ -173,6 +187,59 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                             Clear
                         </Button>
                     </Flex>
+                </Menu.Dropdown>
+            </Menu>
+            <Menu
+                position="bottom-end"
+                withArrow
+                withinPortal
+                shadow="md"
+                arrowOffset={11}
+                offset={2}
+                opened={isCreatedByMenuOpen}
+                onOpen={createdByMenuHelpers.open}
+                onClose={createdByMenuHelpers.close}
+            >
+                <Menu.Target>
+                    <Button
+                        compact
+                        variant="default"
+                        radius="xl"
+                        size="xs"
+                        leftIcon={<MantineIcon icon={IconUser} />}
+                        rightIcon={<MantineIcon icon={IconChevronDown} />}
+                    >
+                        {filters?.createdByUuid
+                            ? findUserName(
+                                  filters.createdByUuid,
+                                  organizationUsers,
+                              )
+                            : 'Created by'}
+                    </Button>
+                </Menu.Target>
+
+                <Menu.Dropdown>
+                    <Select
+                        placeholder="Select a user"
+                        searchable
+                        value={filters?.createdByUuid}
+                        allowDeselect
+                        limit={5}
+                        data={
+                            organizationUsers?.map((user) => ({
+                                value: user.userUuid,
+                                label: `${user.firstName} ${user.lastName}`,
+                            })) || []
+                        }
+                        onChange={(value) => {
+                            onSearchFilterChange({
+                                ...filters,
+                                createdByUuid: value || undefined,
+                            });
+
+                            createdByMenuHelpers.close();
+                        }}
+                    />
                 </Menu.Dropdown>
             </Menu>
         </Group>

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -60,7 +60,9 @@ function findUserName(
 ) {
     const user = userList.find((u) => u.userUuid === userUuid);
 
-    return user ? `${user.firstName} ${user.lastName}` : '';
+    if (user) {
+        return `${user.firstName} ${user.lastName}`;
+    }
 }
 
 const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#5266](https://github.com/lightdash/lightdash/issues/5266)

### Description:

- Adds created by filter to omnibar

https://github.com/lightdash/lightdash/assets/22939015/04a41759-01a5-4588-9f6a-d9982015eef9

Notes: `dashboards` and `saved_charts` are versioned entities but there's a difference, `saved_charts` has `last_version_updated_by_user_uuid` column which means we don't need to join with any other table to apply the filter. `dashboards` on the other hand are not, so we need to join with `dashboard_versions` to get the user UUID of who created the latest version. See: `packages/backend/src/models/SearchModel/utils/filters.ts` - `filterByCreatedByUuid` function and its usage in `packages/backend/src/models/SearchModel/index.ts`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
