### PR TITLE
fix: explicitly close description popover when menu clicked, tweak offset

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -209,6 +209,11 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         });
     };
 
+    const onToggleMenu = () => {
+        toggleHover(false);
+        toggleMenu();
+    };
+
     return (
         <NavLink
             component="div"
@@ -245,7 +250,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         disabled={!description && !isMissing}
                         position="right"
                         /** Ensures the hover card does not overlap with the right-hand menu. */
-                        offset={40}
+                        offset={isFiltered ? 80 : 40}
                     >
                         <Popover.Target>
                             <Highlight
@@ -313,7 +318,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                     isOpened={isMenuOpen}
                     hasDescription={!!description}
                     onViewDescription={onOpenDescriptionView}
-                    onMenuChange={toggleMenu}
+                    onMenuChange={onToggleMenu}
                 />
             }
             data-testid={`tree-single-node-${label}`}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes a flake e2e test on custom dimensions.

### Description:

- Explicitly close description popover when opening item menu
- Tweak popover offset when field is filtered to avoid the menu option being covered by it

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
