### PR TITLE
chore: remove deprecated body-parser use

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -65,7 +65,6 @@
         "ajv-formats": "^2.1.0",
         "apache-arrow": "^15.0.0",
         "bcrypt": "^5.1.1",
-        "body-parser": "^1.19.0",
         "connect-flash": "^0.1.1",
         "connect-session-knex": "^3.0.0",
         "cookie-parser": "^1.4.5",

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -3,7 +3,6 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import { SamplingContext } from '@sentry/types';
-import bodyParser from 'body-parser';
 import flash from 'connect-flash';
 import connectSessionKnex from 'connect-session-knex';
 import cookieParser from 'cookie-parser';
@@ -130,8 +129,8 @@ export default class App {
             express.json({ limit: this.lightdashConfig.maxPayloadSize }),
         );
 
-        expressApp.use(bodyParser.json());
-        expressApp.use(bodyParser.urlencoded({ extended: false }));
+        expressApp.use(express.json());
+        expressApp.use(express.urlencoded({ extended: false }));
         expressApp.use(cookieParser());
 
         expressApp.use(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8296,7 +8296,7 @@ body-parser@1.19.2:
     raw-body "2.4.3"
     type-is "~1.6.18"
 
-body-parser@1.20.1, body-parser@^1.19.0:
+body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz"
   integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==


### PR DESCRIPTION
### Description:

The `body-parser` package is deprecated for use with express `4.16` onwards, and replaced with methods included as part of the `express` object:

https://expressjs.com/en/api.html#express.json
https://expressjs.com/en/api.html#express.urlencoded

This PR removes `body-parser` and uses the equivalent methods instead, which are really just the same methods as included in `body-parser`: https://github.com/expressjs/express/blob/master/lib/express.js#L78

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
