### PR TITLE
fix: clear search on option select

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -171,6 +171,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                 </Group>
             )}
             styles={{
+                itemsWrapper: { gap: 2 },
                 item: {
                     // makes add new item button sticky to bottom
                     '&:last-child:not([value])': {
@@ -186,7 +187,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             }}
             disableSelectedItemFiltering
             searchable
-            clearSearchOnChange={false}
+            clearSearchOnChange={true}
             {...rest}
             searchValue={search}
             onSearchChange={setSearch}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -171,7 +171,6 @@ const FilterStringAutoComplete: FC<Props> = ({
                 </Group>
             )}
             styles={{
-                itemsWrapper: { gap: 2 },
                 item: {
                     // makes add new item button sticky to bottom
                     '&:last-child:not([value])': {
@@ -187,7 +186,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             }}
             disableSelectedItemFiltering
             searchable
-            clearSearchOnChange={true}
+            clearSearchOnChange
             {...rest}
             searchValue={search}
             onSearchChange={setSearch}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/9278

### Description:
This is an easy fix as it's a built in Mantine prop. Also, I added a gap between options because it looked ugly if two or more options were selected under each other.

Before:
![image](https://github.com/lightdash/lightdash/assets/30611343/247bad98-b40a-4726-9a66-77801a976299)

After: 
![image](https://github.com/lightdash/lightdash/assets/30611343/030dd75c-c27e-48e1-ac7d-60bb6c85b823)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
