### PR TITLE
chore: Add service container support, new BaseController class

### DIFF
--- a/packages/backend/src/controllers/baseController.ts
+++ b/packages/backend/src/controllers/baseController.ts
@@ -1,0 +1,12 @@
+import { Controller } from '@tsoa/runtime';
+import type { ServiceRepository } from '../services/ServiceRepository';
+
+/**
+ * Extends tsoa's Controller with additional Lightdash-specific logic.
+ */
+export class BaseController extends Controller {
+    // TODO: This is currently just a placeholder layer over Controller.
+    constructor(protected readonly serviceRepository: ServiceRepository) {
+        super();
+    }
+}

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -16,6 +16,7 @@ import {
     Controller,
     Delete,
     Get,
+    Inject,
     Middlewares,
     OperationId,
     Patch,
@@ -32,6 +33,7 @@ import express from 'express';
 import { userModel } from '../models/models';
 import { UserModel } from '../models/UserModel';
 import { userService } from '../services/services';
+import { UserService } from '../services/UserService';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -53,6 +55,7 @@ export class UserController extends Controller {
         @Request() req: express.Request,
     ): Promise<ApiGetAuthenticatedUserResponse> {
         this.setStatus(200);
+
         return {
             status: 'ok',
             results: UserModel.lightdashUserFromSession(req.user!),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1,0 +1,1 @@
+export class ServiceRepository {}

--- a/packages/backend/src/services/tsoaServiceContainer.ts
+++ b/packages/backend/src/services/tsoaServiceContainer.ts
@@ -1,0 +1,37 @@
+import { Controller, type IocContainerFactory } from '@tsoa/runtime';
+import { BaseController } from '../controllers/baseController';
+import { ServiceRepository } from './ServiceRepository';
+
+/**
+ * For now, we allow both classes extending tsoa's Controller directly, as well as those
+ * extending Lightdash's `BaseController`, and handle both cases accordingly.
+ */
+type TsoaControllerKlass = new () => Controller;
+type BaseControllerKlass = new (
+    serviceRepository: ServiceRepository,
+) => BaseController;
+type RouteControllerKlass = TsoaControllerKlass | BaseControllerKlass;
+
+/**
+ * Used to narrow the controller klass type, so that we can instantiate it with
+ * the correct number of arguments.
+ */
+const isTsoaControllerCtor = (
+    ctor: RouteControllerKlass,
+): ctor is TsoaControllerKlass => ctor.prototype instanceof Controller;
+
+/**
+ * See tsoa.yml
+ *
+ * Override's tsoa's native controller instantiation, and allows us to manage controller
+ * instantiation directly.
+ */
+export const iocContainer: IocContainerFactory = () => ({
+    async get<T extends RouteControllerKlass>(Ctor: T) {
+        if (isTsoaControllerCtor(Ctor)) {
+            return new Ctor();
+        }
+
+        return new Ctor(new ServiceRepository());
+    },
+});

--- a/packages/backend/tsoa.yml
+++ b/packages/backend/tsoa.yml
@@ -1,41 +1,42 @@
 entryFile: src/index.ts
 controllerPathGlobs:
-  - src/**/*Controller.ts
+    - src/**/*Controller.ts
 spec:
-  name: Lightdash API
-  description: >
-    Open API documentation for all public Lightdash API endpoints. 
-    # Authentication
-    Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens
-  contact:
-    name: Lightdash Support
-    email: support@lightdash.com
-    url: "https://docs.lightdash.com/help-and-contact/contact/contact_info/"
-  license: MIT
-  tags:
-    - name: My Account
-      description: These routes allow users to manage their own user account.
-    - name: Organizations
-      description: Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users.
-    - name: Projects
-      description: Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly.
-    - name: Spaces
-      description: Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins.
-    - name: Roles & Permissions
-      description: These routes allow users to manage roles and permissions for their organization.
-      externalDocs:
-        url: "https://docs.lightdash.com/references/roles"
-  outputDirectory: ./src/generated/
-  specVersion: 3
-  securityDefinitions:
-    session_cookie:
-      type: apiKey
-      in: cookie
-      name: connect.sid
-    api_key:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: Value should be 'ApiKey <your key>'
+    name: Lightdash API
+    description: >
+        Open API documentation for all public Lightdash API endpoints. 
+        # Authentication
+        Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens
+    contact:
+        name: Lightdash Support
+        email: support@lightdash.com
+        url: 'https://docs.lightdash.com/help-and-contact/contact/contact_info/'
+    license: MIT
+    tags:
+        - name: My Account
+          description: These routes allow users to manage their own user account.
+        - name: Organizations
+          description: Each user is a member of a single organization. These routes allow users to manage their organization. Most actions are only available to admin users.
+        - name: Projects
+          description: Projects belong to a single organization. These routes allow users to manage their projects, browse content, and execute queries. Users inside an organization might have access to a project from an organization-level role or they might be granted access to a project directly.
+        - name: Spaces
+          description: Spaces allow you to organize charts and dashboards within a project. They also allow granular access to content by allowing you to create private spaces, which are only accessible to the creator and admins.
+        - name: Roles & Permissions
+          description: These routes allow users to manage roles and permissions for their organization.
+          externalDocs:
+              url: 'https://docs.lightdash.com/references/roles'
+    outputDirectory: ./src/generated/
+    specVersion: 3
+    securityDefinitions:
+        session_cookie:
+            type: apiKey
+            in: cookie
+            name: connect.sid
+        api_key:
+            type: apiKey
+            in: header
+            name: Authorization
+            description: Value should be 'ApiKey <your key>'
 routes:
-  routesDir: ./src/generated/
+    routesDir: ./src/generated/
+    iocModule: ./src/services/tsoaServiceContainer


### PR DESCRIPTION
Part of #9169, #9151

### Description:

Adds foundational changes to allow instantiating services via a service container. This is done via:

- A new `BaseController` class that extends `tsoa`'s own `Controller`
- A new `tsoaServiceContainer` module that `tsoa` calls to instantiate controllers.

This PR doesn't do much on its own, besides introduce the above. Follow-up work will be part of separate PRs; but the two main things to do are:

- Update controllers to use `BaseController`
- Update those controllers to use `this.services` to access services
- Update `ServiceRepository` to be able to instantiate all services, and provide a `ServiceRepository` singleton (for now) as part of the controller instantiation

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
