### PR TITLE
fix: use table and field names for FilterDashboardTo component

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -68,6 +68,12 @@ export type DashboardFilterRule<
     label: undefined | string;
 };
 
+export type FilterDashboardToRule = DashboardFilterRule & {
+    target: {
+        fieldName: string;
+    };
+};
+
 export type DashboardFilterRuleOverride = Omit<
     DashboardFilterRule,
     'tileTargets'

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -20,6 +20,7 @@ import {
     DashboardFilterRule,
     DashboardFilters,
     DateFilterRule,
+    FilterDashboardToRule,
     FilterGroup,
     FilterGroupItem,
     FilterOperator,
@@ -320,7 +321,7 @@ export const createDashboardFilterRuleFromField = ({
     availableTileFilters: Record<string, FilterableField[] | undefined>;
     isTemporary: boolean;
     value?: unknown;
-}): DashboardFilterRule =>
+}): FilterDashboardToRule =>
     getFilterRuleWithDefaultValue(
         field,
         {
@@ -330,6 +331,7 @@ export const createDashboardFilterRuleFromField = ({
             target: {
                 fieldId: fieldId(field),
                 tableName: field.table,
+                fieldName: field.name,
             },
             tileTargets: getDefaultTileTargets(field, availableTileFilters),
             disabled: !isTemporary,

--- a/packages/frontend/src/components/DashboardFilter/FilterDashboardTo.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterDashboardTo.tsx
@@ -1,5 +1,5 @@
 import {
-    DashboardFilterRule,
+    FilterDashboardToRule,
     FilterOperator,
     friendlyName,
 } from '@lightdash/common';
@@ -9,33 +9,36 @@ import { FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 
 type Props = {
-    filters: DashboardFilterRule[];
-    onAddFilter: (filter: DashboardFilterRule, isTemporary: boolean) => void;
+    filters: FilterDashboardToRule[];
+    onAddFilter: (filter: FilterDashboardToRule, isTemporary: boolean) => void;
 };
 
-export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => (
-    <>
-        <Menu.Divider />
-        <Menu.Label>Filter dashboard to...</Menu.Label>
+export const FilterDashboardTo: FC<Props> = ({ filters, onAddFilter }) => {
+    return (
+        <>
+            <Menu.Divider />
+            <Menu.Label>Filter dashboard to...</Menu.Label>
 
-        {filters.map((filter) => (
-            <Menu.Item
-                key={filter.id}
-                icon={<MantineIcon icon={IconFilter} />}
-                onClick={() => onAddFilter(filter, true)}
-            >
-                {friendlyName(filter.target.fieldId)} is{' '}
-                {filter.operator === FilterOperator.NULL && (
-                    <Text span fw={500}>
-                        null
-                    </Text>
-                )}
-                {filter.values && filter.values[0] && (
-                    <Text span fw={500}>
-                        {String(filter.values[0])}
-                    </Text>
-                )}
-            </Menu.Item>
-        ))}
-    </>
-);
+            {filters.map((filter) => (
+                <Menu.Item
+                    key={filter.id}
+                    icon={<MantineIcon icon={IconFilter} />}
+                    onClick={() => onAddFilter(filter, true)}
+                >
+                    {friendlyName(filter.target.tableName)} -{' '}
+                    {friendlyName(filter.target.fieldName)} is{' '}
+                    {filter.operator === FilterOperator.NULL && (
+                        <Text span fw={500}>
+                            null
+                        </Text>
+                    )}
+                    {filter.values && filter.values[0] && (
+                        <Text span fw={500}>
+                            {String(filter.values[0])}
+                        </Text>
+                    )}
+                </Menu.Item>
+            ))}
+        </>
+    );
+};

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -8,6 +8,7 @@ import {
     DashboardFilterRule,
     Field,
     fieldId,
+    FilterDashboardToRule,
     getCustomLabelsFromTableConfig,
     getDimensions,
     getFields,
@@ -416,7 +417,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     );
 
     const [dashboardTileFilterOptions, setDashboardTileFilterOptions] =
-        useState<DashboardFilterRule[]>([]);
+        useState<FilterDashboardToRule[]>([]);
 
     const [isCSVExportModalOpen, setIsCSVExportModalOpen] = useState(false);
 

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     createDashboardFilterRuleFromField,
-    DashboardFilterRule,
+    FilterDashboardToRule,
     hasCustomDimension,
     isDimension,
     isField,
@@ -69,7 +69,7 @@ const DashboardCellContextMenu: FC<
 
     const possiblePivotFilters = (
         meta?.pivotReference?.pivotValues || []
-    ).reduce<DashboardFilterRule[]>((acc, pivot) => {
+    ).reduce<FilterDashboardToRule[]>((acc, pivot) => {
         const pivotField = itemsMap?.[pivot?.field];
         if (
             !pivotField ||
@@ -88,11 +88,8 @@ const DashboardCellContextMenu: FC<
             }),
         ];
     }, []);
-    const filters: DashboardFilterRule[] = [
-        ...filterField,
-        ...possiblePivotFilters,
-    ];
 
+    const filters = [...filterField, ...possiblePivotFilters];
     const { track } = useTracking();
     const { user } = useApp();
     const { projectUuid } = useParams<{ projectUuid: string }>();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9179 
### Description:

- Uses table name and field name in `FilterDashboardTo` component

![image](https://github.com/lightdash/lightdash/assets/22939015/ecc13422-ad50-46ff-b7cc-e2f9cec061c2)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
