### PR TITLE
fix: show warning on content not copied on dev previews

### DIFF
--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -13,30 +13,24 @@ import AllowedEmailDomains from './../snippets/allowed-email-domains.mdx';
 Project Admins can invite users to their project and assign users or [groups](/references/groups.mdx) to roles in that project. Note that projects may also be
 accessible by users with organization roles.
 
-| Action                                                 | Project Admin | Project Developer | Project Editor | Project Interactive Viewer | Project Viewer |
-| :----------------------------------------------------- | :-----------: | :---------------: | :------------: | :------------------------: | :------------: |
-| View charts and dashboards                             |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
-| Export results visible in a chart to CSV               |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
-| Export results visible in a chart to Google Sheets     |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
-| Export results to CSV and override the limit           |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| Export results to Google Sheets and override the limit |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| View comments                                          |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
-| Create comments                                        |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| Use the explorer                                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| View underlying data                                   |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| Create/edit scheduled deliveries                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| Create/edit Syncs                                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
-| Create/edit charts and dashboards                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
-| Use the SQL runner                                     |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
-| Manage project access and permissions                  |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
-| Delete project                                         |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
-| Create project previews                                |      ✅       |        ❗️        |      ❗️       |            ❗️             |       ❌       |
-
-:::info
-
-Project previews created by Project Developers, Project Editors or Project Interactive Viewers will not have spaces/charts/dashboards copied from the source project.
-
-:::
+| Action                                                 | Project Admin |     Project Developer      |       Project Editor       | Project Interactive Viewer | Project Viewer |
+| :----------------------------------------------------- | :-----------: | :------------------------: | :------------------------: | :------------------------: | :------------: |
+| View charts and dashboards                             |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
+| Export results visible in a chart to CSV               |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
+| Export results visible in a chart to Google Sheets     |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
+| Export results to CSV and override the limit           |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| Export results to Google Sheets and override the limit |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| View comments                                          |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
+| Create comments                                        |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| Use the explorer                                       |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| View underlying data                                   |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| Create/edit scheduled deliveries                       |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
+| Create/edit Syncs                                      |      ✅       |             ✅             |             ✅             |             ❌             |       ❌       |
+| Create/edit charts and dashboards                      |      ✅       |             ✅             |             ✅             |             ❌             |       ❌       |
+| Use the SQL runner                                     |      ✅       |             ✅             |             ❌             |             ❌             |       ❌       |
+| Manage project access and permissions                  |      ✅       |             ❌             |             ❌             |             ❌             |       ❌       |
+| Delete project                                         |      ✅       |             ❌             |             ❌             |             ❌             |       ❌       |
+| Create project previews                                |      ✅       | [✅ \*](#project-previews) | [✅ \*](#project-previews) | [✅ \*](#project-previews) |       ❌       |
 
 ### Organization Roles
 
@@ -51,6 +45,15 @@ Organization Admins can assign roles to organization members, which gives access
 | Admin for **all** projects                 |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
 | Invite users to organization               |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
 | Manage organization access and permissions |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
+
+:::info
+
+<a name="project-previews" class="hidden-anchor"></a>
+Project previews created by Project Developers, Project Editors or Project
+Interactive Viewers will not have spaces/charts/dashboards copied from the
+source project.
+
+:::
 
 ### Space Roles
 

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -25,6 +25,7 @@ accessible by users with organization roles.
 | Use the explorer                                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | View underlying data                                   |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | Create/edit scheduled deliveries                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| Create project previews                                |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | Create/edit Syncs                                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
 | Create/edit charts and dashboards                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
 | Use the SQL runner                                     |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -13,45 +13,45 @@ import AllowedEmailDomains from './../snippets/allowed-email-domains.mdx';
 Project Admins can invite users to their project and assign users or [groups](/references/groups.mdx) to roles in that project. Note that projects may also be
 accessible by users with organization roles.
 
-| Action                                                 | Project Admin |     Project Developer      |       Project Editor       | Project Interactive Viewer | Project Viewer |
-| :----------------------------------------------------- | :-----------: | :------------------------: | :------------------------: | :------------------------: | :------------: |
-| View charts and dashboards                             |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
-| Export results visible in a chart to CSV               |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
-| Export results visible in a chart to Google Sheets     |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
-| Export results to CSV and override the limit           |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| Export results to Google Sheets and override the limit |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| View comments                                          |      ✅       |             ✅             |             ✅             |             ✅             |       ✅       |
-| Create comments                                        |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| Use the explorer                                       |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| View underlying data                                   |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| Create/edit scheduled deliveries                       |      ✅       |             ✅             |             ✅             |             ✅             |       ❌       |
-| Create/edit Syncs                                      |      ✅       |             ✅             |             ✅             |             ❌             |       ❌       |
-| Create/edit charts and dashboards                      |      ✅       |             ✅             |             ✅             |             ❌             |       ❌       |
-| Use the SQL runner                                     |      ✅       |             ✅             |             ❌             |             ❌             |       ❌       |
-| Manage project access and permissions                  |      ✅       |             ❌             |             ❌             |             ❌             |       ❌       |
-| Delete project                                         |      ✅       |             ❌             |             ❌             |             ❌             |       ❌       |
-| Create project previews                                |      ✅       | [✅ \*](#project-previews) | [✅ \*](#project-previews) | [✅ \*](#project-previews) |       ❌       |
+| Action                                                 | Project Admin | Project Developer | Project Editor | Project Interactive Viewer | Project Viewer |
+| :----------------------------------------------------- | :-----------: | :---------------: | :------------: | :------------------------: | :------------: |
+| View charts and dashboards                             |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
+| Export results visible in a chart to CSV               |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
+| Export results visible in a chart to Google Sheets     |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
+| Export results to CSV and override the limit           |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| Export results to Google Sheets and override the limit |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| View comments                                          |      ✅       |        ✅         |       ✅       |             ✅             |       ✅       |
+| Create comments                                        |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| Use the explorer                                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| View underlying data                                   |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| Create/edit scheduled deliveries                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
+| Create/edit Syncs                                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
+| Create/edit charts and dashboards                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
+| Use the SQL runner                                     |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
+| Manage project access and permissions                  |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
+| Delete project                                         |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
+| Create project previews                                |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
 
 ### Organization Roles
 
 Organization Admins can assign roles to organization members, which gives access to all projects in the organization.
 
-| Action                                     | Organization Admin | Organization Developer | Organization Editor | Organization Interactive Viewer | Organization Viewer | Organization Member |
-| :----------------------------------------- | :----------------: | :--------------------: | :-----------------: | :-----------------------------: | :-----------------: | :-----------------: |
-| Create Personal access tokens              |         ✅         |           ✅           |         ✅          |               ✅                |         ✅          |         ✅          |
-| View **all** projects                      |         ✅         |           ✅           |         ✅          |               ✅                |         ✅          |         ❌          |
-| Create new projects                        |         ✅         |           ✅           |         ✅          |               ✅                |         ❌          |         ❌          |
-| Edit **all** projects                      |         ✅         |           ✅           |         ✅          |               ❌                |         ❌          |         ❌          |
-| Admin for **all** projects                 |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
-| Invite users to organization               |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
-| Manage organization access and permissions |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
+| Action                                     | Organization Admin |   Organization Developer   |    Organization Editor     | Organization Interactive Viewer | Organization Viewer | Organization Member |
+| :----------------------------------------- | :----------------: | :------------------------: | :------------------------: | :-----------------------------: | :-----------------: | :-----------------: |
+| Create Personal access tokens              |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ✅          |
+| View **all** projects                      |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ❌          |
+| Create new projects                        |         ✅         |             ✅             |             ✅             |               ✅                |         ❌          |         ❌          |
+| Edit **all** projects                      |         ✅         |             ✅             |             ✅             |               ❌                |         ❌          |         ❌          |
+| Admin for **all** projects                 |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
+| Invite users to organization               |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
+| Manage organization access and permissions |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
+| Create project previews                    |         ✅         | [✅ \*](#project-previews) | [✅ \*](#project-previews) |   [✅ \*](#project-previews)    |         ❌          |         ❌          |
 
 :::info
 
 <a name="project-previews" class="hidden-anchor"></a>
-Project previews created by Project Developers, Project Editors or Project
-Interactive Viewers will not have spaces/charts/dashboards copied from the
-source project.
+Project previews created by Developers, Editors or Interactive Viewers will not
+have spaces/charts/dashboards copied from the source project.
 
 :::
 

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -30,7 +30,13 @@ accessible by users with organization roles.
 | Use the SQL runner                                     |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
 | Manage project access and permissions                  |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
 | Delete project                                         |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
-| Create project previews                                |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
+| Create project previews                                |      ✅       |        ❗️        |      ❗️       |            ❗️             |       ❌       |
+
+:::info
+
+Project previews created by Project Developers, Project Editors or Project Interactive Viewers will not have spaces/charts/dashboards copied from the source project.
+
+:::
 
 ### Organization Roles
 

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -25,12 +25,12 @@ accessible by users with organization roles.
 | Use the explorer                                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | View underlying data                                   |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | Create/edit scheduled deliveries                       |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
-| Create project previews                                |      ✅       |        ✅         |       ✅       |             ✅             |       ❌       |
 | Create/edit Syncs                                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
 | Create/edit charts and dashboards                      |      ✅       |        ✅         |       ✅       |             ❌             |       ❌       |
 | Use the SQL runner                                     |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
 | Manage project access and permissions                  |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
 | Delete project                                         |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
+| Create project previews                                |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
 
 ### Organization Roles
 

--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -41,11 +41,11 @@ Organization Admins can assign roles to organization members, which gives access
 | Create Personal access tokens              |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ✅          |
 | View **all** projects                      |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ❌          |
 | Create new projects                        |         ✅         |             ✅             |             ✅             |               ✅                |         ❌          |         ❌          |
+| Create project previews                    |         ✅         | [✅ \*](#project-previews) | [✅ \*](#project-previews) |   [✅ \*](#project-previews)    |         ❌          |         ❌          |
 | Edit **all** projects                      |         ✅         |             ✅             |             ✅             |               ❌                |         ❌          |         ❌          |
 | Admin for **all** projects                 |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
 | Invite users to organization               |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
 | Manage organization access and permissions |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
-| Create project previews                    |         ✅         | [✅ \*](#project-previews) | [✅ \*](#project-previews) |   [✅ \*](#project-previews)    |         ❌          |         ❌          |
 
 :::info
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -48,3 +48,7 @@
   margin-top: 0;
   max-width: 15rem;
 }
+
+a.hidden-anchor {
+  scroll-margin-top: 250px
+}

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -423,6 +423,7 @@ export class ProjectService {
             } catch (e) {
                 Sentry.captureException(e);
                 Logger.error(`Unable to copy content on preview ${e}`);
+                throw e;
             }
         }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -95,6 +95,7 @@ import {
     UserWarehouseCredentials,
     WarehouseClient,
     WarehouseTypes,
+    type ApiCreateProjectResults,
 } from '@lightdash/common';
 import { SshTunnel } from '@lightdash/warehouses';
 import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
@@ -357,7 +358,7 @@ export class ProjectService {
         user: SessionUser,
         data: CreateProject,
         method: RequestMethod,
-    ): Promise<Project> {
+    ): Promise<ApiCreateProjectResults> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
@@ -399,6 +400,8 @@ export class ProjectService {
             },
         });
 
+        let hasContentCopy = false;
+
         if (data.copiedFromProjectUuid) {
             try {
                 const { organizationUuid } = await this.projectModel.getSummary(
@@ -420,14 +423,20 @@ export class ProjectService {
                     data.copiedFromProjectUuid,
                     projectUuid,
                 );
+
+                hasContentCopy = true;
             } catch (e) {
                 Sentry.captureException(e);
                 Logger.error(`Unable to copy content on preview ${e}`);
-                throw e;
             }
         }
 
-        return this.projectModel.get(projectUuid);
+        const project = await this.projectModel.get(projectUuid);
+
+        return {
+            hasContentCopy,
+            project,
+        };
     }
 
     async create(

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -2,9 +2,9 @@ import {
     CreateProject,
     DbtProjectType,
     isWeekDay,
-    Project,
     ProjectType,
     WarehouseTypes,
+    type ApiCreateProjectResults,
 } from '@lightdash/common';
 import inquirer from 'inquirer';
 import path from 'path';
@@ -77,7 +77,7 @@ type CreateProjectOptions = {
 };
 export const createProject = async (
     options: CreateProjectOptions,
-): Promise<Project | undefined> => {
+): Promise<ApiCreateProjectResults | undefined> => {
     const dbtVersion = await getSupportedDbtVersion();
 
     const absoluteProjectPath = path.resolve(options.projectDir);
@@ -138,10 +138,10 @@ export const createProject = async (
         copiedFromProjectUuid: options.copiedFromProjectUuid,
         dbtVersion,
     };
-    const createdProject = await lightdashApi<Project>({
+
+    return lightdashApi<ApiCreateProjectResults>({
         method: 'POST',
         url: `/api/v1/org/projects`,
         body: JSON.stringify(project),
     });
-    return createdProject;
 };

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -116,11 +116,14 @@ const createNewProject = async (
         },
     });
     try {
-        const project = await createProject({
+        const results = await createProject({
             ...options,
             name: projectName,
             type: ProjectType.DEFAULT,
         });
+
+        const project = results?.project;
+
         if (!project) {
             spinner.fail('Cancel preview environment');
             return undefined;

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -310,6 +310,7 @@ export const startPreviewHandler = async (
         });
 
         const project = results?.project;
+        const hasContentCopy = Boolean(results?.hasContentCopy);
 
         if (!project) {
             console.error(
@@ -343,6 +344,14 @@ export const startPreviewHandler = async (
             ignoreErrors: true,
         });
         const url = await projectUrl(project);
+
+        if (!hasContentCopy) {
+            console.error(
+                styles.warning(
+                    `\n\nDeveloper preview deployed without any copied content!\n`,
+                ),
+            );
+        }
 
         console.error(`New project created on ${url}`);
         if (process.env.CI === 'true') {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -529,6 +529,11 @@ export type CreateInviteLink = Pick<InviteLink, 'expiresAt' | 'email'> & {
     role?: OrganizationMemberRole;
 };
 
+export type ApiCreateProjectResults = {
+    project: Project;
+    hasContentCopy: boolean;
+};
+
 export type ProjectSavedChartStatus = boolean;
 
 export type ApiFlashResults = Record<string, string[]>;
@@ -608,7 +613,8 @@ type ApiResults =
     | ApiCreateComment['results']
     | ApiGetComments['results']
     | ApiDeleteComment
-    | ApiSuccessEmpty;
+    | ApiSuccessEmpty
+    | ApiCreateProjectResults;
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9378

### Description:

- Updates the docs on who can create project previews.
- Adds info panel about project previews' content to docs
- Displays CLI warning when content wasn't copied

Before with `editor`, `developer`, `interactive viewer`

CLI:
![image](https://github.com/lightdash/lightdash/assets/22939015/8e1615c0-d0d5-4b08-ae4c-98b376d5e9fb)

Backend:
![image](https://github.com/lightdash/lightdash/assets/22939015/88879f41-a2b4-48d4-b096-99677e1ab089)

After with `editor`, `developer`, `interactive viewer`

CLI:
<img width="752" alt="image" src="https://github.com/lightdash/lightdash/assets/22939015/2af4d980-534a-4401-a557-1c7e9271d755">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
