### PR TITLE
fix: semantic layer required dimension message

### DIFF
--- a/packages/frontend/src/features/metricFlow/hooks/useMetricFlowQueryResults.ts
+++ b/packages/frontend/src/features/metricFlow/hooks/useMetricFlowQueryResults.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@lightdash/common';
+import { ApiError, friendlyName } from '@lightdash/common';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { ComponentProps } from 'react';
 import {
@@ -81,6 +81,18 @@ const useMetricFlowQueryResults = (
     }
 
     if (metricFlowQueryResultsQuery.data?.query.status === QueryStatus.FAILED) {
+        let errorMessage =
+            metricFlowQueryResultsQuery.data.query.error || 'Unknown error';
+
+        const requiredDimension = errorMessage.match(
+            /group-by-items do not include '(.*)'/,
+        );
+        if (requiredDimension && requiredDimension[1]) {
+            errorMessage = `The "${friendlyName(
+                requiredDimension[1],
+            )}" dimension is required to calculate metrics values.`;
+        }
+
         return {
             isLoading: false,
             error: {
@@ -88,9 +100,7 @@ const useMetricFlowQueryResults = (
                 error: {
                     name: 'ApiError',
                     statusCode: 500,
-                    message:
-                        metricFlowQueryResultsQuery.data.query.error ||
-                        'Unknown error',
+                    message: errorMessage,
                     data: {},
                 },
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Context: Some metrics require a dimension to be selected. 
Problem: At the moment there isn't a direct way for us to know that before running the query. 
Solution: Show a nicer error message

Before:
<img width="1456" alt="Screenshot 2024-02-28 at 10 10 56" src="https://github.com/lightdash/lightdash/assets/9117144/df4980ae-67a9-4d40-9c59-bb0d16d3cd1c">


After:

<img width="1456" alt="Screenshot 2024-02-28 at 10 10 40" src="https://github.com/lightdash/lightdash/assets/9117144/67923010-5419-4a9e-b21b-e89b5b63278e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
