### PR TITLE
fix: dashboard chart schedulers not appearing

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -422,11 +422,25 @@ export class SchedulerModel {
                 `${SavedChartsTableName}.saved_query_uuid`,
                 `${SchedulerTableName}.saved_chart_uuid`,
             )
-            .leftJoin(
-                SpaceTableName,
-                `${SpaceTableName}.space_id`,
-                `${SavedChartsTableName}.space_id`,
-            )
+            .leftJoin(DashboardsTableName, function joinDashboards() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`);
+            })
+            .leftJoin(SpaceTableName, function joinSpaces() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                ).andOnNotNull(`${SavedChartsTableName}.space_id`);
+                this.orOn(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${DashboardsTableName}.space_id`,
+                );
+            })
             .leftJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9053 

### Description:

`charts` created in `dashboards` were not showing up because they don't belong to a `space` and therefore have `space_id` column set to `NULL`

Since those `charts` belong to a `dashboard` the fix is to join that table in the query to get access to the `space_id` column

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
