### PR TITLE
fix: changing cartesian chart type

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
@@ -47,7 +47,6 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
     colorPalette,
     children,
 }) => {
-    const prevChartConfig = usePrevious(initialChartConfig);
     const cartesianConfig = useCartesianChartConfig({
         initialChartConfig,
         pivotKeys: validPivotDimensions,
@@ -59,13 +58,21 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
         cartesianType,
         colorPalette,
     });
+    const prevChartConfig = usePrevious(initialChartConfig);
+    const prevValidConfig = usePrevious(cartesianConfig.validConfig);
 
     const hasChartConfigChangedInHook = useMemo(() => {
         return (
             !isEqual(initialChartConfig, cartesianConfig.validConfig) &&
-            isEqual(prevChartConfig, initialChartConfig)
+            !isEqual(cartesianConfig.validConfig, prevValidConfig) &&
+            isEqual(initialChartConfig, prevChartConfig)
         );
-    }, [cartesianConfig.validConfig, initialChartConfig, prevChartConfig]);
+    }, [
+        cartesianConfig.validConfig,
+        initialChartConfig,
+        prevChartConfig,
+        prevValidConfig,
+    ]);
 
     useEffect(() => {
         if (!hasChartConfigChangedInHook) return;

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -145,13 +145,20 @@ const useCartesianChartConfig = ({
             : EMPTY_CARTESIAN_CHART_CONFIG;
     }, [dirtyLayout, dirtyEchartsConfig]);
 
+    const prevInitialChartConfig = usePrevious(initialChartConfig);
     const prevValidConfig = usePrevious(validConfig);
     const hasInitialChartConfigPropChanged = useMemo(() => {
         return (
             !isEqual(initialChartConfig, validConfig) &&
+            !isEqual(initialChartConfig, prevInitialChartConfig) &&
             isEqual(validConfig, prevValidConfig)
         );
-    }, [initialChartConfig, prevValidConfig, validConfig]);
+    }, [
+        prevInitialChartConfig,
+        initialChartConfig,
+        prevValidConfig,
+        validConfig,
+    ]);
 
     useEffect(() => {
         if (!hasInitialChartConfigPropChanged) return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#9393](https://github.com/lightdash/lightdash/issues/9393)

### Description:
https://github.com/lightdash/lightdash/pull/9346 caused it to be impossible to change a cartesian chart type

How to reproduce:

1. Create chart
2. Try to change chart type from Bar to Horizontal bar / line, this should work meaning that the bug is fixed
3. Select a table calculation to be in one of the axis
4. Try to change it, this means that changing a table calculation doesn't reset chart config and the fix from https://github.com/lightdash/lightdash/pull/9346 is still working

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
