### PR TITLE
chore: share `ServiceRepository` instance from `App`/`SchedulerApp`

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -300,8 +300,14 @@ export default class App {
         );
 
         // Authentication
-        passport.use(apiKeyPassportStrategy);
-        passport.use(localPassportStrategy);
+        const userService = this.serviceRepository.getUserService();
+
+        passport.use(apiKeyPassportStrategy({ userService }));
+        passport.use(
+            localPassportStrategy({
+                userService,
+            }),
+        );
         if (googlePassportStrategy) {
             passport.use(googlePassportStrategy);
             refresh.use(googlePassportStrategy);

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -307,7 +307,7 @@ export const apiKeyPassportStrategy = new HeaderAPIKeyStrategy(
     true,
     async (token, done) => {
         try {
-            const user = await userService.loginWithPersonalAccessToken(token);
+            const user = userService.loginWithPersonalAccessToken(token);
             return done(null, user);
         } catch {
             return done(

--- a/packages/backend/src/controllers/authentication.ts
+++ b/packages/backend/src/controllers/authentication.ts
@@ -307,7 +307,7 @@ export const apiKeyPassportStrategy = new HeaderAPIKeyStrategy(
     true,
     async (token, done) => {
         try {
-            const user = userService.loginWithPersonalAccessToken(token);
+            const user = await userService.loginWithPersonalAccessToken(token);
             return done(null, user);
         } catch {
             return done(

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -24,10 +24,6 @@ import path from 'path';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import { projectModel } from '../../../models/models';
 import { EncryptionService } from '../../../services/EncryptionService/EncryptionService';
-import {
-    OperationContext,
-    ServiceRepository,
-} from '../../../services/ServiceRepository';
 import { serviceRepository } from '../../../services/services';
 import { DbEmailIn } from '../../entities/emails';
 import { OnboardingTableName } from '../../entities/onboarding';

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -17,6 +17,8 @@ const analytics = new LightdashAnalytics({
 
 /**
  * See ./ServiceRepository for how this will work.
+ *
+ * @deprecated Avoid using this singleton instance, it will not be here for long.
  */
 export const serviceRepository = new ServiceRepository({
     context: new OperationContext({

--- a/packages/backend/src/services/tsoaServiceContainer.ts
+++ b/packages/backend/src/services/tsoaServiceContainer.ts
@@ -1,5 +1,5 @@
 import { Controller, type IocContainerFactory } from '@tsoa/runtime';
-import { Request } from 'express';
+import type { Request } from 'express';
 import { BaseController } from '../controllers/baseController';
 import type { ServiceRepository } from './ServiceRepository';
 

--- a/packages/backend/src/services/tsoaServiceContainer.ts
+++ b/packages/backend/src/services/tsoaServiceContainer.ts
@@ -1,7 +1,7 @@
 import { Controller, type IocContainerFactory } from '@tsoa/runtime';
+import { Request } from 'express';
 import { BaseController } from '../controllers/baseController';
 import type { ServiceRepository } from './ServiceRepository';
-import { serviceRepository } from './services';
 
 /**
  * For now, we allow both classes extending tsoa's Controller directly, as well as those
@@ -27,10 +27,10 @@ const isBaseControllerCtor = (
  * Override's tsoa's native controller instantiation, and allows us to manage controller
  * instantiation directly.
  */
-export const iocContainer: IocContainerFactory = () => ({
+export const iocContainer: IocContainerFactory = (request: Request) => ({
     async get<T extends RouteControllerKlass>(Ctor: T) {
         if (isBaseControllerCtor(Ctor)) {
-            return new Ctor(serviceRepository);
+            return new Ctor(request.services);
         }
 
         return new (Ctor as TsoaControllerKlass)();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9247 
Based on #9304, will rebase after merge.

### Description:

Moves further along the process of introducing `ServiceRepository` + removing direct references to service singleton instances.

- Updates `App` to instantiate `ServiceRepository`
- Updates `SchedulerApp` to instantiate `ServiceRepository`
- Uses the App's own instance across `express`, `passport`, and `tsoa`
  - `passport` and `tsoa` access the shared instance via the express request (`req.services`) or via factory functions
- Deprecates the `serviceRepository` singleton, which is currently used only from within a knex seed file.


Keyword to force frontend e2e tests:
test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
