### PR TITLE
feat: Add support for markdown descriptions for models, in the Explore sidebar models list

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -8,7 +8,9 @@ models:
           sql_on: ${customers.customer_id} = ${membership.customer_id}
         - join: plan
           sql_on: ${membership.plan_id} = ${plan.id}
-    description: >-
+    description: |
+      # Customers
+
       This table has basic information about a customer, as well as some derived
       facts based on a customer's orders
     columns:
@@ -72,9 +74,11 @@ models:
           dimension:
             hidden: true
   - name: orders
-    description: >-
+    description: |
       This table has basic information about orders, as well as some derived
       facts based on payments
+
+      {{ doc("orders_status") }}
     meta:
       joins:
         - join: customers

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -88,12 +88,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     {
                         title: data.label,
                         active: true,
-                        tooltipProps: {
-                            withinPortal: true,
-                            disabled: !data.tables[data.baseTable].description,
-                            label: data.tables[data.baseTable].description,
-                            position: 'right',
-                        },
                     },
                 ]}
             />

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -2,13 +2,14 @@ import { InlineErrorType, SummaryExplore } from '@lightdash/common';
 import {
     Anchor,
     Box,
+    Group,
     Highlight,
     NavLink,
+    Popover,
     Text,
     Tooltip,
-    Transition,
 } from '@mantine/core';
