### PR TITLE
chore: Revert posthog-outage related changes, migrate feature flags to `isFeatureFlagEnabled` helper

### DIFF
--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -3,7 +3,9 @@ import { PostHog } from 'posthog-node';
 import { lightdashConfig } from './config/lightdashConfig';
 
 // How long to wait for Posthog to reply:
-const FLAG_CHECK_TIMEOUT = 350; // ms
+const FLAG_CHECK_TIMEOUT = process.env.POSTHOG_CHECK_TIMEOUT
+    ? parseInt(process.env.POSTHOG_CHECK_TIMEOUT, 10)
+    : 500;
 
 export const postHogClient = lightdashConfig.posthog.projectApiKey
     ? new PostHog(lightdashConfig.posthog.projectApiKey, {

--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -2,10 +2,10 @@ import { FeatureFlags, SessionUser } from '@lightdash/common';
 import { PostHog } from 'posthog-node';
 import { lightdashConfig } from './config/lightdashConfig';
 
-// How long to wait for Posthog to reply:
+// How long to wait for Posthog to reply (in ms):
 const FLAG_CHECK_TIMEOUT = process.env.POSTHOG_CHECK_TIMEOUT
     ? parseInt(process.env.POSTHOG_CHECK_TIMEOUT, 10)
-    : 500;
+    : 500; /* ms */
 
 export const postHogClient = lightdashConfig.posthog.projectApiKey
     ? new PostHog(lightdashConfig.posthog.projectApiKey, {
@@ -32,6 +32,10 @@ export async function isFeatureFlagEnabled(
         return false;
     }
 
+    /**
+     * Check if this flag is enabled via Posthog. The check must resolve within
+     * FLAG_CHECK_TIMEOUT, otherwise we return false.
+     */
     const isEnabled = await Promise.race([
         postHog.isFeatureEnabled(
             flag,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1756,11 +1756,12 @@ export class ProjectService {
                      *
                      * In a follow-up after initial testing, this check should be done somewhere further
                      * down the stack.
-                     *
-                     * NOTE: Temporarily removed due to Posthog outage. Will follow-up with change adding
-                     * a timeout.
                      */
-                    const newTableCalculationsFeatureFlagEnabled = false;
+                    const newTableCalculationsFeatureFlagEnabled =
+                        await isFeatureFlagEnabled(
+                            FeatureFlags.UseInMemoryTableCalculations,
+                            user,
+                        );
 
                     const useNewTableCalculationsEngine =
                         newTableCalculationsFeatureFlagEnabled &&

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -4,6 +4,7 @@ import {
     AuthorizationError,
     ChartType,
     DownloadFileType,
+    FeatureFlags,
     ForbiddenError,
     LightdashPage,
     SessionUser,
@@ -25,7 +26,7 @@ import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { ShareModel } from '../../models/ShareModel';
 import { SpaceModel } from '../../models/SpaceModel';
-import { postHogClient } from '../../postHog';
+import { isFeatureFlagEnabled, postHogClient } from '../../postHog';
 import { getAuthenticationToken } from '../../routers/headlessBrowser';
 import { VERSION } from '../../version';
 import { EncryptionService } from '../EncryptionService/EncryptionService';
@@ -375,8 +376,16 @@ export class UnfurlService {
         const startTime = Date.now();
         let hasError = false;
 
-        const isPuppeteerSetViewportDynamicallyEnabled = false;
-        const isPuppeteerScrollElementIntoViewEnabled = false;
+        const isPuppeteerSetViewportDynamicallyEnabled =
+            await isFeatureFlagEnabled(
+                FeatureFlags.PuppeteerSetViewportDynamically,
+                { userUuid },
+            );
+        const isPuppeteerScrollElementIntoViewEnabled =
+            await isFeatureFlagEnabled(
+                FeatureFlags.PuppeteerScrollElementIntoView,
+                { userUuid },
+            );
 
         return tracer.startActiveSpan(
             'UnfurlService.saveScreenshot',

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -34,5 +34,10 @@ export enum FeatureFlags {
      */
     DashboardTileComments = 'dashboard-tile-comments',
 
+    /**/
     CustomSQLEnabled = 'custom-sql-enabled',
+
+    /**/
+    PuppeteerScrollElementIntoView = 'puppeteer-scroll-element-into-view',
+    PuppeteerSetViewportDynamically = 'puppeteer-set-viewport-dynamically',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9165 
Follow-up to: #9154 

### Description:

- Slightly increases the timeout value for the Posthog feature flag check, and adds an escape hatch via an env var to control the timeout value.
- Migrates `PuppeteerScrollElementIntoView` and `PuppeteerSetViewportDynamically` to the `FeatureFlags` enum, and re-adds the checks for these flags using the `isFeatureFlag` enabled helper
- Re-enables the feature flag check for `UseInMemoryTableCalculations`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
