### PR TITLE
chore: migrate routes to use ServiceRepository

### DIFF
--- a/packages/backend/src/routers/analyticsRouter.ts
+++ b/packages/backend/src/routers/analyticsRouter.ts
@@ -3,7 +3,6 @@ import {
     allowApiKeyAuthentication,
     isAuthenticated,
 } from '../controllers/authentication';
-import { analyticsService } from '../services/services';
 
 export const analyticsRouter = express.Router({ mergeParams: true });
 
@@ -14,10 +13,9 @@ analyticsRouter.get(
     async (req, res, next) => {
         try {
             const { projectUuid } = req.params;
-            const userActivity = await analyticsService.getUserActivity(
-                projectUuid,
-                req.user!,
-            );
+            const userActivity = await req.services
+                .getAnalyticsService()
+                .getUserActivity(projectUuid, req.user!);
             res.json({
                 status: 'ok',
                 results: userActivity,

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -8,7 +8,6 @@ import {
     storeOIDCRedirect,
 } from '../controllers/authentication';
 import { UserModel } from '../models/UserModel';
-import { healthService } from '../services/services';
 import { analyticsRouter } from './analyticsRouter';
 import { dashboardRouter } from './dashboardRouter';
 import { headlessBrowserRouter } from './headlessBrowser';
@@ -30,7 +29,8 @@ apiV1Router.get('/livez', async (req, res, next) => {
 });
 
 apiV1Router.get('/health', async (req, res, next) => {
-    healthService
+    req.services
+        .getHealthService()
         .getHealthState(!!req.user?.userUuid)
         .then((state) =>
             res.json({

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -4,12 +4,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import {
-    analyticsService,
-    dashboardService,
-    projectService,
-    unfurlService,
-} from '../services/services';
 
 export const dashboardRouter = express.Router({ mergeParams: true });
 
@@ -21,10 +15,9 @@ dashboardRouter.get(
         try {
             res.json({
                 status: 'ok',
-                results: await dashboardService.getById(
-                    req.user!,
-                    req.params.dashboardUuid,
-                ),
+                results: await req.services
+                    .getDashboardService()
+                    .getById(req.user!, req.params.dashboardUuid),
             });
         } catch (e) {
             next(e);
@@ -37,7 +30,8 @@ dashboardRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        analyticsService
+        req.services
+            .getAnalyticsService()
             .getDashboardViews(req.params.dashboardUuid)
             .then((results) => {
                 res.json({
@@ -58,11 +52,9 @@ dashboardRouter.patch(
         try {
             res.json({
                 status: 'ok',
-                results: await dashboardService.update(
-                    req.user!,
-                    req.params.dashboardUuid,
-                    req.body,
-                ),
+                results: await req.services
+                    .getDashboardService()
+                    .update(req.user!, req.params.dashboardUuid, req.body),
             });
         } catch (e) {
             next(e);
@@ -79,10 +71,9 @@ dashboardRouter.patch(
         try {
             res.json({
                 status: 'ok',
-                results: await dashboardService.togglePinning(
-                    req.user!,
-                    req.params.dashboardUuid,
-                ),
+                results: await req.services
+                    .getDashboardService()
+                    .togglePinning(req.user!, req.params.dashboardUuid),
             });
         } catch (e) {
             next(e);
@@ -97,7 +88,9 @@ dashboardRouter.delete(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
-            await dashboardService.delete(req.user!, req.params.dashboardUuid);
+            await req.services
+                .getDashboardService()
+                .delete(req.user!, req.params.dashboardUuid);
             res.json({
                 status: 'ok',
                 results: undefined,
@@ -116,10 +109,9 @@ dashboardRouter.get(
         try {
             res.json({
                 status: 'ok',
-                results: await dashboardService.getSchedulers(
-                    req.user!,
-                    req.params.dashboardUuid,
-                ),
+                results: await req.services
+                    .getDashboardService()
+                    .getSchedulers(req.user!, req.params.dashboardUuid),
             });
         } catch (e) {
             next(e);
@@ -136,11 +128,13 @@ dashboardRouter.post(
         try {
             res.json({
                 status: 'ok',
-                results: await dashboardService.createScheduler(
-                    req.user!,
-                    req.params.dashboardUuid,
-                    req.body,
-                ),
+                results: await req.services
+                    .getDashboardService()
+                    .createScheduler(
+                        req.user!,
+                        req.params.dashboardUuid,
+                        req.body,
+                    ),
             });
         } catch (e) {
             next(e);
@@ -154,11 +148,9 @@ dashboardRouter.post(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const results =
-                await projectService.getAvailableFiltersForSavedQueries(
-                    req.user!,
-                    req.body,
-                );
+            const results = await req.services
+                .getProjectService()
+                .getAvailableFiltersForSavedQueries(req.user!, req.body);
 
             res.json({
                 status: 'ok',
@@ -176,12 +168,14 @@ dashboardRouter.post(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const results = await unfurlService.exportDashboard(
-                req.params.dashboardUuid,
-                req.body.queryFilters,
-                req.body.gridWidth,
-                req.user!,
-            );
+            const results = await req.services
+                .getUnfurlService()
+                .exportDashboard(
+                    req.params.dashboardUuid,
+                    req.body.queryFilters,
+                    req.body.gridWidth,
+                    req.user!,
+                );
 
             res.json({
                 status: 'ok',

--- a/packages/backend/src/routers/headlessBrowser.ts
+++ b/packages/backend/src/routers/headlessBrowser.ts
@@ -3,12 +3,10 @@ import { createHmac } from 'crypto';
 import express from 'express';
 import { lightdashConfig } from '../config/lightdashConfig';
 import { userModel } from '../models/models';
-import { EncryptionService } from '../services/EncryptionService/EncryptionService';
 
 const puppeteer = require('puppeteer');
 
 export const headlessBrowserRouter = express.Router({ mergeParams: true });
-export const encryptionService = new EncryptionService({ lightdashConfig });
 
 export const getAuthenticationToken = (value: string) =>
     createHmac('sha512', lightdashConfig.lightdashSecret)

--- a/packages/backend/src/routers/inviteLinksRouter.ts
+++ b/packages/backend/src/routers/inviteLinksRouter.ts
@@ -5,7 +5,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import { userService } from '../services/services';
 
 export const inviteLinksRouter = express.Router();
 
@@ -15,7 +14,9 @@ inviteLinksRouter.get(
     async (req, res, next) => {
         try {
             const { inviteLinkCode } = req.params;
-            const inviteLink = await userService.getInviteLink(inviteLinkCode);
+            const inviteLink = await req.services
+                .getUserService()
+                .getInviteLink(inviteLinkCode);
             res.status(200).json({
                 status: 'ok',
                 results: inviteLink,
@@ -35,10 +36,9 @@ inviteLinksRouter.post(
         try {
             const createInviteLink = req.body as CreateInviteLink;
             const user = req.user!;
-            const inviteLink = await userService.createPendingUserAndInviteLink(
-                user,
-                createInviteLink,
-            );
+            const inviteLink = await req.services
+                .getUserService()
+                .createPendingUserAndInviteLink(user, createInviteLink);
             res.status(201).json({
                 status: 'ok',
                 results: inviteLink,
@@ -56,7 +56,7 @@ inviteLinksRouter.delete(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
-            await userService.revokeAllInviteLinks(req.user!);
+            await req.services.getUserService().revokeAllInviteLinks(req.user!);
             res.status(200).json({
                 status: 'ok',
             });

--- a/packages/backend/src/routers/jobsRouter.ts
+++ b/packages/backend/src/routers/jobsRouter.ts
@@ -3,7 +3,6 @@ import {
     allowApiKeyAuthentication,
     isAuthenticated,
 } from '../controllers/authentication';
-import { projectService } from '../services/services';
 
 export const jobsRouter = express.Router({ mergeParams: true });
 
@@ -18,7 +17,9 @@ jobsRouter.get(
     async (req, res, next) => {
         try {
             const { jobUuid } = req.params;
-            const job = await projectService.getJobStatus(jobUuid, req.user!);
+            const job = await req.services
+                .getProjectService()
+                .getJobStatus(jobUuid, req.user!);
             res.json({
                 status: 'ok',
                 results: job,

--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -10,12 +10,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import {
-    groupService,
-    organizationService,
-    projectService,
-    userService,
-} from '../services/services';
 
 export const organizationRouter = express.Router();
 
@@ -25,7 +19,8 @@ organizationRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) =>
-        projectService
+        req.services
+            .getProjectService()
             .create(
                 req.user!,
                 req.body,
@@ -46,7 +41,8 @@ organizationRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) =>
-        projectService
+        req.services
+            .getProjectService()
             .createWithoutCompile(
                 req.user!,
                 req.body,
@@ -67,7 +63,8 @@ organizationRouter.delete(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) =>
-        projectService
+        req.services
+            .getProjectService()
             .delete(req.params.projectUuid, req.user!)
             .then((results) => {
                 res.json({
@@ -83,9 +80,9 @@ organizationRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const onboarding = await organizationService.getOnboarding(
-                req.user!,
-            );
+            const onboarding = await req.services
+                .getOrganizationService()
+                .getOnboarding(req.user!);
             const results: OnboardingStatus = {
                 ranQuery: !!onboarding.ranQueryAt,
             };
@@ -104,7 +101,9 @@ organizationRouter.post(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            await organizationService.setOnboardingSuccessDate(req.user!);
+            await req.services
+                .getOrganizationService()
+                .setOnboardingSuccessDate(req.user!);
             res.json({
                 status: 'ok',
                 results: undefined,

--- a/packages/backend/src/routers/passwordResetLinksRouter.ts
+++ b/packages/backend/src/routers/passwordResetLinksRouter.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { unauthorisedInDemo } from '../controllers/authentication';
-import { userService } from '../services/services';
 
 export const passwordResetLinksRouter = express.Router();
 
@@ -8,7 +7,8 @@ passwordResetLinksRouter.get(
     '/:code',
     unauthorisedInDemo,
     async (req, res, next) =>
-        userService
+        req.services
+            .getUserService()
             .verifyPasswordResetLink(req.params.code)
             .then(() => {
                 res.json({
@@ -19,7 +19,8 @@ passwordResetLinksRouter.get(
 );
 
 passwordResetLinksRouter.post('/', unauthorisedInDemo, async (req, res, next) =>
-    userService
+    req.services
+        .getUserService()
         .recoverPassword(req.body)
         .then(() => {
             res.json({

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -13,15 +13,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import {
-    csvService,
-    dashboardService,
-    downloadFileService,
-    projectService,
-    savedChartsService,
-    searchService,
-    spaceService,
-} from '../services/services';
 
 export const projectRouter = express.Router({ mergeParams: true });
 
@@ -31,7 +22,8 @@ projectRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        projectService
+        req.services
+            .getProjectService()
             .updateAndScheduleAsyncWork(
                 req.params.projectUuid,
                 req.user!,
@@ -55,17 +47,19 @@ projectRouter.get(
     async (req, res, next) => {
         try {
             const { type, fromDate, toDate, createdByUuid } = req.query;
-            const results = await searchService.getSearchResults(
-                req.user!,
-                req.params.projectUuid,
-                req.params.query,
-                {
-                    type: type?.toString(),
-                    fromDate: fromDate?.toString(),
-                    toDate: toDate?.toString(),
-                    createdByUuid: createdByUuid?.toString(),
-                },
-            );
+            const results = await req.services
+                .getSearchService()
+                .getSearchResults(
+                    req.user!,
+                    req.params.projectUuid,
+                    req.params.query,
+                    {
+                        type: type?.toString(),
+                        fromDate: fromDate?.toString(),
+                        toDate: toDate?.toString(),
+                        createdByUuid: createdByUuid?.toString(),
+                    },
+                );
             res.json({ status: 'ok', results });
         } catch (e) {
             next(e);
@@ -79,8 +73,9 @@ projectRouter.get(
     async (req, res, next) => {
         try {
             const { nanoId } = req.params;
-            const { path: filePath } =
-                await downloadFileService.getDownloadFile(nanoId);
+            const { path: filePath } = await req.services
+                .getDownloadFileService()
+                .getDownloadFile(nanoId);
             const filename = path.basename(filePath);
             res.set('Content-Type', 'text/csv');
             res.set('Content-Disposition', `attachment; filename=${filename}`);
@@ -103,15 +98,17 @@ projectRouter.post(
         try {
             const results = {
                 search: req.body.search,
-                results: await projectService.searchFieldUniqueValues(
-                    req.user!,
-                    req.params.projectUuid,
-                    req.body.table,
-                    req.params.fieldId,
-                    req.body.search,
-                    req.body.limit,
-                    req.body.filters,
-                ),
+                results: await req.services
+                    .getProjectService()
+                    .searchFieldUniqueValues(
+                        req.user!,
+                        req.params.projectUuid,
+                        req.body.table,
+                        req.params.fieldId,
+                        req.body.search,
+                        req.body.limit,
+                        req.body.filters,
+                    ),
             };
 
             res.json({
@@ -131,11 +128,13 @@ projectRouter.post(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
-            const results = await projectService.scheduleCompileProject(
-                req.user!,
-                req.params.projectUuid,
-                getRequestMethod(req.header(LightdashRequestMethodHeader)),
-            );
+            const results = await req.services
+                .getProjectService()
+                .scheduleCompileProject(
+                    req.user!,
+                    req.params.projectUuid,
+                    getRequestMethod(req.header(LightdashRequestMethodHeader)),
+                );
             res.json({
                 status: 'ok',
                 results,
@@ -152,6 +151,8 @@ projectRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
+        const savedChartsService = req.services.getSavedChartService();
+
         if (req.query.duplicateFrom) {
             savedChartsService
                 .duplicate(
@@ -186,7 +187,8 @@ projectRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .updateMultiple(req.user!, req.params.projectUuid, req.body)
             .then((results) => {
                 res.json({
@@ -203,7 +205,8 @@ projectRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        spaceService
+        req.services
+            .getSpaceService()
             .getAllSpaces(req.params.projectUuid, req.user!)
             .then((results) => {
                 res.json({
@@ -220,7 +223,8 @@ projectRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        projectService
+        req.services
+            .getProjectService()
             .getMostPopularAndRecentlyUpdated(req.user!, req.params.projectUuid)
             .then((results) => {
                 res.json({
@@ -238,7 +242,8 @@ projectRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        spaceService
+        req.services
+            .getSpaceService()
             .togglePinning(req.user!, req.params.spaceUuid)
             .then((results) => {
                 res.json({
@@ -262,7 +267,8 @@ projectRouter.get(
 
         const includePrivate = req.query.includePrivate === 'true';
 
-        dashboardService
+        req.services
+            .getDashboardService()
             .getAllByProject(
                 req.user!,
                 req.params.projectUuid,
@@ -285,6 +291,8 @@ projectRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
+        const dashboardService = req.services.getDashboardService();
+
         if (req.query.duplicateFrom) {
             dashboardService
                 .duplicate(
@@ -319,7 +327,8 @@ projectRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        dashboardService
+        req.services
+            .getDashboardService()
             .updateMultiple(req.user!, req.params.projectUuid, req.body)
             .then((results) => {
                 res.json({
@@ -340,7 +349,7 @@ projectRouter.post(
             const { customLabels, sql } = req.body;
             const { projectUuid } = req.params;
 
-            const fileUrl = await csvService.downloadSqlCsv({
+            const fileUrl = await req.services.getCsvService().downloadSqlCsv({
                 user: req.user!,
                 projectUuid,
                 sql,
@@ -364,10 +373,9 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const results: ProjectCatalog = await projectService.getCatalog(
-                req.user!,
-                req.params.projectUuid,
-            );
+            const results: ProjectCatalog = await req.services
+                .getProjectService()
+                .getCatalog(req.user!, req.params.projectUuid);
             res.json({
                 status: 'ok',
                 results,
@@ -384,11 +392,9 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const results: TablesConfiguration =
-                await projectService.getTablesConfiguration(
-                    req.user!,
-                    req.params.projectUuid,
-                );
+            const results: TablesConfiguration = await req.services
+                .getProjectService()
+                .getTablesConfiguration(req.user!, req.params.projectUuid);
             res.json({
                 status: 'ok',
                 results,
@@ -406,8 +412,9 @@ projectRouter.patch(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
-            const results: TablesConfiguration =
-                await projectService.updateTablesConfiguration(
+            const results: TablesConfiguration = await req.services
+                .getProjectService()
+                .updateTablesConfiguration(
                     req.user!,
                     req.params.projectUuid,
                     req.body,
@@ -428,10 +435,9 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const results = await projectService.hasSavedCharts(
-                req.user!,
-                req.params.projectUuid,
-            );
+            const results = await req.services
+                .getProjectService()
+                .hasSavedCharts(req.user!, req.params.projectUuid);
             res.json({
                 status: 'ok',
                 results,

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -4,11 +4,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import {
-    analyticsService,
-    projectService,
-    savedChartsService,
-} from '../services/services';
 
 export const savedChartRouter = express.Router();
 
@@ -17,7 +12,8 @@ savedChartRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .get(req.params.savedQueryUuid, req.user!)
             .then((results) => {
                 res.json({
@@ -34,7 +30,8 @@ savedChartRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .getViewStats(req.user!, req.params.savedQueryUuid)
             .then((results) => {
                 res.json({
@@ -51,7 +48,8 @@ savedChartRouter.get(
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) =>
-        projectService
+        req.services
+            .getProjectService()
             .getAvailableFiltersForSavedQuery(
                 req.user!,
                 req.params.savedQueryUuid,
@@ -71,7 +69,8 @@ savedChartRouter.delete(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .delete(req.user!, req.params.savedQueryUuid)
             .then(() => {
                 res.json({
@@ -89,7 +88,8 @@ savedChartRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .update(req.user!, req.params.savedQueryUuid, req.body)
             .then((results) => {
                 res.json({
@@ -107,7 +107,8 @@ savedChartRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .togglePinning(req.user!, req.params.savedQueryUuid)
             .then((results) => {
                 res.json({
@@ -125,7 +126,8 @@ savedChartRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        savedChartsService
+        req.services
+            .getSavedChartService()
             .createVersion(req.user!, req.params.savedQueryUuid, req.body)
             .then((results) => {
                 res.json({
@@ -145,10 +147,9 @@ savedChartRouter.get(
         try {
             res.json({
                 status: 'ok',
-                results: await savedChartsService.getSchedulers(
-                    req.user!,
-                    req.params.savedQueryUuid,
-                ),
+                results: await req.services
+                    .getSavedChartService()
+                    .getSchedulers(req.user!, req.params.savedQueryUuid),
             });
         } catch (e) {
             next(e);
@@ -165,11 +166,13 @@ savedChartRouter.post(
         try {
             res.json({
                 status: 'ok',
-                results: await savedChartsService.createScheduler(
-                    req.user!,
-                    req.params.savedQueryUuid,
-                    req.body,
-                ),
+                results: await req.services
+                    .getSavedChartService()
+                    .createScheduler(
+                        req.user!,
+                        req.params.savedQueryUuid,
+                        req.body,
+                    ),
             });
         } catch (e) {
             next(e);

--- a/packages/backend/src/routers/slackRouter.ts
+++ b/packages/backend/src/routers/slackRouter.ts
@@ -14,7 +14,6 @@ import {
     unauthorisedInDemo,
 } from '../controllers/authentication';
 import { slackAuthenticationModel } from '../models/models';
-import { downloadFileService } from '../services/services';
 
 // TODO: to be removed once this is refactored. https://github.com/lightdash/lightdash/issues/9174
 const analytics = new LightdashAnalytics({
@@ -74,8 +73,9 @@ slackRouter.get(
     async (req, res, next) => {
         try {
             const { nanoId } = req.params;
-            const { path: filePath } =
-                await downloadFileService.getDownloadFile(nanoId);
+            const { path: filePath } = await req.services
+                .getDownloadFileService()
+                .getDownloadFile(nanoId);
             const normalizedPath = path.normalize(filePath);
             if (!normalizedPath.startsWith('/tmp/')) {
                 throw new NotFoundError(`File not found ${normalizedPath}`);

--- a/packages/backend/src/routers/userRouter.ts
+++ b/packages/backend/src/routers/userRouter.ts
@@ -7,7 +7,6 @@ import {
     isAuthenticated,
     unauthorisedInDemo,
 } from '../controllers/authentication';
-import { personalAccessTokenService, userService } from '../services/services';
 
 export const userRouter = express.Router();
 
@@ -16,7 +15,8 @@ userRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        userService
+        req.services
+            .getUserService()
             .updateUser(req.user!, req.body)
             .then((user) => {
                 res.json({
@@ -29,7 +29,8 @@ userRouter.patch(
 );
 
 userRouter.get('/password', isAuthenticated, async (req, res, next) =>
-    userService
+    req.services
+        .getUserService()
         .hasPassword(req.user!)
         .then((hasPassword: boolean) => {
             res.json({
@@ -45,7 +46,8 @@ userRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) =>
-        userService
+        req.services
+            .getUserService()
             .updatePassword(req.user!, req.body)
             .then(() => {
                 req.logout((err) => {
@@ -67,7 +69,8 @@ userRouter.post(
 );
 
 userRouter.post('/password/reset', unauthorisedInDemo, async (req, res, next) =>
-    userService
+    req.services
+        .getUserService()
         .resetPassword(req.body)
         .then(() => {
             res.json({
@@ -78,7 +81,9 @@ userRouter.post('/password/reset', unauthorisedInDemo, async (req, res, next) =>
 );
 
 userRouter.get('/identities', isAuthenticated, async (req, res, next) => {
-    const identities = await userService.getLinkedIdentities(req.user!);
+    const identities = await req.services
+        .getUserService()
+        .getLinkedIdentities(req.user!);
     res.json({
         status: 'ok',
         results: identities,
@@ -90,7 +95,8 @@ userRouter.delete(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        userService
+        req.services
+            .getUserService()
             .deleteLinkedIdentity(req.user!, req.body)
             .then(() => {
                 res.json({
@@ -106,7 +112,8 @@ userRouter.patch(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        userService
+        req.services
+            .getUserService()
             .completeUserSetup(req.user!, req.body)
             .then((results) => {
                 res.json({
@@ -123,7 +130,8 @@ userRouter.post(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        personalAccessTokenService
+        req.services
+            .getPersonalAccessTokenService()
             .createPersonalAccessToken(
                 req.user!,
                 req.body,
@@ -139,7 +147,8 @@ userRouter.get(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        personalAccessTokenService
+        req.services
+            .getPersonalAccessTokenService()
             .getAllPersonalAccessTokens(req.user!)
             .then((results) =>
                 res.json({
@@ -156,7 +165,8 @@ userRouter.delete(
     isAuthenticated,
     unauthorisedInDemo,
     async (req, res, next) => {
-        personalAccessTokenService
+        req.services
+            .getPersonalAccessTokenService()
             .deletePersonalAccessToken(req.user!, req.params.tokenUuid)
             .then(() =>
                 res.json({


### PR DESCRIPTION
Closes: #9151 

### Description:

Follow-up to other PRs included in the related ticket above. Expands the service repository support to express routers under `routers/`.

This is, for now at least, done via a middleware that injects `ServiceRepository` under `req.services` - the same singleton `ServiceRepository` used for controllers.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
