### PR TITLE
chore: stabilize profile e2e test

### DIFF
--- a/packages/e2e/cypress/e2e/app/settings/profile.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/profile.cy.ts
@@ -22,8 +22,14 @@ describe('Settings - Profile', () => {
         cy.visit('/');
         cy.findByTestId('user-avatar').click();
         cy.findByRole('menuitem', { name: 'User settings' }).click();
-        cy.get('[data-cy="first-name-input"]').clear().type('Kevin');
-        cy.get('[data-cy="last-name-input"]').clear().type('Space');
+        cy.get('[data-cy="first-name-input"]').should(
+            'have.value',
+            SEED_ORG_1_ADMIN.first_name,
+        ); // wait for form to populate
+        cy.get('[data-cy="first-name-input"]').clear();
+        cy.get('[data-cy="first-name-input"]').type('Kevin');
+        cy.get('[data-cy="last-name-input"]').clear();
+        cy.get('[data-cy="last-name-input"]').type('Space');
         cy.get('[data-cy="update-profile-settings"]').click();
         cy.findByText('Success! User details were updated.').should(
             'be.visible',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Profile e2e test was flaky since the form was only populated once we were typing the new values.

Example where it has a mix of David and Kevin.

<img width="1380" alt="Screenshot 2024-03-11 at 20 10 57" src="https://github.com/lightdash/lightdash/assets/9117144/72492be4-c72f-416b-9b1d-71ad8d5aaea3">

We also had a warning about chaining clearing and typing methods.

<img width="572" alt="Screenshot 2024-03-11 at 20 18 32" src="https://github.com/lightdash/lightdash/assets/9117144/2bb0029d-c4a1-4126-b9ca-0aaeb4103335">

I added an instruction to make sure the form is populated and split clearing and typing instructions.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
