### PR TITLE
fix: duplicate preview vector issue

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1094,6 +1094,7 @@ export class ProjectModel {
                               spaces.map((d) => {
                                   const createSpace = {
                                       ...d,
+                                      search_vector: undefined,
                                       space_id: undefined,
                                       space_uuid: undefined,
                                       project_id: previewProject.project_id,
@@ -1153,6 +1154,7 @@ export class ProjectModel {
                                   }
                                   const createChart = {
                                       ...d,
+                                      search_vector: undefined,
                                       saved_query_id: undefined,
                                       saved_query_uuid: undefined,
                                       space_id: getNewSpace(d.space_id),
@@ -1349,6 +1351,7 @@ export class ProjectModel {
                               dashboards.map((d) => {
                                   const createDashboard = {
                                       ...d,
+                                      search_vector: undefined,
                                       dashboard_id: undefined,
                                       dashboard_uuid: undefined,
                                       space_id: getNewSpace(d.space_id),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1195,6 +1195,7 @@ export class ProjectModel {
                                   }
                                   const createChart = {
                                       ...d,
+                                      search_vector: undefined,
                                       saved_query_id: undefined,
                                       saved_query_uuid: undefined,
                                       space_id: null,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/9273
### Description:

Fixes: 



>     2024-03-07 10:51:31 [Lightdash] error: Unable to copy content on preview error: insert into "spaces" ("created_at", "created_by_user_id", "is_private", "name", "project_id", "search_vector") values ($1, $2, $3, $4, $5, $6) returning * - cannot insert a non-DEFAULT value into column "search_vector"

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2024-03-07 10-58-11](https://github.com/lightdash/lightdash/assets/1983672/44c84107-3bcf-4fd7-aa49-824d2d6a9542)
### Reviewer actions



- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
