### PR TITLE
fix: ensure date time picker inputs are all in sync

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -216,8 +216,14 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                             : moment();
 
                     const dateValue = valueIsDate
-                        ? formatDate(value, undefined, true)
+                        ? formatDate(
+                              // Treat the date as UTC, then remove its timezone information before formatting
+                              moment.utc(value).format('YYYY-MM-DD'),
+                              undefined,
+                              false,
+                          )
                         : formatDate(defaultDate, undefined, false);
+
                     filterRuleDefaults.values = [dateValue];
                 }
                 break;

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -108,12 +108,7 @@ export function formatDate(
     timeInterval: TimeFrames = TimeFrames.DAY,
     convertToUTC: boolean = false,
 ): string {
-    const momentDate = moment(date);
-    if (convertToUTC) {
-        // Calculate the offset and add it to the date to prevent the day from changing
-        const offset = momentDate.utcOffset();
-        momentDate.add(offset, 'minutes').utc();
-    }
+    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
     return momentDate.format(getDateFormat(timeInterval));
 }
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -108,7 +108,12 @@ export function formatDate(
     timeInterval: TimeFrames = TimeFrames.DAY,
     convertToUTC: boolean = false,
 ): string {
-    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
+    const momentDate = moment(date);
+    if (convertToUTC) {
+        // Calculate the offset and add it to the date to prevent the day from changing
+        const offset = momentDate.utcOffset();
+        momentDate.add(offset, 'minutes').utc();
+    }
     return momentDate.format(getDateFormat(timeInterval));
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8942

### Description:

This ensures that `value` depends on `valueFormat` 
Also changed the `moment` usage with `dayjs` 

When `valueFormat` is processed, then `value` is assigned to its value but parsed 

Tested when locally I'm in San Francisco - this is related to the issue reported, where the value of the input wasn't matching the day selected on the date calendar input + the time input below
<img width="440" alt="Screenshot 2024-03-08 at 15 52 29" src="https://github.com/lightdash/lightdash/assets/7611706/e435f0c8-93ff-45cd-bc6d-c0a48a071107">



Then in London
<img width="639" alt="Screenshot 2024-03-08 at 15 52 55" src="https://github.com/lightdash/lightdash/assets/7611706/72494cf7-4e36-44a9-8442-39379c620ce8">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
