### PR TITLE
chore: allow passing serviceProviders during App/SchedulerApp instancing

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -46,6 +46,7 @@ import { apiV1Router } from './routers/apiV1Router';
 import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import {
     OperationContext,
+    ServiceProviderMap,
     ServiceRepository,
 } from './services/ServiceRepository';
 import { wrapOtelSpan } from './utils';
@@ -72,6 +73,7 @@ type AppArguments = {
     port: string | number;
     otelSdk: NodeSDK;
     environment?: 'production' | 'development';
+    serviceProviders?: ServiceProviderMap;
 };
 
 export default class App {
@@ -107,6 +109,7 @@ export default class App {
             },
         });
         this.serviceRepository = new ServiceRepository({
+            serviceProviders: args.serviceProviders,
             context: new OperationContext({
                 operationId: 'App#ctor',
                 lightdashAnalytics: this.analytics,

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -11,6 +11,7 @@ import { SchedulerWorker } from './scheduler/SchedulerWorker';
 import { registerWorkerMetrics } from './schedulerMetrics';
 import {
     OperationContext,
+    ServiceProviderMap,
     ServiceRepository,
 } from './services/ServiceRepository';
 import { VERSION } from './version';
@@ -20,6 +21,7 @@ type SchedulerAppArguments = {
     port: string | number;
     environment?: 'production' | 'development';
     otelSdk: NodeSDK;
+    serviceProviders?: ServiceProviderMap;
 };
 
 export default class SchedulerApp {
@@ -53,6 +55,7 @@ export default class SchedulerApp {
             },
         });
         this.serviceRepository = new ServiceRepository({
+            serviceProviders: args.serviceProviders,
             context: new OperationContext({
                 lightdashAnalytics: this.analytics,
                 lightdashConfig: this.lightdashConfig,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -105,17 +105,20 @@ type ServiceFactoryMethod<T extends ServiceManifest> = {
     [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
 };
 
+export type ServiceProvider<T extends ServiceManifest> = (providerArgs: {
+    repository: ServiceRepository;
+    context: OperationContext;
+}) => T[keyof T];
+
 /**
  * Structure for describing service providers:
  *
  *   <serviceName> -> providerMethod
  */
-type ServiceProviderMap<T extends ServiceManifest> = Partial<{
-    [K in keyof T]: (providerArgs: {
-        repository: ServiceRepository;
-        context: OperationContext;
-    }) => T[keyof T];
-}>;
+export type ServiceProviderMap<T extends ServiceManifest = ServiceManifest> =
+    Partial<{
+        [K in keyof T]: ServiceProvider<T>;
+    }>;
 
 /**
  * Placeholder ServiceRepository context.
@@ -172,7 +175,7 @@ abstract class ServiceRepositoryBase {
      * NOTE: This exact implementation is temporary, and is likely to be adjusted soon
      * as part of the dependency injection rollout.
      */
-    protected providers: ServiceProviderMap<ServiceManifest>;
+    protected providers: ServiceProviderMap;
 
     /**
      * See @type OperationContext

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -105,7 +105,7 @@ type ServiceFactoryMethod<T extends ServiceManifest> = {
     [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
 };
 
-export type ServiceProvider<T extends ServiceManifest> = (providerArgs: {
+type ServiceProvider<T extends ServiceManifest> = (providerArgs: {
     repository: ServiceRepository;
     context: OperationContext;
 }) => T[keyof T];


### PR DESCRIPTION
### Description:

Allows configuring service providers within `ServiceRepository` when creating an `App` or `SchedulerApp` instance.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
