### PR TITLE
fix: user space access query

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -537,7 +537,7 @@ export class SpaceModel {
 
     private async _getSpaceAccess(
         spaceUuid: string,
-        filters: { userUuid?: string } | undefined,
+        filters?: { userUuid?: string },
     ): Promise<SpaceShare[]> {
         const access = await this.database
             .table(SpaceTableName)
@@ -711,12 +711,8 @@ export class SpaceModel {
                     ...inheritedGroupRoles,
                 ]);
 
-                // exclude all users that were converted to organization members and have no space access
+                // exclude users with no space role
                 if (!highestRole) {
-                    // revoke direct access from the space
-                    if (user_with_direct_access) {
-                        this.removeSpaceAccess(spaceUuid, user_uuid);
-                    }
                     return acc;
                 }
                 return [
@@ -742,10 +738,6 @@ export class SpaceModel {
         spaceUuid: string,
     ): Promise<SpaceShare[]> {
         return this._getSpaceAccess(spaceUuid, { userUuid });
-    }
-
-    async getSpaceAccess(spaceUuid: string): Promise<SpaceShare[]> {
-        return this._getSpaceAccess(spaceUuid, {});
     }
 
     async getSpaceQueries(
@@ -921,7 +913,7 @@ export class SpaceModel {
                 pinnedListOrder: row.order,
                 queries: await this.getSpaceQueries([row.space_uuid]),
                 dashboards: await this.getSpaceDashboards([row.space_uuid]),
-                access: await this.getSpaceAccess(row.space_uuid),
+                access: await this._getSpaceAccess(row.space_uuid),
             })),
         );
     }
