### PR TITLE
chore: update eslint configuration (unused imports, vars, type modifier)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.6.3",
+        "eslint-plugin-unused-imports": "^3.1.0",
         "husky": "^7.0.0",
         "jest": "^29.7.0",
         "lint-staged": "^12.1.2",

--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
             'error',
             {
                 argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
                 ignoreRestSiblings: true
             },
         ],

--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -11,15 +11,29 @@ module.exports = {
         'airbnb-typescript/base',
         'prettier',
     ],
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'unused-imports'],
     rules: {
         'import/prefer-default-export': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
         'no-console': 'off',
         'no-underscore-dangle': 'off',
         'max-classes-per-file': 'off',
         'no-case-declarations': 'off',
         'no-template-curly-in-string': 'off',
         eqeqeq: 'error',
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
+        ],
     },
 };

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -11,12 +11,27 @@ module.exports = {
         'prettier',
         'plugin:json/recommended',
     ],
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'unused-imports'],
     rules: {
         'no-console': 'off',
         'import/prefer-default-export': 'off',
         'no-restricted-syntax': 'off',
         'no-throw-literal': 'off',
         '@typescript-eslint/no-throw-literal': 'off',
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
+        ],
     },
 };

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
             'error',
             {
                 argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
                 ignoreRestSiblings: true
             },
         ],

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -11,15 +11,25 @@ module.exports = {
         'prettier',
         'plugin:json/recommended',
     ],
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'unused-imports'],
     rules: {
         'no-case-declarations': 'off',
         'no-template-curly-in-string': 'off',
         'import/prefer-default-export': 'off',
-        'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
         '@typescript-eslint/no-unused-vars': [
-            'warn',
-            { argsIgnorePattern: '^_' },
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
         ],
     },
 };

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
             'error',
             {
                 argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
                 ignoreRestSiblings: true
             },
         ],

--- a/packages/e2e/.eslintrc.js
+++ b/packages/e2e/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
             'error',
             {
                 argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
                 ignoreRestSiblings: true
             },
         ],

--- a/packages/e2e/.eslintrc.js
+++ b/packages/e2e/.eslintrc.js
@@ -11,5 +11,22 @@ module.exports = {
         'airbnb-typescript/base',
         'prettier',
     ],
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'unused-imports'],
+    rules: {
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
+        ],
+    }
 };

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
             'error',
             {
                 argsIgnorePattern: '^_',
+                varsIgnorePattern: '^_',
                 ignoreRestSiblings: true
             },
         ],

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
         project: './tsconfig.json',
         createDefaultProgram: true,
     },
-    ignorePatterns: ['**/styles/*.css'],
+    ignorePatterns: ['**/styles/*.css', '.eslintrc.js'],
     extends: [
         './../../.eslintrc.js',
         'plugin:@typescript-eslint/recommended',
@@ -23,9 +23,8 @@ module.exports = {
         'plugin:react/recommended',
         'airbnb-typescript',
         'prettier',
-
         'plugin:jest-dom/recommended',
-        'plugin:testing-library/react',
+        'plugin:testing-library/react'
     ],
     plugins: [
         '@typescript-eslint',
@@ -36,9 +35,9 @@ module.exports = {
         'prettier',
         'react-hooks',
         'react',
-
         'jest-dom',
         'testing-library',
+        'unused-imports'
     ],
 
     settings: {
@@ -92,5 +91,21 @@ module.exports = {
         'testing-library/no-await-sync-queries': 'error',
         'testing-library/no-debugging-utils': 'warn',
         'testing-library/no-dom-import': 'off',
+
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
+        ],
     },
 };

--- a/packages/warehouses/.eslintrc.js
+++ b/packages/warehouses/.eslintrc.js
@@ -11,12 +11,26 @@ module.exports = {
         'prettier',
         'plugin:json/recommended',
     ],
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'unused-imports'],
     rules: {
         'max-classes-per-file': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
         'no-case-declarations': 'off',
         'import/prefer-default-export': 'off',
         'class-methods-use-this': 'off',
+        'unused-imports/no-unused-imports': 'warn',
+        '@typescript-eslint/consistent-type-imports': [
+            'error',
+            {
+                prefer: 'type-imports',
+                fixStyle: 'inline-type-imports'
+            }
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                argsIgnorePattern: '^_',
+                ignoreRestSiblings: true
+            },
+        ],
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10707,6 +10707,18 @@ eslint-plugin-testing-library@^6.2.0:
   dependencies:
     "@typescript-eslint/utils" "^5.58.0"
 
+eslint-plugin-unused-imports@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz#db015b569d3774e17a482388c95c17bd303bc602"
+  integrity sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
**NOTE:** This PR is part of a bundle of PRs; due to the amount of automated changes, I'm splitting them up and merging them into this single PR after testing/review.

### Description:

Updates default `eslint` rules across all packages:

- Unused vars are disallowed, unless as part of a rest assignment or args prefixed with `_`
- Unused imports raise a warning. The goal is to later convert this to an error, once it's verified to be safe
- Type-only imports must be prefixed with the `type` modifier, with preference for the inline modifier: (`import { type X } from 'foo'`)

I intentionally kept each project's configuration separate so that we can adjust these shared rules per-project as needed, for now.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
