### PR TITLE
feat: show modal before chart, dashboard duplication

### DIFF
--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -159,6 +159,7 @@ projectRouter.post(
                     req.user!,
                     req.params.projectUuid,
                     req.query.duplicateFrom.toString(),
+                    req.body,
                 )
                 .then((results) => {
                     res.json({

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -282,6 +282,7 @@ projectRouter.post(
                     req.user!,
                     req.params.projectUuid,
                     req.query.duplicateFrom.toString(),
+                    req.body,
                 )
                 .then((results) => {
                     res.status(201).json({

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -343,10 +343,7 @@ export class DashboardService {
         const duplicatedDashboard = {
             ...dashboard,
             description: data.dashboardDesc,
-            name:
-                dashboard.name === data.dashboardName
-                    ? `Copy - ${dashboard.name}`
-                    : data.dashboardName,
+            name: data.dashboardName,
         };
 
         const newDashboard = await this.dashboardModel.create(

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -318,6 +318,7 @@ export class DashboardService {
         user: SessionUser,
         projectUuid: string,
         dashboardUuid: string,
+        data: { dashboardName: string; dashboardDesc: string },
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getById(dashboardUuid);
         const space = await this.spaceModel.getSpaceSummary(
@@ -341,7 +342,11 @@ export class DashboardService {
 
         const duplicatedDashboard = {
             ...dashboard,
-            name: `Copy of ${dashboard.name}`,
+            description: data.dashboardDesc,
+            name:
+                dashboard.name === data.dashboardName
+                    ? `Copy - ${dashboard.name}`
+                    : data.dashboardName,
         };
 
         const newDashboard = await this.dashboardModel.create(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -693,6 +693,7 @@ export class SavedChartService {
         user: SessionUser,
         projectUuid: string,
         chartUuid: string,
+        data: { chartName: string; chartDesc: string },
     ): Promise<SavedChart> {
         const chart = await this.savedChartModel.get(chartUuid);
         const space = await this.spaceModel.getSpaceSummary(chart.spaceUuid);
@@ -719,7 +720,11 @@ export class SavedChartService {
         };
         const base = {
             ...chart,
-            name: `Copy of ${chart.name}`,
+            name:
+                chart.name === data.chartName
+                    ? `Copy - ${chart.name}`
+                    : data.chartName, // avoid duplicate names
+            description: data.chartDesc,
             updatedByUser: user,
         };
         if (chart.dashboardUuid) {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -720,10 +720,7 @@ export class SavedChartService {
         };
         const base = {
             ...chart,
-            name:
-                chart.name === data.chartName
-                    ? `Copy - ${chart.name}`
-                    : data.chartName, // avoid duplicate names
+            name: data.chartName,
             description: data.chartDesc,
             updatedByUser: user,
         };

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -121,7 +121,7 @@ const useCreatePullRequestForChartFieldsMutation = (
     /* useMutation<GitIntegrationConfiguration, ApiError>(
         ['git-integration', 'pull-request'],
         () => createPullRequestForChartFields(projectUuid, chartUuid!),
-        
+
     );*/
     const { showToastSuccess, showToastError } = useToaster();
 
@@ -220,7 +220,6 @@ const SavedChartsHeader: FC = () => {
         savedChart?.uuid,
     );
     const { mutate: duplicateChart } = useDuplicateChartMutation();
-    const chartId = savedChart?.uuid || '';
     const chartBelongsToDashboard: boolean = !!savedChart?.dashboardUuid;
 
     const hasGoogleDriveEnabled =
@@ -345,6 +344,17 @@ const SavedChartsHeader: FC = () => {
             history.push({
                 pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/view`,
             });
+    };
+
+    const handleDuplicateChart = () => {
+        if (!savedChart) return;
+
+        // TODO: ideally this should open ChartDuplicateModal instead of calling the mutation directly
+        duplicateChart({
+            uuid: savedChart.uuid,
+            name: `Copy - ${savedChart.name}`,
+            description: savedChart.description,
+        });
     };
 
     return (
@@ -548,9 +558,7 @@ const SavedChartsHeader: FC = () => {
                                             icon={
                                                 <MantineIcon icon={IconCopy} />
                                             }
-                                            onClick={() => {
-                                                duplicateChart(chartId);
-                                            }}
+                                            onClick={handleDuplicateChart}
                                         >
                                             Duplicate
                                         </Menu.Item>

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -13,17 +13,11 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useEffect, type FC } from 'react';
 import { useParams } from 'react-router-dom';
-import {
-    useDuplicateDashboardMutation,
-    useMoveDashboardMutation,
-} from '../../../hooks/dashboard/useDashboard';
+import { useMoveDashboardMutation } from '../../../hooks/dashboard/useDashboard';
 import { useChartPinningMutation } from '../../../hooks/pinning/useChartPinningMutation';
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
 import { useSpacePinningMutation } from '../../../hooks/pinning/useSpaceMutation';
-import {
-    useDuplicateChartMutation,
-    useMoveChartMutation,
-} from '../../../hooks/useSavedQuery';
+import { useMoveChartMutation } from '../../../hooks/useSavedQuery';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import ChartDeleteModal from '../modal/ChartDeleteModal';
 import ChartDuplicateModal from '../modal/ChartDuplicateModal';

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -26,8 +26,10 @@ import {
 } from '../../../hooks/useSavedQuery';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import ChartDeleteModal from '../modal/ChartDeleteModal';
+import ChartDuplicateModal from '../modal/ChartDuplicateModal';
 import ChartUpdateModal from '../modal/ChartUpdateModal';
 import DashboardDeleteModal from '../modal/DashboardDeleteModal';
+import DashboardDuplicateModal from '../modal/DashboardDuplicateModal';
 import DashboardUpdateModal from '../modal/DashboardUpdateModal';
 import SpaceActionModal, { ActionType } from '../SpaceActionModal';
 
@@ -90,12 +92,6 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     const { mutate: pinChart } = useChartPinningMutation();
     const { mutate: pinDashboard } = useDashboardPinningMutation();
     const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
-    const { mutate: duplicateChart } = useDuplicateChartMutation({
-        showRedirectButton: true,
-    });
-    const { mutate: duplicateDashboard } = useDuplicateDashboardMutation({
-        showRedirectButton: true,
-    });
 
     const handleReset = useCallback(() => {
         onAction({ type: ResourceViewItemAction.CLOSE });
@@ -156,35 +152,12 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
         }
     }, [action, pinChart, pinDashboard, pinSpace]);
 
-    const handleDuplicate = useCallback(() => {
-        if (action.type !== ResourceViewItemAction.DUPLICATE) return;
-
-        switch (action.item.type) {
-            case ResourceViewItemType.CHART:
-                return duplicateChart(action.item.data.uuid);
-            case ResourceViewItemType.DASHBOARD:
-                return duplicateDashboard(action.item.data.uuid);
-            default:
-                return assertUnreachable(
-                    action.item,
-                    'Resource type not supported',
-                );
-        }
-    }, [action, duplicateChart, duplicateDashboard]);
-
     useEffect(() => {
         if (action.type === ResourceViewItemAction.MOVE_TO_SPACE) {
             handleMoveToSpace();
             handleReset();
         }
     }, [action, handleMoveToSpace, handleReset]);
-
-    useEffect(() => {
-        if (action.type === ResourceViewItemAction.DUPLICATE) {
-            handleDuplicate();
-            handleReset();
-        }
-    }, [action, handleDuplicate, handleReset]);
 
     useEffect(() => {
         if (action.type === ResourceViewItemAction.PIN_TO_HOMEPAGE) {
@@ -296,8 +269,35 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                     onSubmitForm={handleCreateSpace}
                 />
             );
-        case ResourceViewItemAction.CLOSE:
+
         case ResourceViewItemAction.DUPLICATE:
+            switch (action.item.type) {
+                case ResourceViewItemType.CHART:
+                    return (
+                        <ChartDuplicateModal
+                            opened
+                            uuid={action.item.data.uuid}
+                            onClose={handleReset}
+                            onConfirm={handleReset}
+                        />
+                    );
+                case ResourceViewItemType.DASHBOARD:
+                    return (
+                        <DashboardDuplicateModal
+                            opened
+                            uuid={action.item.data.uuid}
+                            onClose={handleReset}
+                            onConfirm={handleReset}
+                        />
+                    );
+                default:
+                    return assertUnreachable(
+                        action.item,
+                        'Resource type not supported',
+                    );
+            }
+
+        case ResourceViewItemAction.CLOSE:
         case ResourceViewItemAction.MOVE_TO_SPACE:
         case ResourceViewItemAction.PIN_TO_HOMEPAGE:
             return null;

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -16,14 +16,14 @@ import {
     useSavedQuery,
 } from '../../../hooks/useSavedQuery';
 
-interface ChartUpdateModalProps extends ModalProps {
+interface ChartDuplicateModalProps extends ModalProps {
     uuid: string;
     onConfirm?: () => void;
 }
 
 type FormState = Pick<SavedChart, 'name' | 'description'>;
 
-const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
+const ChartDuplicateModal: FC<ChartDuplicateModalProps> = ({
     uuid,
     onConfirm,
     ...modalProps
@@ -104,4 +104,4 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
     );
 };
 
-export default ChartUpdateModal;
+export default ChartDuplicateModal;

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -18,7 +18,7 @@ import {
 
 interface ChartDuplicateModalProps extends ModalProps {
     uuid: string;
-    onConfirm?: () => void;
+    onConfirm?: (savedChart: SavedChart) => void;
 }
 
 type FormState = Pick<SavedChart, 'name' | 'description'>;
@@ -40,7 +40,7 @@ const ChartDuplicateModal: FC<ChartDuplicateModalProps> = ({
         if (!savedQuery) return;
 
         const initialValues = {
-            name: 'Copy - ' + savedQuery.name,
+            name: `Copy of ${savedQuery.name}`,
             description: savedQuery.description,
         };
 
@@ -58,12 +58,13 @@ const ChartDuplicateModal: FC<ChartDuplicateModalProps> = ({
         isInitialLoading || !savedQuery || !form.initialized || isUpdating;
 
     const handleConfirm = form.onSubmit(async (data) => {
-        await duplicateChart({
+        const updatedChart = await duplicateChart({
             uuid: uuid,
             name: data.name,
             description: data.description,
         });
-        onConfirm?.();
+
+        onConfirm?.(updatedChart);
     });
 
     return (

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -3,14 +3,14 @@ import {
     Button,
     Group,
     Modal,
-    ModalProps,
     Stack,
     Textarea,
     TextInput,
     Title,
+    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { FC, useEffect } from 'react';
+import { useEffect, type FC } from 'react';
 import {
     useDuplicateChartMutation,
     useSavedQuery,

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -35,21 +35,18 @@ const ChartDuplicateModal: FC<ChartDuplicateModalProps> = ({
     const { data: chart, isInitialLoading } = useSavedQuery({ id: uuid });
 
     const form = useForm<FormState>({
-        initialValues: {
-            name: '',
-            description: '',
-        },
+        initialValues: { name: '', description: '' },
     });
-
-    const { setValues } = form;
 
     useEffect(() => {
         if (!chart) return;
-        setValues({
+        const initialValues = {
             name: 'Copy - ' + chart.name,
             description: chart.description,
-        });
-    }, [chart, setValues]);
+        };
+        form.setInitialValues(initialValues);
+        form.setValues(initialValues);
+    }, [chart]);
 
     if (isInitialLoading || !chart) {
         return null;

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -1,0 +1,107 @@
+import { SavedChart } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Textarea,
+    TextInput,
+    Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { FC, useEffect } from 'react';
+import {
+    useDuplicateChartMutation,
+    useSavedQuery,
+} from '../../../hooks/useSavedQuery';
+
+interface ChartUpdateModalProps extends ModalProps {
+    uuid: string;
+    onConfirm?: () => void;
+}
+
+type FormState = Pick<SavedChart, 'name' | 'description'>;
+
+const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
+    uuid,
+    onConfirm,
+    ...modalProps
+}) => {
+    const { mutateAsync: duplicateChart, isLoading } =
+        useDuplicateChartMutation({
+            showRedirectButton: true,
+        });
+    const { data: chart, isInitialLoading } = useSavedQuery({ id: uuid });
+
+    const form = useForm<FormState>({
+        initialValues: {
+            name: '',
+            description: '',
+        },
+    });
+
+    const { setValues } = form;
+
+    useEffect(() => {
+        if (!chart) return;
+        setValues({
+            name: 'Copy - ' + chart.name,
+            description: chart.description,
+        });
+    }, [chart, setValues]);
+
+    if (isInitialLoading || !chart) {
+        return null;
+    }
+
+    const handleConfirm = form.onSubmit(async (data) => {
+        await duplicateChart({
+            uuid: uuid,
+            name: data.name,
+            description: data.description,
+        });
+        onConfirm?.();
+    });
+
+    return (
+        <Modal title={<Title order={4}>Duplicate Chart</Title>} {...modalProps}>
+            <form title="Duplicate Chart" onSubmit={handleConfirm}>
+                <Stack spacing="lg" pt="sm">
+                    <TextInput
+                        label="Enter a memorable name for your chart"
+                        required
+                        placeholder="eg. How many weekly active users do we have?"
+                        disabled={isLoading}
+                        {...form.getInputProps('name')}
+                    />
+
+                    <Textarea
+                        label="Chart description"
+                        placeholder="A few words to give your team some context"
+                        disabled={isLoading}
+                        autosize
+                        maxRows={3}
+                        {...form.getInputProps('description')}
+                    />
+
+                    <Group position="right" mt="sm">
+                        <Button variant="outline" onClick={modalProps.onClose}>
+                            Cancel
+                        </Button>
+
+                        <Button
+                            disabled={!form.isValid()}
+                            loading={isLoading}
+                            type="submit"
+                        >
+                            Create duplicate
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};
+
+export default ChartUpdateModal;

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -1,4 +1,5 @@
 import { SavedChart } from '@lightdash/common';
+import type { ModalProps } from '@mantine/core';
 import {
     Button,
     Group,
@@ -7,10 +8,10 @@ import {
     Textarea,
     TextInput,
     Title,
-    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { useEffect, type FC } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 import {
     useDuplicateChartMutation,
     useSavedQuery,

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -1,4 +1,4 @@
-import { SavedChart } from '@lightdash/common';
+import { type SavedChart } from '@lightdash/common';
 import type { ModalProps } from '@mantine/core';
 import {
     Button,

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -1,5 +1,4 @@
 import { type SavedChart } from '@lightdash/common';
-import type { ModalProps } from '@mantine/core';
 import {
     Button,
     Group,
@@ -8,10 +7,10 @@ import {
     Textarea,
     TextInput,
     Title,
+    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import type { FC } from 'react';
-import { useEffect } from 'react';
+import { useEffect, type FC } from 'react';
 import {
     useDuplicateChartMutation,
     useSavedQuery,

--- a/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDuplicateModal.tsx
@@ -46,6 +46,8 @@ const ChartDuplicateModal: FC<ChartDuplicateModalProps> = ({
         };
         form.setInitialValues(initialValues);
         form.setValues(initialValues);
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [chart]);
 
     if (isInitialLoading || !chart) {

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -3,14 +3,14 @@ import {
     Button,
     Group,
     Modal,
-    ModalProps,
     Stack,
     Textarea,
     TextInput,
     Title,
+    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { FC, useEffect } from 'react';
+import { useEffect, type FC } from 'react';
 import {
     useDashboardQuery,
     useDuplicateDashboardMutation,

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -1,0 +1,110 @@
+import { Dashboard } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Modal,
+    ModalProps,
+    Stack,
+    Textarea,
+    TextInput,
+    Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { FC, useEffect } from 'react';
+import {
+    useDashboardQuery,
+    useDuplicateDashboardMutation,
+} from '../../../hooks/dashboard/useDashboard';
+
+interface DashboardDuplicateModalProps extends ModalProps {
+    uuid: string;
+    onConfirm?: () => void;
+}
+
+type FormState = Pick<Dashboard, 'name' | 'description'>;
+
+const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
+    uuid,
+    onConfirm,
+    ...modalProps
+}) => {
+    const { mutateAsync: duplicateDashboard, isLoading } =
+        useDuplicateDashboardMutation({
+            showRedirectButton: true,
+        });
+    const { data: dashboard, isInitialLoading } = useDashboardQuery(uuid);
+
+    const form = useForm<FormState>({
+        initialValues: {
+            name: '',
+            description: '',
+        },
+    });
+
+    const { setValues } = form;
+
+    useEffect(() => {
+        if (!dashboard) return;
+        setValues({
+            name: 'Copy - ' + dashboard.name,
+            description: dashboard.description ?? '',
+        });
+    }, [dashboard, setValues]);
+
+    if (isInitialLoading || !dashboard) {
+        return null;
+    }
+
+    const handleConfirm = form.onSubmit(async (data) => {
+        await duplicateDashboard({
+            uuid: uuid,
+            name: data.name,
+            description: data.description,
+        });
+        onConfirm?.();
+    });
+
+    return (
+        <Modal
+            title={<Title order={4}>Duplicate Dashboard</Title>}
+            {...modalProps}
+        >
+            <form title="Duplicate Dashboard" onSubmit={handleConfirm}>
+                <Stack spacing="lg" pt="sm">
+                    <TextInput
+                        label="Enter a memorable name for your dashboard"
+                        required
+                        placeholder="eg. KPI Dashboards"
+                        disabled={isLoading}
+                        {...form.getInputProps('name')}
+                    />
+
+                    <Textarea
+                        label="Description"
+                        placeholder="A few words to give your team some context"
+                        disabled={isLoading}
+                        autosize
+                        maxRows={3}
+                        {...form.getInputProps('description')}
+                    />
+
+                    <Group position="right" mt="sm">
+                        <Button variant="outline" onClick={modalProps.onClose}>
+                            Cancel
+                        </Button>
+
+                        <Button
+                            disabled={!form.isValid()}
+                            loading={isLoading}
+                            type="submit"
+                        >
+                            Create duplicate
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};
+
+export default DashboardDuplicateModal;

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -1,4 +1,4 @@
-import { Dashboard } from '@lightdash/common';
+import { type Dashboard } from '@lightdash/common';
 import type { ModalProps } from '@mantine/core';
 import {
     Button,

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -46,6 +46,8 @@ const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
         };
         form.setInitialValues(initialValues);
         form.setValues(initialValues);
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dashboard]);
 
     if (isInitialLoading || !dashboard) {

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -1,4 +1,5 @@
 import { Dashboard } from '@lightdash/common';
+import type { ModalProps } from '@mantine/core';
 import {
     Button,
     Group,
@@ -7,10 +8,10 @@ import {
     Textarea,
     TextInput,
     Title,
-    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { useEffect, type FC } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 import {
     useDashboardQuery,
     useDuplicateDashboardMutation,

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -1,5 +1,4 @@
 import { type Dashboard } from '@lightdash/common';
-import type { ModalProps } from '@mantine/core';
 import {
     Button,
     Group,
@@ -8,10 +7,10 @@ import {
     Textarea,
     TextInput,
     Title,
+    type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import type { FC } from 'react';
-import { useEffect } from 'react';
+import { useEffect, type FC } from 'react';
 import {
     useDashboardQuery,
     useDuplicateDashboardMutation,

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -35,21 +35,18 @@ const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
     const { data: dashboard, isInitialLoading } = useDashboardQuery(uuid);
 
     const form = useForm<FormState>({
-        initialValues: {
-            name: '',
-            description: '',
-        },
+        initialValues: { name: '', description: '' },
     });
-
-    const { setValues } = form;
 
     useEffect(() => {
         if (!dashboard) return;
-        setValues({
+        const initialValues = {
             name: 'Copy - ' + dashboard.name,
             description: dashboard.description ?? '',
-        });
-    }, [dashboard, setValues]);
+        };
+        form.setInitialValues(initialValues);
+        form.setValues(initialValues);
+    }, [dashboard]);
 
     if (isInitialLoading || !dashboard) {
         return null;

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -36,11 +36,12 @@ const createDashboard = async (projectUuid: string, data: CreateDashboard) =>
 const duplicateDashboard = async (
     projectUuid: string,
     dashboardUuid: string,
+    data: { dashboardName: string; dashboardDesc: string },
 ): Promise<Dashboard> =>
     lightdashApi<Dashboard>({
         url: `/projects/${projectUuid}/dashboards?duplicateFrom=${dashboardUuid}`,
         method: 'POST',
-        body: undefined,
+        body: JSON.stringify(data),
     });
 
 const updateDashboard = async (id: string, data: UpdateDashboard) =>
@@ -316,8 +317,16 @@ export const useDuplicateDashboardMutation = (
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
-    return useMutation<Dashboard, ApiError, Dashboard['uuid']>(
-        (dashboardUuid) => duplicateDashboard(projectUuid, dashboardUuid),
+    return useMutation<
+        Dashboard,
+        ApiError,
+        Pick<Dashboard, 'uuid' | 'name' | 'description'>
+    >(
+        ({ uuid, name, description }) =>
+            duplicateDashboard(projectUuid, uuid, {
+                dashboardName: name,
+                dashboardDesc: description ?? '',
+            }),
         {
             mutationKey: ['dashboard_create', projectUuid],
             onSuccess: async (data) => {

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -43,11 +43,12 @@ const createSavedQuery = async (
 const duplicateSavedQuery = async (
     projectUuid: string,
     chartUuid: string,
+    data: { chartName: string; chartDesc: string },
 ): Promise<SavedChart> =>
     lightdashApi<SavedChart>({
         url: `/projects/${projectUuid}/saved?duplicateFrom=${chartUuid}`,
         method: 'POST',
-        body: undefined,
+        body: JSON.stringify(data),
     });
 
 export const deleteSavedQuery = async (id: string) =>
@@ -407,8 +408,16 @@ export const useDuplicateChartMutation = (
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
-    return useMutation<SavedChart, ApiError, SavedChart['uuid']>(
-        (chartUuid) => duplicateSavedQuery(projectUuid, chartUuid),
+    return useMutation<
+        SavedChart,
+        ApiError,
+        Pick<SavedChart, 'uuid' | 'name' | 'description'>
+    >(
+        ({ uuid, name, description }) =>
+            duplicateSavedQuery(projectUuid, uuid, {
+                chartName: name,
+                chartDesc: description ?? '',
+            }),
         {
             mutationKey: ['saved_query_create', projectUuid],
             onSuccess: async (data) => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -687,6 +687,7 @@ const Dashboard: FC = () => {
                         opened={isDuplicateModalOpen}
                         uuid={dashboard.uuid}
                         onClose={duplicateModalHandlers.close}
+                        onConfirm={duplicateModalHandlers.close}
                     />
                 )}
             </Page>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -437,7 +437,12 @@ const Dashboard: FC = () => {
 
     const handleDuplicateDashboard = () => {
         if (!dashboard) return;
-        duplicateDashboard(dashboard.uuid);
+        // FIXME: show a Duplicate Dashboard modal here like when duplicating from the resource list menu
+        duplicateDashboard({
+            uuid: dashboard.uuid,
+            name: dashboard.name,
+            description: dashboard.description,
+        });
     };
 
     const handleDeleteDashboard = () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/9280

### Description:
Added a modal for charts and dashboards to be able to edit the `name` and `description` before duplicating. For this I had to modify the backend serivices too (`SavedChartService`, `DashboardService`) and the corresponding hooks since they did not take the necessary parameters on the request. Tested manually.

[Screencast from 2024-03-12 22-01-05.webm](https://github.com/lightdash/lightdash/assets/30611343/a37d9854-520c-4769-b7c9-be74c315640e)



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
