### PR TITLE
fix: remove Monaco from font-family for ace-editor

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -115,5 +115,9 @@ export const getMantineThemeOverride = (overrides?: {
         '.ace_editor.ace_autocomplete': {
             width: '500px',
         },
+        '.ace_editor *': {
+            fontFamily:
+                "Menlo, 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
+        },
     }),
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9321

### Description:

The default `font-family` for the editor is `'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`.
Monaco font causes cursor to be off the current character.

- Removes 'Monaco' from the editor `font-family`

Before:

https://github.com/lightdash/lightdash/assets/22939015/d9fdffec-e25a-4222-aaf2-e208605b289b

After:

https://github.com/lightdash/lightdash/assets/22939015/706b8f26-94e4-45ea-ae47-e185457a3443

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
