### PR TITLE
chore: improve performance of comment details

### DIFF
--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -15,7 +15,6 @@ import { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getNameInitials } from '../utils';
 import { CommentTimestamp } from './CommentTimestamp';
-import { CommentWithMentions } from './CommentWithMentions';
 
 type Props = {
     comment: Comment;
@@ -42,7 +41,7 @@ export const CommentDetail: FC<Props> = ({
                         {getNameInitials(comment.user.name)}
                     </Avatar>
                 </Grid.Col>
-                <Grid.Col span={18}>
+                <Grid.Col span={18} maw="inherit">
                     <Group position="apart">
                         <Group spacing="xs">
                             <Text fz="xs" fw={600}>
@@ -96,12 +95,15 @@ export const CommentDetail: FC<Props> = ({
                             )}
                         </Group>
                     </Group>
-                    <Box fz="xs" mb="two">
-                        <CommentWithMentions
-                            readonly
-                            content={comment.textHtml}
-                        />
-                    </Box>
+                    <Box
+                        dangerouslySetInnerHTML={{
+                            __html: comment.textHtml,
+                        }}
+                        fz="xs"
+                        sx={{
+                            wordBreak: 'break-word',
+                        }}
+                    />
                 </Grid.Col>
             </Grid>
         </Box>

--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -41,7 +41,7 @@ export const CommentDetail: FC<Props> = ({
                         {getNameInitials(comment.user.name)}
                     </Avatar>
                 </Grid.Col>
-                <Grid.Col span={18} maw="inherit">
+                <Grid.Col span={18}>
                     <Group position="apart">
                         <Group spacing="xs">
                             <Text fz="xs" fw={600}>

--- a/packages/frontend/src/features/comments/components/CommentForm.tsx
+++ b/packages/frontend/src/features/comments/components/CommentForm.tsx
@@ -81,7 +81,6 @@ export const CommentForm: FC<Props> = ({
                     <Grid.Col span={18} w={mode === 'reply' ? 300 : 350}>
                         {isSuccess && userNames && (
                             <CommentWithMentions
-                                readonly={false}
                                 suggestions={userNames}
                                 shouldClearEditor={shouldClearEditor}
                                 setShouldClearEditor={setShouldClearEditor}

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/index.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/index.tsx
@@ -9,7 +9,6 @@ import { SuggestionsItem } from '../../types';
 import { generateSuggestionWrapper } from './generateSuggestionWrapper';
 
 type Props = {
-    readonly: boolean;
     suggestions?: SuggestionsItem[];
     content?: string;
     onUpdate?: (editor: Editor | null) => void;
@@ -18,7 +17,6 @@ type Props = {
 };
 
 export const CommentWithMentions: FC<Props> = ({
-    readonly,
     suggestions,
     onUpdate,
     content,
@@ -28,7 +26,6 @@ export const CommentWithMentions: FC<Props> = ({
     const theme = useMantineTheme();
 
     const editor = useEditor({
-        editable: !readonly,
         extensions: [
             StarterKit,
             Mention.configure({
@@ -60,14 +57,11 @@ export const CommentWithMentions: FC<Props> = ({
         <RichTextEditor
             editor={editor}
             styles={{
-                root: {
-                    border: readonly ? 'none' : 'default',
-                },
                 content: {
                     maxHeight: 100,
                     overflowY: 'auto',
                     '& > .tiptap': {
-                        padding: readonly ? 0 : 6,
+                        padding: 6,
                     },
                 },
             }}

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -32,10 +32,6 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     const [isReplyingTo, setIsReplyingTo] = useState<string | undefined>(
         undefined,
     );
-    const canReply = !!(
-        canCreateDashboardComments &&
-        (isReplyingTo || isRepliesOpen)
-    );
 
     const { mutateAsync: createReply, isLoading: isCreatingReply } =
         useCreateComment();
@@ -64,7 +60,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
         <Stack spacing="two" ref={targetRef}>
             <CommentDetail
                 comment={comment}
-                canReply={canReply}
+                canReply={canCreateDashboardComments}
                 onReply={() => handleReply()}
                 // can remove any comment or the comment is created by the current user
                 canRemove={comment.canRemove}

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -137,7 +137,7 @@ export const DashboardTileComments: FC<
         return null;
     }
 
-    const hasComments = comments && comments.length === 0;
+    const hasComments = comments && comments.length > 0;
 
     return (
         <Popover
@@ -153,7 +153,7 @@ export const DashboardTileComments: FC<
                 onClose?.();
             }}
         >
-            <Popover.Dropdown p={0} w={400}>
+            <Popover.Dropdown p={0} w={400} maw={400}>
                 <Stack
                     id="comments-stack"
                     ref={scrollableRef}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Instead of creating a `tiptap` instance for each comment, let's just use a `Box` component where we set its html to the output html from tiptap (`comment.textHtml`)

Other bits that weren't properly managed from merge conflicts:  https://github.com/lightdash/lightdash/commit/630408ee18eb297ddfe22e02442b845c15aefeff
And a clarification/fix of a confusing variable name: https://github.com/lightdash/lightdash/commit/e9c1555d255912075acb0e889d3fbc7551c023b3


Additionally, I have adjusted the popover width for the comments list to be more constrained, addressing an issue where an excessively long comment could expand the list's width. The width and maximum width have now been set to 400 in packages/frontend/src/features/comments/components/DashboardTileComments.tsx, ensuring a tighter control over the dimensions.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
