### PR TITLE
fix: remove posthog check for UseInMemoryTableCalculations

### DIFF
--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -43,7 +43,9 @@ export async function isFeatureFlagEnabled(
                 : {},
         ),
         new Promise<boolean>((resolve) => {
-            setTimeout(() => resolve(false), FLAG_CHECK_TIMEOUT);
+            setTimeout(() => {
+                resolve(false);
+            }, FLAG_CHECK_TIMEOUT);
         }),
     ]);
 

--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -2,6 +2,9 @@ import { FeatureFlags, SessionUser } from '@lightdash/common';
 import { PostHog } from 'posthog-node';
 import { lightdashConfig } from './config/lightdashConfig';
 
+// How long to wait for Posthog to reply:
+const FLAG_CHECK_TIMEOUT = 350; // ms
+
 export const postHogClient = lightdashConfig.posthog.projectApiKey
     ? new PostHog(lightdashConfig.posthog.projectApiKey, {
           host: lightdashConfig.posthog.apiHost,
@@ -27,17 +30,22 @@ export async function isFeatureFlagEnabled(
         return false;
     }
 
-    const isEnabled = await postHog.isFeatureEnabled(
-        flag,
-        user.userUuid,
-        user.organizationUuid != null
-            ? {
-                  groups: {
-                      organization: user.organizationUuid,
-                  },
-              }
-            : {},
-    );
+    const isEnabled = await Promise.race([
+        postHog.isFeatureEnabled(
+            flag,
+            user.userUuid,
+            user.organizationUuid != null
+                ? {
+                      groups: {
+                          organization: user.organizationUuid,
+                      },
+                  }
+                : {},
+        ),
+        new Promise<boolean>((resolve) => {
+            setTimeout(() => resolve(false), FLAG_CHECK_TIMEOUT);
+        }),
+    ]);
 
     // isFeatureEnabled returns boolean | undefined, so we force it into a boolean:
     return !!isEnabled;

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -20,7 +20,7 @@ export const projectAdapterFromConfig = async (
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
     dbtVersion: SupportedDbtVersions,
-    useDbtLs: boolean,
+    useDbtLs: boolean = true,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -734,10 +734,6 @@ export class ProjectService {
     }> {
         const sshTunnel = new SshTunnel(data.warehouseConnection);
         await sshTunnel.connect();
-        const useDbtLs = await isFeatureFlagEnabled(
-            FeatureFlags.UseDbtLs,
-            user,
-        );
         const adapter = await projectAdapterFromConfig(
             data.dbtConnection,
             sshTunnel.overrideCredentials,
@@ -746,7 +742,6 @@ export class ProjectService {
                 onWarehouseCatalogChange: () => {},
             },
             data.dbtVersion || DefaultSupportedDbtVersion,
-            useDbtLs,
         );
         try {
             await adapter.test();
@@ -803,10 +798,6 @@ export class ProjectService {
             await this.projectModel.getWarehouseFromCache(projectUuid);
         const sshTunnel = new SshTunnel(project.warehouseConnection);
         await sshTunnel.connect();
-        const useDbtLs = await isFeatureFlagEnabled(
-            FeatureFlags.UseDbtLs,
-            user,
-        );
 
         const adapter = await projectAdapterFromConfig(
             project.dbtConnection,
@@ -821,7 +812,6 @@ export class ProjectService {
                 },
             },
             project.dbtVersion || DefaultSupportedDbtVersion,
-            useDbtLs,
         );
         return { adapter, sshTunnel };
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1757,14 +1757,11 @@ export class ProjectService {
                      *
                      * In a follow-up after initial testing, this check should be done somewhere further
                      * down the stack.
+                     *
+                     * NOTE: Temporarily removed due to Posthog outage. Will follow-up with change adding
+                     * a timeout.
                      */
-                    const newTableCalculationsFeatureFlagEnabled =
-                        await isFeatureFlagEnabled(
-                            FeatureFlags.UseInMemoryTableCalculations,
-                            {
-                                userUuid: user.userUuid,
-                            },
-                        );
+                    const newTableCalculationsFeatureFlagEnabled = false;
 
                     const useNewTableCalculationsEngine =
                         newTableCalculationsFeatureFlagEnabled &&

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -124,7 +124,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SshKeyPairModel } from '../../models/SshKeyPairModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
 import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
-import { isFeatureFlagEnabled, postHogClient } from '../../postHog';
+import { isFeatureFlagEnabled } from '../../postHog';
 import { projectAdapterFromConfig } from '../../projectAdapters/projectAdapter';
 import { buildQuery, CompiledQuery } from '../../queryBuilder';
 import { compileMetricQuery } from '../../queryCompiler';

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -375,31 +375,8 @@ export class UnfurlService {
         const startTime = Date.now();
         let hasError = false;
 
-        const isPuppeteerSetViewportDynamicallyEnabled =
-            (await postHogClient?.isFeatureEnabled(
-                'puppeteer-set-viewport-dynamically',
-                userUuid,
-                organizationUuid !== undefined
-                    ? {
-                          groups: {
-                              organization: organizationUuid,
-                          },
-                      }
-                    : {},
-            )) ?? false;
-
-        const isPuppeteerScrollElementIntoViewEnabled =
-            (await postHogClient?.isFeatureEnabled(
-                'puppeteer-scroll-element-into-view',
-                userUuid,
-                organizationUuid !== undefined
-                    ? {
-                          groups: {
-                              organization: organizationUuid,
-                          },
-                      }
-                    : {},
-            )) ?? false;
+        const isPuppeteerSetViewportDynamicallyEnabled = false;
+        const isPuppeteerScrollElementIntoViewEnabled = false;
 
         return tracer.startActiveSpan(
             'UnfurlService.saveScreenshot',

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -6,12 +6,6 @@
  */
 export enum FeatureFlags {
     /**
-     * Use dbt ls when compiling lightdash projects with "refresh dbt"
-     * See  ProjectService for example usage.
-     */
-    UseDbtLs = 'use-dbt-ls',
-
-    /**
      * Use shared color assignments for cartesian-type charts, when possible. This
      * essentially means we try to have the same dimension translate into the same
      * color in the org's color palette every time.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Unblocks (part of?) the query experience during Posthog outage: https://status.posthog.com/

### Description:

Temporarily removes `UseInMemoryTableCalculations` feature flag check.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
