### PR TITLE
chore: update controllers to use injected `ServiceRepository` for service access

### DIFF
--- a/packages/backend/src/controllers/baseController.ts
+++ b/packages/backend/src/controllers/baseController.ts
@@ -6,7 +6,7 @@ import type { ServiceRepository } from '../services/ServiceRepository';
  */
 export class BaseController extends Controller {
     // TODO: This is currently just a placeholder layer over Controller.
-    constructor(protected readonly serviceRepository: ServiceRepository) {
+    constructor(protected readonly services: ServiceRepository) {
         super();
     }
 }

--- a/packages/backend/src/controllers/commentsController.ts
+++ b/packages/backend/src/controllers/commentsController.ts
@@ -20,7 +20,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { commentService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -47,15 +46,17 @@ export class CommentsController extends BaseController {
         @Body()
         body: Pick<Comment, 'text' | 'replyTo' | 'mentions' | 'textHtml'>,
     ): Promise<ApiCreateComment> {
-        const commentId = await commentService.createComment(
-            req.user!,
-            dashboardUuid,
-            dashboardTileUuid,
-            body.text,
-            body.textHtml,
-            body.replyTo ?? null,
-            body.mentions,
-        );
+        const commentId = await this.services
+            .getCommentService()
+            .createComment(
+                req.user!,
+                dashboardUuid,
+                dashboardTileUuid,
+                body.text,
+                body.textHtml,
+                body.replyTo ?? null,
+                body.mentions,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -77,10 +78,9 @@ export class CommentsController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetComments> {
-        const results = await commentService.findCommentsForDashboard(
-            req.user!,
-            dashboardUuid,
-        );
+        const results = await this.services
+            .getCommentService()
+            .findCommentsForDashboard(req.user!, dashboardUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -103,11 +103,9 @@ export class CommentsController extends BaseController {
         @Path() commentId: string,
         @Request() req: express.Request,
     ): Promise<ApiResolveComment> {
-        await commentService.resolveComment(
-            req.user!,
-            dashboardUuid,
-            commentId,
-        );
+        await this.services
+            .getCommentService()
+            .resolveComment(req.user!, dashboardUuid, commentId);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -129,7 +127,9 @@ export class CommentsController extends BaseController {
         @Path() commentId: string,
         @Request() req: express.Request,
     ): Promise<ApiResolveComment> {
-        await commentService.deleteComment(req.user!, dashboardUuid, commentId);
+        await this.services
+            .getCommentService()
+            .deleteComment(req.user!, dashboardUuid, commentId);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/csvController.ts
+++ b/packages/backend/src/controllers/csvController.ts
@@ -11,7 +11,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { schedulerService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -33,7 +32,9 @@ export class CsvController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCsvUrlResponse> {
         this.setStatus(200);
-        const csvDetails = await schedulerService.getCsvUrl(req.user!, jobId);
+        const csvDetails = await this.services
+            .getSchedulerService()
+            .getCsvUrl(req.user!, jobId);
         return {
             status: 'ok',
             results: {

--- a/packages/backend/src/controllers/dbtCloudIntegrationController.ts
+++ b/packages/backend/src/controllers/dbtCloudIntegrationController.ts
@@ -16,7 +16,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { projectService } from '../services/services';
 import { isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -39,10 +38,9 @@ export class DbtCloudIntegrationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.findDbtCloudIntegration(
-                req.user!,
-                projectUuid,
-            ),
+            results: await this.services
+                .getProjectService()
+                .findDbtCloudIntegration(req.user!, projectUuid),
         };
     }
 
@@ -61,11 +59,9 @@ export class DbtCloudIntegrationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.upsertDbtCloudIntegration(
-                req.user!,
-                projectUuid,
-                req.body,
-            ),
+            results: await this.services
+                .getProjectService()
+                .upsertDbtCloudIntegration(req.user!, projectUuid, req.body),
         };
     }
 
@@ -79,7 +75,9 @@ export class DbtCloudIntegrationController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiDbtCloudSettingsDeleteSuccess> {
-        await projectService.deleteDbtCloudIntegration(req.user!, projectUuid);
+        await this.services
+            .getProjectService()
+            .deleteDbtCloudIntegration(req.user!, projectUuid);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -22,7 +22,6 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { CsvService } from '../services/CsvService/CsvService';
-import { projectService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -48,7 +47,9 @@ export class ExploreController extends BaseController {
         @Body() body: any[], // tsoa doesn't seem to work with explores from CLI
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await projectService.setExplores(req.user!, projectUuid, body);
+        await this.services
+            .getProjectService()
+            .setExplores(req.user!, projectUuid, body);
 
         return {
             status: 'ok',
@@ -65,8 +66,9 @@ export class ExploreController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiExploresResults }> {
         this.setStatus(200);
-        const results: ApiExploresResults =
-            await projectService.getAllExploresSummary(
+        const results: ApiExploresResults = await this.services
+            .getProjectService()
+            .getAllExploresSummary(
                 req.user!,
                 projectUuid,
                 req.query.filtered === 'true',
@@ -89,11 +91,9 @@ export class ExploreController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiExploreResults }> {
         this.setStatus(200);
-        const results = await projectService.getExplore(
-            req.user!,
-            projectUuid,
-            exploreId,
-        );
+        const results = await this.services
+            .getProjectService()
+            .getExplore(req.user!, projectUuid, exploreId);
 
         return {
             status: 'ok',
@@ -114,12 +114,9 @@ export class ExploreController extends BaseController {
         this.setStatus(200);
 
         const results = (
-            await projectService.compileQuery(
-                req.user!,
-                body,
-                projectUuid,
-                exploreId,
-            )
+            await this.services
+                .getProjectService()
+                .compileQuery(req.user!, body, projectUuid, exploreId)
         ).query;
 
         return {

--- a/packages/backend/src/controllers/gitIntegrationController.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.ts
@@ -17,7 +17,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { gitIntegrationService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -40,10 +39,9 @@ export class GitIntegrationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await gitIntegrationService.getConfiguration(
-                req.user!,
-                projectUuid,
-            ),
+            results: await this.services
+                .getGitIntegrationService()
+                .getConfiguration(req.user!, projectUuid),
         };
     }
 
@@ -63,8 +61,9 @@ export class GitIntegrationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results:
-                await gitIntegrationService.createPullRequestForChartFields(
+            results: await this.services
+                .getGitIntegrationService()
+                .createPullRequestForChartFields(
                     req.user!,
                     projectUuid,
                     chartUuid,
@@ -92,8 +91,9 @@ export class GitIntegrationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results:
-                await gitIntegrationService.createPullRequestForCustomMetrics(
+            results: await this.services
+                .getGitIntegrationService()
+                .createPullRequestForCustomMetrics(
                     req.user!,
                     projectUuid,
                     body.customMetrics,

--- a/packages/backend/src/controllers/githubController.ts
+++ b/packages/backend/src/controllers/githubController.ts
@@ -13,7 +13,6 @@ import {
 import express from 'express';
 import { getGithubApp, getOctokitRestForApp } from '../clients/github/Github';
 import { lightdashConfig } from '../config/lightdashConfig';
-import { githubAppService } from '../services/services';
 import { isAuthenticated, unauthorisedInDemo } from './authentication';
 import { BaseController } from './baseController';
 
@@ -116,12 +115,14 @@ export class GithubInstallController extends BaseController {
             if (installation === undefined)
                 throw new Error('Invalid installation id');
 
-            await githubAppService.upsertInstallation(
-                state,
-                installation_id,
-                token,
-                refreshToken,
-            );
+            await this.services
+                .getGithubAppService()
+                .upsertInstallation(
+                    state,
+                    installation_id,
+                    token,
+                    refreshToken,
+                );
             const redirectUrl = new URL(req.session.oauth?.returnTo || '/');
             req.session.oauth = {};
             this.setStatus(302);
@@ -135,7 +136,9 @@ export class GithubInstallController extends BaseController {
     async uninstallGithubAppForOrganization(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        await githubAppService.deleteAppInstallation(req.user!);
+        await this.services
+            .getGithubAppService()
+            .deleteAppInstallation(req.user!);
         // todo: uninstall app with octokit
         this.setStatus(200);
         return {
@@ -155,9 +158,9 @@ export class GithubInstallController extends BaseController {
         this.setStatus(200);
 
         // todo: move all to service
-        const installationId = await githubAppService.getInstallationId(
-            req.user!,
-        );
+        const installationId = await this.services
+            .getGithubAppService()
+            .getInstallationId(req.user!);
 
         if (installationId === undefined)
             throw new Error('Invalid Github installation id');

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -18,7 +18,6 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { GdriveService } from '../services/GdriveService/GdriveService';
-import { userService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -40,7 +39,9 @@ export class GoogleDriveController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await userService.getAccessToken(req.user!),
+            results: await this.services
+                .getUserService()
+                .getAccessToken(req.user!),
         };
     }
 

--- a/packages/backend/src/controllers/groupsController.ts
+++ b/packages/backend/src/controllers/groupsController.ts
@@ -28,7 +28,6 @@ import {
     CreateDBProjectGroupAccess,
     UpdateDBProjectGroupAccess,
 } from '../database/entities/projectGroupAccess';
-import { groupService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -58,12 +57,9 @@ export class GroupsController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await groupService.get(
-                req.user!,
-                groupUuid,
-                includeMembers,
-                offset,
-            ),
+            results: await this.services
+                .getGroupService()
+                .get(req.user!, groupUuid, includeMembers, offset),
         };
     }
 
@@ -83,7 +79,7 @@ export class GroupsController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await groupService.delete(req.user!, groupUuid);
+        await this.services.getGroupService().delete(req.user!, groupUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -107,10 +103,12 @@ export class GroupsController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        const createdMember = await groupService.addGroupMember(req.user!, {
-            groupUuid,
-            userUuid,
-        });
+        const createdMember = await this.services
+            .getGroupService()
+            .addGroupMember(req.user!, {
+                groupUuid,
+                userUuid,
+            });
         this.setStatus(createdMember === undefined ? 204 : 201);
         return {
             status: 'ok',
@@ -135,10 +133,12 @@ export class GroupsController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        const deleted = await groupService.removeGroupMember(req.user!, {
-            userUuid,
-            groupUuid,
-        });
+        const deleted = await this.services
+            .getGroupService()
+            .removeGroupMember(req.user!, {
+                userUuid,
+                groupUuid,
+            });
         this.setStatus(deleted ? 200 : 204);
         return {
             status: 'ok',
@@ -160,7 +160,9 @@ export class GroupsController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await groupService.getGroupMembers(req.user!, groupUuid),
+            results: await this.services
+                .getGroupService()
+                .getGroupMembers(req.user!, groupUuid),
         };
     }
 
@@ -179,7 +181,9 @@ export class GroupsController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateGroupWithMembers,
     ): Promise<ApiGroupResponse> {
-        const group = await groupService.update(req.user!, groupUuid, body);
+        const group = await this.services
+            .getGroupService()
+            .update(req.user!, groupUuid, body);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -203,11 +207,13 @@ export class GroupsController extends BaseController {
         @Body() projectGroupAccess: Pick<CreateDBProjectGroupAccess, 'role'>,
         @Request() req: express.Request,
     ): Promise<ApiCreateProjectGroupAccess> {
-        const results = await groupService.addProjectAccess(req.user!, {
-            groupUuid,
-            projectUuid,
-            role: projectGroupAccess.role,
-        });
+        const results = await this.services
+            .getGroupService()
+            .addProjectAccess(req.user!, {
+                groupUuid,
+                projectUuid,
+                role: projectGroupAccess.role,
+            });
         this.setStatus(200);
         return {
             status: 'ok',
@@ -232,11 +238,13 @@ export class GroupsController extends BaseController {
         projectGroupAccess: UpdateDBProjectGroupAccess,
         @Request() req: express.Request,
     ): Promise<ApiUpdateProjectGroupAccess> {
-        const results = await groupService.updateProjectAccess(
-            req.user!,
-            { groupUuid, projectUuid },
-            projectGroupAccess,
-        );
+        const results = await this.services
+            .getGroupService()
+            .updateProjectAccess(
+                req.user!,
+                { groupUuid, projectUuid },
+                projectGroupAccess,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -259,10 +267,12 @@ export class GroupsController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        const removed = await groupService.removeProjectAccess(req.user!, {
-            groupUuid,
-            projectUuid,
-        });
+        const removed = await this.services
+            .getGroupService()
+            .removeProjectAccess(req.user!, {
+                groupUuid,
+                projectUuid,
+            });
         this.setStatus(removed ? 200 : 204);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/notificationsController.ts
+++ b/packages/backend/src/controllers/notificationsController.ts
@@ -20,7 +20,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { notificationsService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -42,10 +41,9 @@ export class NotificationsController extends BaseController {
         @Request() req: express.Request,
         @Query() type: ApiNotificationResourceType,
     ): Promise<ApiGetNotifications> {
-        const results = await notificationsService.getNotifications(
-            req.user!.userUuid,
-            type,
-        );
+        const results = await this.services
+            .getNotificationService()
+            .getNotifications(req.user!.userUuid, type);
 
         this.setStatus(200);
         return {
@@ -67,7 +65,9 @@ export class NotificationsController extends BaseController {
         @Path() notificationId: string,
         @Body() body: ApiNotificationUpdateParams,
     ): Promise<ApiSuccessEmpty> {
-        await notificationsService.updateNotification(notificationId, body);
+        await this.services
+            .getNotificationService()
+            .updateNotification(notificationId, body);
 
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -33,7 +33,6 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { userModel } from '../models/models';
-import { organizationService, userService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -58,7 +57,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.get(req.user!),
+            results: await this.services
+                .getOrganizationService()
+                .get(req.user!),
         };
     }
 
@@ -75,7 +76,9 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateOrganization,
     ): Promise<ApiSuccessEmpty> {
-        await organizationService.createAndJoinOrg(req.user!, body);
+        await this.services
+            .getOrganizationService()
+            .createAndJoinOrg(req.user!, body);
         const sessionUser = await userModel.findSessionUserByUUID(
             req.user!.userUuid,
         );
@@ -106,7 +109,7 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateOrganization,
     ): Promise<ApiSuccessEmpty> {
-        await organizationService.updateOrg(req.user!, body);
+        await this.services.getOrganizationService().updateOrg(req.user!, body);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -126,7 +129,9 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() organizationUuid: string,
     ): Promise<ApiSuccessEmpty> {
-        await organizationService.delete(organizationUuid, req.user!);
+        await this.services
+            .getOrganizationService()
+            .delete(organizationUuid, req.user!);
         await new Promise<void>((resolve, reject) => {
             req.session.destroy((err) => {
                 if (err) {
@@ -155,7 +160,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.getProjects(req.user!),
+            results: await this.services
+                .getOrganizationService()
+                .getProjects(req.user!),
         };
     }
 
@@ -173,10 +180,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.getUsers(
-                req.user!,
-                includeGroups,
-            ),
+            results: await this.services
+                .getOrganizationService()
+                .getUsers(req.user!, includeGroups),
         };
     }
 
@@ -195,10 +201,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.getMemberByUuid(
-                req.user!,
-                userUuid,
-            ),
+            results: await this.services
+                .getOrganizationService()
+                .getMemberByUuid(req.user!, userUuid),
         };
     }
 
@@ -224,11 +229,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.updateMember(
-                req.user!,
-                userUuid,
-                body,
-            ),
+            results: await this.services
+                .getOrganizationService()
+                .updateMember(req.user!, userUuid, body),
         };
     }
 
@@ -248,7 +251,7 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() userUuid: string,
     ): Promise<ApiSuccessEmpty> {
-        await userService.delete(req.user!, userUuid);
+        await this.services.getUserService().delete(req.user!, userUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -269,9 +272,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.getAllowedEmailDomains(
-                req.user!,
-            ),
+            results: await this.services
+                .getOrganizationService()
+                .getAllowedEmailDomains(req.user!),
         };
     }
 
@@ -290,10 +293,9 @@ export class OrganizationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await organizationService.updateAllowedEmailDomains(
-                req.user!,
-                body,
-            ),
+            results: await this.services
+                .getOrganizationService()
+                .updateAllowedEmailDomains(req.user!, body),
         };
     }
 
@@ -313,10 +315,9 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateGroup,
     ): Promise<ApiGroupResponse> {
-        const group = await organizationService.addGroupToOrganization(
-            req.user!,
-            body,
-        );
+        const group = await this.services
+            .getOrganizationService()
+            .addGroupToOrganization(req.user!, body);
         this.setStatus(201);
         return {
             status: 'ok',
@@ -336,10 +337,9 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Query() includeMembers?: number,
     ): Promise<ApiGroupListResponse> {
-        const groups = await organizationService.listGroupsInOrganization(
-            req.user!,
-            includeMembers,
-        );
+        const groups = await this.services
+            .getOrganizationService()
+            .listGroupsInOrganization(req.user!, includeMembers);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/pinningController.ts
+++ b/packages/backend/src/controllers/pinningController.ts
@@ -17,7 +17,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { pinningService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -44,11 +43,9 @@ export class PinningController extends BaseController {
         @Path() pinnedListUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPinnedItems> {
-        const pinnedItems = await pinningService.getPinnedItems(
-            req.user!,
-            projectUuid,
-            pinnedListUuid,
-        );
+        const pinnedItems = await this.services
+            .getPinningService()
+            .getPinnedItems(req.user!, projectUuid, pinnedListUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -78,12 +75,14 @@ export class PinningController extends BaseController {
         @Body()
         body: Array<UpdatePinnedItemOrder>,
     ): Promise<ApiPinnedItems> {
-        const pinnedItems = await pinningService.updatePinnedItemsOrder(
-            req.user!,
-            projectUuid,
-            pinnedListUuid,
-            body,
-        );
+        const pinnedItems = await this.services
+            .getPinningService()
+            .updatePinnedItemsOrder(
+                req.user!,
+                projectUuid,
+                pinnedListUuid,
+                body,
+            );
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -32,7 +32,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { projectService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -58,7 +57,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getProject(projectUuid, req.user!),
+            results: await this.services
+                .getProjectService()
+                .getProject(projectUuid, req.user!),
         };
     }
 
@@ -78,7 +79,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getCharts(req.user!, projectUuid),
+            results: await this.services
+                .getProjectService()
+                .getCharts(req.user!, projectUuid),
         };
     }
 
@@ -98,7 +101,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getSpaces(req.user!, projectUuid),
+            results: await this.services
+                .getProjectService()
+                .getSpaces(req.user!, projectUuid),
         };
     }
 
@@ -116,10 +121,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiProjectAccessListResponse> {
         this.setStatus(200);
-        const results = await projectService.getProjectAccess(
-            req.user!,
-            projectUuid,
-        );
+        const results = await this.services
+            .getProjectService()
+            .getProjectAccess(req.user!, projectUuid);
         return {
             status: 'ok',
             results,
@@ -144,11 +148,9 @@ export class ProjectController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetProjectMemberResponse> {
-        const results = await projectService.getProjectMemberAccess(
-            req.user!,
-            projectUuid,
-            userUuid,
-        );
+        const results = await this.services
+            .getProjectService()
+            .getProjectMemberAccess(req.user!, projectUuid, userUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -174,7 +176,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await projectService.createProjectAccess(req.user!, projectUuid, body);
+        await this.services
+            .getProjectService()
+            .createProjectAccess(req.user!, projectUuid, body);
         return {
             status: 'ok',
             results: undefined,
@@ -200,12 +204,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await projectService.updateProjectAccess(
-            req.user!,
-            projectUuid,
-            userUuid,
-            body,
-        );
+        await this.services
+            .getProjectService()
+            .updateProjectAccess(req.user!, projectUuid, userUuid, body);
         return {
             status: 'ok',
             results: undefined,
@@ -230,11 +231,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await projectService.deleteProjectAccess(
-            req.user!,
-            projectUuid,
-            userUuid,
-        );
+        await this.services
+            .getProjectService()
+            .deleteProjectAccess(req.user!, projectUuid, userUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -253,10 +252,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiGetProjectGroupAccesses> {
         this.setStatus(200);
-        const results = await projectService.getProjectGroupAccesses(
-            req.user!,
-            projectUuid,
-        );
+        const results = await this.services
+            .getProjectService()
+            .getProjectGroupAccesses(req.user!, projectUuid);
         return {
             status: 'ok',
             results,
@@ -286,11 +284,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.runSqlQuery(
-                req.user!,
-                projectUuid,
-                body.sql,
-            ),
+            results: await this.services
+                .getProjectService()
+                .runSqlQuery(req.user!, projectUuid, body.sql),
         };
     }
 
@@ -310,11 +306,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
-        const totalResult = await projectService.calculateTotalFromQuery(
-            req.user!,
-            projectUuid,
-            body,
-        );
+        const totalResult = await this.services
+            .getProjectService()
+            .calculateTotalFromQuery(req.user!, projectUuid, body);
         return {
             status: 'ok',
             results: totalResult,
@@ -331,10 +325,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: Record<string, DbtExposure> }> {
         this.setStatus(200);
-        const exposures = await projectService.getDbtExposures(
-            req.user!,
-            projectUuid,
-        );
+        const exposures = await this.services
+            .getProjectService()
+            .getDbtExposures(req.user!, projectUuid);
         return {
             status: 'ok',
             results: exposures,
@@ -355,10 +348,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getProjectCredentialsPreference(
-                req.user!,
-                projectUuid,
-            ),
+            results: await this.services
+                .getProjectService()
+                .getProjectCredentialsPreference(req.user!, projectUuid),
         };
     }
 
@@ -372,11 +364,13 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await projectService.upsertProjectCredentialsPreference(
-            req.user!,
-            projectUuid,
-            userWarehouseCredentialsUuid,
-        );
+        await this.services
+            .getProjectService()
+            .upsertProjectCredentialsPreference(
+                req.user!,
+                projectUuid,
+                userWarehouseCredentialsUuid,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -404,10 +398,9 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getCustomMetrics(
-                req.user!,
-                projectUuid,
-            ),
+            results: await this.services
+                .getProjectService()
+                .getCustomMetrics(req.user!, projectUuid),
         };
     }
 }

--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -21,7 +21,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { projectService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -67,8 +66,9 @@ export class RunViewChartQueryController extends BaseController {
             additionalMetrics: body.additionalMetrics,
             customDimensions: body.customDimensions,
         };
-        const results: ApiQueryResults =
-            await projectService.runUnderlyingDataQuery(
+        const results: ApiQueryResults = await this.services
+            .getProjectService()
+            .runUnderlyingDataQuery(
                 req.user!,
                 metricQuery,
                 projectUuid,
@@ -111,14 +111,16 @@ export class RunViewChartQueryController extends BaseController {
             additionalMetrics: body.additionalMetrics,
             customDimensions: body.customDimensions,
         };
-        const results: ApiQueryResults = await projectService.runExploreQuery(
-            req.user!,
-            metricQuery,
-            projectUuid,
-            exploreId,
-            body.csvLimit,
-            body.granularity,
-        );
+        const results: ApiQueryResults = await this.services
+            .getProjectService()
+            .runExploreQuery(
+                req.user!,
+                metricQuery,
+                projectUuid,
+                exploreId,
+                body.csvLimit,
+                body.granularity,
+            );
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -21,7 +21,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { projectService, savedChartsService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -57,7 +56,7 @@ export class SavedChartController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.runViewChartQuery({
+            results: await this.services.getProjectService().runViewChartQuery({
                 user: req.user!,
                 chartUuid,
                 versionUuid: undefined,
@@ -85,15 +84,17 @@ export class SavedChartController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.getChartAndResults({
-                user: req.user!,
-                chartUuid,
-                dashboardFilters: body.dashboardFilters,
-                invalidateCache: body.invalidateCache,
-                dashboardSorts: body.dashboardSorts,
-                granularity: body.granularity,
-                dashboardUuid: body.dashboardUuid,
-            }),
+            results: await this.services
+                .getProjectService()
+                .getChartAndResults({
+                    user: req.user!,
+                    chartUuid,
+                    dashboardFilters: body.dashboardFilters,
+                    invalidateCache: body.invalidateCache,
+                    dashboardSorts: body.dashboardSorts,
+                    granularity: body.granularity,
+                    dashboardUuid: body.dashboardUuid,
+                }),
         };
     }
 
@@ -113,7 +114,9 @@ export class SavedChartController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await savedChartsService.getHistory(req.user!, chartUuid),
+            results: await this.services
+                .getSavedChartService()
+                .getHistory(req.user!, chartUuid),
         };
     }
 
@@ -135,11 +138,9 @@ export class SavedChartController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await savedChartsService.getVersion(
-                req.user!,
-                chartUuid,
-                versionUuid,
-            ),
+            results: await this.services
+                .getSavedChartService()
+                .getVersion(req.user!, chartUuid, versionUuid),
         };
     }
 
@@ -161,7 +162,7 @@ export class SavedChartController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await projectService.runViewChartQuery({
+            results: await this.services.getProjectService().runViewChartQuery({
                 user: req.user!,
                 chartUuid,
                 versionUuid,
@@ -189,7 +190,9 @@ export class SavedChartController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await savedChartsService.rollback(req.user!, chartUuid, versionUuid);
+        await this.services
+            .getSavedChartService()
+            .rollback(req.user!, chartUuid, versionUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -215,12 +218,14 @@ export class SavedChartController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
-        const totalResult = await projectService.calculateTotalFromSavedChart(
-            req.user!,
-            chartUuid,
-            body.dashboardFilters,
-            body.invalidateCache,
-        );
+        const totalResult = await this.services
+            .getProjectService()
+            .calculateTotalFromSavedChart(
+                req.user!,
+                chartUuid,
+                body.dashboardFilters,
+                body.invalidateCache,
+            );
         return {
             status: 'ok',
             results: totalResult,

--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -23,7 +23,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { schedulerService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -51,10 +50,9 @@ export class SchedulerController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await schedulerService.getSchedulerLogs(
-                req.user!,
-                projectUuid,
-            ),
+            results: await this.services
+                .getSchedulerService()
+                .getSchedulerLogs(req.user!, projectUuid),
         };
     }
 
@@ -74,10 +72,9 @@ export class SchedulerController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await schedulerService.getScheduler(
-                req.user!,
-                schedulerUuid,
-            ),
+            results: await this.services
+                .getSchedulerService()
+                .getScheduler(req.user!, schedulerUuid),
         };
     }
 
@@ -103,11 +100,9 @@ export class SchedulerController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await schedulerService.updateScheduler(
-                req.user!,
-                schedulerUuid,
-                body,
-            ),
+            results: await this.services
+                .getSchedulerService()
+                .updateScheduler(req.user!, schedulerUuid, body),
         };
     }
 
@@ -133,11 +128,9 @@ export class SchedulerController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await schedulerService.setSchedulerEnabled(
-                req.user!,
-                schedulerUuid,
-                body.enabled,
-            ),
+            results: await this.services
+                .getSchedulerService()
+                .setSchedulerEnabled(req.user!, schedulerUuid, body.enabled),
         };
     }
 
@@ -162,7 +155,9 @@ export class SchedulerController extends BaseController {
         results: undefined;
     }> {
         this.setStatus(200);
-        await schedulerService.deleteScheduler(req.user!, schedulerUuid);
+        await this.services
+            .getSchedulerService()
+            .deleteScheduler(req.user!, schedulerUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -185,10 +180,9 @@ export class SchedulerController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await schedulerService.getScheduledJobs(
-                req.user!,
-                schedulerUuid,
-            ),
+            results: await this.services
+                .getSchedulerService()
+                .getScheduledJobs(req.user!, schedulerUuid),
         };
     }
 
@@ -207,7 +201,9 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiJobStatusResponse> {
         this.setStatus(200);
-        const { status, details } = await schedulerService.getJobStatus(jobId);
+        const { status, details } = await this.services
+            .getSchedulerService()
+            .getJobStatus(jobId);
         return {
             status: 'ok',
             results: {
@@ -239,8 +235,11 @@ export class SchedulerController extends BaseController {
         return {
             status: 'ok',
             results: {
-                jobId: (await schedulerService.sendScheduler(req.user!, body))
-                    .jobId,
+                jobId: (
+                    await this.services
+                        .getSchedulerService()
+                        .sendScheduler(req.user!, body)
+                ).jobId,
             },
         };
     }

--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -17,7 +17,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { shareService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -40,7 +39,9 @@ export class ShareController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await shareService.getShareUrl(req.user!, nanoId),
+            results: await this.services
+                .getShareService()
+                .getShareUrl(req.user!, nanoId),
         };
     }
 
@@ -57,11 +58,9 @@ export class ShareController extends BaseController {
         @Body() body: CreateShareUrl,
         @Request() req: express.Request,
     ): Promise<ApiShareResponse> {
-        const shareUrl = await shareService.createShareUrl(
-            req.user!,
-            body.path,
-            body.params,
-        );
+        const shareUrl = await this.services
+            .getShareService()
+            .createShareUrl(req.user!, body.path, body.params);
         this.setStatus(201);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -22,7 +22,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { spaceService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -50,11 +49,9 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
         this.setStatus(200);
-        const results = await spaceService.getSpace(
-            projectUuid,
-            req.user!,
-            spaceUuid,
-        );
+        const results = await this.services
+            .getSpaceService()
+            .getSpace(projectUuid, req.user!, spaceUuid);
         return {
             status: 'ok',
             results,
@@ -82,11 +79,9 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
         this.setStatus(200);
-        const results = await spaceService.createSpace(
-            projectUuid,
-            req.user!,
-            body,
-        );
+        const results = await this.services
+            .getSpaceService()
+            .createSpace(projectUuid, req.user!, body);
         return {
             status: 'ok',
             results,
@@ -113,7 +108,7 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await spaceService.deleteSpace(req.user!, spaceUuid);
+        await this.services.getSpaceService().deleteSpace(req.user!, spaceUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -143,11 +138,9 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
         this.setStatus(200);
-        const results = await spaceService.updateSpace(
-            req.user!,
-            spaceUuid,
-            body,
-        );
+        const results = await this.services
+            .getSpaceService()
+            .updateSpace(req.user!, spaceUuid, body);
         return {
             status: 'ok',
             results,
@@ -177,7 +170,9 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await spaceService.addSpaceShare(req.user!, spaceUuid, body.userUuid);
+        await this.services
+            .getSpaceService()
+            .addSpaceShare(req.user!, spaceUuid, body.userUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -207,7 +202,9 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await spaceService.removeSpaceShare(req.user!, spaceUuid, userUuid);
+        await this.services
+            .getSpaceService()
+            .removeSpaceShare(req.user!, spaceUuid, userUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/sshController.ts
+++ b/packages/backend/src/controllers/sshController.ts
@@ -10,7 +10,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { sshKeyPairService } from '../services/services';
 import { isAuthenticated, unauthorisedInDemo } from './authentication';
 import { BaseController } from './baseController';
 
@@ -25,7 +24,7 @@ export class SshController extends BaseController {
     async createSshKeyPair(
         @Request() req: express.Request,
     ): Promise<ApiSshKeyPairResponse> {
-        const results = await sshKeyPairService.create();
+        const results = await this.services.getSshKeyPairService().create();
         this.setStatus(201);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/userAttributesController.ts
+++ b/packages/backend/src/controllers/userAttributesController.ts
@@ -22,7 +22,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { userAttributesService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -50,7 +49,9 @@ export class UserAttributesController extends BaseController {
         );
         return {
             status: 'ok',
-            results: await userAttributesService.getAll(req.user!, context),
+            results: await this.services
+                .getUserAttributesService()
+                .getAll(req.user!, context),
         };
     }
 
@@ -74,7 +75,9 @@ export class UserAttributesController extends BaseController {
 
         return {
             status: 'ok',
-            results: await userAttributesService.create(req.user!, body),
+            results: await this.services
+                .getUserAttributesService()
+                .create(req.user!, body),
         };
     }
 
@@ -100,11 +103,9 @@ export class UserAttributesController extends BaseController {
 
         return {
             status: 'ok',
-            results: await userAttributesService.update(
-                req.user!,
-                userAttributeUuid,
-                body,
-            ),
+            results: await this.services
+                .getUserAttributesService()
+                .update(req.user!, userAttributeUuid, body),
         };
     }
 
@@ -126,7 +127,9 @@ export class UserAttributesController extends BaseController {
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
 
-        await userAttributesService.delete(req.user!, userAttributeUuid);
+        await this.services
+            .getUserAttributesService()
+            .delete(req.user!, userAttributeUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -30,7 +30,6 @@ import {
 import express from 'express';
 import { userModel } from '../models/models';
 import { UserModel } from '../models/UserModel';
-import { userService } from '../services/services';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -78,7 +77,9 @@ export class UserController extends BaseController {
                 'Password must contain at least 8 characters, 1 letter and 1 number or 1 special character',
             );
         }
-        const sessionUser = await userService.registerOrActivateUser(body);
+        const sessionUser = await this.services
+            .getUserService()
+            .registerOrActivateUser(body);
         return new Promise((resolve, reject) => {
             req.login(sessionUser, (err) => {
                 if (err) {
@@ -104,9 +105,9 @@ export class UserController extends BaseController {
     async createEmailOneTimePasscode(
         @Request() req: express.Request,
     ): Promise<ApiEmailStatusResponse> {
-        const status = await userService.sendOneTimePasscodeToPrimaryEmail(
-            req.user!,
-        );
+        const status = await this.services
+            .getUserService()
+            .sendOneTimePasscodeToPrimaryEmail(req.user!);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -127,10 +128,9 @@ export class UserController extends BaseController {
         @Query() passcode?: string,
     ): Promise<ApiEmailStatusResponse> {
         // Throws 404 error if not found
-        const status = await userService.getPrimaryEmailStatus(
-            req.user!,
-            passcode,
-        );
+        const status = await this.services
+            .getUserService()
+            .getPrimaryEmailStatus(req.user!, passcode);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -149,7 +149,9 @@ export class UserController extends BaseController {
     async getOrganizationsUserCanJoin(
         @Request() req: express.Request,
     ): Promise<ApiUserAllowedOrganizationsResponse> {
-        const status = await userService.getAllowedOrganizations(req.user!);
+        const status = await this.services
+            .getUserService()
+            .getAllowedOrganizations(req.user!);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -174,7 +176,9 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
         @Path() organizationUuid: string,
     ): Promise<ApiSuccessEmpty> {
-        await userService.joinOrg(req.user!, organizationUuid);
+        await this.services
+            .getUserService()
+            .joinOrg(req.user!, organizationUuid);
         const sessionUser = await userModel.findSessionUserByUUID(
             req.user!.userUuid,
         );
@@ -203,7 +207,9 @@ export class UserController extends BaseController {
     async deleteUser(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        await userService.delete(req.user!, req.user!.userUuid);
+        await this.services
+            .getUserService()
+            .delete(req.user!, req.user!.userUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -224,7 +230,9 @@ export class UserController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await userService.getWarehouseCredentials(req.user!),
+            results: await this.services
+                .getUserService()
+                .getWarehouseCredentials(req.user!),
         };
     }
 
@@ -244,10 +252,9 @@ export class UserController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await userService.createWarehouseCredentials(
-                req.user!,
-                body,
-            ),
+            results: await this.services
+                .getUserService()
+                .createWarehouseCredentials(req.user!, body),
         };
     }
 
@@ -268,11 +275,9 @@ export class UserController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await userService.updateWarehouseCredentials(
-                req.user!,
-                uuid,
-                body,
-            ),
+            results: await this.services
+                .getUserService()
+                .updateWarehouseCredentials(req.user!, uuid, body),
         };
     }
 
@@ -286,7 +291,9 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
         @Path() uuid: string,
     ): Promise<ApiSuccessEmpty> {
-        await userService.deleteWarehouseCredentials(req.user!, uuid);
+        await this.services
+            .getUserService()
+            .deleteWarehouseCredentials(req.user!, uuid);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -15,7 +15,6 @@ import {
     Body,
     Delete,
     Get,
-    Inject,
     Middlewares,
     OperationId,
     Patch,
@@ -32,7 +31,6 @@ import express from 'express';
 import { userModel } from '../models/models';
 import { UserModel } from '../models/UserModel';
 import { userService } from '../services/services';
-import { UserService } from '../services/UserService';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -15,6 +15,7 @@ import {
     Body,
     Delete,
     Get,
+    Inject,
     Middlewares,
     OperationId,
     Patch,
@@ -31,6 +32,7 @@ import express from 'express';
 import { userModel } from '../models/models';
 import { UserModel } from '../models/UserModel';
 import { userService } from '../services/services';
+import { UserService } from '../services/UserService';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/backend/src/controllers/validationController.ts
+++ b/packages/backend/src/controllers/validationController.ts
@@ -22,7 +22,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { validationService } from '../services/services';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -55,12 +54,9 @@ export class ValidationController extends BaseController {
         return {
             status: 'ok',
             results: {
-                jobId: await validationService.validate(
-                    req.user!,
-                    projectUuid,
-                    context,
-                    body.explores,
-                ),
+                jobId: await this.services
+                    .getValidationService()
+                    .validate(req.user!, projectUuid, context, body.explores),
             },
         };
     }
@@ -85,12 +81,9 @@ export class ValidationController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await validationService.get(
-                req.user!,
-                projectUuid,
-                fromSettings,
-                jobId,
-            ),
+            results: await this.services
+                .getValidationService()
+                .get(req.user!, projectUuid, fromSettings, jobId),
         };
     }
 
@@ -110,7 +103,9 @@ export class ValidationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiValidationDismissResponse> {
         this.setStatus(200);
-        await validationService.delete(req.user!, validationId);
+        await this.services
+            .getValidationService()
+            .delete(req.user!, validationId);
         return {
             status: 'ok',
         };

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6641,7 +6641,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1024.7",
+        "version": "0.1024.8",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1,1 +1,204 @@
-export class ServiceRepository {}
+import type { AnalyticsService } from './AnalyticsService/AnalyticsService';
+import type { CommentService } from './CommentService/CommentService';
+import type { CsvService } from './CsvService/CsvService';
+import type { DashboardService } from './DashboardService/DashboardService';
+import type { DownloadFileService } from './DownloadFileService/DownloadFileService';
+import type { EncryptionService } from './EncryptionService/EncryptionService';
+import type { GdriveService } from './GdriveService/GdriveService';
+import type { GithubAppService } from './GithubAppService/GithubAppService';
+import type { GitIntegrationService } from './GitIntegrationService/GitIntegrationService';
+import type { GroupsService } from './GroupService';
+import type { HealthService } from './HealthService/HealthService';
+import type { NotificationsService } from './NotificationsService/NotificationsService';
+import type { OrganizationService } from './OrganizationService/OrganizationService';
+import type { PersonalAccessTokenService } from './PersonalAccessTokenService';
+import type { PinningService } from './PinningService/PinningService';
+import type { ProjectService } from './ProjectService/ProjectService';
+import type { SavedChartService } from './SavedChartsService/SavedChartService';
+import type { SchedulerService } from './SchedulerService/SchedulerService';
+import type { SearchService } from './SearchService/SearchService';
+import type { ShareService } from './ShareService/ShareService';
+import type { SpaceService } from './SpaceService/SpaceService';
+import type { SshKeyPairService } from './SshKeyPairService';
+import type { UnfurlService } from './UnfurlService/UnfurlService';
+import type { UserAttributesService } from './UserAttributesService/UserAttributesService';
+import type { UserService } from './UserService';
+import type { ValidationService } from './ValidationService/ValidationService';
+
+/**
+ * Interface outlining all services available under the `ServiceRepository`. Add new services to
+ * this list (in alphabetical order, please!) to have typescript help ensure you've updated the
+ * service repository correctly.
+ */
+interface ServiceManifest {
+    analyticsService: AnalyticsService;
+    commentService: CommentService;
+    csvService: CsvService;
+    dashboardService: DashboardService;
+    downloadFileService: DownloadFileService;
+    encryptionService: EncryptionService;
+    gitIntegrationService: GitIntegrationService;
+    githubAppService: GithubAppService;
+    gdriveService: GdriveService;
+    groupService: GroupsService;
+    healthService: HealthService;
+    notificationService: NotificationsService;
+    organizationService: OrganizationService;
+    personalAccessTokenService: PersonalAccessTokenService;
+    pinningService: PinningService;
+    projectService: ProjectService;
+    savedChartService: SavedChartService;
+    schedulerService: SchedulerService;
+    searchService: SearchService;
+    shareService: ShareService;
+    sshKeyPairService: SshKeyPairService;
+    spaceService: SpaceService;
+    unfurlService: UnfurlService;
+    userAttributesService: UserAttributesService;
+    userService: UserService;
+    validationService: ValidationService;
+}
+
+/**
+ * Enforces the presence of getter methods for all services declared in the manifest.
+ */
+type ServiceFactoryMethod<T extends ServiceManifest> = {
+    [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+/**
+ * Intermediate abstract class used to enforce service factory methods via the `ServiceFactoryMethod`
+ * type. We need this extra thin layer to ensure we are statically aware of all members.
+ */
+abstract class ServiceRepositoryBase {
+    /**
+     * Container for service instances. Can be replaced with bare class members once
+     * this class is handling service instantiation directly, and not just behaving as
+     * a dumb proxy.
+     */
+    protected _services: ServiceManifest;
+
+    constructor({ services }: { services: ServiceManifest }) {
+        this._services = services;
+    }
+}
+
+/**
+ * Bare service repository class, which acts as a container for all existing
+ * services, and as a point to share instantiation and common logic.
+ *
+ * If you need to access a service, you should do it through an instance of this
+ * repository - ideally one that you accessed through a controller, or otherwise
+ * via dependency injection.
+ *
+ * NOTE: For now, this repository simply exposes services instantiated in `./services.ts`,
+ *       and provided to this repository directly. At a later stage, this repository will
+ *       handle instantiating all services internally, including cross-service dependencies.
+ */ export class ServiceRepository
+    extends ServiceRepositoryBase
+    implements ServiceFactoryMethod<ServiceManifest>
+{
+    public getAnalyticsService(): AnalyticsService {
+        return this._services.analyticsService;
+    }
+
+    public getCommentService(): CommentService {
+        return this._services.commentService;
+    }
+
+    public getCsvService(): CsvService {
+        return this._services.csvService;
+    }
+
+    public getDashboardService(): DashboardService {
+        return this._services.dashboardService;
+    }
+
+    public getDownloadFileService(): DownloadFileService {
+        return this._services.downloadFileService;
+    }
+
+    public getEncryptionService(): EncryptionService {
+        return this._services.encryptionService;
+    }
+
+    public getGitIntegrationService(): GitIntegrationService {
+        return this._services.gitIntegrationService;
+    }
+
+    public getGithubAppService(): GithubAppService {
+        return this._services.githubAppService;
+    }
+
+    public getGdriveService(): GdriveService {
+        return this._services.gdriveService;
+    }
+
+    public getGroupService(): GroupsService {
+        return this._services.groupService;
+    }
+
+    public getHealthService(): HealthService {
+        return this._services.healthService;
+    }
+
+    public getNotificationService(): NotificationsService {
+        return this._services.notificationService;
+    }
+
+    public getOrganizationService(): OrganizationService {
+        return this._services.organizationService;
+    }
+
+    public getPersonalAccessTokenService(): PersonalAccessTokenService {
+        return this._services.personalAccessTokenService;
+    }
+
+    public getPinningService(): PinningService {
+        return this._services.pinningService;
+    }
+
+    public getProjectService(): ProjectService {
+        return this._services.projectService;
+    }
+
+    public getSavedChartService(): SavedChartService {
+        return this._services.savedChartService;
+    }
+
+    public getSchedulerService(): SchedulerService {
+        return this._services.schedulerService;
+    }
+
+    public getSearchService(): SearchService {
+        return this._services.searchService;
+    }
+
+    public getShareService(): ShareService {
+        return this._services.shareService;
+    }
+
+    public getSshKeyPairService(): SshKeyPairService {
+        return this._services.sshKeyPairService;
+    }
+
+    public getSpaceService(): SpaceService {
+        return this._services.spaceService;
+    }
+
+    public getUnfurlService(): UnfurlService {
+        return this._services.unfurlService;
+    }
+
+    public getUserAttributesService(): UserAttributesService {
+        return this._services.userAttributesService;
+    }
+
+    public getUserService(): UserService {
+        return this._services.userService;
+    }
+
+    public getValidationService(): ValidationService {
+        return this._services.validationService;
+    }
+}

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -53,6 +53,7 @@ import { ProjectService } from './ProjectService/ProjectService';
 import { SavedChartService } from './SavedChartsService/SavedChartService';
 import { SchedulerService } from './SchedulerService/SchedulerService';
 import { SearchService } from './SearchService/SearchService';
+import { ServiceRepository } from './ServiceRepository';
 import { ShareService } from './ShareService/ShareService';
 import { SpaceService } from './SpaceService/SpaceService';
 import { SshKeyPairService } from './SshKeyPairService';
@@ -281,4 +282,38 @@ export const commentService = new CommentService({
 
 export const notificationsService = new NotificationsService({
     notificationsModel,
+});
+
+/**
+ * See ./ServiceRepository for how this will work.
+ */
+export const serviceRepository = new ServiceRepository({
+    services: {
+        analyticsService,
+        commentService,
+        csvService,
+        dashboardService,
+        downloadFileService,
+        encryptionService,
+        gdriveService,
+        githubAppService,
+        gitIntegrationService,
+        groupService,
+        healthService,
+        organizationService,
+        personalAccessTokenService,
+        pinningService,
+        projectService,
+        schedulerService,
+        searchService,
+        shareService,
+        spaceService,
+        sshKeyPairService,
+        unfurlService,
+        userAttributesService,
+        userService,
+        validationService,
+        notificationService: notificationsService,
+        savedChartService: savedChartsService,
+    },
 });

--- a/packages/backend/src/services/tsoaServiceContainer.ts
+++ b/packages/backend/src/services/tsoaServiceContainer.ts
@@ -1,5 +1,5 @@
 import { Controller, type IocContainerFactory } from '@tsoa/runtime';
-import type { BaseController } from '../controllers/baseController';
+import { BaseController } from '../controllers/baseController';
 import type { ServiceRepository } from './ServiceRepository';
 import { serviceRepository } from './services';
 
@@ -17,9 +17,9 @@ type RouteControllerKlass = TsoaControllerKlass | BaseControllerKlass;
  * Used to narrow the controller klass type, so that we can instantiate it with
  * the correct number of arguments.
  */
-const isTsoaControllerCtor = (
+const isBaseControllerCtor = (
     ctor: RouteControllerKlass,
-): ctor is TsoaControllerKlass => ctor.prototype instanceof Controller;
+): ctor is BaseControllerKlass => ctor.prototype instanceof BaseController;
 
 /**
  * See tsoa.yml
@@ -29,10 +29,10 @@ const isTsoaControllerCtor = (
  */
 export const iocContainer: IocContainerFactory = () => ({
     async get<T extends RouteControllerKlass>(Ctor: T) {
-        if (isTsoaControllerCtor(Ctor)) {
-            return new Ctor();
+        if (isBaseControllerCtor(Ctor)) {
+            return new Ctor(serviceRepository);
         }
 
-        return new Ctor(serviceRepository);
+        return new (Ctor as TsoaControllerKlass)();
     },
 });

--- a/packages/backend/src/services/tsoaServiceContainer.ts
+++ b/packages/backend/src/services/tsoaServiceContainer.ts
@@ -1,6 +1,7 @@
 import { Controller, type IocContainerFactory } from '@tsoa/runtime';
-import { BaseController } from '../controllers/baseController';
-import { ServiceRepository } from './ServiceRepository';
+import type { BaseController } from '../controllers/baseController';
+import type { ServiceRepository } from './ServiceRepository';
+import { serviceRepository } from './services';
 
 /**
  * For now, we allow both classes extending tsoa's Controller directly, as well as those
@@ -8,7 +9,7 @@ import { ServiceRepository } from './ServiceRepository';
  */
 type TsoaControllerKlass = new () => Controller;
 type BaseControllerKlass = new (
-    serviceRepository: ServiceRepository,
+    repository: ServiceRepository,
 ) => BaseController;
 type RouteControllerKlass = TsoaControllerKlass | BaseControllerKlass;
 
@@ -32,6 +33,6 @@ export const iocContainer: IocContainerFactory = () => ({
             return new Ctor();
         }
 
-        return new Ctor(new ServiceRepository());
+        return new Ctor(serviceRepository);
     },
 });


### PR DESCRIPTION
**See #9232 for the full context.**

This PR is a follow-up to #9233, and will be rebased once that (and its parent) are merged.
Closes: #9169
Implements part of #9151 

### Description:

Updates all controllers to use the injected `ServiceRepository` to access services, instead of relying on the singleton export from `./services`.

This is functionally the same as before, since we're ultimately using our singleton services as part of the `ServiceRepository` setup, but this allows us to later move forward to proper dependency injection.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
