### PR TITLE
fix: navbar layout issues

### DIFF
--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -1,0 +1,72 @@
+import { Button, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { useEffect, useMemo, type FC } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import MantineIcon from '../common/MantineIcon';
+
+type Props = {
+    projectUuid: string;
+};
+
+export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
+    const history = useHistory();
+    const { savedQueryUuid, mode } = useParams<{
+        savedQueryUuid: string;
+        mode?: string;
+    }>();
+
+    const { getEditingDashboardInfo, clearDashboardStorage } =
+        useDashboardStorage();
+    const { name: dashboardName, dashboardUuid } = getEditingDashboardInfo();
+
+    useEffect(() => {
+        window.addEventListener('unload', clearDashboardStorage);
+        return () =>
+            window.removeEventListener('unload', clearDashboardStorage);
+    }, [clearDashboardStorage]);
+
+    const action = useMemo(() => {
+        if (!savedQueryUuid) {
+            return 'creating';
+        }
+        switch (mode) {
+            case 'edit':
+                return 'editing';
+            case 'view':
+            default:
+                return 'viewing';
+        }
+    }, [savedQueryUuid, mode]);
+
+    return (
+        <>
+            <MantineIcon icon={IconInfoCircle} color="white" size="sm" />
+            <Text color="white" fw={500} fz="xs" mx="xxs">
+                You are {action} this chart from within "{dashboardName}"
+            </Text>
+            <Tooltip
+                withinPortal
+                label="Cancel chart creation and return to dashboard"
+                position="bottom"
+                maw={350}
+            >
+                <Button
+                    onClick={() => {
+                        history.push(
+                            `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
+                                savedQueryUuid ? 'view' : 'edit'
+                            }`,
+                        );
+                    }}
+                    size="xs"
+                    ml="md"
+                    variant="white"
+                    compact
+                >
+                    Cancel
+                </Button>
+            </Tooltip>
+        </>
+    );
+};

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -58,6 +58,9 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
                                 savedQueryUuid ? 'view' : 'edit'
                             }`,
                         );
+
+                        // Also clear dashboard storage when navigating back to dashboard
+                        clearDashboardStorage();
                     }}
                     size="xs"
                     ml="md"

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -1,0 +1,76 @@
+import { ActionIcon, Box, Button, Group } from '@mantine/core';
+import { type FC } from 'react';
+import { Link } from 'react-router-dom';
+import Omnibar from '../../features/omnibar';
+import Logo from '../../svgs/logo-icon.svg?react';
+import BrowseMenu from './BrowseMenu';
+import ExploreMenu from './ExploreMenu';
+import HeadwayMenuItem from './HeadwayMenuItem';
+import HelpMenu from './HelpMenu';
+import { NotificationsMenu } from './NotificationsMenu';
+import ProjectSwitcher from './ProjectSwitcher';
+import SettingsMenu from './SettingsMenu';
+import UserCredentialsSwitcher from './UserCredentialsSwitcher';
+import UserMenu from './UserMenu';
+
+type Props = {
+    activeProjectUuid: string | undefined;
+    isLoadingActiveProject: boolean;
+};
+
+export const MainNavBarContent: FC<Props> = ({
+    activeProjectUuid,
+    isLoadingActiveProject,
+}) => {
+    const homeUrl = activeProjectUuid
+        ? `/projects/${activeProjectUuid}/home`
+        : '/';
+
+    return (
+        <>
+            <Group align="center" sx={{ flexShrink: 0 }}>
+                <ActionIcon
+                    component={Link}
+                    to={homeUrl}
+                    title="Home"
+                    size="lg"
+                >
+                    <Logo />
+                </ActionIcon>
+
+                {!isLoadingActiveProject && activeProjectUuid && (
+                    <>
+                        <Button.Group>
+                            <ExploreMenu projectUuid={activeProjectUuid} />
+                            <BrowseMenu projectUuid={activeProjectUuid} />
+                        </Button.Group>
+                        <Omnibar projectUuid={activeProjectUuid} />
+                    </>
+                )}
+            </Group>
+
+            <Box sx={{ flexGrow: 1 }} />
+
+            <Group sx={{ flexShrink: 0 }}>
+                <Button.Group>
+                    <SettingsMenu />
+
+                    {!isLoadingActiveProject && activeProjectUuid && (
+                        <NotificationsMenu projectUuid={activeProjectUuid} />
+                    )}
+
+                    <HelpMenu />
+
+                    {!isLoadingActiveProject && activeProjectUuid && (
+                        <HeadwayMenuItem projectUuid={activeProjectUuid} />
+                    )}
+
+                    <ProjectSwitcher />
+                </Button.Group>
+
+                <UserCredentialsSwitcher />
+                <UserMenu />
+            </Group>
+        </>
+    );
+};

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -1,0 +1,14 @@
+import { Center, Text } from '@mantine/core';
+import { IconTool } from '@tabler/icons-react';
+import { BANNER_HEIGHT } from '.';
+import MantineIcon from '../common/MantineIcon';
+
+export const PreviewBanner = () => (
+    <Center pos="fixed" w="100%" h={BANNER_HEIGHT} bg="blue.6">
+        <MantineIcon icon={IconTool} color="white" size="sm" />
+        <Text color="white" fw={500} fz="xs" mx="xxs">
+            This is a preview environment. Any changes you make here will not
+            affect production.
+        </Text>
+    </Center>
+);

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -1,104 +1,49 @@
 import { ProjectType } from '@lightdash/common';
 import {
-    ActionIcon,
     Box,
-    Button,
-    Center,
     getDefaultZIndex,
-    Group,
     Header,
     MantineProvider,
-    Text,
-    Tooltip,
+    type MantineTheme,
 } from '@mantine/core';
-import { IconInfoCircle, IconTool } from '@tabler/icons-react';
-import { memo, useEffect, useMemo, type FC } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
-import Omnibar from '../../features/omnibar';
+import { memo, useCallback, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProjects } from '../../hooks/useProjects';
 import { useApp } from '../../providers/AppProvider';
-import Logo from '../../svgs/logo-icon.svg?react';
-import MantineIcon from '../common/MantineIcon';
-import BrowseMenu from './BrowseMenu';
-import ExploreMenu from './ExploreMenu';
-import HeadwayMenuItem from './HeadwayMenuItem';
-import HelpMenu from './HelpMenu';
-import { NotificationsMenu } from './NotificationsMenu';
-import ProjectSwitcher from './ProjectSwitcher';
-import SettingsMenu from './SettingsMenu';
-import UserCredentialsSwitcher from './UserCredentialsSwitcher';
-import UserMenu from './UserMenu';
+import { DashboardExplorerBanner } from './DashboardExplorerBanner';
+import { MainNavBarContent } from './MainNavBarContent';
+import { PreviewBanner } from './PreviewBanner';
 
 export const NAVBAR_HEIGHT = 50;
 export const BANNER_HEIGHT = 35;
 
-const PreviewBanner = () => (
-    <Center pos="fixed" w="100%" h={BANNER_HEIGHT} bg="blue.6">
-        <MantineIcon icon={IconTool} color="white" size="sm" />
-        <Text color="white" fw={500} fz="xs" mx="xxs">
-            This is a preview environment. Any changes you make here will not
-            affect production.
-        </Text>
-    </Center>
-);
+enum NavBarMode {
+    DEFAULT = 'default',
+    EDITING_DASHBOARD_CHART = 'editingDashboardChart',
+}
 
-const DashboardExplorerBanner: FC<{
-    dashboardName: string;
-    projectUuid: string;
-    dashboardUuid: string;
-}> = ({ dashboardName, projectUuid, dashboardUuid }) => {
-    const history = useHistory();
-    const { savedQueryUuid, mode } = useParams<{
-        savedQueryUuid: string;
-        mode?: string;
-    }>();
+const defaultNavbarStyles = {
+    alignItems: 'center',
+    boxShadow: 'lg',
+    justifyContent: 'flex-start',
+};
 
-    const action = useMemo(() => {
-        if (!savedQueryUuid) {
-            return 'creating';
-        }
-        switch (mode) {
-            case 'edit':
-                return 'editing';
-            case 'view':
-                return 'viewing';
-            default:
-                return 'viewing';
-        }
-    }, [savedQueryUuid, mode]);
+const useNavBarMode = () => {
+    const { getIsEditingDashboardChart } = useDashboardStorage();
 
-    return (
-        <Center w="100%" h={BANNER_HEIGHT} bg="blue.6">
-            <MantineIcon icon={IconInfoCircle} color="white" size="sm" />
-            <Text color="white" fw={500} fz="xs" mx="xxs">
-                You are {action} this chart from within "{dashboardName}"
-            </Text>
-            <Tooltip
-                withinPortal
-                label="Cancel chart creation and return to dashboard"
-                position="bottom"
-                maw={350}
-            >
-                <Button
-                    onClick={() => {
-                        history.push(
-                            `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
-                                savedQueryUuid ? 'view' : 'edit'
-                            }`,
-                        );
-                    }}
-                    size="xs"
-                    ml="md"
-                    variant="white"
-                    compact
-                >
-                    Cancel
-                </Button>
-            </Tooltip>
-        </Center>
+    const isEditingDashboardChart = getIsEditingDashboardChart();
+
+    const navBarMode = useMemo(
+        () =>
+            isEditingDashboardChart
+                ? NavBarMode.EDITING_DASHBOARD_CHART
+                : NavBarMode.DEFAULT,
+        [isEditingDashboardChart],
     );
+
+    return { navBarMode };
 };
 
 const NavBar = memo(() => {
@@ -106,19 +51,9 @@ const NavBar = memo(() => {
     const { data: projects } = useProjects();
     const { activeProjectUuid, isLoading: isLoadingActiveProject } =
         useActiveProjectUuid({ refetchOnMount: true });
-    const {
-        getIsEditingDashboardChart,
-        getEditingDashboardInfo,
-        clearDashboardStorage,
-    } = useDashboardStorage();
-
     const { isFullscreen } = useApp();
 
-    const dashboardInfo = getEditingDashboardInfo();
-
-    const homeUrl = activeProjectUuid
-        ? `/projects/${activeProjectUuid}/home`
-        : '/';
+    const { navBarMode } = useNavBarMode();
 
     const isCurrentProjectPreview = !!projects?.find(
         (project) =>
@@ -126,88 +61,51 @@ const NavBar = memo(() => {
             project.type === ProjectType.PREVIEW,
     );
 
-    useEffect(() => {
-        window.addEventListener('unload', clearDashboardStorage);
-        return () =>
-            window.removeEventListener('unload', clearDashboardStorage);
-    }, [clearDashboardStorage]);
-
-    if (getIsEditingDashboardChart()) {
-        return (
-            <DashboardExplorerBanner
-                dashboardName={dashboardInfo.name || ''}
-                projectUuid={projectUuid}
-                dashboardUuid={dashboardInfo.dashboardUuid || ''}
-            />
-        );
-    }
-
+    const getHeaderStyles = useCallback(
+        (theme: MantineTheme) => ({
+            ...defaultNavbarStyles,
+            ...(navBarMode === NavBarMode.EDITING_DASHBOARD_CHART && {
+                justifyContent: 'center',
+                borderBottom: 'none',
+                backgroundColor: theme.colors.blue['6'],
+                color: 'white',
+            }),
+        }),
+        [navBarMode],
+    );
     const headerContainerHeight =
         NAVBAR_HEIGHT + (isCurrentProjectPreview ? BANNER_HEIGHT : 0);
 
+    const renderNavBarContent = () => {
+        switch (navBarMode) {
+            case NavBarMode.EDITING_DASHBOARD_CHART:
+                return <DashboardExplorerBanner projectUuid={projectUuid} />;
+            case NavBarMode.DEFAULT:
+            default:
+                return (
+                    <MainNavBarContent
+                        activeProjectUuid={activeProjectUuid}
+                        isLoadingActiveProject={isLoadingActiveProject}
+                    />
+                );
+        }
+    };
+
     return (
         <MantineProvider inherit theme={{ colorScheme: 'dark' }}>
-            {isCurrentProjectPreview ? <PreviewBanner /> : null}
+            {isCurrentProjectPreview && <PreviewBanner />}
             {/* hack to make navbar fixed and maintain space */}
             <Box h={!isFullscreen ? headerContainerHeight : 0} />
             <Header
                 height={NAVBAR_HEIGHT}
                 fixed
-                mt={isCurrentProjectPreview ? BANNER_HEIGHT : 'none'}
+                mt={isCurrentProjectPreview ? BANNER_HEIGHT : 0}
                 display={isFullscreen ? 'none' : 'flex'}
                 px="md"
                 zIndex={getDefaultZIndex('app')}
-                sx={{
-                    alignItems: 'center',
-                    boxShadow: 'lg',
-                }}
+                styles={(theme) => ({ root: getHeaderStyles(theme) })}
             >
-                {/* Header content */}
-                <Group align="center" sx={{ flexShrink: 0 }}>
-                    <ActionIcon
-                        component={Link}
-                        to={homeUrl}
-                        title="Home"
-                        size="lg"
-                    >
-                        <Logo />
-                    </ActionIcon>
-
-                    {!isLoadingActiveProject && activeProjectUuid ? (
-                        <>
-                            <Button.Group>
-                                <ExploreMenu projectUuid={activeProjectUuid} />
-                                <BrowseMenu projectUuid={activeProjectUuid} />
-                            </Button.Group>
-                            <Omnibar projectUuid={activeProjectUuid} />
-                        </>
-                    ) : null}
-                </Group>
-
-                <Box sx={{ flexGrow: 1 }} />
-
-                <Group sx={{ flexShrink: 0 }}>
-                    <Button.Group>
-                        <SettingsMenu />
-
-                        {!isLoadingActiveProject && activeProjectUuid ? (
-                            <NotificationsMenu
-                                projectUuid={activeProjectUuid}
-                            />
-                        ) : null}
-
-                        <HelpMenu />
-
-                        {!isLoadingActiveProject && activeProjectUuid ? (
-                            <HeadwayMenuItem projectUuid={activeProjectUuid} />
-                        ) : null}
-
-                        <ProjectSwitcher />
-                    </Button.Group>
-
-                    <UserCredentialsSwitcher />
-                    <UserMenu />
-                </Group>
+                {renderNavBarContent()}
             </Header>
         </MantineProvider>
     );

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -1,4 +1,4 @@
-import { ProjectType } from '@lightdash/common';
+import { assertUnreachable, ProjectType } from '@lightdash/common';
 import {
     Box,
     getDefaultZIndex,
@@ -81,12 +81,16 @@ const NavBar = memo(() => {
             case NavBarMode.EDITING_DASHBOARD_CHART:
                 return <DashboardExplorerBanner projectUuid={projectUuid} />;
             case NavBarMode.DEFAULT:
-            default:
                 return (
                     <MainNavBarContent
                         activeProjectUuid={activeProjectUuid}
                         isLoadingActiveProject={isLoadingActiveProject}
                     />
+                );
+            default:
+                assertUnreachable(
+                    navBarMode,
+                    `Unknown navBarMode ${navBarMode}`,
                 );
         }
     };

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -135,7 +135,6 @@ type Props = {
     sidebar?: React.ReactNode;
     isSidebarOpen?: boolean;
     header?: React.ReactNode;
-    hasBanner?: boolean;
 } & Omit<StyleProps, 'withSidebar' | 'withHeader'>;
 
 const Page: FC<React.PropsWithChildren<Props>> = ({
@@ -152,7 +151,6 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     withNavbar = true,
     withPaddedContent = false,
     withSidebarFooter = false,
-    hasBanner = false,
 
     children,
 }) => {
@@ -166,8 +164,6 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             project.type === ProjectType.PREVIEW,
     );
 
-    hasBanner = hasBanner || isCurrentProjectPreview;
-
     const { classes } = usePageStyles(
         {
             withCenteredContent,
@@ -180,7 +176,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             withPaddedContent,
             withSidebar: !!sidebar,
             withSidebarFooter,
-            hasBanner,
+            hasBanner: isCurrentProjectPreview,
         },
         { name: 'Page' },
     );

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -7,7 +7,6 @@ import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
 import ForbiddenPanel from '../components/ForbiddenPanel';
-import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplore } from '../hooks/useExplore';
 import {
     useDateZoomGranularitySearch,
@@ -28,8 +27,6 @@ const ExplorerWithUrlParams = memo(() => {
     );
     const { data } = useExplore(tableId);
 
-    const { getIsEditingDashboardChart } = useDashboardStorage();
-
     const clearQuery = useExplorerContext(
         (context) => context.actions.clearQuery,
     );
@@ -41,7 +38,6 @@ const ExplorerWithUrlParams = memo(() => {
             sidebar={<ExploreSideBar />}
             withFullHeight
             withPaddedContent
-            hasBanner={getIsEditingDashboardChart()}
         >
             <Explorer />
         </Page>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7531 #8364

### Description:

When users were editing charts from dashboards, they would see an issue with the Page layout where the Explorer sidebar and the whole `Page` seemed cropped. 
The reason why this is happening currently if because: 
- the main nav bar behaves one way, has specific height, styling, etc
- the blue banner that we render when `editing charts from dashboards` is a different component, with less of the styling we apply to the main nav bar

Instead of replacing the `Navbar` completely when that's the case, we can just render different content inside the same component.

What was done: 
- Created separate components for: `main nav bar content`, `dashboard explorer banner`, and the `preview banner`
- On the `index.tsx` of `NavBar`, we have now a Nav bar chooser hook, that controls the content & styles of the Header. 
- Consequently, we now don't need the `hasBanner` prop for the `Page` component, but we **still** let the Page component apply styles when the project is PREVIEW.


Here is a screen recording:
https://github.com/lightdash/lightdash/assets/7611706/8c041466-ea8a-4e3a-8ca7-2cec775f9812



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