-import { useHover } from '@mantine/hooks';
+import { useToggle } from '@mantine/hooks';
 import {
     IconAlertTriangle,
     IconInfoCircle,
@@ -16,6 +17,11 @@ import {
 } from '@tabler/icons-react';
 import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import { useItemDetail } from '../ExploreTree/TableTree/ItemDetailContext';
+import {
+    ItemDetailMarkdown,
+    ItemDetailPreview,
+} from '../ExploreTree/TableTree/ItemDetailPreview';
 
 type ExploreNavLinkProps = {
     explore: SummaryExplore;
@@ -28,7 +34,21 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
     query,
     onClick,
 }: ExploreNavLinkProps) => {
-    const { ref, hovered } = useHover<HTMLButtonElement>();
+    const { showItemDetail, isItemDetailOpen } = useItemDetail();
+    const [isHover, toggleHover] = useToggle();
+
+    const onOpenDescriptionView = () => {
+        toggleHover(false);
+        showItemDetail({
+            header: (
+                <Group spacing="sm">
+                    <MantineIcon icon={IconTable} size="lg" color="gray.7" />
+                    <Text size="md">{explore.label}</Text>
+                </Group>
+            ),
+            detail: <ItemDetailMarkdown source={explore.description ?? ''} />,
+        });
+    };
 
     if ('errors' in explore) {
         const showNoDimensionsIcon = explore.errors.every(
@@ -90,33 +110,48 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
 
     return (
         <NavLink
-            ref={ref}
             role="listitem"
             icon={<MantineIcon icon={IconTable} size="lg" color="gray.7" />}
             onClick={onClick}
+            onMouseEnter={() => toggleHover(true)}
+            onMouseLeave={() => toggleHover(false)}
             label={
-                <Highlight component={Text} highlight={query ?? ''} truncate>
-                    {explore.label}
-                </Highlight>
-            }
-            rightSection={
-                <Transition mounted={hovered} transition="fade">
-                    {(styles) => (
-                        <Tooltip
-                            withinPortal
-                            position="right"
-                            label={explore.description}
-                            multiline
+                <Popover
+                    opened={isHover}
+                    keepMounted={false}
+                    shadow="sm"
+                    withinPortal
+                    disabled={!explore.description || isItemDetailOpen}
+                    position="right"
+                >
+                    <Popover.Target>
+                        <Highlight
+                            component={Text}
+                            highlight={query ?? ''}
+                            truncate
                         >
-                            <MantineIcon
-                                icon={IconInfoCircle}
-                                color="gray.7"
-                                size="lg"
-                                style={styles}
-                            />
-                        </Tooltip>
-                    )}
-                </Transition>
+                            {explore.label}
+                        </Highlight>
+                    </Popover.Target>
+                    <Popover.Dropdown
+                        p="xs"
+                        /**
+                         * Takes up space to the right, so it's OK to go fairly wide in the interest
+                         * of readability.
+                         */
+                        maw={500}
+                        /**
+                         * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
+                         * while interacting with the hovercard.
+                         */
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <ItemDetailPreview
+                            onViewDescription={onOpenDescriptionView}
+                            description={explore.description}
+                        />
+                    </Popover.Dropdown>
+                </Popover>
             }
         />
     );

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -1,14 +1,5 @@
 import { InlineErrorType, SummaryExplore } from '@lightdash/common';
-import {
-    Anchor,
-    Box,
-    Group,
-    Highlight,
-    NavLink,
-    Popover,
-    Text,
-    Tooltip,
-} from '@mantine/core';
+import { Anchor, Box, Highlight, NavLink, Text, Tooltip } from '@mantine/core';
 import { useToggle } from '@mantine/hooks';
 import {
     IconAlertTriangle,
@@ -17,11 +8,7 @@ import {
 } from '@tabler/icons-react';
 import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
-import { useItemDetail } from '../ExploreTree/TableTree/ItemDetailContext';
-import {
-    ItemDetailMarkdown,
-    ItemDetailPreview,
-} from '../ExploreTree/TableTree/ItemDetailPreview';
+import { TableItemDetailPreview } from '../ExploreTree/TableTree/ItemDetailPreview';
 
 type ExploreNavLinkProps = {
     explore: SummaryExplore;
@@ -34,21 +21,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
     query,
     onClick,
 }: ExploreNavLinkProps) => {
-    const { showItemDetail, isItemDetailOpen } = useItemDetail();
     const [isHover, toggleHover] = useToggle();
-
-    const onOpenDescriptionView = () => {
-        toggleHover(false);
-        showItemDetail({
-            header: (
-                <Group spacing="sm">
-                    <MantineIcon icon={IconTable} size="lg" color="gray.7" />
-                    <Text size="md">{explore.label}</Text>
-                </Group>
-            ),
-            detail: <ItemDetailMarkdown source={explore.description ?? ''} />,
-        });
-    };
 
     if ('errors' in explore) {
         const showNoDimensionsIcon = explore.errors.every(
@@ -116,42 +89,20 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
             onMouseEnter={() => toggleHover(true)}
             onMouseLeave={() => toggleHover(false)}
             label={
-                <Popover
-                    opened={isHover}
-                    keepMounted={false}
-                    shadow="sm"
-                    withinPortal
-                    disabled={!explore.description || isItemDetailOpen}
-                    position="right"
+                <TableItemDetailPreview
+                    label={explore.label}
+                    description={explore.description}
+                    showPreview={isHover}
+                    closePreview={() => toggleHover(false)}
                 >
-                    <Popover.Target>
-                        <Highlight
-                            component={Text}
-                            highlight={query ?? ''}
-                            truncate
-                        >
-                            {explore.label}
-                        </Highlight>
-                    </Popover.Target>
-                    <Popover.Dropdown
-                        p="xs"
-                        /**
-                         * Takes up space to the right, so it's OK to go fairly wide in the interest
-                         * of readability.
-                         */
-                        maw={500}
-                        /**
-                         * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
-                         * while interacting with the hovercard.
-                         */
-                        onClick={(event) => event.stopPropagation()}
+                    <Highlight
+                        component={Text}
+                        highlight={query ?? ''}
+                        truncate
                     >
-                        <ItemDetailPreview
-                            onViewDescription={onOpenDescriptionView}
-                            description={explore.description}
-                        />
-                    </Popover.Dropdown>
-                </Popover>
+                        {explore.label}
+                    </Highlight>
+                </TableItemDetailPreview>
             }
         />
     );

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -94,6 +94,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                     description={explore.description}
                     showPreview={isHover}
                     closePreview={() => toggleHover(false)}
+                    offset={0}
                 >
                     <Highlight
                         component={Text}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -18,6 +18,7 @@ import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import SuboptimalState from '../../common/SuboptimalState/SuboptimalState';
 import ExplorePanel from '../ExplorePanel';
+import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailContext';
 import ExploreGroup from './ExploreGroup';
 import ExploreNavLink from './ExploreNavLink';
 
@@ -180,15 +181,17 @@ const ExploreSideBar = memo(() => {
     }, [clearExplore, history, projectUuid]);
 
     return (
-        <TrackSection name={SectionName.SIDEBAR}>
-            <Stack h="100%" sx={{ flexGrow: 1 }}>
-                {!tableName ? (
-                    <BasePanel />
-                ) : (
-                    <ExplorePanel onBack={handleBack} />
-                )}
-            </Stack>
-        </TrackSection>
+        <ItemDetailProvider>
+            <TrackSection name={SectionName.SIDEBAR}>
+                <Stack h="100%" sx={{ flexGrow: 1 }}>
+                    {!tableName ? (
+                        <BasePanel />
+                    ) : (
+                        <ExplorePanel onBack={handleBack} />
+                    )}
+                </Stack>
+            </TrackSection>
+        </ItemDetailProvider>
     );
 });
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -1,7 +1,19 @@
-import { Anchor, Box, Flex, Title, useMantineTheme } from '@mantine/core';
+import {
+    Anchor,
+    Box,
+    Flex,
+    Group,
+    Popover,
+    Text,
+    Title,
+    useMantineTheme,
+} from '@mantine/core';
+import { IconTable } from '@tabler/icons-react';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
-import { FC } from 'react';
+import { FC, PropsWithChildren } from 'react';
 import { rehypeRemoveHeaderLinks } from '../../../../utils/markdownUtils';
+import MantineIcon from '../../../common/MantineIcon';
+import { useItemDetail } from './ItemDetailContext';
 
 /**
  * Renders markdown for an item's description, with additional constraints
@@ -85,5 +97,67 @@ export const ItemDetailPreview: FC<{
                 </Box>
             )}
         </Flex>
+    );
+};
+
+/**
+ * Helper for using ItemDetailPreview with tables or models.
+ */
+export const TableItemDetailPreview = ({
+    showPreview,
+    closePreview,
+    label,
+    description,
+    children,
+}: PropsWithChildren<{
+    showPreview: boolean;
+    closePreview: () => void;
+    description?: string;
+    label: string;
+}>) => {
+    const { showItemDetail } = useItemDetail();
+
+    const onOpenDescriptionView = () => {
+        closePreview();
+        showItemDetail({
+            header: (
+                <Group spacing="sm">
+                    <MantineIcon icon={IconTable} size="lg" color="gray.7" />
+                    <Text size="md">{label}</Text>
+                </Group>
+            ),
+            detail: <ItemDetailMarkdown source={description ?? ''} />,
+        });
+    };
+
+    return (
+        <Popover
+            opened={showPreview}
+            keepMounted={false}
+            shadow="sm"
+            withinPortal
+            disabled={!description}
+            position="right"
+        >
+            <Popover.Target>{children}</Popover.Target>
+            <Popover.Dropdown
+                p="xs"
+                /**
+                 * Takes up space to the right, so it's OK to go fairly wide in the interest
+                 * of readability.
+                 */
+                maw={500}
+                /**
+                 * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
+                 * while interacting with the hovercard.
+                 */
+                onClick={(event) => event.stopPropagation()}
+            >
+                <ItemDetailPreview
+                    onViewDescription={onOpenDescriptionView}
+                    description={description}
+                />
+            </Popover.Dropdown>
+        </Popover>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -1,0 +1,89 @@
+import { Anchor, Box, Flex, Title, useMantineTheme } from '@mantine/core';
+import ReactMarkdownPreview from '@uiw/react-markdown-preview';
+import { FC } from 'react';
+import { rehypeRemoveHeaderLinks } from '../../../../utils/markdownUtils';
+
+/**
+ * Renders markdown for an item's description, with additional constraints
+ * to avoid markdown styling from completely throwing its surroundings out
+ * of whack.
+ */
+export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
+    const theme = useMantineTheme();
+    return (
+        <ReactMarkdownPreview
+            skipHtml
+            linkTarget="_blank"
+            components={{
+                h1: ({ children }) => <Title order={2}>{children}</Title>,
+                h2: ({ children }) => <Title order={3}>{children}</Title>,
+                h3: ({ children }) => <Title order={4}>{children}</Title>,
+            }}
+            rehypeRewrite={rehypeRemoveHeaderLinks}
+            source={source}
+            disallowedElements={['img']}
+            style={{
+                fontSize: theme.fontSizes.sm,
+            }}
+        />
+    );
+};
+
+/**
+ * Renders a truncated version of an item's description, with an option
+ * to read the full description if necessary.
+ */
+export const ItemDetailPreview: FC<{
+    description?: string;
+    onViewDescription: () => void;
+}> = ({ description, onViewDescription }) => {
+    if (!description) return null;
+
+    /**
+     * This value is pretty arbitrary - it's an amount of characters that will exceed
+     * a single line, and for which the 'Read more' option should make sense, and not
+     * be an annoyance.
+     *
+     * It's better to err on the side of caution, and show the 'Read more' option even
+     * if unnecessarily so.
+     */
+    const isTruncated = description.length > 180;
+
+    return (
+        <Flex direction="column" gap={'xs'}>
+            <Box
+                mah={140}
+                style={{
+                    overflow: 'hidden',
+                    textOverflow: 'clip',
+                }}
+            >
+                <ItemDetailMarkdown source={description} />
+            </Box>
+            {isTruncated && (
+                <Box
+                    ta={'center'}
+                    /**
+                     * Forces the 'Read more' option to slightly overlap with the content, and show
+                     * a slight fade effect.
+                     */
+                    mt={-30}
+                    pt={20}
+                    style={{
+                        background:
+                            'linear-gradient(rgba(255,255,255,0) 0%, rgba(255,255,255,1) 60%, rgba(255,255,255,1) 100%)',
+                    }}
+                >
+                    <Anchor
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onViewDescription();
+                        }}
+                    >
+                        Read full description
+                    </Anchor>
+                </Box>
+            )}
+        </Flex>
+    );
+};

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -1,7 +1,6 @@
 import {
     Anchor,
     Box,
-    Flex,
     Group,
     Popover,
     Text,
@@ -62,31 +61,24 @@ export const ItemDetailPreview: FC<{
     const isTruncated = description.length > 180;
 
     return (
-        <Flex direction="column" gap={'xs'}>
+        <Box>
             <Box
-                mah={140}
+                mah={120}
                 style={{
                     overflow: 'hidden',
-                    textOverflow: 'clip',
+
+                    // If we're over the truncation limit, use a mask to fade out the bottom of the container.
+                    maskImage: isTruncated
+                        ? 'linear-gradient(180deg, white 0%, white 80%, transparent 100%)'
+                        : undefined,
                 }}
             >
                 <ItemDetailMarkdown source={description} />
             </Box>
             {isTruncated && (
-                <Box
-                    ta={'center'}
-                    /**
-                     * Forces the 'Read more' option to slightly overlap with the content, and show
-                     * a slight fade effect.
-                     */
-                    mt={-30}
-                    pt={20}
-                    style={{
-                        background:
-                            'linear-gradient(rgba(255,255,255,0) 0%, rgba(255,255,255,1) 60%, rgba(255,255,255,1) 100%)',
-                    }}
-                >
+                <Box ta={'center'}>
                     <Anchor
+                        size={'xs'}
                         onClick={(e) => {
                             e.preventDefault();
                             onViewDescription();
@@ -96,7 +88,7 @@ export const ItemDetailPreview: FC<{
                     </Anchor>
                 </Box>
             )}
-        </Flex>
+        </Box>
     );
 };
 
@@ -141,7 +133,6 @@ export const TableItemDetailPreview = ({
         >
             <Popover.Target>{children}</Popover.Target>
             <Popover.Dropdown
-                p="xs"
                 /**
                  * Takes up space to the right, so it's OK to go fairly wide in the interest
                  * of readability.

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -100,12 +100,15 @@ export const TableItemDetailPreview = ({
     closePreview,
     label,
     description,
+    /** Position offset for the preview popover */
+    offset = 20,
     children,
 }: PropsWithChildren<{
     showPreview: boolean;
     closePreview: () => void;
     description?: string;
     label: string;
+    offset?: number;
 }>) => {
     const { showItemDetail } = useItemDetail();
 
@@ -130,6 +133,8 @@ export const TableItemDetailPreview = ({
             withinPortal
             disabled={!description}
             position="right"
+            withArrow
+            offset={offset}
         >
             <Popover.Target>{children}</Popover.Target>
             <Popover.Dropdown

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -154,6 +154,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         keepMounted={false}
                         shadow="sm"
                         withinPortal
+                        withArrow
                         disabled={!description && !isMissing}
                         position="right"
                         /** Ensures the hover card does not overlap with the right-hand menu. */

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -11,119 +11,28 @@ import {
     timeFrameConfigs,
 } from '@lightdash/common';
 import {
-    Anchor,
-    Box,
-    Flex,
     Group,
     Highlight,
     NavLink,
     Popover,
     Text,
-    Title,
     Tooltip,
-    useMantineTheme,
 } from '@mantine/core';
 import { IconAlertTriangle, IconFilter } from '@tabler/icons-react';
-import MarkdownPreview from '@uiw/react-markdown-preview';
 import { darken, lighten } from 'polished';
 import { FC } from 'react';
 import { useToggle } from 'react-use';
 import { getItemBgColor } from '../../../../../hooks/useColumns';
 import { useFilters } from '../../../../../hooks/useFilters';
-import { rehypeRemoveHeaderLinks } from '../../../../../utils/markdownUtils';
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useItemDetail } from '../ItemDetailContext';
+import { ItemDetailMarkdown, ItemDetailPreview } from '../ItemDetailPreview';
 import { Node, useTableTreeContext } from './TreeProvider';
 import TreeSingleNodeActions from './TreeSingleNodeActions';
 
 type Props = {
     node: Node;
-};
-
-/**
- * Renders markdown for an item's description, with additional constraints
- * to avoid markdown styling from completely throwing its surroundings out
- * of whack.
- */
-const NodeDetailMarkdown: FC<{ source: string }> = ({ source }) => {
-    const theme = useMantineTheme();
-    return (
-        <MarkdownPreview
-            skipHtml
-            linkTarget="_blank"
-            components={{
-                h1: ({ children }) => <Title order={2}>{children}</Title>,
-                h2: ({ children }) => <Title order={3}>{children}</Title>,
-                h3: ({ children }) => <Title order={4}>{children}</Title>,
-            }}
-            rehypeRewrite={rehypeRemoveHeaderLinks}
-            source={source}
-            disallowedElements={['img']}
-            style={{
-                fontSize: theme.fontSizes.sm,
-            }}
-        />
-    );
-};
-
-/**
- * Renders a truncated version of an item's description, with an option
- * to read the full description if necessary.
- */
-const NodeDetailPreview: FC<{
-    description?: string;
-    onViewDescription: () => void;
-}> = ({ description, onViewDescription }) => {
-    if (!description) return null;
-
-    /**
-     * This value is pretty arbitrary - it's an amount of characters that will exceed
-     * a single line, and for which the 'Read more' option should make sense, and not
-     * be an annoyance.
-     *
-     * It's better to err on the side of caution, and show the 'Read more' option even
-     * if unnecessarily so.
-     */
-    const isTruncated = description.length > 180;
-
-    return (
-        <Flex direction="column" gap={'xs'}>
-            <Box
-                mah={140}
-                style={{
-                    overflow: 'hidden',
-                    textOverflow: 'clip',
-                }}
-            >
-                <NodeDetailMarkdown source={description} />
-            </Box>
-            {isTruncated && (
-                <Box
-                    ta={'center'}
-                    /**
-                     * Forces the 'Read more' option to slightly overlap with the content, and show
-                     * a slight fade effect.
-                     */
-                    mt={-30}
-                    pt={20}
-                    style={{
-                        background:
-                            'linear-gradient(rgba(255,255,255,0) 0%, rgba(255,255,255,1) 60%, rgba(255,255,255,1) 100%)',
-                    }}
-                >
-                    <Anchor
-                        onClick={(e) => {
-                            e.preventDefault();
-                            onViewDescription();
-                        }}
-                    >
-                        Read full description
-                    </Anchor>
-                </Box>
-            )}
-        </Flex>
-    );
 };
 
 const TreeSingleNode: FC<Props> = ({ node }) => {
@@ -200,9 +109,9 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                 </Group>
             ),
             detail: description ? (
-                <NodeDetailMarkdown
+                <ItemDetailMarkdown
                     source={description ?? ''}
-                ></NodeDetailMarkdown>
+                ></ItemDetailMarkdown>
             ) : (
                 <Text color="gray">No description available.</Text>
             ),
@@ -278,7 +187,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             {isMissing ? (
                                 `This field from '${item.table}' table is no longer available`
                             ) : (
-                                <NodeDetailPreview
+                                <ItemDetailPreview
                                     onViewDescription={onOpenDescriptionView}
                                     description={description}
                                 />

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -109,9 +109,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                 </Group>
             ),
             detail: description ? (
-                <ItemDetailMarkdown
-                    source={description ?? ''}
-                ></ItemDetailMarkdown>
+                <ItemDetailMarkdown source={description}></ItemDetailMarkdown>
             ) : (
                 <Text color="gray">No description available.</Text>
             ),

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -3,7 +3,7 @@ import {
     CompiledTable,
     CustomDimension,
 } from '@lightdash/common';
-import { Group, MantineProvider, NavLink, Text, Tooltip } from '@mantine/core';
+import { MantineProvider, NavLink, Text } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
 import type { FC } from 'react';
 import { useToggle } from 'react-use';
@@ -12,6 +12,7 @@ import { getMantineThemeOverride } from '../../../../mantineTheme';
 import { TrackSection } from '../../../../providers/TrackingProvider';
 import { SectionName } from '../../../../types/Events';
 import MantineIcon from '../../../common/MantineIcon';
+import { TableItemDetailPreview } from './ItemDetailPreview';
 import TableTreeSections from './TableTreeSections';
 
 type TableTreeWrapperProps = {
@@ -26,26 +27,26 @@ const TableTreeWrapper: FC<React.PropsWithChildren<TableTreeWrapperProps>> = ({
     table,
     children,
 }) => {
+    const [isHover, toggleHover] = useToggle(false);
+
     return (
         <NavLink
             opened={isOpen}
             onChange={toggle}
+            onMouseEnter={() => toggleHover(true)}
+            onMouseLeave={() => toggleHover(false)}
             icon={<MantineIcon icon={IconTable} size="lg" color="gray.7" />}
             label={
-                <Tooltip
-                    label={table.description}
-                    position="top-start"
-                    withinPortal
-                    maw={350}
-                    multiline
-                    sx={{ whiteSpace: 'normal' }}
+                <TableItemDetailPreview
+                    label={table.label}
+                    description={table.description}
+                    showPreview={isHover}
+                    closePreview={() => toggleHover(false)}
                 >
-                    <Group>
-                        <Text truncate fw={600}>
-                            {table.label}
-                        </Text>
-                    </Group>
-                </Tooltip>
+                    <Text truncate fw={600}>
+                        {table.label}
+                    </Text>
+                </TableItemDetailPreview>
             }
             styles={{
                 root: {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -12,7 +12,6 @@ import { getMantineThemeOverride } from '../../../../mantineTheme';
 import { TrackSection } from '../../../../providers/TrackingProvider';
 import { SectionName } from '../../../../types/Events';
 import MantineIcon from '../../../common/MantineIcon';
-import { ItemDetailProvider } from './ItemDetailContext';
 import TableTreeSections from './TableTreeSections';
 
 type TableTreeWrapperProps = {
@@ -114,24 +113,22 @@ const TableTree: FC<Props> = ({
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <MantineProvider inherit theme={themeOverride}>
-                <ItemDetailProvider>
-                    <Wrapper
-                        isOpen={isSearching || isOpen}
-                        toggle={toggle}
+                <Wrapper
+                    isOpen={isSearching || isOpen}
+                    toggle={toggle}
+                    table={table}
+                >
+                    <TableTreeSections
                         table={table}
-                    >
-                        <TableTreeSections
-                            table={table}
-                            searchQuery={searchQuery}
-                            additionalMetrics={additionalMetrics}
-                            customDimensions={customDimensions}
-                            missingCustomMetrics={missingCustomMetrics}
-                            missingFields={missingFields}
-                            selectedDimensions={selectedDimensions}
-                            {...rest}
-                        />
-                    </Wrapper>
-                </ItemDetailProvider>
+                        searchQuery={searchQuery}
+                        additionalMetrics={additionalMetrics}
+                        customDimensions={customDimensions}
+                        missingCustomMetrics={missingCustomMetrics}
+                        missingFields={missingFields}
+                        selectedDimensions={selectedDimensions}
+                        {...rest}
+                    />
+                </Wrapper>
             </MantineProvider>
         </TrackSection>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Follow-up to #1174 
Ticket: #9148 

### Description:

Extends markdown/longer description support to the Explore sidebar's models list

![Kapture 2024-02-29 at 10 42 55](https://github.com/lightdash/lightdash/assets/382538/6437f3ac-6478-4f5d-990b-96d5ae13c842)
![Kapture 2024-02-29 at 13 44 54](https://github.com/lightdash/lightdash/assets/382538/ed50b0a2-778e-41bc-8e07-8a08c1cf6b6d)

- Removes tooltip from breadcrumb for simplicity for now, will re-introduce it with markdown support on a follow-up if deemed necessary, but requires more work to ensure it works well across different breadcrumb uses.
- Adds support for markdown descriptions on models
- Reshuffles some code around to remove duplication around model descriptions + minor cleanup


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
