### PR TITLE
fix: semantic layer expired query

### DIFF
--- a/packages/frontend/src/features/metricFlow/hooks/useMetricFlowQueryResults.ts
+++ b/packages/frontend/src/features/metricFlow/hooks/useMetricFlowQueryResults.ts
@@ -41,6 +41,8 @@ const useMetricFlowQueryResults = (
         queryKey: ['metric_flow_query', projectUuid, query],
         enabled: !!projectUuid && !!Object.keys(query?.metrics ?? {}).length,
         queryFn: () => createMetricFlowQuery(projectUuid!, query!),
+        staleTime: 0,
+        cacheTime: 0,
         ...useCreateQueryOptions,
     });
     const queryId = metricFlowQuery.data?.createQuery.queryId;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Context: we need to first create a query and then use the query ID to fetch the results. 
Problem: `@tanstack/react-query` useQuery was caching the query ID so we were trying to fetch the results from an expired query ID.

Before:


https://github.com/lightdash/lightdash/assets/9117144/8925fa5e-b16e-42f7-965f-7dcb0fda4068



After:


https://github.com/lightdash/lightdash/assets/9117144/94bee1cf-8458-496b-840b-35c43d5ba21b




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