@@ -1002,7 +994,7 @@ export class SpaceModel {
             pinnedListOrder: space.pinnedListOrder,
             queries: await this.getSpaceQueries([space.uuid]),
             dashboards: await this.getSpaceDashboards([space.uuid]),
-            access: await this.getSpaceAccess(space.uuid),
+            access: await this._getSpaceAccess(space.uuid),
         };
     }
 

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -552,10 +552,15 @@ export class SpaceModel {
                 `${ProjectTableName}.organization_id`,
             )
             .leftJoin(
+                UserTableName,
+                `${OrganizationMembershipsTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .leftJoin(
                 ProjectMembershipsTableName,
                 function joinProjectMembershipTable() {
                     this.on(
-                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
                         '=',
                         `${ProjectMembershipsTableName}.user_id`,
                     ).andOn(
@@ -567,7 +572,7 @@ export class SpaceModel {
             )
             .leftJoin(SpaceShareTableName, function joinSpaceShareTable() {
                 this.on(
-                    `${OrganizationMembershipsTableName}.user_id`,
+                    `${UserTableName}.user_id`,
                     '=',
                     `${SpaceShareTableName}.user_id`,
                 ).andOn(
@@ -594,11 +599,6 @@ export class SpaceModel {
                         `${ProjectGroupAccessTableName}.project_uuid`,
                     );
                 },
-            )
-            .leftJoin(
-                UserTableName,
-                `${OrganizationMembershipsTableName}.user_id`,
-                `${UserTableName}.user_id`,
             )
             .innerJoin(
                 EmailTableName,

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -63,7 +63,10 @@ export class CommentService {
 
         try {
             space = await this.spaceModel.getSpaceSummary(spaceUuid);
-            spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+            spaceAccess = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                spaceUuid,
+            );
         } catch (e) {
             Sentry.captureException(e);
             console.error(e);

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -57,7 +57,7 @@ jest.mock('../../models/models', () => ({
         getFullSpace: jest.fn(async () => publicSpace),
         getSpaceSummary: jest.fn(async () => publicSpace),
         getFirstAccessibleSpace: jest.fn(async () => space),
-        getSpaceAccess: jest.fn(async () => []),
+        getUserSpaceAccess: jest.fn(async () => []),
     },
     analyticsModel: {
         addDashboardViewEvent: jest.fn(async () => null),

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -148,7 +148,8 @@ export class DashboardService {
         );
         const dashboardAccesses = await Promise.all(
             dashboards.map(async (dashboard) => {
-                const spaceAccess = await this.spaceModel.getSpaceAccess(
+                const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+                    user.userUuid,
                     dashboard.spaceUuid,
                 );
                 return {
@@ -190,7 +191,8 @@ export class DashboardService {
         const space = await this.spaceModel.getSpaceSummary(
             dashboardDao.spaceUuid,
         );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             dashboardDao.spaceUuid,
         );
         const dashboard = {
@@ -257,7 +259,10 @@ export class DashboardService {
             ? await this.spaceModel.get(dashboard.spaceUuid)
             : await getFirstSpace();
 
-        const spaceAccess = await this.spaceModel.getSpaceAccess(space.uuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            space.uuid,
+        );
 
         if (
             user.ability.cannot(
@@ -307,7 +312,8 @@ export class DashboardService {
         const space = await this.spaceModel.getSpaceSummary(
             dashboardDao.spaceUuid,
         );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             dashboardDao.spaceUuid,
         );
         const dashboard = {
@@ -437,7 +443,8 @@ export class DashboardService {
         const space = await this.spaceModel.getSpaceSummary(
             existingDashboardDao.spaceUuid,
         );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             existingDashboardDao.spaceUuid,
         );
         const existingDashboard = {
@@ -529,7 +536,8 @@ export class DashboardService {
         const space = await this.spaceModel.getSpaceSummary(
             existingDashboardDao.spaceUuid,
         );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             existingDashboardDao.spaceUuid,
         );
         const existingDashboard = {
@@ -599,7 +607,10 @@ export class DashboardService {
                     dashboard.spaceUuid,
                 );
                 const dashboardSpaceAccess =
-                    await this.spaceModel.getSpaceAccess(dashboard.spaceUuid);
+                    await this.spaceModel.getUserSpaceAccess(
+                        user.userUuid,
+                        dashboard.spaceUuid,
+                    );
                 return user.ability.can(
                     'update',
                     subject('Dashboard', {
@@ -638,7 +649,10 @@ export class DashboardService {
                     dashboard.spaceUuid,
                 );
                 const dashboardSpaceAccess =
-                    await this.spaceModel.getSpaceAccess(dashboard.spaceUuid);
+                    await this.spaceModel.getUserSpaceAccess(
+                        user.userUuid,
+                        dashboard.spaceUuid,
+                    );
                 return {
                     ...dashboard,
                     isPrivate: dashboardSpace.isPrivate,
@@ -654,7 +668,10 @@ export class DashboardService {
         const { organizationUuid, projectUuid, spaceUuid } =
             await this.dashboardModel.getById(dashboardUuid);
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'delete',
@@ -755,7 +772,8 @@ export class DashboardService {
         const space = await this.spaceModel.getSpaceSummary(
             dashboardDao.spaceUuid,
         );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             dashboardDao.spaceUuid,
         );
         const dashboard = {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -324,7 +324,10 @@ Affected charts:
     ): Promise<PullRequestCreated> {
         const chartDao = await this.savedChartModel.get(chartUuid);
         const space = await this.spaceModel.getSpaceSummary(chartDao.spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(chartDao.spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            chartDao.spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -398,7 +401,10 @@ Affected charts:
             const space = await this.spaceModel.getSpaceSummary(
                 chart.spaceUuid,
             );
-            const access = this.spaceModel.getSpaceAccess(chart.spaceUuid);
+            const access = this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                chart.spaceUuid,
+            );
             return user.ability.can(
                 'manage',
                 subject('SavedChart', {

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -73,7 +73,8 @@ export class PinningService {
                         organizationUuid: space.organizationUuid,
                         projectUuid,
                         isPrivate: space.isPrivate,
-                        access: await this.spaceModel.getSpaceAccess(
+                        access: await this.spaceModel.getUserSpaceAccess(
+                            user.userUuid,
                             space.uuid,
                         ),
                     }),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1220,7 +1220,10 @@ export class ProjectService {
             ),
         ]);
 
-        const access = await this.spaceModel.getSpaceAccess(space.uuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            space.uuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1307,7 +1310,10 @@ export class ProjectService {
             ),
         ]);
 
-        const access = await this.spaceModel.getSpaceAccess(space.uuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            space.uuid,
+        );
 
         if (
             user.ability.cannot(
@@ -2774,7 +2780,10 @@ export class ProjectService {
                 savedChart.spaceUuid,
             );
 
-            const access = await this.spaceModel.getSpaceAccess(space.uuid);
+            const access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                space.uuid,
+            );
 
             if (
                 user.ability.cannot(
@@ -2861,7 +2870,8 @@ export class ProjectService {
 
             const filterPromises = savedCharts.map(async (savedChart) => {
                 const spaceAccess = spaceAccessMap.get(savedChart.spaceUuid);
-                const access = await this.spaceModel.getSpaceAccess(
+                const access = await this.spaceModel.getUserSpaceAccess(
+                    user.userUuid,
                     savedChart.spaceUuid,
                 );
 
@@ -3211,7 +3221,10 @@ export class ProjectService {
                     hasViewAccessToSpace(
                         user,
                         space,
-                        await this.spaceModel.getSpaceAccess(space.uuid),
+                        await this.spaceModel.getUserSpaceAccess(
+                            user.userUuid,
+                            space.uuid,
+                        ),
                     ),
             ),
         );
@@ -3333,7 +3346,10 @@ export class ProjectService {
                 hasViewAccessToSpace(
                     user,
                     space,
-                    await this.spaceModel.getSpaceAccess(space.uuid),
+                    await this.spaceModel.getUserSpaceAccess(
+                        user.userUuid,
+                        space.uuid,
+                    ),
                 ),
             ),
         );
@@ -3530,7 +3546,8 @@ export class ProjectService {
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );
-        const access = await this.spaceModel.getSpaceAccess(
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             savedChart.spaceUuid,
         );
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -87,7 +87,8 @@ export class SavedChartService {
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );
-        const access = await this.spaceModel.getSpaceAccess(
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             savedChart.spaceUuid,
         );
         if (
@@ -139,7 +140,10 @@ export class SavedChartService {
     ): Promise<boolean> {
         try {
             const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-            const access = await this.spaceModel.getSpaceAccess(space.uuid);
+            const access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                space.uuid,
+            );
             return await hasViewAccessToSpace(user, space, access);
         } catch (e) {
             return false;
@@ -280,7 +284,10 @@ export class SavedChartService {
             await this.savedChartModel.getSummary(savedChartUuid);
 
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -334,7 +341,10 @@ export class SavedChartService {
             await this.savedChartModel.getSummary(savedChartUuid);
 
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -445,7 +455,8 @@ export class SavedChartService {
             const space = await this.spaceModel.getSpaceSummary(
                 chart.spaceUuid,
             );
-            const access = await this.spaceModel.getSpaceAccess(
+            const access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
                 chart.spaceUuid,
             );
             return user.ability.can(
@@ -470,7 +481,8 @@ export class SavedChartService {
                 const space = await this.spaceModel.getSpaceSummary(
                     savedChart.spaceUuid,
                 );
-                const access = await this.spaceModel.getSpaceAccess(
+                const access = await this.spaceModel.getUserSpaceAccess(
+                    user.userUuid,
                     savedChart.spaceUuid,
                 );
                 return {
@@ -495,7 +507,10 @@ export class SavedChartService {
         const { organizationUuid, projectUuid, spaceUuid } =
             await this.savedChartModel.getSummary(savedChartUuid);
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -532,7 +547,8 @@ export class SavedChartService {
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );
-        const access = await this.spaceModel.getSpaceAccess(
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             savedChart.spaceUuid,
         );
         if (
@@ -557,7 +573,8 @@ export class SavedChartService {
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );
-        const access = await this.spaceModel.getSpaceAccess(
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
             savedChart.spaceUuid,
         );
 
@@ -613,7 +630,10 @@ export class SavedChartService {
                 savedChart.spaceUuid,
             );
             isPrivate = space.isPrivate;
-            access = await this.spaceModel.getSpaceAccess(savedChart.spaceUuid);
+            access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                savedChart.spaceUuid,
+            );
         }
 
         if (
@@ -667,7 +687,10 @@ export class SavedChartService {
     ): Promise<SavedChart> {
         const chart = await this.savedChartModel.get(chartUuid);
         const space = await this.spaceModel.getSpaceSummary(chart.spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(chart.spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            chart.spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'create',
@@ -800,7 +823,10 @@ export class SavedChartService {
     ): Promise<ChartHistory> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const space = await this.spaceModel.getSpaceSummary(chart.spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(chart.spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            chart.spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -839,7 +865,10 @@ export class SavedChartService {
     ): Promise<ChartVersion> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const space = await this.spaceModel.getSpaceSummary(chart.spaceUuid);
-        const access = await this.spaceModel.getSpaceAccess(chart.spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            chart.spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'view',

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -147,7 +147,10 @@ export class SchedulerService {
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
 
             const [space] = await this.spaceModel.find({ spaceUuid });
-            const access = await this.spaceModel.getSpaceAccess(spaceUuid);
+            const access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                spaceUuid,
+            );
             if (
                 user.ability.cannot(
                     'view',
@@ -164,7 +167,10 @@ export class SchedulerService {
             const { organizationUuid, spaceUuid, projectUuid } =
                 await this.dashboardModel.getById(scheduler.dashboardUuid);
             const [space] = await this.spaceModel.find({ spaceUuid });
-            const spaceAccess = this.spaceModel.getSpaceAccess(spaceUuid);
+            const spaceAccess = this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                spaceUuid,
+            );
 
             if (
                 user.ability.cannot(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -3,8 +3,7 @@ import {
     ChartSummary,
     CreateSchedulerAndTargets,
     CreateSchedulerLog,
-    Dashboard,
-    DashboardScheduler,
+    DashboardDAO,
     ForbiddenError,
     isChartScheduler,
     isCreateSchedulerSlackTarget,
@@ -78,35 +77,19 @@ export class SchedulerService {
 
     private async getSchedulerResource(
         scheduler: Scheduler,
-    ): Promise<ChartSummary | Dashboard> {
+    ): Promise<ChartSummary | DashboardDAO> {
         return isChartScheduler(scheduler)
             ? this.savedChartModel.getSummary(scheduler.savedChartUuid)
-            : this.getSchedulerDashboard(scheduler);
-    }
-
-    private async getSchedulerDashboard(
-        scheduler: DashboardScheduler,
-    ): Promise<Dashboard> {
-        const dashboardDao = await this.dashboardModel.getById(
-            scheduler.dashboardUuid,
-        );
-        const space = await this.spaceModel.getSpaceSummary(
-            dashboardDao.spaceUuid,
-        );
-        const spaceAccess = await this.spaceModel.getSpaceAccess(
-            dashboardDao.spaceUuid,
-        );
-        return {
-            ...dashboardDao,
-            isPrivate: space.isPrivate,
-            access: spaceAccess,
-        };
+            : this.dashboardModel.getById(scheduler.dashboardUuid);
     }
 
     private async checkUserCanUpdateSchedulerResource(
         user: SessionUser,
         schedulerUuid: string,
-    ): Promise<{ scheduler: Scheduler; resource: ChartSummary | Dashboard }> {
+    ): Promise<{
+        scheduler: Scheduler;
+        resource: ChartSummary | DashboardDAO;
+    }> {
         // editors can "manage" scheduled deliveries,
         // which means they can edit scheduled deliveries created from other users, even admins
         // however, interactive users can only "create" scheduled deliveries,

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -98,7 +98,10 @@ export class SearchService {
             const spaceUuid: string =
                 'spaceUuid' in item ? item.spaceUuid : item.uuid;
             const itemSpace = spaces.find((s) => s.uuid === spaceUuid);
-            const access = await this.spaceModel.getSpaceAccess(spaceUuid);
+            const access = await this.spaceModel.getUserSpaceAccess(
+                user.userUuid,
+                spaceUuid,
+            );
             return itemSpace && hasViewAccessToSpace(user, itemSpace, access);
         };
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -170,7 +170,10 @@ export class SpaceService {
         updateSpace: UpdateSpace,
     ): Promise<Space> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -210,7 +213,10 @@ export class SpaceService {
 
     async deleteSpace(user: SessionUser, spaceUuid: string): Promise<void> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'delete',
@@ -241,7 +247,10 @@ export class SpaceService {
         shareWithUserUuid: string,
     ): Promise<void> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -263,7 +272,10 @@ export class SpaceService {
         shareWithUserUuid: string,
     ): Promise<void> {
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        const spaceAccess = await this.spaceModel.getSpaceAccess(spaceUuid);
+        const spaceAccess = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -640,7 +640,10 @@ export class ValidationService {
                     hasViewAccessToSpace(
                         user,
                         space,
-                        await this.spaceModel.getSpaceAccess(space.uuid),
+                        await this.spaceModel.getUserSpaceAccess(
+                            user.userUuid,
+                            space.uuid,
+                        ),
                     );
                 if (hasAccess) return validation;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We were fetching all the org users when checking the user space access. The more users an org has the slower the query was. Since we checked the space access in most endpoints, it was slowing down the entire app.

Changes:
- filter query by user uuid
- move user table join to be first to optimize query filtering + fix sequencial scans in following joins
- removed logic that removes user access on get
- remove space access call in scheduler

The only places where we still fetch all the org members access are for:
- get space endpoint
- deprecated endpoint `/spaces-and-content` 


Force frontend e2e test:
test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
