### PR TITLE
fix: remove /spaces-and-content endpoint

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1,5 +1,6 @@
 import {
     ApiCalculateTotalResponse,
+    ApiChartListResponse,
     ApiChartSummaryListResponse,
     ApiErrorPayload,
     ApiGetProjectGroupAccesses,
@@ -75,13 +76,35 @@ export class ProjectController extends BaseController {
     async getChartsInProject(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-    ): Promise<ApiChartSummaryListResponse> {
+    ): Promise<ApiChartListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
                 .getCharts(req.user!, projectUuid),
+        };
+    }
+
+    /**
+     * List all charts summaries in a project
+     * @param projectUuid The uuid of the project to get charts for
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/chart-summaries')
+    @OperationId('ListChartSummariesInProject')
+    async getChartSummariesInProject(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiChartSummaryListResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .getChartSummaries(req.user!, projectUuid),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2914,7 +2914,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_':
+    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -2922,9 +2922,9 @@ const models: TsoaRoute.Models = {
                 nestedProperties: {
                     name: { dataType: 'string', required: true },
                     description: { dataType: 'string' },
-                    organizationUuid: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
-                    projectUuid: { dataType: 'string', required: true },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    updatedByUser: { ref: 'UpdatedByUser' },
                     spaceUuid: { dataType: 'string', required: true },
                     pinnedListUuid: {
                         dataType: 'union',
@@ -2934,50 +2934,66 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     spaceName: { dataType: 'string', required: true },
-                    dashboardUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    dashboardName: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
                 },
                 validators: {},
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartType: {
-        dataType: 'refEnum',
-        enums: ['cartesian', 'table', 'big_number', 'pie', 'custom'],
+    ViewStatistics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                firstViewedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                views: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartSummary: {
+    SpaceQuery: {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_',
+                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_',
                 },
+                { ref: 'ViewStatistics' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        validationErrors: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ValidationSummary',
+                            },
+                        },
                         chartType: {
                             dataType: 'union',
                             subSchemas: [
-                                { ref: 'ChartType' },
+                                { ref: 'ChartKind' },
                                 { dataType: 'undefined' },
                             ],
+                            required: true,
                         },
                     },
                 },
@@ -2993,7 +3009,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: {
                     dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
+                    array: { dataType: 'refAlias', ref: 'SpaceQuery' },
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -4148,11 +4164,57 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceMemberRole: {
+        dataType: 'refEnum',
+        enums: ['viewer', 'editor'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceShare: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                inheritedFrom: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['organization'] },
+                        { dataType: 'enum', enums: ['project'] },
+                        { dataType: 'enum', enums: ['group'] },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                inheritedRole: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'OrganizationMemberRole' },
+                        { ref: 'ProjectMemberRole' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                hasDirectAccess: { dataType: 'boolean', required: true },
+                role: { ref: 'SpaceMemberRole', required: true },
+                email: { dataType: 'string', required: true },
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SavedChart: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                access: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
+                    required: true,
+                },
+                isPrivate: { dataType: 'boolean', required: true },
                 colorPalette: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -4895,93 +4957,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    description: { dataType: 'string' },
-                    uuid: { dataType: 'string', required: true },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    updatedByUser: { ref: 'UpdatedByUser' },
-                    spaceUuid: { dataType: 'string', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    pinnedListOrder: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                },
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ViewStatistics: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                firstViewedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                views: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceQuery: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_',
-                },
-                { ref: 'ViewStatistics' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        validationErrors: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'refAlias',
-                                ref: 'ValidationSummary',
-                            },
-                        },
-                        chartType: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'ChartKind' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
@@ -5055,46 +5030,6 @@ const models: TsoaRoute.Models = {
     SpaceDashboard: {
         dataType: 'refAlias',
         type: { ref: 'DashboardBasicDetails', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceMemberRole: {
-        dataType: 'refEnum',
-        enums: ['viewer', 'editor'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SpaceShare: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                inheritedFrom: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['organization'] },
-                        { dataType: 'enum', enums: ['project'] },
-                        { dataType: 'enum', enums: ['group'] },
-                        { dataType: 'undefined' },
-                    ],
-                    required: true,
-                },
-                inheritedRole: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'OrganizationMemberRole' },
-                        { ref: 'ProjectMemberRole' },
-                        { dataType: 'undefined' },
-                    ],
-                    required: true,
-                },
-                hasDirectAccess: { dataType: 'boolean', required: true },
-                role: { ref: 'SpaceMemberRole', required: true },
-                email: { dataType: 'string', required: true },
-                lastName: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Space: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2914,7 +2914,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_':
+    'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -2942,7 +2942,6 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
-                    spaceName: { dataType: 'string', required: true },
                 },
                 validators: {},
             },
@@ -2974,7 +2973,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_',
+                    ref: 'Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_',
                 },
                 { ref: 'ViewStatistics' },
                 {
@@ -3002,7 +3001,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiChartSummaryListResponse: {
+    ApiChartListResponse: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -3010,6 +3009,94 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'SpaceQuery' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    description: { dataType: 'string' },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    spaceUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    spaceName: { dataType: 'string', required: true },
+                    dashboardUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    dashboardName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartType: {
+        dataType: 'refEnum',
+        enums: ['cartesian', 'table', 'big_number', 'pie', 'custom'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        chartType: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartType' },
+                                { dataType: 'undefined' },
+                            ],
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiChartSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ChartSummary' },
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -8933,6 +9020,62 @@ export function RegisterRoutes(app: express.Router) {
                 }
 
                 const promise = controller.getChartsInProject.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/chart-summaries',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getChartSummariesInProject,
+        ),
+
+        async function ProjectController_getChartSummariesInProject(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ProjectController>(
+                    ProjectController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.getChartSummariesInProject.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3253,7 +3253,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_": {
+            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -3261,14 +3261,15 @@
                     "description": {
                         "type": "string"
                     },
-                    "organizationUuid": {
-                        "type": "string"
-                    },
                     "uuid": {
                         "type": "string"
                     },
-                    "projectUuid": {
-                        "type": "string"
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUser": {
+                        "$ref": "#/components/schemas/UpdatedByUser"
                     },
                     "spaceUuid": {
                         "type": "string"
@@ -3277,45 +3278,67 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "pinnedListOrder": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "spaceName": {
                         "type": "string"
-                    },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "dashboardName": {
-                        "type": "string",
-                        "nullable": true
                     }
                 },
                 "required": [
                     "name",
-                    "organizationUuid",
                     "uuid",
-                    "projectUuid",
+                    "updatedAt",
                     "spaceUuid",
                     "pinnedListUuid",
-                    "spaceName",
-                    "dashboardUuid",
-                    "dashboardName"
+                    "pinnedListOrder",
+                    "spaceName"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "ChartType": {
-                "enum": ["cartesian", "table", "big_number", "pie", "custom"],
-                "type": "string"
+            "ViewStatistics": {
+                "properties": {
+                    "firstViewedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["firstViewedAt", "views"],
+                "type": "object"
             },
-            "ChartSummary": {
+            "SpaceQuery": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_"
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ViewStatistics"
                     },
                     {
                         "properties": {
+                            "validationErrors": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationSummary"
+                                },
+                                "type": "array"
+                            },
                             "chartType": {
-                                "$ref": "#/components/schemas/ChartType"
+                                "$ref": "#/components/schemas/ChartKind"
                             }
                         },
                         "type": "object"
@@ -3326,7 +3349,7 @@
                 "properties": {
                     "results": {
                         "items": {
-                            "$ref": "#/components/schemas/ChartSummary"
+                            "$ref": "#/components/schemas/SpaceQuery"
                         },
                         "type": "array"
                     },
@@ -4590,8 +4613,66 @@
                     }
                 ]
             },
+            "SpaceMemberRole": {
+                "enum": ["viewer", "editor"],
+                "type": "string"
+            },
+            "SpaceShare": {
+                "properties": {
+                    "inheritedFrom": {
+                        "type": "string",
+                        "enum": ["organization", "project", "group"]
+                    },
+                    "inheritedRole": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationMemberRole"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ProjectMemberRole"
+                            }
+                        ]
+                    },
+                    "hasDirectAccess": {
+                        "type": "boolean"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/SpaceMemberRole"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "hasDirectAccess",
+                    "role",
+                    "email",
+                    "lastName",
+                    "firstName",
+                    "userUuid"
+                ],
+                "type": "object"
+            },
             "SavedChart": {
                 "properties": {
+                    "access": {
+                        "items": {
+                            "$ref": "#/components/schemas/SpaceShare"
+                        },
+                        "type": "array"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    },
                     "colorPalette": {
                         "items": {
                             "type": "string"
@@ -4678,6 +4759,8 @@
                     }
                 },
                 "required": [
+                    "access",
+                    "isPrivate",
                     "colorPalette",
                     "dashboardName",
                     "dashboardUuid",
@@ -5478,94 +5561,6 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "uuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedByUser": {
-                        "$ref": "#/components/schemas/UpdatedByUser"
-                    },
-                    "spaceUuid": {
-                        "type": "string"
-                    },
-                    "pinnedListUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "pinnedListOrder": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "required": [
-                    "name",
-                    "uuid",
-                    "updatedAt",
-                    "spaceUuid",
-                    "pinnedListUuid",
-                    "pinnedListOrder"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ViewStatistics": {
-                "properties": {
-                    "firstViewedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "views": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["firstViewedAt", "views"],
-                "type": "object"
-            },
-            "SpaceQuery": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ViewStatistics"
-                    },
-                    {
-                        "properties": {
-                            "validationErrors": {
-                                "items": {
-                                    "$ref": "#/components/schemas/ValidationSummary"
-                                },
-                                "type": "array"
-                            },
-                            "chartType": {
-                                "$ref": "#/components/schemas/ChartKind"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
@@ -5654,55 +5649,6 @@
             },
             "SpaceDashboard": {
                 "$ref": "#/components/schemas/DashboardBasicDetails"
-            },
-            "SpaceMemberRole": {
-                "enum": ["viewer", "editor"],
-                "type": "string"
-            },
-            "SpaceShare": {
-                "properties": {
-                    "inheritedFrom": {
-                        "type": "string",
-                        "enum": ["organization", "project", "group"]
-                    },
-                    "inheritedRole": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/OrganizationMemberRole"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ProjectMemberRole"
-                            }
-                        ]
-                    },
-                    "hasDirectAccess": {
-                        "type": "boolean"
-                    },
-                    "role": {
-                        "$ref": "#/components/schemas/SpaceMemberRole"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "userUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "hasDirectAccess",
-                    "role",
-                    "email",
-                    "lastName",
-                    "firstName",
-                    "userUuid"
-                ],
-                "type": "object"
             },
             "Space": {
                 "properties": {
@@ -6641,7 +6587,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1024.8",
+        "version": "0.1030.5",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3253,7 +3253,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_": {
+            "Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -3282,9 +3282,6 @@
                         "type": "number",
                         "format": "double",
                         "nullable": true
-                    },
-                    "spaceName": {
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -3293,8 +3290,7 @@
                     "updatedAt",
                     "spaceUuid",
                     "pinnedListUuid",
-                    "pinnedListOrder",
-                    "spaceName"
+                    "pinnedListOrder"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -3324,7 +3320,7 @@
             "SpaceQuery": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-spaceName-or-pinnedListUuid-or-pinnedListOrder_"
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-updatedAt-or-updatedByUser-or-description-or-spaceUuid-or-pinnedListUuid-or-pinnedListOrder_"
                     },
                     {
                         "$ref": "#/components/schemas/ViewStatistics"
@@ -3345,11 +3341,97 @@
                     }
                 ]
             },
-            "ApiChartSummaryListResponse": {
+            "ApiChartListResponse": {
                 "properties": {
                     "results": {
                         "items": {
                             "$ref": "#/components/schemas/SpaceQuery"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "dashboardName": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "name",
+                    "organizationUuid",
+                    "uuid",
+                    "projectUuid",
+                    "spaceUuid",
+                    "pinnedListUuid",
+                    "spaceName",
+                    "dashboardUuid",
+                    "dashboardName"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ChartType": {
+                "enum": ["cartesian", "table", "big_number", "pie", "custom"],
+                "type": "string"
+            },
+            "ChartSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_"
+                    },
+                    {
+                        "properties": {
+                            "chartType": {
+                                "$ref": "#/components/schemas/ChartType"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiChartSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ChartSummary"
                         },
                         "type": "array"
                     },
@@ -6587,7 +6669,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1030.5",
+        "version": "0.1030.8",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -8950,7 +9032,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
+                                    "$ref": "#/components/schemas/ApiChartListResponse"
                                 }
                             }
                         }
@@ -8967,6 +9049,47 @@
                     }
                 },
                 "description": "List all charts in a project",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the project to get charts for",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/chart-summaries": {
+            "get": {
+                "operationId": "ListChartSummariesInProject",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiChartSummaryListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List all charts summaries in a project",
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": [

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -230,7 +230,6 @@ export class SpaceModel {
                     lastName: savedQuery.last_name,
                 },
                 spaceUuid: space.space_uuid,
-                spaceName: space.name,
                 pinnedListUuid: savedQuery.pinned_list_uuid,
                 pinnedListOrder: savedQuery.order,
                 chartType: savedQuery.chart_kind,
@@ -786,7 +785,6 @@ export class SpaceModel {
                     order: number;
                     validation_errors: DbValidationTable[];
                     space_uuid: string;
-                    space_name: string;
                 }[]
             >([
                 `saved_queries.saved_query_uuid`,
@@ -815,7 +813,6 @@ export class SpaceModel {
                     ) as validation_errors
                 `),
                 `${SpaceTableName}.space_uuid`,
-                `${SpaceTableName}.name as space_name`,
             ]);
 
         if (filters?.recentlyUpdated || filters?.mostPopular) {
@@ -858,7 +855,6 @@ export class SpaceModel {
                 lastName: savedQuery.last_name,
             },
             spaceUuid: savedQuery.space_uuid,
-            spaceName: savedQuery.space_name,
             views: parseInt(savedQuery.views, 10),
             firstViewedAt: savedQuery.first_viewed_at,
             chartType: savedQuery.chart_kind,

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -201,24 +201,6 @@ projectRouter.patch(
 );
 
 projectRouter.get(
-    '/spaces-and-content',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    async (req, res, next) => {
-        req.services
-            .getSpaceService()
-            .getAllSpaces(req.params.projectUuid, req.user!)
-            .then((results) => {
-                res.json({
-                    status: 'ok',
-                    results,
-                });
-            })
-            .catch(next);
-    },
-);
-
-projectRouter.get(
     '/most-popular-and-recently-updated',
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -265,7 +265,6 @@ export const spacesWithSavedCharts: Space[] = [
                 name: 'saved chart name',
                 updatedAt: new Date(),
                 spaceUuid: 'uuid',
-                spaceName: 'space',
                 pinnedListUuid: null,
                 pinnedListOrder: null,
                 chartType: ChartKind.AREA,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -265,6 +265,7 @@ export const spacesWithSavedCharts: Space[] = [
                 name: 'saved chart name',
                 updatedAt: new Date(),
                 spaceUuid: 'uuid',
+                spaceName: 'space',
                 pinnedListUuid: null,
                 pinnedListOrder: null,
                 chartType: ChartKind.AREA,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3199,7 +3199,7 @@ export class ProjectService {
     async getCharts(
         user: SessionUser,
         projectUuid: string,
-    ): Promise<ChartSummary[]> {
+    ): Promise<SpaceQuery[]> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
@@ -3233,11 +3233,9 @@ export class ProjectService {
             (_, index) => allowedSpacesBooleans[index],
         );
 
-        const charts = await this.savedChartModel.find({
-            projectUuid,
-            spaceUuids: allowedSpaces.map((s) => s.uuid),
-        });
-        return charts;
+        return this.spaceModel.getSpaceQueries(
+            allowedSpaces.map((s) => s.uuid),
+        );
     }
 
     async getMostPopularAndRecentlyUpdated(

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -75,24 +75,6 @@ export class SpaceService {
         this.pinnedListModel = args.pinnedListModel;
     }
 
-    async getAllSpaces(
-        projectUuid: string,
-        user: SessionUser,
-    ): Promise<Space[]> {
-        const spaces = await this.spaceModel.getAllSpaces(projectUuid);
-        return spaces.filter(
-            (space) =>
-                user.ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: space.organizationUuid,
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ) && hasDirectAccessToSpace(user, space),
-        );
-    }
-
     async getSpace(
         projectUuid: string,
         user: SessionUser,

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -374,7 +374,6 @@ export type SpaceQuery = Pick<
     | 'updatedByUser'
     | 'description'
     | 'spaceUuid'
-    | 'spaceName'
     | 'pinnedListUuid'
     | 'pinnedListOrder'
 > &
@@ -554,6 +553,11 @@ export type ChartSummary = Pick<
 > & { chartType?: ChartType | undefined };
 
 export type ApiChartSummaryListResponse = {
+    status: 'ok';
+    results: ChartSummary[];
+};
+
+export type ApiChartListResponse = {
     status: 'ok';
     results: SpaceQuery[];
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -374,6 +374,7 @@ export type SpaceQuery = Pick<
     | 'updatedByUser'
     | 'description'
     | 'spaceUuid'
+    | 'spaceName'
     | 'pinnedListUuid'
     | 'pinnedListOrder'
 > &
@@ -554,7 +555,7 @@ export type ChartSummary = Pick<
 
 export type ApiChartSummaryListResponse = {
     status: 'ok';
-    results: ChartSummary[];
+    results: SpaceQuery[];
 };
 
 export type ChartHistory = {

--- a/packages/e2e/cypress/e2e/api/README.md
+++ b/packages/e2e/cypress/e2e/api/README.md
@@ -61,7 +61,7 @@ POST /projects/:projectUuid/explores/:exploreId/compileQuery AUTH
 POST /projects/:projectUuid/explores/:exploreId/runQuery AUTH
 POST /projects/:projectUuid/refresh AUTH
 POST /projects/:projectUuid/saved AUTH
-GET /projects/:projectUuid/spaces-and-content AUTH
+GET /projects/:projectUuid/spaces AUTH
 GET /projects/:projectUuid/dashboards AUTH
 POST /projects/:projectUuid/dashboards AUTH
 POST /projects/:projectUuid/sqlQuery AUTH

--- a/packages/e2e/cypress/e2e/api/api.cy.ts
+++ b/packages/e2e/cypress/e2e/api/api.cy.ts
@@ -171,13 +171,11 @@ describe('Lightdash API', () => {
     it('Should get success response (200) from GET savedChartRouter endpoints', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
 
-                const savedChartUuid = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 const endpoints = [
                     `/saved/${savedChartUuid}`,
@@ -301,7 +299,7 @@ describe('Lightdash API forbidden tests', () => {
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            // `/projects/${projectUuid}/spaces-and-content`, // This will return 200 but an empty list, check test below
+            `/projects/${projectUuid}/spaces`,
             // `/projects/${projectUuid}/dashboards`, // This will return 200 but an empty list, check test below
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
@@ -317,22 +315,6 @@ describe('Lightdash API forbidden tests', () => {
             }).then((resp) => {
                 expect(resp.status).to.eq(403);
             });
-        });
-    });
-
-    it('Should get an empty list of spaces from projects', () => {
-        cy.anotherLogin();
-
-        const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request({
-            url: `${apiUrl}/projects/${projectUuid}/spaces-and-content`,
-            failOnStatusCode: false,
-        }).then((resp) => {
-            cy.log(resp.body);
-            expect(resp.status).to.eq(200);
-            expect(resp.body).to.have.property('status', 'ok');
-
-            expect(resp.body.results).to.have.length(0);
         });
     });
 
@@ -401,13 +383,11 @@ describe('Lightdash API forbidden tests', () => {
         cy.login(); // Make request as first user to get the chartUuid
 
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
                 cy.log(projectResponse.body);
-                const savedChartUuid = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 cy.anotherLogin(); // Now we login as another user
 

--- a/packages/e2e/cypress/e2e/api/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/api/dashboard.cy.ts
@@ -188,12 +188,11 @@ describe('Lightdash dashboard', () => {
     it('Should update chart that belongs to dashboard', () => {
         const newDescription = 'updated chart description';
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
         ).then((response) => {
             // Get the latest dashboard created via API
             const dashboard = response.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-                .dashboards.sort((d) => d.updatedAt)
+                .sort((d) => d.updatedAt)
                 .reverse()
                 .find((s) => s.name === dashboardName);
 
@@ -230,12 +229,11 @@ describe('Lightdash dashboard', () => {
     });
     it('Should get chart summaries without charts that belongs to dashboard', () => {
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
         ).then((response) => {
             // Get the latest dashboard created via API
             const dashboard = response.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-                .dashboards.sort((d) => d.updatedAt)
+                .sort((d) => d.updatedAt)
                 .reverse()
                 .find((s) => s.name === dashboardName);
 

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -34,7 +34,7 @@ describe('Lightdash API organization permission tests', () => {
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            // `/projects/${projectUuid}/spaces-and-content`, // This will return 200 but an empty list, check test below
+            `/projects/${projectUuid}/spaces`,
             // `/projects/${projectUuid}/dashboards`, // This will return 200 but an empty list, check test below
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
@@ -50,21 +50,6 @@ describe('Lightdash API organization permission tests', () => {
             }).then((resp) => {
                 expect(resp.status).to.eq(403);
             });
-        });
-    });
-
-    it('Should get an empty list of spaces from projects', () => {
-        cy.anotherLogin();
-
-        const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request({
-            url: `${apiUrl}/projects/${projectUuid}/spaces-and-content`,
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(200);
-            expect(resp.body).to.have.property('status', 'ok');
-
-            expect(resp.body.results).to.have.length(0);
         });
     });
 
@@ -132,12 +117,10 @@ describe('Lightdash API organization permission tests', () => {
         cy.login(); // Make request as first user to get the chartUuid
 
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
-                const savedChartUuid = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 cy.anotherLogin(); // Now we login as another user
 

--- a/packages/e2e/cypress/e2e/api/pinning.cy.ts
+++ b/packages/e2e/cypress/e2e/api/pinning.cy.ts
@@ -8,11 +8,9 @@ describe('Lightdash pinning endpoints', () => {
     });
     it('Should pin/unpin chart', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
-                const savedChart = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0];
+                const savedChart = projectResponse.body.results[0];
 
                 // change once
                 cy.request(

--- a/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/projectPermissions.cy.ts
@@ -94,7 +94,8 @@ describe('Lightdash API tests for member user with admin project permissions', (
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            `/projects/${projectUuid}/spaces-and-content`,
+            `/projects/${projectUuid}/spaces`,
+            `/projects/${projectUuid}/charts`,
             `/projects/${projectUuid}/dashboards`,
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
@@ -198,11 +199,9 @@ describe('Lightdash API tests for member user with admin project permissions', (
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -221,11 +220,9 @@ describe('Lightdash API tests for member user with admin project permissions', (
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -333,12 +330,11 @@ describe('Lightdash API tests for member user with admin project permissions', (
     });
     it('Should get success response (200) from GET savedChartRouter endpoints', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
 
-                const savedChartUuid =
-                    projectResponse.body.results[0].queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 const endpoints = [
                     `/saved/${savedChartUuid}`,
@@ -442,7 +438,8 @@ describe('Lightdash API tests for member user with editor project permissions', 
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            `/projects/${projectUuid}/spaces-and-content`,
+            `/projects/${projectUuid}/spaces`,
+            `/projects/${projectUuid}/charts`,
             `/projects/${projectUuid}/dashboards`,
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
@@ -474,13 +471,11 @@ describe('Lightdash API tests for member user with editor project permissions', 
 
     it('Should get success response (200) from GET savedChartRouter endpoints', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
 
-                const savedChartUuid = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 const endpoints = [
                     `/saved/${savedChartUuid}`,
@@ -874,11 +869,9 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -897,11 +890,9 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -1029,7 +1020,8 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            `/projects/${projectUuid}/spaces-and-content`,
+            `/projects/${projectUuid}/spaces`,
+            `/projects/${projectUuid}/charts`,
             `/projects/${projectUuid}/dashboards`,
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
@@ -1135,11 +1127,9 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -1158,11 +1148,9 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         const projectUuid = SEED_PROJECT.project_uuid;
 
         // Fetch a chart from spaces
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (spacesResponse) => {
-                const savedChartUuid = spacesResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = spacesResponse.body.results[0].uuid;
                 const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
                 cy.request({
                     url: `${apiUrl}${endpoint}`,
@@ -1251,13 +1239,11 @@ describe('Lightdash API tests for member user with viewer project permissions', 
     });
     it('Should get success response (200) from GET savedChartRouter endpoints', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
                 expect(projectResponse.status).to.eq(200);
 
-                const savedChartUuid = projectResponse.body.results.find(
-                    (space) => space.queries.length > 0,
-                ).queries[0].uuid;
+                const savedChartUuid = projectResponse.body.results[0].uuid;
 
                 const endpoints = [
                     `/saved/${savedChartUuid}`,
@@ -1356,7 +1342,7 @@ describe('Lightdash API tests for member user with NO project permissions', () =
         const endpoints = [
             `/projects/${projectUuid}`,
             `/projects/${projectUuid}/explores`,
-            // `/projects/${projectUuid}/spaces-and-content`,  // This will return 200 but an empty list, check test below
+            `/projects/${projectUuid}/spaces`,
             `/projects/${projectUuid}/catalog`,
             `/projects/${projectUuid}/tablesConfiguration`,
             `/projects/${projectUuid}/hasSavedCharts`,
@@ -1371,18 +1357,6 @@ describe('Lightdash API tests for member user with NO project permissions', () =
                 expect(resp.status).to.eq(403);
             });
         });
-    });
-
-    it('Should get an empty list of spaces from projects', () => {
-        const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
-            (resp) => {
-                expect(resp.status).to.eq(200);
-                expect(resp.body).to.have.property('status', 'ok');
-
-                expect(resp.body.results).to.have.length(0);
-            },
-        );
     });
 
     it('Should get an empty list of dashboards from projects', () => {

--- a/packages/e2e/cypress/e2e/api/scheduler.cy.ts
+++ b/packages/e2e/cypress/e2e/api/scheduler.cy.ts
@@ -37,15 +37,13 @@ describe('Lightdash scheduler endpoints', () => {
     });
     it('Should create/update/delete chart scheduler', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        cy.request(`${apiUrl}/projects/${projectUuid}/spaces-and-content`).then(
+        cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
             (projectResponse) => {
-                const savedChart = projectResponse.body.results
-                    .find((s) => s.name === SEED_PROJECT.name)
-                    .queries.find(
-                        (s) =>
-                            s.name ===
-                            'How much revenue do we have per payment method?',
-                    );
+                const savedChart = projectResponse.body.results.find(
+                    (s) =>
+                        s.name ===
+                        'How much revenue do we have per payment method?',
+                );
 
                 // Create
                 cy.request<{ results: SchedulerAndTargets }>({

--- a/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/spacePermissions.cy.ts
@@ -299,19 +299,6 @@ describe('Lightdash API tests for an project admin accessing other private space
         cy.loginWithEmail(email);
     });
 
-    it('Should not list charts or dashboards from private spaces', () => {
-        cy.request({
-            url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(200);
-            const privateSpace = resp.body.results.find(
-                (space) => space.name === 'private space',
-            );
-            expect(privateSpace).to.eq(undefined);
-        });
-    });
-
     it('Should list private spaces', () => {
         cy.request({
             url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,

--- a/packages/e2e/cypress/e2e/app/minimal.cy.ts
+++ b/packages/e2e/cypress/e2e/app/minimal.cy.ts
@@ -8,16 +8,13 @@ describe('Minimal pages', () => {
     });
     it('I can view a minimal chart', () => {
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
         ).then((projectResponse) => {
-            const savedChart = projectResponse.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-
-                .queries.find(
-                    (s) =>
-                        s.name ===
-                        'How much revenue do we have per payment method?',
-                );
+            const savedChart = projectResponse.body.results.find(
+                (s) =>
+                    s.name ===
+                    'How much revenue do we have per payment method?',
+            );
 
             cy.visit(
                 `/minimal/projects/${SEED_PROJECT.project_uuid}/saved/${savedChart.uuid}`,
@@ -31,16 +28,13 @@ describe('Minimal pages', () => {
 
     it('I can view a minimal table', () => {
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
         ).then((projectResponse) => {
-            const savedChart = projectResponse.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-
-                .queries.find(
-                    (s) =>
-                        s.name ===
-                        'Which customers have not recently ordered an item?',
-                );
+            const savedChart = projectResponse.body.results.find(
+                (s) =>
+                    s.name ===
+                    'Which customers have not recently ordered an item?',
+            );
 
             cy.visit(
                 `/minimal/projects/${SEED_PROJECT.project_uuid}/saved/${savedChart.uuid}`,
@@ -55,14 +49,11 @@ describe('Minimal pages', () => {
 
     it('I can view a minimal big number', () => {
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
         ).then((projectResponse) => {
-            const savedChart = projectResponse.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-
-                .queries.find(
-                    (s) => s.name === `What's our total revenue to date?`,
-                );
+            const savedChart = projectResponse.body.results.find(
+                (s) => s.name === `What's our total revenue to date?`,
+            );
 
             cy.visit(
                 `/minimal/projects/${SEED_PROJECT.project_uuid}/saved/${savedChart.uuid}`,
@@ -74,11 +65,11 @@ describe('Minimal pages', () => {
     });
     it('I can view a minimal dashboard', () => {
         cy.request(
-            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces-and-content`,
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
         ).then((projectResponse) => {
-            const dashboard = projectResponse.body.results
-                .find((s) => s.name === SEED_PROJECT.name)
-                .dashboards.find((s) => s.name === `Jaffle dashboard`);
+            const dashboard = projectResponse.body.results.find(
+                (s) => s.name === `Jaffle dashboard`,
+            );
 
             cy.visit(
                 `/minimal/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboard.uuid}`,

--- a/packages/frontend/src/hooks/useChartSummaries.ts
+++ b/packages/frontend/src/hooks/useChartSummaries.ts
@@ -1,10 +1,10 @@
-import { type ApiError, type SpaceQuery } from '@lightdash/common';
+import { type ApiError, type ChartSummary } from '@lightdash/common';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
 const getChartSummariesInProject = async (projectUuid: string) => {
-    return lightdashApi<SpaceQuery[]>({
-        url: `/projects/${projectUuid}/charts`,
+    return lightdashApi<ChartSummary[]>({
+        url: `/projects/${projectUuid}/chart-summaries`,
         method: 'GET',
         body: undefined,
     });
@@ -12,10 +12,10 @@ const getChartSummariesInProject = async (projectUuid: string) => {
 
 export const useChartSummaries = (
     projectUuid: string,
-    useQueryFetchOptions?: UseQueryOptions<SpaceQuery[], ApiError>,
+    useQueryFetchOptions?: UseQueryOptions<ChartSummary[], ApiError>,
 ) => {
-    return useQuery<SpaceQuery[], ApiError>({
-        queryKey: ['project', projectUuid, 'charts'],
+    return useQuery<ChartSummary[], ApiError>({
+        queryKey: ['project', projectUuid, 'chart-summaries'],
         queryFn: () => getChartSummariesInProject(projectUuid),
         ...useQueryFetchOptions,
     });

--- a/packages/frontend/src/hooks/useChartSummaries.ts
+++ b/packages/frontend/src/hooks/useChartSummaries.ts
@@ -1,9 +1,9 @@
-import { type ApiError, type ChartSummary } from '@lightdash/common';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { type ApiError, type SpaceQuery } from '@lightdash/common';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
 const getChartSummariesInProject = async (projectUuid: string) => {
-    return lightdashApi<ChartSummary[]>({
+    return lightdashApi<SpaceQuery[]>({
         url: `/projects/${projectUuid}/charts`,
         method: 'GET',
         body: undefined,
@@ -12,9 +12,9 @@ const getChartSummariesInProject = async (projectUuid: string) => {
 
 export const useChartSummaries = (
     projectUuid: string,
-    useQueryFetchOptions?: UseQueryOptions<ChartSummary[], ApiError>,
+    useQueryFetchOptions?: UseQueryOptions<SpaceQuery[], ApiError>,
 ) => {
-    return useQuery<ChartSummary[], ApiError>({
+    return useQuery<SpaceQuery[], ApiError>({
         queryKey: ['project', projectUuid, 'charts'],
         queryFn: () => getChartSummariesInProject(projectUuid),
         ...useQueryFetchOptions,

--- a/packages/frontend/src/hooks/useChartSummaries.ts
+++ b/packages/frontend/src/hooks/useChartSummaries.ts
@@ -1,5 +1,5 @@
 import { type ApiError, type ChartSummary } from '@lightdash/common';
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
 const getChartSummariesInProject = async (projectUuid: string) => {

--- a/packages/frontend/src/hooks/useCharts.ts
+++ b/packages/frontend/src/hooks/useCharts.ts
@@ -1,0 +1,22 @@
+import { ApiError, SpaceQuery } from '@lightdash/common';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const getChartsInProject = async (projectUuid: string) => {
+    return lightdashApi<SpaceQuery[]>({
+        url: `/projects/${projectUuid}/charts`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useCharts = (
+    projectUuid: string,
+    useQueryFetchOptions?: UseQueryOptions<SpaceQuery[], ApiError>,
+) => {
+    return useQuery<SpaceQuery[], ApiError>({
+        queryKey: ['project', projectUuid, 'charts'],
+        queryFn: () => getChartsInProject(projectUuid),
+        ...useQueryFetchOptions,
+    });
+};

--- a/packages/frontend/src/hooks/useCharts.ts
+++ b/packages/frontend/src/hooks/useCharts.ts
@@ -1,5 +1,5 @@
-import { ApiError, SpaceQuery } from '@lightdash/common';
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import type { ApiError, SpaceQuery } from '@lightdash/common';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
 const getChartsInProject = async (projectUuid: string) => {

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -15,24 +15,6 @@ import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
 import useUser from './user/useUser';
 
-const getSpaces = async (projectUuid: string) =>
-    lightdashApi<Space[]>({
-        url: `/projects/${projectUuid}/spaces-and-content`,
-        method: 'GET',
-        body: undefined,
-    });
-
-const useSpaces = (
-    projectUuid: string,
-    queryOptions?: UseQueryOptions<Space[], ApiError>,
-) => {
-    return useQuery<Space[], ApiError>(
-        ['spaces', projectUuid],
-        () => getSpaces(projectUuid),
-        { ...queryOptions },
-    );
-};
-
 const getSpaceSummaries = async (projectUuid: string) => {
     return lightdashApi<SpaceSummary[]>({
         url: `/projects/${projectUuid}/spaces`,
@@ -63,14 +45,6 @@ export const useSpaceSummaries = (
             ...queryOptions,
         },
     );
-};
-
-// DEPRECATED: masks usage of `/spaces-and-content` endpoint
-// Use `useSpaceSummaries` where possible
-export const useSavedCharts = (projectUuid: string) => {
-    const spaces = useSpaces(projectUuid);
-    const allCharts = spaces.data?.flatMap((space) => space.queries);
-    return { ...spaces, data: allCharts };
 };
 
 const getSpace = async (projectUuid: string, spaceUuid: string) =>

--- a/packages/frontend/src/pages/MobileCharts.tsx
+++ b/packages/frontend/src/pages/MobileCharts.tsx
@@ -13,13 +13,13 @@ import MantineIcon from '../components/common/MantineIcon';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { useSavedCharts } from '../hooks/useSpaces';
+import { useChartSummaries } from '../hooks/useChartSummaries';
 import { useApp } from '../providers/AppProvider';
 
 const MobileCharts: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isInitialLoading, data: savedQueries = [] } =
-        useSavedCharts(projectUuid);
+        useChartSummaries(projectUuid);
     const { user } = useApp();
     const cannotView = user.data?.ability?.cannot('view', 'SavedChart');
     const [search, setSearch] = useState<string>('');

--- a/packages/frontend/src/pages/MobileCharts.tsx
+++ b/packages/frontend/src/pages/MobileCharts.tsx
@@ -13,13 +13,13 @@ import MantineIcon from '../components/common/MantineIcon';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { useChartSummaries } from '../hooks/useChartSummaries';
+import { useCharts } from '../hooks/useCharts';
 import { useApp } from '../providers/AppProvider';
 
 const MobileCharts: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isInitialLoading, data: savedQueries = [] } =
-        useChartSummaries(projectUuid);
+        useCharts(projectUuid);
     const { user } = useApp();
     const cannotView = user.data?.ability?.cannot('view', 'SavedChart');
     const [search, setSearch] = useState<string>('');

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -14,13 +14,13 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { useChartSummaries } from '../hooks/useChartSummaries';
+import { useCharts } from '../hooks/useCharts';
 import { useApp } from '../providers/AppProvider';
 
 const SavedQueries: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isInitialLoading, data: savedQueries = [] } =
-        useChartSummaries(projectUuid);
+        useCharts(projectUuid);
 
     const { user, health } = useApp();
     const cannotView = user.data?.ability?.cannot('view', 'SavedChart');

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -14,13 +14,13 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { SortDirection } from '../components/common/ResourceView/ResourceViewList';
-import { useSavedCharts } from '../hooks/useSpaces';
+import { useChartSummaries } from '../hooks/useChartSummaries';
 import { useApp } from '../providers/AppProvider';
 
 const SavedQueries: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isInitialLoading, data: savedQueries = [] } =
-        useSavedCharts(projectUuid);
+        useChartSummaries(projectUuid);
 
     const { user, health } = useApp();
     const cannotView = user.data?.ability?.cannot('view', 'SavedChart');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Problem: 
The deprecated/spaces-and-content endpoint fetches all the spaces, all the charts and all the dashboards. With our changes to the space permissions, this involves more heavy queries to the database.

Changes:
- remove /spaces-and-content endpoint
- add a new endpoint `/charts` and rename the existing one to `/chart-summaries`. 
- amend all e2e tests to use /spaces or /charts or /dashboards endpoints instead


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
