### PR TITLE
feat: enable hiding dashboard chart title

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -202,34 +202,22 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                         )}
                                         {isEditMode && (
                                             <>
-                                                <Tooltip
-                                                    disabled={
-                                                        !belongsToDashboard
-                                                    }
-                                                    label="Tile content in charts from dashboards is not editable"
-                                                >
-                                                    <Box>
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconEdit
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                setIsEditingTileContent(
-                                                                    true,
-                                                                )
-                                                            }
-                                                            disabled={
-                                                                belongsToDashboard
-                                                            }
-                                                        >
-                                                            Edit tile content
-                                                        </Menu.Item>
-                                                    </Box>
-                                                </Tooltip>
+                                                <Box>
+                                                    <Menu.Item
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconEdit}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setIsEditingTileContent(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Edit tile content
+                                                    </Menu.Item>
+                                                </Box>
                                                 {belongsToDashboard ? (
                                                     <Menu.Item
                                                         color="red"

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -13,7 +13,6 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconChartAreaLine, IconEye, IconEyeOff } from '@tabler/icons-react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import MantineIcon from '../../common/MantineIcon';
@@ -81,14 +80,7 @@ const ChartUpdateModal = ({
                     <Flex align="flex-end" gap="xs">
                         <TextInput
                             label="Title"
-                            placeholder={
-                                form.values.uuid
-                                    ? savedCharts?.find(
-                                          (chart) =>
-                                              chart.uuid === form.values.uuid,
-                                      )?.name
-                                    : undefined
-                            }
+                            placeholder={tile.properties.chartName || undefined}
                             {...form.getInputProps('title')}
                             style={{ flex: 1 }}
                             disabled={form.values.hideTitle}
@@ -111,36 +103,38 @@ const ChartUpdateModal = ({
                             />
                         </ActionIcon>
                     </Flex>
-                    <Select
-                        styles={(theme) => ({
-                            separator: {
-                                position: 'sticky',
-                                top: 0,
-                                backgroundColor: 'white',
-                            },
-                            separatorLabel: {
-                                color: theme.colors.gray[6],
-                                fontWeight: 500,
-                            },
-                        })}
-                        id="savedChartUuid"
-                        name="savedChartUuid"
-                        label="Select chart"
-                        data={(savedCharts || []).map(
-                            ({ uuid, name, spaceName }) => {
-                                return {
-                                    value: uuid,
-                                    label: name,
-                                    group: spaceName,
-                                };
-                            },
-                        )}
-                        disabled={isInitialLoading}
-                        withinPortal
-                        {...form.getInputProps('uuid')}
-                        searchable
-                        placeholder="Search..."
-                    />
+                    {!tile.properties.belongsToDashboard && (
+                        <Select
+                            styles={(theme) => ({
+                                separator: {
+                                    position: 'sticky',
+                                    top: 0,
+                                    backgroundColor: 'white',
+                                },
+                                separatorLabel: {
+                                    color: theme.colors.gray[6],
+                                    fontWeight: 500,
+                                },
+                            })}
+                            id="savedChartUuid"
+                            name="savedChartUuid"
+                            label="Select chart"
+                            data={(savedCharts || []).map(
+                                ({ uuid, name, spaceName }) => {
+                                    return {
+                                        value: uuid,
+                                        label: name,
+                                        group: spaceName,
+                                    };
+                                },
+                            )}
+                            disabled={isInitialLoading}
+                            withinPortal
+                            {...form.getInputProps('uuid')}
+                            searchable
+                            placeholder="Search..."
+                        />
+                    )}
                     <Group spacing="xs" position="right" mt="md">
                         <Button onClick={() => onClose?.()} variant="outline">
                             Cancel


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9240 

### Description:

- Allows to hide the title of a chart belonging to a dashboard
- Hides the select to replace chart if tile is a dashboard chart

https://github.com/lightdash/lightdash/assets/22939015/bf84592c-d81d-424e-8c1b-37966771e0ec

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
