### PR TITLE
feat: notify people in thread without mentions as well

### DIFF
--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -236,15 +236,13 @@ export class CommentModel {
     }
 
     async findUsersThatCommentedInDashboardTile(
-        dashboardUuid: string,
         dashboardTileUuid: string,
     ): Promise<Pick<LightdashUser, 'userUuid'>[]> {
         const usersThatCommentedInDashboardTile = await this.database(
             DashboardTileCommentsTableName,
         )
-            .select('user_uuid')
-            .where('dashboard_tile_uuid', dashboardTileUuid)
-            .andWhere('dashboard_uuid', dashboardUuid);
+            .distinct('user_uuid')
+            .where('dashboard_tile_uuid', dashboardTileUuid);
 
         return usersThatCommentedInDashboardTile.map((comment) => ({
             userUuid: comment.user_uuid,

--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -235,6 +235,22 @@ export class CommentModel {
         );
     }
 
+    async findUsersThatCommentedInDashboardTile(
+        dashboardUuid: string,
+        dashboardTileUuid: string,
+    ): Promise<Pick<LightdashUser, 'userUuid'>[]> {
+        const usersThatCommentedInDashboardTile = await this.database(
+            DashboardTileCommentsTableName,
+        )
+            .select('user_uuid')
+            .where('dashboard_tile_uuid', dashboardTileUuid)
+            .andWhere('dashboard_uuid', dashboardUuid);
+
+        return usersThatCommentedInDashboardTile.map((comment) => ({
+            userUuid: comment.user_uuid,
+        }));
+    }
+
     async resolveComment(commentId: string): Promise<void> {
         await this.database(DashboardTileCommentsTableName)
             .update({ resolved: true })

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -64,13 +64,19 @@ export class NotificationsModel {
             .update(updateData);
     }
 
-    async createDashboardCommentNotification(
-        userUuid: string,
-        commentAuthor: LightdashUser,
-        comment: Comment,
-        dashboard: Dashboard,
-        dashboardTile: DashboardTile | undefined,
-    ) {
+    async createDashboardCommentNotification({
+        userUuid,
+        commentAuthor,
+        comment,
+        dashboard,
+        dashboardTile,
+    }: {
+        userUuid: string;
+        commentAuthor: LightdashUser;
+        comment: Comment;
+        dashboard: Dashboard;
+        dashboardTile: DashboardTile | undefined;
+    }) {
         if (comment.mentions.length > 0 && dashboardTile) {
             await Promise.all(
                 comment.mentions.map(async (mentionUserUuid) => {

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -64,35 +64,58 @@ export class NotificationsModel {
             .update(updateData);
     }
 
+    private static generateDashboardCommentNotificationMessage({
+        commentAuthor,
+        dashboardName,
+        dashboardTileTitle,
+        tagged,
+    }: {
+        commentAuthor: LightdashUser;
+        dashboardName: string;
+        dashboardTileTitle: string | undefined;
+        tagged: boolean;
+    }) {
+        return `${commentAuthor.firstName} ${commentAuthor.lastName} ${
+            tagged ? 'tagged you' : 'commented'
+        } in dashboard "${dashboardName}" ${
+            dashboardTileTitle ? `in tile "${dashboardTileTitle}"` : ''
+        }`;
+    }
+
     async createDashboardCommentNotification({
         userUuid,
         commentAuthor,
         comment,
+        usersToNotify,
         dashboard,
         dashboardTile,
     }: {
         userUuid: string;
         commentAuthor: LightdashUser;
         comment: Comment;
+        usersToNotify: { userUuid: string; tagged: boolean }[];
         dashboard: Dashboard;
         dashboardTile: DashboardTile | undefined;
     }) {
-        if (comment.mentions.length > 0 && dashboardTile) {
+        if (usersToNotify.length > 0 && dashboardTile) {
             await Promise.all(
-                comment.mentions.map(async (mentionUserUuid) => {
-                    if (mentionUserUuid !== userUuid) {
+                usersToNotify.map(async (mentionUserUuid) => {
+                    if (mentionUserUuid.userUuid !== userUuid) {
                         await this.database(NotificationsTableName).insert({
-                            user_uuid: mentionUserUuid,
+                            user_uuid: mentionUserUuid.userUuid,
                             resource_uuid: comment.commentId,
                             resource_type:
                                 DbNotificationResourceType.DashboardComments,
-                            message: `${commentAuthor.firstName} ${
-                                commentAuthor.lastName
-                            } tagged you in dashboard "${dashboard.name}" ${
-                                dashboardTile.properties.title
-                                    ? `in tile "${dashboardTile.properties.title}"`
-                                    : ''
-                            }`,
+                            message:
+                                NotificationsModel.generateDashboardCommentNotificationMessage(
+                                    {
+                                        commentAuthor,
+                                        dashboardName: dashboard.name,
+                                        dashboardTileTitle:
+                                            dashboardTile.properties.title,
+                                        tagged: mentionUserUuid.tagged,
+                                    },
+                                ),
                             url: `/dashboards/${dashboard.uuid}`,
                             metadata: JSON.stringify({
                                 dashboard_uuid: dashboard.uuid,

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -95,39 +95,37 @@ export class NotificationsModel {
         comment: Comment;
         usersToNotify: { userUuid: string; tagged: boolean }[];
         dashboard: Dashboard;
-        dashboardTile: DashboardTile | undefined;
+        dashboardTile: DashboardTile;
     }) {
-        if (usersToNotify.length > 0 && dashboardTile) {
-            await Promise.all(
-                usersToNotify.map(async (mentionUserUuid) => {
-                    if (mentionUserUuid.userUuid !== userUuid) {
-                        await this.database(NotificationsTableName).insert({
-                            user_uuid: mentionUserUuid.userUuid,
-                            resource_uuid: comment.commentId,
-                            resource_type:
-                                DbNotificationResourceType.DashboardComments,
-                            message:
-                                NotificationsModel.generateDashboardCommentNotificationMessage(
-                                    {
-                                        commentAuthor,
-                                        dashboardName: dashboard.name,
-                                        dashboardTileTitle:
-                                            dashboardTile.properties.title,
-                                        tagged: mentionUserUuid.tagged,
-                                    },
-                                ),
-                            url: `/dashboards/${dashboard.uuid}`,
-                            metadata: JSON.stringify({
-                                dashboard_uuid: dashboard.uuid,
-                                dashboard_name: dashboard.name,
-                                dashboard_tile_uuid: dashboardTile.uuid,
-                                dashboard_tile_name:
-                                    dashboardTile.properties.title ?? '',
-                            }),
-                        });
-                    }
-                }),
-            );
-        }
+        await Promise.all(
+            usersToNotify.map(async (mentionUserUuid) => {
+                if (mentionUserUuid.userUuid !== userUuid) {
+                    await this.database(NotificationsTableName).insert({
+                        user_uuid: mentionUserUuid.userUuid,
+                        resource_uuid: comment.commentId,
+                        resource_type:
+                            DbNotificationResourceType.DashboardComments,
+                        message:
+                            NotificationsModel.generateDashboardCommentNotificationMessage(
+                                {
+                                    commentAuthor,
+                                    dashboardName: dashboard.name,
+                                    dashboardTileTitle:
+                                        dashboardTile.properties.title,
+                                    tagged: mentionUserUuid.tagged,
+                                },
+                            ),
+                        url: `/dashboards/${dashboard.uuid}`,
+                        metadata: JSON.stringify({
+                            dashboard_uuid: dashboard.uuid,
+                            dashboard_name: dashboard.name,
+                            dashboard_tile_uuid: dashboardTile.uuid,
+                            dashboard_tile_name:
+                                dashboardTile.properties.title ?? '',
+                        }),
+                    });
+                }
+            }),
+        );
     }
 }

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -178,8 +178,7 @@ export class CommentService {
             throw new Error('Failed to create comment');
         }
 
-        // Intentionally not awaiting this promise to avoid slowing down the response
-        this.createCommentNotification({
+        await this.createCommentNotification({
             userUuid: user.userUuid,
             comment,
             dashboard,

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -131,13 +131,13 @@ export class CommentService {
                 user.userUuid,
             );
 
-            await this.notificationsModel.createDashboardCommentNotification(
-                user.userUuid,
+            await this.notificationsModel.createDashboardCommentNotification({
+                userUuid: user.userUuid,
                 commentAuthor,
                 comment,
                 dashboard,
                 dashboardTile,
-            );
+            });
         }
 
         return comment.commentId;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8998

### Description:

Users who have also commented in a tile should also be notified when there's a new comment.
If, on the newest comment, there's a tag to user X, don't send an extra notification to user X (just the tag one will be sufficient).

There are now 2 types of messages for comments notifications: 
- tagged
- non-tagged (interacted?)

<img width="604" alt="Screenshot 2024-03-06 at 14 56 53" src="https://github.com/lightdash/lightdash/assets/7611706/3d32d34e-a1d4-4980-89f3-dc1fa4eaa11c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
