### PR TITLE
fix: always show toast on version update

### DIFF
--- a/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
+++ b/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
@@ -1,23 +1,13 @@
 import { IconReload } from '@tabler/icons-react';
 import { FC, useEffect, useState } from 'react';
-import { useRouteMatch } from 'react-router-dom';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
 
-const routesThatCantBeAutoRefreshed = [
-    '/projects/:projectUuid/tables/:tableId',
-    '/projects/:projectUuid/saved/:savedQueryUuid/edit',
-    '/projects/:projectUuid/dashboards/:dashboardUuid/edit',
-    '/projects/:projectUuid/sqlRunner',
-];
 const VersionAutoUpdater: FC = () => {
     const [version, setVersion] = useState<string>();
     const { showToastPrimary } = useToaster();
     const { data: healthData } = useHealth({
         refetchInterval: 1200000, // 20 minutes in milliseconds
-    });
-    const isRouteThatCantBeAutoRefreshed = useRouteMatch({
-        path: routesThatCantBeAutoRefreshed,
     });
 
     useEffect(() => {
@@ -25,23 +15,19 @@ const VersionAutoUpdater: FC = () => {
             if (!version) {
                 setVersion(healthData.version);
             } else if (version !== healthData.version) {
-                if (isRouteThatCantBeAutoRefreshed) {
-                    showToastPrimary({
-                        key: 'new-version-available',
-                        autoClose: false,
-                        title: 'A new version of Lightdash is ready for you!',
-                        action: {
-                            children: 'Use new version',
-                            icon: IconReload,
-                            onClick: () => window.location.reload(),
-                        },
-                    });
-                } else {
-                    window.location.reload();
-                }
+                showToastPrimary({
+                    key: 'new-version-available',
+                    autoClose: false,
+                    title: 'A new version of Lightdash is ready for you!',
+                    action: {
+                        children: 'Use new version',
+                        icon: IconReload,
+                        onClick: () => window.location.reload(),
+                    },
+                });
             }
         }
-    }, [version, isRouteThatCantBeAutoRefreshed, healthData, showToastPrimary]);
+    }, [version, healthData, showToastPrimary]);
 
     return null;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9162 

### Description:

- Removes auto refresh on lightdash version update in favor of showing toast.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
