### PR TITLE
refactor: any => unknown in CLI (part II.)

### DIFF
--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
         'no-restricted-syntax': 'off',
         'no-throw-literal': 'off',
         '@typescript-eslint/no-throw-literal': 'off',
+        '@typescript-eslint/no-explicit-any': 'error',
     },
 };

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -30,8 +30,8 @@ const identifyUser = async (): Promise<Config['user']> => {
 
 export interface AnalyticsTrack {
     event: string;
-    properties?: Record<string, any>;
-    context?: Record<string, any>;
+    properties?: Record<string, unknown>;
+    context?: Record<string, unknown>;
 }
 
 type BaseTrack = Omit<AnalyticsTrack, 'context'>;

--- a/packages/cli/src/analytics/rudder-sdk-node.d.ts
+++ b/packages/cli/src/analytics/rudder-sdk-node.d.ts
@@ -8,22 +8,22 @@ declare module '@rudderstack/rudder-sdk-node' {
     interface Identify {
         anonymousId?: string;
         userId?: string;
-        traits?: Record<string, any>;
-        context?: Record<string, any>;
+        traits?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
     interface Group {
         anonymousId?: string;
         userId?: string;
         groupId: string;
-        traits?: Record<string, any>;
-        context?: Record<string, any>;
+        traits?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
     export interface Track {
         userId?: string;
         anonymousId?: string;
         event: string;
-        properties?: Record<string, any>;
-        context?: Record<string, any>;
+        properties?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
 
     declare class Analytics {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -36,8 +36,8 @@ const getRawConfig = async (): Promise<Config> => {
     try {
         const raw = yaml.load(await fs.readFile(configFilePath, 'utf8'));
         return raw as Config;
-    } catch (e: any) {
-        if (e.code === 'ENOENT') {
+    } catch (e: unknown) {
+        if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
             return {} as Config;
         }
         throw e;

--- a/packages/cli/src/dbt/context.ts
+++ b/packages/cli/src/dbt/context.ts
@@ -40,7 +40,7 @@ export const getDbtContext = async ({
             `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${msg}`,
         );
     }
-    const config = yaml.load(file) as any;
+    const config = yaml.load(file) as Record<string, string>;
 
     const targetSubDir = config['target-path'] || './target';
 
@@ -50,8 +50,8 @@ export const getDbtContext = async ({
     const modelsSubDir = config['models-path'] || './models';
     const modelsDir = path.join(projectDir, modelsSubDir);
     return {
-        projectName: config.name as string,
-        profileName: config.profile as string,
+        projectName: config.name,
+        profileName: config.profile,
         targetDir,
         modelsDir,
     };

--- a/packages/cli/src/dbt/context.ts
+++ b/packages/cli/src/dbt/context.ts
@@ -26,7 +26,7 @@ export const getDbtContext = async ({
 
     try {
         file = await fs.readFile(projectFilename, { encoding: 'utf-8' });
-    } catch (e: any) {
+    } catch (e: unknown) {
         if (projectDir !== path.parse(projectDir).root) {
             const parentDir = path.join(projectDir, '..');
             return await getDbtContext({
@@ -35,8 +35,9 @@ export const getDbtContext = async ({
             });
         }
 
+        const msg = e instanceof Error ? e.message : '-';
         throw new ParseError(
-            `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${e.message}`,
+            `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${msg}`,
         );
     }
     const config = yaml.load(file) as any;

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -30,9 +30,8 @@ export const loadManifest = async ({
             await fs.readFile(filename, { encoding: 'utf-8' }),
         ) as DbtManifest;
         return manifest;
-    } catch (err: any) {
-        throw new Error(
-            `Could not load manifest from ${filename}:\n  ${err.message}`,
-        );
+    } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : '-';
+        throw new Error(`Could not load manifest from ${filename}:\n  ${msg}`);
     }
 };

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -372,8 +372,8 @@ export const getCompiledModels = async (
                     (l): l is { resource_type: string; unique_id: string } =>
                         l !== null,
                 )
-                .filter((model: any) => model.resource_type === 'model')
-                .map((model: any) => model.unique_id);
+                .filter((model) => model.resource_type === 'model')
+                .map((model) => model.unique_id);
 
             allModelIds = allModelIds.filter((modelId) =>
                 filteredModelIds.includes(modelId),

--- a/packages/cli/src/dbt/profile.ts
+++ b/packages/cli/src/dbt/profile.ts
@@ -22,9 +22,10 @@ export const loadDbtTarget = async ({
         const raw = await fs.readFile(profilePath, { encoding: 'utf8' });
         const rendered = renderProfilesYml(raw);
         allProfiles = yaml.load(rendered) as Profiles;
-    } catch (e: any) {
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
         throw new ParseError(
-            `Could not find a valid profiles.yml file at ${profilePath}:\n  ${e.message}`,
+            `Could not find a valid profiles.yml file at ${profilePath}:\n  ${msg}`,
         );
     }
     const profile = allProfiles[profileName];

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -75,8 +75,8 @@ const findModelInYaml = async ({
                 Required<Pick<YamlSchema, 'models'>>,
             modelIndex,
         };
-    } catch (e: any) {
-        if (e.code === 'ENOENT') {
+    } catch (e: unknown) {
+        if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
             return undefined;
         }
         throw e;

--- a/packages/cli/src/dbt/targets/Bigquery/oauth.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/oauth.ts
@@ -26,7 +26,10 @@ export const getBigqueryCredentialsFromOauth = async (): Promise<
         'key' in credentials.credential
     ) {
         // Works with service credentials
-        const { email, key, projectId } = credentials.credential as any;
+        const { email, key, projectId } = credentials.credential as Record<
+            string,
+            string
+        >;
 
         return {
             client_email: email,

--- a/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
@@ -81,9 +81,10 @@ export const getBigqueryCredentialsFromServiceAccount = async (
                 string,
                 string
             >;
-        } catch (e: any) {
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : '-';
             throw new ParseError(
-                `Cannot read keyfile for bigquery target expect at: ${keyfilePath}:\n  ${e.message}`,
+                `Cannot read keyfile for bigquery target expect at: ${keyfilePath}:\n  ${msg}`,
             );
         }
     }

--- a/packages/cli/src/dbt/targets/snowflake.ts
+++ b/packages/cli/src/dbt/targets/snowflake.ts
@@ -108,9 +108,10 @@ export const convertSnowflakeSchema = async (
         if (keyfilePath) {
             try {
                 privateKey = await fs.readFile(keyfilePath, 'utf8');
-            } catch (e: any) {
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : '-';
                 throw new ParseError(
-                    `Cannot read keyfile for snowflake target at: ${keyfilePath}:\n  ${e.message}`,
+                    `Cannot read keyfile for snowflake target at: ${keyfilePath}:\n  ${msg}`,
                 );
             }
         }

--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -13,7 +13,7 @@ const nunjucksContext = {
 
 export const renderProfilesYml = (
     raw: string,
-    context?: Record<string, any>,
+    context?: Record<string, unknown>,
 ) => {
     const template = nunjucks.compile(raw, nunjucksEnv);
     const rendered = template.render({

--- a/packages/cli/src/dbt/types.ts
+++ b/packages/cli/src/dbt/types.ts
@@ -3,7 +3,7 @@ export type LoadProfileArgs = {
     profileName: string;
     targetName?: string;
 };
-export type Target = Record<string, any> & {
+export type Target = Record<string, unknown> & {
     type: string;
 };
 type Profile = {

--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -16,7 +16,7 @@ class GlobalState {
         return this.activeSpinner;
     }
 
-    log(message: any, ...optionalParams: any[]) {
+    log(message: unknown, ...optionalParams: unknown[]) {
         const spinner = this.getActiveSpinner();
         const shouldRestartSpinner = spinner?.isSpinning;
         spinner?.stop();

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -63,8 +63,9 @@ export const dbtCompile = async (options: DbtCompileOptions) => {
         const { stdout, stderr } = await execa('dbt', ['compile', ...args]);
         console.error(stdout);
         console.error(stderr);
-    } catch (e: any) {
-        throw new ParseError(`Failed to run dbt compile:\n  ${e.message}`);
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
+        throw new ParseError(`Failed to run dbt compile:\n  ${msg}`);
     }
 };
 
@@ -93,9 +94,10 @@ export const dbtList = async (
         GlobalState.debug(`> Models: ${models.join(' ')}`);
         console.error(stderr);
         return models;
-    } catch (e: any) {
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
         throw new ParseError(
-            `Error executing 'dbt ls':\n  ${e.message}\nEnsure you're on the latest patch version. '--use-dbt-list' is true by default; if you encounter issues, try using '--use-dbt-list=false`,
+            `Error executing 'dbt ls':\n  ${msg}\nEnsure you're on the latest patch version. '--use-dbt-list' is true by default; if you encounter issues, try using '--use-dbt-list=false`,
         );
     }
 };

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -18,8 +18,9 @@ export const getDbtVersion = async () => {
         if (version === null || version.length === 0)
             throw new ParseError(`Can't locate dbt --version: ${logs}`);
         return version[0].split(':')[1].trim();
-    } catch (e: any) {
-        throw new ParseError(`Failed to get dbt --version:\n  ${e.message}`);
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
+        throw new ParseError(`Failed to get dbt --version:\n  ${msg}`);
     }
 };
 

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -22,10 +22,13 @@ export const dbtRunHandler = async (
         },
     });
 
-    const commands = command.parent.args.reduce((acc: any, arg: any) => {
-        if (arg === '--verbose') return acc;
-        return [...acc, arg];
-    }, []);
+    const commands = command.parent.args.reduce(
+        (acc: unknown[], arg: unknown) => {
+            if (arg === '--verbose') return acc;
+            return [...acc, arg];
+        },
+        [],
+    );
 
     GlobalState.debug(`> Running dbt command: ${commands}`);
 
@@ -34,15 +37,16 @@ export const dbtRunHandler = async (
             stdio: 'inherit',
         });
         await subprocess;
-    } catch (e: any) {
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
         await LightdashAnalytics.track({
             event: 'dbt_command.error',
             properties: {
                 command: `${commands}`,
-                error: `${e.message}`,
+                error: `${msg}`,
             },
         });
-        throw new ParseError(`Failed to run dbt:\n  ${e.message}`);
+        throw new ParseError(`Failed to run dbt:\n  ${msg}`);
     }
     await generateHandler({
         ...options,

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -12,6 +12,7 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
 
 export const dbtRunHandler = async (
     options: DbtRunHandlerOptions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     command: any,
 ) => {
     GlobalState.setVerbose(options.verbose);

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -136,8 +136,9 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                         : ymlString,
                 );
             } catch (e) {
+                const msg = e instanceof Error ? e.message : '-';
                 throw new ParseError(
-                    `Failed to write file ${outputFilePath}\n ${e}`,
+                    `Failed to write file ${outputFilePath}\n ${msg}`,
                 );
             }
             spinner.succeed(
@@ -145,13 +146,14 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     ` ➡️  ${path.relative(process.cwd(), outputFilePath)}`,
                 )}`,
             );
-        } catch (e: any) {
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : '-';
             await LightdashAnalytics.track({
                 event: 'generate.error',
                 properties: {
                     executionId,
                     trigger: 'generate',
-                    error: `${e.message}`,
+                    error: `${msg}`,
                 },
             });
             spinner.fail(`  Failed to generate ${compiledModel.name}.yml`);

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -83,13 +83,14 @@ export const generateExposuresHandler = async (
                 countExposures: Object.keys(exposures).length,
             },
         });
-    } catch (e: any) {
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
         await LightdashAnalytics.track({
             event: 'generate_exposures.error',
             properties: {
                 executionId,
                 trigger: 'generate',
-                error: `${e.message}`,
+                error: `${msg}`,
             },
         });
         spinner.fail(`  Failed to generate exposures file'`);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -69,7 +69,7 @@
         /* Advanced Options */
         "skipLibCheck": true /* Skip type checking of declaration files. */,
         "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-        "useUnknownInCatchVariables": false
+        "useUnknownInCatchVariables": true
     },
     "include": ["src/**/*.ts", "src/**/*.json"]
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: https://github.com/lightdash/lightdash/issues/3790

### Description:
Part II of converting `any` to `unknown` in the CLI. With this PR the CLI package is now free from all `any` except one in `handlers/dbt/run.ts` which I couldn't find a proper type for. Also, the  `@typescript-eslint/no-explicit-any` rule is configured to throw an error from now on.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
