### PR TITLE
chore: remove unused metric code with tests

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1,5 +1,4 @@
 import { SupportedDbtAdapter } from '../types/dbt';
-import { extractEntityNameFromIdColumn } from '../types/metricQuery';
 import { attachTypesToModels, convertTable } from './translator';
 import {
     DBT_METRIC,
@@ -9,7 +8,6 @@ import {
     DBT_METRIC_WITH_SQL_FIELD,
     DBT_V9_METRIC,
     expectedModelWithType,
-    INVALID_ID_COLUMN_NAMES,
     LIGHTDASH_TABLE_SQL_WHERE,
     LIGHTDASH_TABLE_WITHOUT_AUTO_METRICS,
     LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS,
@@ -35,7 +33,6 @@ import {
     MODEL_WITH_SQL_WHERE,
     MODEL_WITH_WRONG_METRIC,
     MODEL_WITH_WRONG_METRICS,
-    VALID_ID_COLUMN_NAMES,
     warehouseSchema,
     warehouseSchemaWithMissingColumn,
     warehouseSchemaWithMissingTable,
@@ -104,20 +101,6 @@ describe('attachTypesToModels', () => {
                 false,
             )[0],
         ).toEqual(expectedModelWithType);
-    });
-});
-
-describe('autogenerate metrics', () => {
-    it('should extract entity names from valid id column names', () => {
-        VALID_ID_COLUMN_NAMES.forEach(({ input, output }) => {
-            expect(extractEntityNameFromIdColumn(input)).toEqual(output);
-        });
-    });
-
-    it('should return null entity names for invalid id columns names', () => {
-        INVALID_ID_COLUMN_NAMES.forEach((name) => {
-            expect(extractEntityNameFromIdColumn(name)).toBeNull();
-        });
     });
 });
 

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -76,23 +76,6 @@ export type SortField = {
     descending: boolean; // Direction of the sort
 };
 
-const idPattern = /(.+)id$/i;
-export const extractEntityNameFromIdColumn = (
-    columnName: string,
-): string | null => {
-    const match = columnName.match(idPattern);
-    if (!match || columnName.toLowerCase().endsWith('valid')) {
-        return null;
-    }
-    return (
-        match[1]
-            .toLowerCase()
-            .split(/[^a-z]/)
-            .filter((x) => x)
-            .join('_') || null
-    );
-};
-
 export const getAdditionalMetricLabel = (item: AdditionalMetric) =>
     `${friendlyName(item.table)} ${item.label}`;
 


### PR DESCRIPTION
### Description:

removing metric query code which is only used in tests

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
