### PR TITLE
fix: use hardcoded search_rank alias

### DIFF
--- a/packages/backend/src/models/SearchModel/utils/filters.ts
+++ b/packages/backend/src/models/SearchModel/utils/filters.ts
@@ -39,10 +39,10 @@ export function filterByCreatedAt<T extends {}, R>(
             throw new ParameterError('fromDate cannot be in the future');
         }
 
-        filteredQuery.whereRaw(
-            `Date(${tableName}.created_at) >= ?`,
-            fromDateObj.startOf('day').toDate(),
-        );
+        filteredQuery.whereRaw('Date(:createdAtColumn:) >= :date', {
+            createdAtColumn: `${tableName}.created_at`,
+            date: fromDateObj.startOf('day').toDate(),
+        });
     }
 
     if (toDateObj) {
@@ -54,10 +54,10 @@ export function filterByCreatedAt<T extends {}, R>(
             throw new ParameterError('toDate cannot be in the future');
         }
 
-        filteredQuery.whereRaw(
-            `Date(${tableName}.created_at) <= ?`,
-            toDateObj.endOf('day').toDate(),
-        );
+        filteredQuery.whereRaw('Date(:createdAtColumn:) <= :date', {
+            createdAtColumn: `${tableName}.created_at`,
+            date: toDateObj.endOf('day').toDate(),
+        });
     }
 
     return filteredQuery;

--- a/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
+++ b/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
@@ -9,12 +9,15 @@ export function getFullTextSearchRankCalcSql(
     return database.raw(
         `ROUND(
             ts_rank_cd(
-                ${tableName}.${searchVectorColumnName},
-                websearch_to_tsquery('lightdash_english_config', ?),
+                :searchVectorColumn:,
+                websearch_to_tsquery('lightdash_english_config', :query),
                 32
             )::numeric,
             6
         )::float`,
-        [query],
+        {
+            searchVectorColumn: `${tableName}.${searchVectorColumnName}`,
+            query,
+        },
     );
 }

--- a/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
+++ b/packages/backend/src/models/SearchModel/utils/fullTextSearch.ts
@@ -1,7 +1,5 @@
 import { Knex } from 'knex';
 
-export const SEARCH_RANK_COLUMN_NAME = 'search_rank';
-
 export function getFullTextSearchRankCalcSql(
     database: Knex,
     tableName: string,
@@ -16,7 +14,7 @@ export function getFullTextSearchRankCalcSql(
                 32
             )::numeric,
             6
-        )::float as ${SEARCH_RANK_COLUMN_NAME}`,
+        )::float`,
         [query],
     );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Sets the `search_rank` alias in the query rather than in raw sql
- Uses named bindings for search rank raw sql
- Uses named bindings for created at filter raw sql

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
