### PR TITLE
fix: remove collision handling logic from color mapping

### DIFF
--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -91,26 +91,10 @@ export const useChartColorConfig = ({
 
             // Project the hashed value into the available color space:
             const colorIdx = hashedValue % colorPalette.length;
+            const colorHex = colorPalette[colorIdx];
 
-            // Look at our existing color mappings so we can figure out if we need
-            // to try and avoid any of the current colors:
-            const colorsToAvoid = [...colorMappings.values()];
-            let colorHex = colorPalette[colorIdx];
-
-            // Intersect colors we've already used with our color palette, and try to find the
-            // next available color on the list.
-            if (colorsToAvoid.includes(colorHex)) {
-                const intersection = colorPalette.filter(
-                    (v) => !colorsToAvoid.includes(v),
-                );
-
-                if (intersection.length > 0) {
-                    colorHex = intersection[0];
-                }
-            }
-
-            // Keep track of this identifier->color pairing so we can reuse it without
-            // treating it as a collision:
+            // Keep track of this identifier->color pairing so we can bypass the
+            // hashing later.
             colorMappings.set(identifier, colorHex);
 
             return colorHex;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #9297 

Note: will not merge until a follow-up PR is ready to make mapping toggle-able.

### Description:

- Removes the single source of variability in color assignment, which could introduce confusion and/or unexpected differences in color mapping going from chart editor->dashboard.

Note: this change may increase the chance of color collisions, particularly with a lower amount of series/groups.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
