### PR TITLE
feat: scroll to comment when notification clicked

### DIFF
--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -167,6 +167,8 @@ export const DashboardTileComments: FC<
             onClose={() => {
                 onClose?.();
             }}
+            closeOnClickOutside
+            onChange={setOpenedComments}
         >
             <Popover.Dropdown p={0} w={400} maw={400}>
                 <Stack

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { useScrollIntoView } from '@mantine/hooks';
 import { IconMessage } from '@tabler/icons-react';
-import { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo, useRef, useState } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useApp } from '../../../providers/AppProvider';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
@@ -20,6 +20,7 @@ import { EventName } from '../../../types/Events';
 import { useGetNotifications } from '../../notifications';
 import { useUpdateNotification } from '../../notifications/hooks/useNotifications';
 import { useCreateComment } from '../hooks/useComments';
+import { useScrollToDashboardCommentViaSearchParam } from '../hooks/useScrollToDashboardCommentViaSearchParam';
 import { CommentForm } from './CommentForm';
 import { DashboardCommentAndReplies } from './DashboardCommentAndReplies';
 
@@ -35,14 +36,28 @@ export const DashboardTileComments: FC<
     const { user } = useApp();
     const { track } = useTracking();
 
+    const [openedComments, setOpenedComments] = useState(opened);
+
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const canCreateDashboardComments = useDashboardContext(
         (c) => c.dashboardCommentsCheck?.canCreateDashboardComments,
     );
+    const dashboard = useDashboardContext((c) => c.dashboard);
     const comments = useDashboardContext(
         (c) => c.dashboardComments && c.dashboardComments[dashboardTileUuid],
     );
+
+    const targetRefComments = useRef<HTMLDivElement>(null);
+
+    useScrollToDashboardCommentViaSearchParam({
+        ref: targetRefComments,
+        dashboardTileUuid,
+        enabled: !!(dashboard && comments),
+        onScrolled: () => {
+            setOpenedComments(true);
+        },
+    });
 
     // Scroll to the last comment when a new comment is added
     const { scrollIntoView, targetRef, scrollableRef } =
@@ -147,7 +162,7 @@ export const DashboardTileComments: FC<
             position="bottom-end"
             offset={4}
             arrowOffset={10}
-            opened={opened}
+            opened={openedComments}
             onOpen={handleOnOpen}
             onClose={() => {
                 onClose?.();
@@ -195,7 +210,7 @@ export const DashboardTileComments: FC<
                 </Box>
             </Popover.Dropdown>
 
-            <Popover.Target>
+            <Popover.Target ref={targetRefComments}>
                 <Indicator
                     label={comments && comments.length}
                     size={12}
@@ -211,7 +226,15 @@ export const DashboardTileComments: FC<
                 >
                     <ActionIcon
                         size="sm"
-                        onClick={() => (opened ? onClose?.() : onOpen?.())}
+                        onClick={() => {
+                            if (openedComments) {
+                                onClose?.();
+                            } else {
+                                onOpen?.();
+                            }
+
+                            setOpenedComments((prev) => !prev);
+                        }}
                     >
                         <MantineIcon icon={IconMessage} />
                     </ActionIcon>

--- a/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
+++ b/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
@@ -1,3 +1,4 @@
+import { useMantineTheme } from '@mantine/core';
 import { useLayoutEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -19,6 +20,7 @@ export const useScrollToDashboardCommentViaSearchParam = ({
     dashboardTileUuid: string;
     onScrolled: () => void;
 }) => {
+    const theme = useMantineTheme();
     const [isSuccess, setIsSuccess] = useState(false);
     // get search with uselocation param tile uuid
     const { search } = useLocation();
@@ -40,7 +42,36 @@ export const useScrollToDashboardCommentViaSearchParam = ({
                         block: 'start',
                     });
                 setIsSuccess(true);
+                ref.current?.animate(
+                    [
+                        {
+                            backgroundColor: 'transparent',
+                            borderRadius: theme.radius.sm,
+                        },
+                        {
+                            backgroundColor: theme.colors.yellow[1],
+                            borderRadius: theme.radius.sm,
+                        },
+                        {
+                            backgroundColor: 'transparent',
+                            borderRadius: theme.radius.sm,
+                        },
+                    ],
+                    {
+                        duration: 4000,
+                        iterations: 5,
+                    },
+                );
             }, 200);
         }
-    }, [tileUuid, dashboardTileUuid, enabled, ref, onScrolled, isSuccess]);
+    }, [
+        tileUuid,
+        dashboardTileUuid,
+        enabled,
+        ref,
+        onScrolled,
+        isSuccess,
+        theme.radius.sm,
+        theme.colors.yellow,
+    ]);
 };

--- a/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
+++ b/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
@@ -1,6 +1,6 @@
 import { useMantineTheme } from '@mantine/core';
