### PR TITLE
fix: fixes title wrapper hover for charts in dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -145,19 +145,16 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                     withinPortal
                                     maw={400}
                                 >
-                                    {!hideTitle ? (
-                                        <TileTitleLink
-                                            ref={titleRef}
-                                            href={titleHref}
-                                            $hovered={titleHovered}
-                                            target="_blank"
-                                            className="non-draggable"
-                                        >
-                                            {title}
-                                        </TileTitleLink>
-                                    ) : (
-                                        <Box />
-                                    )}
+                                    <TileTitleLink
+                                        ref={titleRef}
+                                        href={titleHref}
+                                        $hovered={titleHovered}
+                                        target="_blank"
+                                        className="non-draggable"
+                                        hidden={hideTitle}
+                                    >
+                                        {title}
+                                    </TileTitleLink>
                                 </Tooltip>
                             </Group>
                         </TitleWrapper>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -146,21 +146,15 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                     maw={400}
                                 >
                                     {!hideTitle ? (
-                                        belongsToDashboard ? (
-                                            <Text fw={600} size="md">
-                                                {title}
-                                            </Text>
-                                        ) : (
-                                            <TileTitleLink
-                                                ref={titleRef}
-                                                href={titleHref}
-                                                $hovered={titleHovered}
-                                                target="_blank"
-                                                className="non-draggable"
-                                            >
-                                                {title}
-                                            </TileTitleLink>
-                                        )
+                                        <TileTitleLink
+                                            ref={titleRef}
+                                            href={titleHref}
+                                            $hovered={titleHovered}
+                                            target="_blank"
+                                            className="non-draggable"
+                                        >
+                                            {title}
+                                        </TileTitleLink>
                                     ) : (
                                         <Box />
                                     )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Fixes charts belonging to dashboard not wrapping the title
- Fixes hiding and showing again the title caused not expanding on hover

https://github.com/lightdash/lightdash/assets/22939015/b486b5e5-ffb6-4a20-ae13-1c00207cf7cd

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
