### PR TITLE
feat: consistent color mapping via sequential assignment

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -75,7 +75,7 @@ type VisualizationContext = {
     setPivotDimensions: (value: string[] | undefined) => void;
 
     getSeriesColor: (seriesLike: SeriesLike, seriesIndex: number) => string;
-    getGroupColor: (groupNameOrId: string) => string;
+    getGroupColor: (groupPrefix: string, groupName: string) => string;
 
     colorPalette: string[];
 };
@@ -215,13 +215,10 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
 
     /**
      * Gets a shared color for a given group name.
-     *
-     * NOTE: The feature flag is handled by the caller; until the flag is removed,
-     * it's the easiest way to access the necessary context to get a fallback color.
      */
     const getGroupColor = useCallback(
-        (groupNameOrId: string) => {
-            return calculateKeyColorAssignment(groupNameOrId);
+        (groupPrefix: string, identifier: string) => {
+            return calculateKeyColorAssignment(groupPrefix, identifier);
         },
         [calculateKeyColorAssignment],
     );

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
@@ -270,6 +270,7 @@ const PieChartSeriesConfig: FC = () => {
     if (!isPieChartConfig) return null;
 
     const {
+        groupFieldIds,
         valueLabel,
         valueLabelChange,
         showValue,
@@ -370,7 +371,10 @@ const PieChartSeriesConfig: FC = () => {
                                                     groupColorOverrides[
                                                         groupLabel
                                                     ] ??
-                                                    getGroupColor(groupLabel)
+                                                    getGroupColor(
+                                                        groupFieldIds.join('_'),
+                                                        groupLabel,
+                                                    )
                                                 }
                                                 label={
                                                     groupLabelOverrides[

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -33,6 +33,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
             selectedMetric,
             data,
             sortedGroupLabels,
+            groupFieldIds,
             validConfig: {
                 valueLabel: valueLabelDefault,
                 showValue: showValueDefault,
@@ -62,8 +63,11 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                     groupValueOptionOverrides?.[name]?.showPercentage ??
                     showPercentageDefault;
 
+                // Use all group field IDs as the group prefix for color assignment:
+                const groupPrefix = groupFieldIds.join('_');
                 const itemColor =
-                    groupColorOverrides?.[name] ?? getGroupColor(name);
+                    groupColorOverrides?.[name] ??
+                    getGroupColor(groupPrefix, name);
 
                 const config: PieSeriesDataPoint = {
                     id: name,

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -87,10 +87,16 @@ export const useChartColorConfig = ({
         (group: string, identifier: string) => {
             let groupMappings = colorMappings.get(group);
 
+            /**
+             * If we already picked a color for this group/identifier pair, return it:
+             */
             if (groupMappings && groupMappings.has(identifier)) {
                 return colorPalette[groupMappings.get(identifier)!];
             }
 
+            /**
+             * If this is the first time we're seeing this group, create a sub-map for it:
+             */
             if (!groupMappings) {
                 groupMappings = new Map<string, number>();
                 colorMappings.set(group, groupMappings);

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -117,8 +117,6 @@ export const useChartColorConfig = ({
             // Keep track of the color idx used for this identifier, within this group:
             groupMappings.set(identifier, nextIdx);
 
-            console.log(`A ${group}->${identifier} ${nextIdx} ${colorHex}`);
-
             return colorHex;
         },
         [colorPalette, colorMappings],

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -1,6 +1,14 @@
 import { type Series } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
-import { createContext, useCallback, useContext, useRef, type FC } from 'react';
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    type FC,
+} from 'react';
+import { useLocation } from 'react-router-dom';
 import { type EChartSeries } from './echarts/useEchartsCartesianConfig';
 
 /**
@@ -28,12 +36,30 @@ const ChartColorMappingContext =
 export const ChartColorMappingContextProvider: FC<
     React.PropsWithChildren<{}>
 > = ({ children }) => {
+    const location = useLocation();
+
     /**
      * Changes to colorMappings are intentionally kept outside the React render loop,
      * we don't want to trigger re-renders for every mapping assignment, and we're
      * creating assignments during the render process anyway.
      */
     const colorMappings = useRef(new Map<string, Map<string, number>>());
+
+    /**
+     * Any time the path changes, if we have any color mappings in the context,
+     * we reset them completely. This prevents things like playing around with
+     * filters, or editing a chart, from 'polluting' the mappings table in
+     * unpredictable ways.
+     *
+     * This could alternatively be implemented as contexts further down the tree,
+     * but this approach ensures mappings are always shared at the highest possible
+     * level regardless of how/where a chart is being rendered.
+     */
+    useEffect(() => {
+        if (colorMappings.current.size > 0) {
+            colorMappings.current = new Map<string, Map<string, number>>();
+        }
+    }, [location.pathname]);
 
     return (
         <ChartColorMappingContext.Provider

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -91,26 +91,10 @@ export const useChartColorConfig = ({
 
             // Project the hashed value into the available color space:
             const colorIdx = hashedValue % colorPalette.length;
+            const colorHex = colorPalette[colorIdx];
 
-            // Look at our existing color mappings so we can figure out if we need
-            // to try and avoid any of the current colors:
-            const colorsToAvoid = [...colorMappings.values()];
-            let colorHex = colorPalette[colorIdx];
-
-            // Intersect colors we've already used with our color palette, and try to find the
-            // next available color on the list.
-            if (colorsToAvoid.includes(colorHex)) {
-                const intersection = colorPalette.filter(
-                    (v) => !colorsToAvoid.includes(v),
-                );
-
-                if (intersection.length > 0) {
-                    colorHex = intersection[0];
-                }
-            }
-
-            // Keep track of this identifier->color pairing so we can reuse it without
-            // treating it as a collision:
+            // Keep track of this identifier->color pairing so we can bypass the
+            // hashing later.
             colorMappings.set(identifier, colorHex);
 
             return colorHex;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9297 

### Description:

Changes consistent color assignment to provide higher quality mapping, via grouped+sequential assignment.

In short: colors are assigned to series respecting the order of the color palette, instead of through a hash of the identifier string.

<img width="644" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/d51cc991-e643-491a-adb7-fb328d6f6862">
<img width="633" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/e41c456d-8909-46a1-82d5-0093dcfe6170">



### Implementation details:

- Null, empty strings, etc are always assigned a gray color.
- Colors are no longer assigned based on a hash of the group or identifier
- Colors are assigned following the order defined in the color palette
- If the same color has already been assigned to a group or identifier, we reuse that assignment across different charts in a dashboard
- Assignments are tracked through sub-groups, based on their underlying table/model or other grouping mechanism. This allows multiple unrelated charts to cycle through available colors in parallel.
- Assignments are tracked via the numeric index of the color in the palette, instead of the resolved color hexcode.

Example structure of the `colorMappings` map after rendering a dashboard:

<img width="374" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/230e365a-e744-4e03-a9d2-bac53cf088a2">

## How is this better?

- Colors _feel_ more predictable, and more closely match the color palette - not just in absolute colors used, but also in how they are displayed in order.
- Greatly reduces the chance of color collisions for neighboring series.

## How is this worse?

- Color assignments are more susceptible to load times: a dashboard containing multiple charts across the same dimensions, but with different filters, will still have colors consistently assigned, but those colors may become less neatly ordered.
  - E.g if the first chart to load for `customer_first_name` has one filter, and the second chart has a different filter on the same dimension, the values of the first loaded chart will have first pick of the color assignments, and could influence the order of colors for all subsequent charts on the same dimension.

Example of two charts on the same dashboard, with the pie chart of the left side having a filter on `First Name`. Colors are still applied consistently, but the pie chart has a segment that does not follow the expected color order, since 'Aaron' was first "seen" before the pie chart was rendered.

<img width="1133" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/b593a2cb-fd4e-4eff-9fc2-a8b418bfd682">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
