### PR TITLE
chore: Add `query_strategy` property for saved queries; allow enabling in-memory table calcs for new queries only

### DIFF
--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -70,6 +70,7 @@ export class RunViewChartQueryController extends Controller {
             tableCalculations: body.tableCalculations,
             additionalMetrics: body.additionalMetrics,
             customDimensions: body.customDimensions,
+            metadata: body.metadata,
         };
         const results: ApiQueryResults =
             await projectService.runUnderlyingDataQuery(
@@ -114,6 +115,7 @@ export class RunViewChartQueryController extends Controller {
             tableCalculations: body.tableCalculations,
             additionalMetrics: body.additionalMetrics,
             customDimensions: body.customDimensions,
+            metadata: body.metadata,
         };
         const results: ApiQueryResults = await projectService.runExploreQuery(
             req.user!,

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -7,8 +7,8 @@ import {
     CustomFormat,
     DBFieldTypes,
     MetricFilterRule,
+    MetricQueryStrategy,
     MetricType,
-    NumberSeparator,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -82,6 +82,7 @@ export type DbSavedChartVersion = {
     chart_config: ChartConfig['config'] | undefined;
     pivot_dimensions: string[] | undefined;
     updated_by_user_uuid: string | undefined;
+    query_strategy: MetricQueryStrategy | undefined;
 };
 
 export type SavedChartVersionsTable = Knex.CompositeTableType<
@@ -99,6 +100,7 @@ export type CreateDbSavedChartVersion = Pick<
     | 'pivot_dimensions'
     | 'chart_config'
     | 'updated_by_user_uuid'
+    | 'query_strategy'
 >;
 
 type DbSavedChartVersionField = {

--- a/packages/backend/src/database/migrations/20240227170646_add_strategy_to_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20240227170646_add_strategy_to_saved_queries.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const savedQueriesVersionsTable = 'saved_queries_versions';
+const columnName = 'query_strategy';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(savedQueriesVersionsTable, (t) => {
+        t.text(columnName).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(savedQueriesVersionsTable, (t) => {
+        t.dropColumn(columnName);
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -988,6 +988,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricQueryStrategy: {
+        dataType: 'refEnum',
+        enums: ['in_memory_table_calculations'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricQuery: {
         dataType: 'refAlias',
         type: {
@@ -996,9 +1001,9 @@ const models: TsoaRoute.Models = {
                 metadata: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        queryStrategy: { ref: 'MetricQueryStrategy' },
                         hasADateDimension: {
                             ref: 'Pick_CompiledDimension.label-or-name_',
-                            required: true,
                         },
                     },
                 },
@@ -1157,6 +1162,7 @@ const models: TsoaRoute.Models = {
                 metadata: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        queryStrategy: { ref: 'MetricQueryStrategy' },
                         hasADateDimension: {
                             ref: 'Pick_CompiledDimension.label-or-name_',
                             required: true,
@@ -3102,9 +3108,9 @@ const models: TsoaRoute.Models = {
                 metadata: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        queryStrategy: { ref: 'MetricQueryStrategy' },
                         hasADateDimension: {
                             ref: 'Pick_CompiledDimension.label-or-name_',
-                            required: true,
                         },
                     },
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1028,15 +1028,22 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
+            "MetricQueryStrategy": {
+                "description": "If specified as a property of a metric query, is stored alongside the\nsaved query, and ultimately may affect how the query is executed.\n\nIf you greatly modify how a query strategy works, consider instead adding\nit as a new version (e.g InMemoryTableCalculationsV2)\n\nIf no value is specified, the organization/global default is assumed.",
+                "enum": ["in_memory_table_calculations"],
+                "type": "string"
+            },
             "MetricQuery": {
                 "properties": {
                     "metadata": {
                         "properties": {
+                            "queryStrategy": {
+                                "$ref": "#/components/schemas/MetricQueryStrategy"
+                            },
                             "hasADateDimension": {
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": ["hasADateDimension"],
                         "type": "object"
                     },
                     "customDimensions": {
@@ -1215,6 +1222,9 @@
                 "properties": {
                     "metadata": {
                         "properties": {
+                            "queryStrategy": {
+                                "$ref": "#/components/schemas/MetricQueryStrategy"
+                            },
                             "hasADateDimension": {
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
@@ -3465,11 +3475,13 @@
                 "properties": {
                     "metadata": {
                         "properties": {
+                            "queryStrategy": {
+                                "$ref": "#/components/schemas/MetricQueryStrategy"
+                            },
                             "hasADateDimension": {
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": ["hasADateDimension"],
                         "type": "object"
                     },
                     "granularity": {
@@ -6529,7 +6541,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1018.4",
+        "version": "0.1018.7",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -13,6 +13,7 @@ import {
     getCustomDimensionId,
     isFormat,
     LightdashUser,
+    MetricQueryStrategy,
     NotFoundError,
     Organization,
     Project,
@@ -74,6 +75,7 @@ type DbSavedChartDetails = {
     last_name: string;
     pinned_list_uuid: string;
     dashboard_uuid: string | null;
+    query_strategy: MetricQueryStrategy | undefined;
 };
 
 const createSavedChartVersionField = async (
@@ -140,6 +142,7 @@ const createSavedChartVersion = async (
             tableCalculations,
             additionalMetrics,
             customDimensions,
+            metadata,
         },
         chartConfig,
         tableConfig,
@@ -158,6 +161,7 @@ const createSavedChartVersion = async (
                 chart_type: chartConfig.type,
                 chart_config: chartConfig.config,
                 updated_by_user_uuid: updatedByUser?.userUuid,
+                query_strategy: metadata?.queryStrategy,
             })
             .returning('*');
         const promises: Promise<any>[] = [];
@@ -624,6 +628,7 @@ export class SavedChartModel {
                     'saved_queries_versions.created_at',
                     'saved_queries_versions.chart_config',
                     'saved_queries_versions.pivot_dimensions',
+                    'saved_queries_versions.query_strategy',
                     `${OrganizationTableName}.organization_uuid`,
                     `${OrganizationTableName}.chart_colors`,
                     `${UserTableName}.user_uuid`,
@@ -819,6 +824,13 @@ export class SavedChartModel {
                         binWidth: cd.bin_width,
                         customRange: cd.custom_range,
                     })),
+                    ...(savedQuery.query_strategy
+                        ? {
+                              metadata: {
+                                  queryStrategy: savedQuery.query_strategy,
+                              },
+                          }
+                        : {}),
                 },
                 chartConfig,
                 tableConfig: {

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -25,8 +25,6 @@ import {
 import {
     SavedChartsTableName,
     SavedChartTable,
-    SavedChartVersionsTable,
-    SavedChartVersionsTableName,
 } from '../../database/entities/savedCharts';
 import { DbSpace, SpaceTableName } from '../../database/entities/spaces';
 import { UserTable, UserTableName } from '../../database/entities/users';

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -15,6 +15,19 @@ import {
 import { Filters, MetricFilterRule } from './filter';
 import { DateGranularity } from './timeFrames';
 
+/**
+ * If specified as a property of a metric query, is stored alongside the
+ * saved query, and ultimately may affect how the query is executed.
+ *
+ * If you greatly modify how a query strategy works, consider instead adding
+ * it as a new version (e.g InMemoryTableCalculationsV2)
+ *
+ * If no value is specified, the organization/global default is assumed.
+ */
+export enum MetricQueryStrategy {
+    InMemoryTableCalculations = 'in_memory_table_calculations',
+}
+
 export interface AdditionalMetric {
     label?: string;
     type: MetricType;
@@ -63,7 +76,8 @@ export type MetricQuery = {
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     customDimensions?: CustomDimension[];
     metadata?: {
-        hasADateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+        hasADateDimension?: Pick<CompiledDimension, 'label' | 'name'>;
+        queryStrategy?: MetricQueryStrategy;
     };
 };
 export type CompiledMetricQuery = MetricQuery & {
@@ -121,7 +135,8 @@ export type MetricQueryResponse = {
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     customDimensions?: CustomDimension[];
     metadata?: {
-        hasADateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+        hasADateDimension?: Pick<CompiledDimension, 'label' | 'name'>;
+        queryStrategy?: MetricQueryStrategy;
     };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5814,7 +5814,7 @@
   resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-2.47.0.tgz#b704e7ae98f95be8bd6e938b4b2e84cd20b0cf31"
   integrity sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==
   dependencies:
-    "@tabler/icons" "2.32.0"
+    "@tabler/icons" "2.47.0"
     prop-types "^15.7.2"
 
 "@tabler/icons@2.47.0":


### PR DESCRIPTION
Closes: #9081 

### Description:

- Adds a new column, `saved_queries_versions.query_strategy`
- Adds a new `MetricQueryStrategy` enum, with possible values for the above column
- Tags query versions saved with the table calculations feature flag enabled with `MetricQueryStrategy.InMemoryTableCalculations`, and uses this property to decide if a query uses the new table calculations engine.
- Updates models, controllers + frontend hooks to correctly pass values around.

The column can be used to version different implementations of the same strategy (by adding additional enum members, e.g `InMemoryTableCalculationsV2`), or other query strategies in the future.

An undefined value signals the "default" strategy should be used.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
