### PR TITLE
fix: allow viewers to export csv from dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -316,7 +316,27 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const [isMovingChart, setIsMovingChart] = useState(false);
     const { user } = useApp();
 
-    const userCanManageChart = user.data?.ability?.can('manage', 'SavedChart');
+    const userCanManageChart = user.data?.ability?.can(
+        'manage',
+        subject('SavedChart', {
+            organizationUuid: chart.organizationUuid,
+            projectUuid: chart.projectUuid,
+        }),
+    );
+    const userCanManageExplore = user.data?.ability?.can(
+        'manage',
+        subject('Explore', {
+            organizationUuid: chart.organizationUuid,
+            projectUuid: chart.projectUuid,
+        }),
+    );
+    const userCanExportData = user.data?.ability.can(
+        'manage',
+        subject('ExportCsv', {
+            organizationUuid: chart.organizationUuid,
+            projectUuid: chart.projectUuid,
+        }),
+    );
 
     const { openUnderlyingDataModal } = useMetricQueryDataContext();
 
@@ -631,7 +651,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 belongsToDashboard={belongsToDashboard}
                 extraMenuItems={
                     savedChartUuid !== null &&
-                    user.data?.ability?.can('manage', 'Explore') && (
+                    (userCanManageExplore ||
+                        userCanManageChart ||
+                        userCanExportData) && (
                         <Tooltip
                             disabled={!isEditMode}
                             label="Finish editing dashboard to use these actions"
@@ -644,7 +666,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                     />
                                 )}
 
-                                {chartPathname && (
+                                {userCanManageExplore && chartPathname && (
                                     <Menu.Item
                                         icon={
                                             <MantineIcon icon={IconTelescope} />
@@ -666,7 +688,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                     </Menu.Item>
                                 )}
 
-                                {chart.chartConfig.type === ChartType.TABLE && (
+                                {userCanExportData && (
                                     <Menu.Item
                                         icon={
                                             <MantineIcon
@@ -681,12 +703,15 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                         Export CSV
                                     </Menu.Item>
                                 )}
-                                {chart.chartConfig.type === ChartType.TABLE && (
-                                    <ExportGoogleSheet
-                                        savedChart={chartWithDashboardFilters}
-                                        disabled={isEditMode}
-                                    />
-                                )}
+                                {chart.chartConfig.type === ChartType.TABLE &&
+                                    userCanExportData && (
+                                        <ExportGoogleSheet
+                                            savedChart={
+                                                chartWithDashboardFilters
+                                            }
+                                            disabled={isEditMode}
+                                        />
+                                    )}
 
                                 {chart.dashboardUuid && userCanManageChart && (
                                     <Menu.Item


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9097 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Export CSV option is now available to VIEWERS and for all chart types.

<img width="1338" alt="Screenshot 2024-02-26 at 15 06 43" src="https://github.com/lightdash/lightdash/assets/9117144/003fc5ba-c617-4fb6-90a5-0f96277ae561">

<img width="1347" alt="Screenshot 2024-02-26 at 15 08 50" src="https://github.com/lightdash/lightdash/assets/9117144/14ea80d3-e0ba-4c9b-8e9b-75e6e365e7d6">

Exporting chart images and exporting to google sheet not included in this ticket. We can create a ticket if users ask for it.  

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
