### PR TITLE
chore: inform macos requirement of xcrun

### DIFF
--- a/packages/cli/track.sh
+++ b/packages/cli/track.sh
@@ -70,9 +70,24 @@ has_curl() {
     has_cmd curl
 }
 
+inform_macos_xcrun_requirement() {
+    # Check if xcrun is installed
+    if ! command -v xcrun >/dev/null 2>&1; then
+        echo "⚠️  macOS users: Before installing the Lightdash CLI, make sure you have 'xcrun' installed."
+        echo "    You can install it by running the following command:"
+        echo "    xcode-select --install"
+        echo "    After installing 'xcrun', you can proceed with the Lightdash CLI installation."
+        echo ""
+    fi
+}
+
 if  [[ $NODE_ENV == "development" || "$CI" == "true" ]]; then 
     echo "Do not send tracking on NODE_ENV=$NODE_ENV or CI=$CI mode" 
     exit 0 
+fi
+
+if is_mac; then
+    inform_macos_xcrun_requirement
 fi
 
 track() {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9314 

### Description:

Inform macOS users on `xcrun` requirement on pre-install of lightdash CLI

Error message:
<img width="844" alt="Screenshot 2024-03-15 at 14 26 16" src="https://github.com/lightdash/lightdash/assets/7611706/eea7ee58-96e1-43bd-b710-58a2bf6448a0">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
