### PR TITLE
fix: assume yes in cli generate command

### DIFF
--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -119,6 +119,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     includeMeta: !options.excludeMeta,
                     projectDir: absoluteProjectPath,
                     projectName: context.projectName,
+                    assumeYes: options.assumeYes,
                 },
             );
             try {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9107 

### Description:

Updated the `findAndUpdateModelYaml` and `askOverwriteDescription` to assume yes if `-y` or `--assume-yes` flag used with generate command.

For testing - added a column to `deletedColumnNames` so that change is needed in column list.

Commands : assume-yes

```
node ./packages/cli/dist/index.js generate -y
node ./packages/cli/dist/index.js generate --assume-yes
```

Before:

![image](https://github.com/lightdash/lightdash/assets/85165953/23858537-cd9e-42b4-951d-c04d229933cb)

After:

![image](https://github.com/lightdash/lightdash/assets/85165953/ff25825b-2a36-49af-8599-11d4863e72e3)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
