### PR TITLE
fix: use symbolSize to hide the symbol but display the labels

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1,6 +1,7 @@
 import {
     ApiQueryResults,
     applyCustomFormat,
+    assertUnreachable,
     CartesianChart,
     CartesianSeriesType,
     DimensionType,
@@ -251,6 +252,7 @@ export type EChartSeries = {
     };
     data?: unknown[];
     showSymbol?: boolean;
+    symbolSize?: number;
 };
 
 const getFormattedValue = (
@@ -624,6 +626,31 @@ const getPivotSeries = ({
     };
 };
 
+/**
+ * Get the series symbol configuration for a simple series
+ * This is used to hide the symbol if showSymbol is false for line and area charts
+ *
+ * Issue reference: https://github.com/apache/echarts/issues/19178
+ */
+const getSimpleSeriesSymbolConfig = (series: Series) => {
+    const { showSymbol, type } = series;
+    switch (type) {
+        case CartesianSeriesType.LINE:
+        case CartesianSeriesType.AREA:
+            return {
+                showSymbol: true,
+                symbolSize: showSymbol ? 4 : 0,
+            };
+        case CartesianSeriesType.BAR:
+        case CartesianSeriesType.SCATTER:
+            return {
+                showSymbol: showSymbol ?? true,
+            };
+        default:
+            return assertUnreachable(type, `unexpected series type: ${type}`);
+    }
+};
+
 type GetSimpleSeriesArg = {
     series: Series;
     itemsMap: ItemsMap;
@@ -666,7 +693,7 @@ const getSimpleSeries = ({
     tooltip: {
         valueFormatter: valueFormatter(yFieldHash, itemsMap),
     },
-    showSymbol: series.showSymbol ?? true,
+    ...getSimpleSeriesSymbolConfig(series),
     ...(series.label?.show && {
         label: {
             ...series.label,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8857 

### Description:

- This issue was previously reported in the `echarts` repository: https://github.com/apache/echarts/issues/19178
- Implements suggestion to use `symbolSize: 0` to hide the symbol but still display the labels for `line` and `area` charts

 NOTE: This is a frontend only implementation that depending on the `showSymbol` value for `line` and `area` charts we either set `symbolSize` to `0` or `4` (default size: https://echarts.apache.org/en/option.html#series-line.symbolSize). We could also add this value to be saved on the database, but I didn't find a good enough reason to do it as we can simply infer the `symbolSize` value from the `showSymbol` value for display purposes.

Before:
![image](https://github.com/lightdash/lightdash/assets/22939015/f031d8e5-d306-4c77-9c80-92dbc74da73a)

After:
![image](https://github.com/lightdash/lightdash/assets/22939015/b2a4a82e-0dcf-40dd-991f-0ad14698beaa)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
