### PR TITLE
fix: validate preview project

### DIFF
--- a/docs/docs/guides/cli/how-to-use-lightdash-validate.mdx
+++ b/docs/docs/guides/cli/how-to-use-lightdash-validate.mdx
@@ -46,7 +46,7 @@ You can use this output to block a deploy on Github actions like this
 - name: Start preview 
   run: lightdash start-preview 
 - name: Validate 
-  run: lightdash validate 
+  run: lightdash validate --project ${{ steps.start-preview.outputs.project_uuid }}
 ```
 
 To learn more about setting up GitHub actions for Lightdash, check out the docs [here](/snippets/automatically-deploy-your-changes-using-github-action)

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -91,7 +91,7 @@ export const validateHandler = async (options: ValidateHandlerOptions) => {
 
     if (options.project) {
         console.error(`Validating project ${projectUuid}\n`);
-    } else if (config.context?.previewProject) {
+    } else if (config.context?.previewProject === projectUuid) {
         console.error(
             `Validating preview project ${styles.bold(
                 config.context?.previewName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9088 

### Description:

Added the condition to only show preview message if `config.context?.previewProject === projectUuid` and updated the command in docs.

The bug was occuring because the `start-preview` command does not affect the current project selected in the CLI in the config which in turn is used by `lightdash validate`. 
Our condition only checks for the presence of `previewProject` and not if its currently selected.

https://github.com/lightdash/lightdash/blob/feae273a5e985223a7eb9487ee6c7df0ff2012bc/packages/cli/src/handlers/validate.ts#L94

If we want to validate preview projects after `start-preview` without the `--project` flag, we can call `setProject` method to update selected project in CLI whenever `start-preview` is run.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
