### PR TITLE
fix: include eslint-plugin-unused-imports as dev dep in frontend, common

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,6 +10,7 @@
     "devDependencies": {
         "@types/pegjs": "^0.10.3",
         "@types/sanitize-html": "^2.11.0",
+        "eslint-plugin-unused-imports": "^3.1.0",
         "typescript-json-schema": "^0.54.0"
     },
     "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -119,6 +119,7 @@
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^6.2.0",
+        "eslint-plugin-unused-imports": "^3.1.0",
         "isomorphic-fetch": "^3.0.0",
         "jsdom": "^24.0.0",
         "lightningcss": "^1.22.0",


### PR DESCRIPTION
### Description:

Explicitly includes `eslint-plugin-unused-imports` in the packages that depend on it.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
