### PR TITLE
fix: allow interactive viewers setting filter operator to isNull and not null

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -6,6 +6,7 @@ import {
     Field,
     fieldId,
     FilterableField,
+    FilterOperator,
     isField,
     isFilterableField,
     matchFieldByType,
@@ -138,14 +139,22 @@ const FilterConfiguration: FC<Props> = ({
             setDraftFilterRule((oldFilterRule) => {
                 // TODO: Maybe this isn't the best place to do this.
                 // All this says is if a filter *was* disabled and had no
-                // value but now has a value, enable it. This is a way of
-                // keeping disabled and 'no value' in sync.
-                return oldFilterRule &&
-                    !oldFilterRule?.values?.length &&
-                    oldFilterRule?.disabled &&
-                    newFilterRule.values?.length
-                    ? { ...newFilterRule, disabled: false }
-                    : newFilterRule;
+                // value but now has a value, enable it. Also enable it if
+                // The operator requires no value (null/not null)
+                // This is a way of keeping disabled and 'no value' in sync.
+                let isNewFilterDisabled = newFilterRule.disabled;
+                if (
+                    (oldFilterRule &&
+                        oldFilterRule.disabled &&
+                        !oldFilterRule.values?.length &&
+                        newFilterRule.values?.length) ||
+                    newFilterRule.operator === FilterOperator.NULL ||
+                    newFilterRule.operator === FilterOperator.NOT_NULL
+                ) {
+                    isNewFilterDisabled = false;
+                }
+
+                return { ...newFilterRule, disabled: isNewFilterDisabled };
             });
         },
         [setDraftFilterRule],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9029 

### Description:

Allow viewers to set filters that were 'any value' to null or not null. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
