### PR TITLE
refactor: any => unknown in CLI (Part II.)

### DIFF
--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
         'no-restricted-syntax': 'off',
         'no-throw-literal': 'off',
         '@typescript-eslint/no-throw-literal': 'off',
+        '@typescript-eslint/no-explicit-any': 'error',
     },
 };

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -30,8 +30,8 @@ const identifyUser = async (): Promise<Config['user']> => {
 
 export interface AnalyticsTrack {
     event: string;
-    properties?: Record<string, any>;
-    context?: Record<string, any>;
+    properties?: Record<string, unknown>;
+    context?: Record<string, unknown>;
 }
 
 type BaseTrack = Omit<AnalyticsTrack, 'context'>;

--- a/packages/cli/src/analytics/rudder-sdk-node.d.ts
+++ b/packages/cli/src/analytics/rudder-sdk-node.d.ts
@@ -8,22 +8,22 @@ declare module '@rudderstack/rudder-sdk-node' {
     interface Identify {
         anonymousId?: string;
         userId?: string;
-        traits?: Record<string, any>;
-        context?: Record<string, any>;
+        traits?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
     interface Group {
         anonymousId?: string;
         userId?: string;
         groupId: string;
-        traits?: Record<string, any>;
-        context?: Record<string, any>;
+        traits?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
     export interface Track {
         userId?: string;
         anonymousId?: string;
         event: string;
-        properties?: Record<string, any>;
-        context?: Record<string, any>;
+        properties?: Record<string, unknown>;
+        context?: Record<string, unknown>;
     }
 
     declare class Analytics {

--- a/packages/cli/src/dbt/context.ts
+++ b/packages/cli/src/dbt/context.ts
@@ -40,7 +40,7 @@ export const getDbtContext = async ({
             `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${msg}`,
         );
     }
-    const config = yaml.load(file) as any;
+    const config = yaml.load(file) as Record<string, string>;
 
     const targetSubDir = config['target-path'] || './target';
 
@@ -50,8 +50,8 @@ export const getDbtContext = async ({
     const modelsSubDir = config['models-path'] || './models';
     const modelsDir = path.join(projectDir, modelsSubDir);
     return {
-        projectName: config.name as string,
-        profileName: config.profile as string,
+        projectName: config.name,
+        profileName: config.profile,
         targetDir,
         modelsDir,
     };

--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -3,6 +3,8 @@ import {
     ParseError,
     WarehouseTypes,
 } from '@lightdash/common';
+import { JSONSchemaType } from 'ajv';
+import { ajv } from '../../../ajv';
 import { Target } from '../../types';
 import { getBigqueryCredentialsFromOauth } from './oauth';
 import {
@@ -10,36 +12,90 @@ import {
     getBigqueryCredentialsFromServiceAccountJson,
 } from './serviceAccount';
 
+type BigqueryTarget = {
+    project: string;
+    dataset: string;
+    priority?: 'interactive' | 'batch';
+    retries?: number;
+    location?: string;
+    maximum_bytes_billed?: number;
+    timeout_seconds?: number;
+};
+
+export const bigqueryTargetJsonSchema: JSONSchemaType<BigqueryTarget> = {
+    type: 'object',
+    properties: {
+        project: {
+            type: 'string',
+        },
+        dataset: {
+            type: 'string',
+        },
+        priority: {
+            type: 'string',
+            enum: ['interactive', 'batch'],
+            nullable: true,
+        },
+        retries: {
+            type: 'integer',
+            nullable: true,
+        },
+        location: {
+            type: 'string',
+            nullable: true,
+        },
+        maximum_bytes_billed: {
+            type: 'integer',
+            nullable: true,
+        },
+        timeout_seconds: {
+            type: 'integer',
+            nullable: true,
+        },
+    },
+    required: ['project', 'dataset'],
+};
+
 export const convertBigquerySchema = async (
     target: Target,
 ): Promise<CreateBigqueryCredentials> => {
-    let getBigqueryCredentials;
-    switch (target.method) {
-        case 'oauth':
-            getBigqueryCredentials = getBigqueryCredentialsFromOauth;
-            break;
-        case 'service-account':
-            getBigqueryCredentials = getBigqueryCredentialsFromServiceAccount;
-            break;
-        case 'service-account-json':
-            getBigqueryCredentials =
-                getBigqueryCredentialsFromServiceAccountJson;
-            break;
-        default:
-            throw new ParseError(
-                `BigQuery method ${target.method} is not yet supported`,
-            );
-    }
+    const validate = ajv.compile<BigqueryTarget>(bigqueryTargetJsonSchema);
+    if (validate(target)) {
+        let getBigqueryCredentials;
+        switch (target.method) {
+            case 'oauth':
+                getBigqueryCredentials = getBigqueryCredentialsFromOauth;
+                break;
+            case 'service-account':
+                getBigqueryCredentials =
+                    getBigqueryCredentialsFromServiceAccount;
+                break;
+            case 'service-account-json':
+                getBigqueryCredentials =
+                    getBigqueryCredentialsFromServiceAccountJson;
+                break;
+            default:
+                throw new ParseError(
+                    `BigQuery method ${target.method} is not yet supported`,
+                );
+        }
 
-    return {
-        type: WarehouseTypes.BIGQUERY,
-        project: target.project,
-        dataset: target.dataset,
-        timeoutSeconds: target.timeout_seconds,
-        priority: target.priority,
-        keyfileContents: await getBigqueryCredentials(target),
-        retries: target.retries,
-        maximumBytesBilled: target.maximum_bytes_billed,
-        location: target.location || undefined,
-    };
+        return {
+            type: WarehouseTypes.BIGQUERY,
+            project: target.project,
+            dataset: target.dataset,
+            timeoutSeconds: target.timeout_seconds,
+            priority: target.priority,
+            keyfileContents: await getBigqueryCredentials(target),
+            retries: target.retries,
+            maximumBytesBilled: target.maximum_bytes_billed,
+            location: target.location,
+        };
+    }
+    const lineErrorMessages = (validate.errors || [])
+        .map((err) => `Field at ${err.instancePath} ${err.message}`)
+        .join('\n');
+    throw new ParseError(
+        `Couldn't read profiles.yml file for ${target.type}:\n  ${lineErrorMessages}`,
+    );
 };

--- a/packages/cli/src/dbt/targets/Bigquery/oauth.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/oauth.ts
@@ -26,7 +26,10 @@ export const getBigqueryCredentialsFromOauth = async (): Promise<
         'key' in credentials.credential
     ) {
         // Works with service credentials
-        const { email, key, projectId } = credentials.credential as any;
+        const { email, key, projectId } = credentials.credential as Record<
+            string,
+            string
+        >;
 
         return {
             client_email: email,

--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -13,7 +13,7 @@ const nunjucksContext = {
 
 export const renderProfilesYml = (
     raw: string,
-    context?: Record<string, any>,
+    context?: Record<string, unknown>,
 ) => {
     const template = nunjucks.compile(raw, nunjucksEnv);
     const rendered = template.render({

--- a/packages/cli/src/dbt/types.ts
+++ b/packages/cli/src/dbt/types.ts
@@ -3,7 +3,7 @@ export type LoadProfileArgs = {
     profileName: string;
     targetName?: string;
 };
-export type Target = Record<string, any> & {
+export type Target = Record<string, unknown> & {
     type: string;
 };
 type Profile = {

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -12,6 +12,7 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
 
 export const dbtRunHandler = async (
     options: DbtRunHandlerOptions,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     command: any,
 ) => {
     GlobalState.setVerbose(options.verbose);

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -1,4 +1,5 @@
 import { ParseError } from '@lightdash/common';
+import { Command } from 'commander';
 import execa from 'execa';
 import { LightdashAnalytics } from '../../analytics/analytics';
 import GlobalState from '../../globalState';
@@ -12,10 +13,14 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
 
 export const dbtRunHandler = async (
     options: DbtRunHandlerOptions,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    command: any,
+    command: Command,
 ) => {
     GlobalState.setVerbose(options.verbose);
+
+    if (!command.parent) {
+        throw new Error('Parent command not found');
+    }
+
     await LightdashAnalytics.track({
         event: 'dbt_command.started',
         properties: {
@@ -23,13 +28,10 @@ export const dbtRunHandler = async (
         },
     });
 
-    const commands = command.parent.args.reduce(
-        (acc: unknown[], arg: unknown) => {
-            if (arg === '--verbose') return acc;
-            return [...acc, arg];
-        },
-        [],
-    );
+    const commands = command.parent.args.reduce<string[]>((acc, arg) => {
+        if (arg === '--verbose') return acc;
+        return [...acc, arg];
+    }, []);
 
     GlobalState.debug(`> Running dbt command: ${commands}`);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: https://github.com/lightdash/lightdash/issues/3790

### Description:
Part II of converting `any` to `unknown` in the CLI. With this PR the CLI package is now free from all `any` except one in `handlers/dbt/run.ts` which I couldn't find a proper type for. Also, the `@typescript-eslint/no-explicit-any` rule is configured to throw an error from now on.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
