### PR TITLE
fix: dont disable delete on user search

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -398,7 +398,7 @@ const UsersView: FC = () => {
                                     disabled={
                                         user.data?.userUuid ===
                                             orgUser.userUuid ||
-                                        organizationUsers.length <= 1
+                                        organizationUsers.length < 1
                                     }
                                 />
                             ))


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9191 
### Description:

A user reported they couldnt delete users they had searched for. This is a tiny fix. I don't know why the code was like this, but I everything seems to work well now. 

You can test by searching for a user. If there was only one search result, the delete button was being disabled. Now they should be deletable. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
