### PR TITLE
chore: analytics untyped events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1001,9 +1001,7 @@ export class LightdashAnalytics extends Analytics {
         });
     }
 
-    track<T extends BaseTrack = BaseTrack>(
-        payload: TypedEvent | UntypedEvent<T>,
-    ) {
+    track<T extends BaseTrack>(payload: TypedEvent | UntypedEvent<T>) {
         if (isUserUpdatedEvent(payload)) {
             const basicEventProperties = {
                 is_tracking_anonymized: payload.properties.isTrackingAnonymized,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Goal: allow to have other events but not allow to override existing events.

Example of a new event that is not part of this repo
```
type BananaEvent = BaseTrack & {
    event: 'banana.deleted';
    userId: string;
    properties: {
        organizationId: string;
        bananaId: string;
    };
};

this.analytics.track<BananaEvent>({
    userId: user.userUuid,
    event: 'banana.deleted',
    properties: {
        organizationId: user.userUuid,
        bananaId: userUuid,
    },
});
```

Example of a new event that tries to override an event in this repo. It throws an error.
```
type BadUserUpdatedEvent = BaseTrack & {
    event: 'user.updated';
    userId: string;
    properties: {
        organizationId: string;
        bananaId: string;
    };
};

this.analytics.track({
    userId: user.userUuid,
    event: 'user.updated',
    properties: {
        organizationId: user.userUuid,
        bananaId: userUuid,
    },
});
```

<img width="1148" alt="Screenshot 2024-03-13 at 14 04 41" src="https://github.com/lightdash/lightdash/assets/9117144/80a367a8-12e3-42c4-9734-c3a11945cab0">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
