### PR TITLE
style: apply correct color style override to resource indicator 

### DIFF
--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -224,9 +224,12 @@ export const ResourceIndicator: FC<
                     opened={opened || isHovering}
                 >
                     <MantineIcon
-                        {...iconProps}
+                        icon={iconProps.icon}
                         onMouseEnter={handleMouseEnter}
                         onMouseLeave={handleMouseLeave}
+                        style={{
+                            color: iconProps.color, // NOTE: If react-tabler icon is filled, then we have to override the color this way
+                        }}
                     />
                 </Tooltip>
             }

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
 import {
-    IconAlertTriangle,
+    IconAlertTriangleFilled,
     IconChevronDown,
     IconChevronUp,
 } from '@tabler/icons-react';
@@ -137,8 +137,8 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                 item.data.validationErrors?.length ? (
                                     <ResourceIndicator
                                         iconProps={{
-                                            fill: 'red',
-                                            icon: IconAlertTriangle,
+                                            icon: IconAlertTriangleFilled,
+                                            color: 'red',
                                         }}
                                         tooltipProps={{
                                             maw: 300,

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
@@ -7,7 +7,7 @@ import { Anchor } from '@mantine/core';
 import {
     Icon123,
     IconAbc,
-    IconAlertTriangle,
+    IconAlertTriangleFilled,
     IconBrowser,
     IconFolder,
     IconLayoutDashboard,
@@ -99,8 +99,8 @@ export const OmnibarItemIconWithIndicator: FC<
     item.item && 'validationErrors' in item.item ? (
         <ResourceIndicator
             iconProps={{
-                fill: 'red',
-                icon: IconAlertTriangle,
+                color: 'red',
+                icon: IconAlertTriangleFilled,
             }}
             tooltipProps={{
                 maw: 300,


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9326

### Description:

Replace `triangle` icon with the filled version

Apply color with `style` override


<img width="1038" alt="Screenshot 2024-03-15 at 17 35 50" src="https://github.com/lightdash/lightdash/assets/7611706/bb40e671-4aa1-462c-93eb-bff06e6d3a7c">


<img width="176" alt="Screenshot 2024-03-15 at 17 32 42" src="https://github.com/lightdash/lightdash/assets/7611706/fbe646d0-1080-4c00-8262-0bff030e88eb">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