-import { useLayoutEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 /**
  * Scroll to dashboard comment via search param `tileUuid`
@@ -23,8 +23,9 @@ export const useScrollToDashboardCommentViaSearchParam = ({
     const theme = useMantineTheme();
     const [isSuccess, setIsSuccess] = useState(false);
     // get search with uselocation param tile uuid
-    const { search } = useLocation();
-    const searchParams = new URLSearchParams(search);
+    const history = useHistory();
+    const { search, pathname } = useLocation();
+    const searchParams = useMemo(() => new URLSearchParams(search), [search]);
     const tileUuid = searchParams.get('tileUuid');
 
     useLayoutEffect(() => {
@@ -36,32 +37,40 @@ export const useScrollToDashboardCommentViaSearchParam = ({
         ) {
             onScrolled();
             setTimeout(() => {
-                if (ref.current)
+                if (ref.current) {
                     ref.current.scrollIntoView({
                         behavior: 'smooth',
                         block: 'start',
                     });
-                setIsSuccess(true);
-                ref.current?.animate(
-                    [
+                    setIsSuccess(true);
+                    ref.current.animate(
+                        [
+                            {
+                                backgroundColor: 'transparent',
+                                borderRadius: theme.radius.sm,
+                            },
+                            {
+                                backgroundColor: theme.colors.yellow[1],
+                                borderRadius: theme.radius.sm,
+                            },
+                            {
+                                backgroundColor: 'transparent',
+                                borderRadius: theme.radius.sm,
+                            },
+                        ],
                         {
-                            backgroundColor: 'transparent',
-                            borderRadius: theme.radius.sm,
+                            duration: 4000,
+                            iterations: 2,
                         },
-                        {
-                            backgroundColor: theme.colors.yellow[1],
-                            borderRadius: theme.radius.sm,
-                        },
-                        {
-                            backgroundColor: 'transparent',
-                            borderRadius: theme.radius.sm,
-                        },
-                    ],
-                    {
-                        duration: 4000,
-                        iterations: 5,
-                    },
-                );
+                    );
+
+                    // Clear the search param after scrolling to the comment
+                    searchParams.delete('tileUuid');
+                    history.replace({
+                        pathname,
+                        search: searchParams.toString(),
+                    });
+                }
             }, 200);
         }
     }, [
@@ -73,5 +82,8 @@ export const useScrollToDashboardCommentViaSearchParam = ({
         isSuccess,
         theme.radius.sm,
         theme.colors.yellow,
+        searchParams,
+        history,
+        pathname,
     ]);
 };

--- a/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
+++ b/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
@@ -1,0 +1,39 @@
+import { useLayoutEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const useScrollToDashboardCommentViaSearchParam = ({
+    ref,
+    enabled,
+    dashboardTileUuid,
+    onScrolled,
+}: {
+    ref: React.MutableRefObject<HTMLDivElement | null>;
+    enabled: boolean;
+    dashboardTileUuid: string;
+    onScrolled: () => void;
+}) => {
+    const [isSuccess, setIsSuccess] = useState(false);
+    // get search with uselocation param tile uuid
+    const { search } = useLocation();
+    const searchParams = new URLSearchParams(search);
+    const tileUuid = searchParams.get('tileUuid');
+
+    useLayoutEffect(() => {
+        if (
+            !isSuccess &&
+            tileUuid === dashboardTileUuid &&
+            ref.current &&
+            enabled
+        ) {
+            onScrolled();
+            setTimeout(() => {
+                if (ref.current)
+                    ref.current.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                    });
+                setIsSuccess(true);
+            }, 200);
+        }
+    }, [tileUuid, dashboardTileUuid, enabled, ref, onScrolled, isSuccess]);
+};

--- a/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
+++ b/packages/frontend/src/features/comments/hooks/useScrollToDashboardCommentViaSearchParam.ts
@@ -1,6 +1,13 @@
 import { useLayoutEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
+/**
+ * Scroll to dashboard comment via search param `tileUuid`
+ * @param ref - ref to the element to scroll to
+ * @param enabled - if true, scroll to the element
+ * @param dashboardTileUuid - the dashboard tile uuid
+ * @param onScrolled - callback to call when scrolled
+ */
 export const useScrollToDashboardCommentViaSearchParam = ({
     ref,
     enabled,

--- a/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
@@ -63,7 +63,13 @@ export const DashboardCommentsNotifications: FC<Props> = ({
                 },
             });
 
-            history.push(`/projects/${projectUuid}${notification.url}`);
+            history.push(
+                `/projects/${projectUuid}${notification.url}${
+                    notification.metadata?.dashboardTileUuid
+                        ? `?tileUuid=${notification.metadata?.dashboardTileUuid}`
+                        : ''
+                }`,
+            );
         },
         [history, projectUuid, track, updateNotification],
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9048

### Description:

Uses `scrollTo` with refs and then animates the icon for a few seconds. 
Scrolling only happens when dashboard and comments data has been settled.

Note:
I tried to use Mantine's hook `useScrollIntoView` but it wouldn't work as expected: 
- ref would be identified successfully 
- scrolling would work great
- **but**, the grid wouldn't render - I think `react-grid-layout` might have some CSS visibility in place that ignores whatever Mantine is using for scrolling. I guess it's good that with vanilla JS we achieve what we want


https://github.com/lightdash/lightdash/assets/7611706/3f9530ac-cd36-4c80-a27e-f7583073e3e7



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
