### PR TITLE
refactor: stop importing models directly

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -32,7 +32,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { userModel } from '../models/models';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -79,9 +78,9 @@ export class OrganizationController extends BaseController {
         await this.services
             .getOrganizationService()
             .createAndJoinOrg(req.user!, body);
-        const sessionUser = await userModel.findSessionUserByUUID(
-            req.user!.userUuid,
-        );
+        const sessionUser = await req.services
+            .getUserService()
+            .getSessionByUserUuid(req.user!.userUuid);
         await new Promise<void>((resolve, reject) => {
             req.login(sessionUser, (err) => {
                 if (err) {

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -30,7 +30,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { userModel } from '../models/models';
 import { UserModel } from '../models/UserModel';
 import {
     allowApiKeyAuthentication,
@@ -181,9 +180,9 @@ export class UserController extends BaseController {
         await this.services
             .getUserService()
             .joinOrg(req.user!, organizationUuid);
-        const sessionUser = await userModel.findSessionUserByUUID(
-            req.user!.userUuid,
-        );
+        const sessionUser = await req.services
+            .getUserService()
+            .getSessionByUserUuid(req.user!.userUuid);
         await new Promise<void>((resolve, reject) => {
             req.login(sessionUser, (err) => {
                 if (err) {

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -22,7 +22,7 @@ import bcrypt from 'bcrypt';
 import { Knex } from 'knex';
 import path from 'path';
 import { lightdashConfig } from '../../../config/lightdashConfig';
-import { projectModel } from '../../../models/models';
+import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { EncryptionService } from '../../../services/EncryptionService/EncryptionService';
 import { serviceRepository } from '../../../services/services';
 import { DbEmailIn } from '../../entities/emails';
@@ -207,10 +207,11 @@ export async function seed(knex: Knex): Promise<void> {
                 SEED_PROJECT.project_uuid,
                 RequestMethod.UNKNOWN,
             );
-        await projectModel.saveExploresToCache(
-            SEED_PROJECT.project_uuid,
-            explores,
-        );
+        await new ProjectModel({
+            database: knex,
+            lightdashConfig,
+            encryptionService: enc,
+        }).saveExploresToCache(SEED_PROJECT.project_uuid, explores);
     } catch (e) {
         console.error(e);
         throw e;

--- a/packages/backend/src/database/seeds/development/02_saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/02_saved_queries.ts
@@ -7,9 +7,15 @@ import {
     SEED_PROJECT,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import { savedChartModel } from '../../../models/models';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+import { SavedChartModel } from '../../../models/SavedChartModel';
 
 export async function seed(knex: Knex): Promise<void> {
+    const savedChartModel = new SavedChartModel({
+        database: knex,
+        lightdashConfig,
+    });
+
     // Deletes ALL existing entries
     await knex('saved_queries').del();
 

--- a/packages/backend/src/overrideUserPassword.ts
+++ b/packages/backend/src/overrideUserPassword.ts
@@ -1,5 +1,7 @@
+import { lightdashConfig } from './config/lightdashConfig';
+import database from './database/database';
 import Logger from './logging/logger';
-import { userModel } from './models/models';
+import { UserModel } from './models/UserModel';
 
 (async function init() {
     Logger.warn(`Override user password`);
@@ -13,6 +15,8 @@ import { userModel } from './models/models';
     if (!newPassword) {
         throw new Error('New password is undefined');
     }
+
+    const userModel = new UserModel({ database, lightdashConfig });
 
     Logger.info(`Get user by email: ${email}`);
     const user = await userModel.findSessionUserByPrimaryEmail(email);

--- a/packages/backend/src/routers/headlessBrowser.ts
+++ b/packages/backend/src/routers/headlessBrowser.ts
@@ -2,7 +2,6 @@ import { ForbiddenError } from '@lightdash/common';
 import { createHmac } from 'crypto';
 import express from 'express';
 import { lightdashConfig } from '../config/lightdashConfig';
-import { userModel } from '../models/models';
 
 const puppeteer = require('puppeteer');
 
@@ -21,7 +20,9 @@ headlessBrowserRouter.post('/login/:userUuid', async (req, res, next) => {
         if (hash !== req.body.token) {
             throw new ForbiddenError();
         }
-        const sessionUser = await userModel.findSessionUserByUUID(userUuid);
+        const sessionUser = await req.services
+            .getUserService()
+            .getSessionByUserUuid(userUuid);
 
         req.login(sessionUser, (err) => {
             if (err) {

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -5,58 +5,49 @@ import { S3Client } from '../../clients/Aws/s3';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { lightdashConfig } from '../../config/lightdashConfig';
-import {
-    analyticsModel,
-    dashboardModel,
-    downloadFileModel,
-    jobModel,
-    onboardingModel,
-    projectModel,
-    savedChartModel,
-    spaceModel,
-    sshKeyPairModel,
-    userAttributesModel,
-    userModel,
-    userWarehouseCredentialsModel,
-} from '../../models/models';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { DownloadFileModel } from '../../models/DownloadFileModel';
+import { JobModel } from '../../models/JobModel/JobModel';
+import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SshKeyPairModel } from '../../models/SshKeyPairModel';
+import { UserAttributesModel } from '../../models/UserAttributesModel';
+import { UserModel } from '../../models/UserModel';
+import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { ProjectService } from '../ProjectService/ProjectService';
 import { CsvService } from './CsvService';
 import { itemMap, metricQuery } from './CsvService.mock';
 
-jest.mock('../../models/models', () => ({
-    savedChartModel: {},
-    dashboardModel: {},
-    userModel: {},
-    downloadFileModel: {},
-}));
-
 describe('Csv service', () => {
     const csvService = new CsvService({
         lightdashConfig,
         analytics: analyticsMock,
-        userModel,
+        userModel: {} as UserModel,
         projectService: new ProjectService({
             lightdashConfig,
             analytics: analyticsMock,
-            analyticsModel,
-            dashboardModel,
+            analyticsModel: {} as AnalyticsModel,
+            dashboardModel: {} as DashboardModel,
             emailClient: {} as EmailClient,
-            jobModel,
-            onboardingModel,
-            projectModel,
+            jobModel: {} as JobModel,
+            onboardingModel: {} as OnboardingModel,
+            projectModel: {} as ProjectModel,
             s3CacheClient: {} as S3CacheClient,
-            savedChartModel,
-            spaceModel,
-            sshKeyPairModel,
-            userAttributesModel,
-            userWarehouseCredentialsModel,
+            savedChartModel: {} as SavedChartModel,
+            spaceModel: {} as SpaceModel,
+            sshKeyPairModel: {} as SshKeyPairModel,
+            userAttributesModel: {} as UserAttributesModel,
+            userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
             schedulerClient: {} as SchedulerClient,
         }),
         s3Client: {} as S3Client,
-        savedChartModel,
-        dashboardModel,
-        downloadFileModel,
+        savedChartModel: {} as SavedChartModel,
+        dashboardModel: {} as DashboardModel,
+        downloadFileModel: {} as DownloadFileModel,
         schedulerClient: {} as SchedulerClient,
     });
 

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -6,17 +6,15 @@ import {
     ProjectMemberRole,
     SessionUser,
 } from '@lightdash/common';
-import {
-    analyticsModel,
-    dashboardModel,
-    pinnedListModel,
-    savedChartModel,
-    schedulerModel,
-    spaceModel,
-} from '../../models/models';
 
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { SlackClient } from '../../clients/Slack/SlackClient';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { DashboardService } from './DashboardService';
 import {
@@ -37,42 +35,38 @@ import {
 
 jest.mock('../../database/database', () => ({}));
 
-jest.mock('../../models/models', () => ({
-    dashboardModel: {
-        getAllByProject: jest.fn(async () => dashboardsDetails),
+const dashboardModel = {
+    getAllByProject: jest.fn(async () => dashboardsDetails),
 
-        getById: jest.fn(async () => dashboard),
+    getById: jest.fn(async () => dashboard),
 
-        create: jest.fn(async () => dashboard),
+    create: jest.fn(async () => dashboard),
 
-        update: jest.fn(async () => dashboard),
+    update: jest.fn(async () => dashboard),
 
-        delete: jest.fn(async () => dashboard),
+    delete: jest.fn(async () => dashboard),
 
-        addVersion: jest.fn(async () => dashboard),
+    addVersion: jest.fn(async () => dashboard),
 
-        getOrphanedCharts: jest.fn(async () => []),
-    },
+    getOrphanedCharts: jest.fn(async () => []),
+};
 
-    spaceModel: {
-        getFullSpace: jest.fn(async () => publicSpace),
-        getSpaceSummary: jest.fn(async () => publicSpace),
-        getFirstAccessibleSpace: jest.fn(async () => space),
-        getUserSpaceAccess: jest.fn(async () => []),
-    },
-    analyticsModel: {
-        addDashboardViewEvent: jest.fn(async () => null),
-    },
-    pinnedListModel: {},
-    schedulerModel: {},
-    savedChartModel: {
-        get: jest.fn(async () => chart),
-        delete: jest.fn(async () => ({
-            uuid: 'chart_uuid',
-            projectUuid: 'project_uuid',
-        })),
-    },
-}));
+const spaceModel = {
+    getFullSpace: jest.fn(async () => publicSpace),
+    getSpaceSummary: jest.fn(async () => publicSpace),
+    getFirstAccessibleSpace: jest.fn(async () => space),
+    getUserSpaceAccess: jest.fn(async () => []),
+};
+const analyticsModel = {
+    addDashboardViewEvent: jest.fn(async () => null),
+};
+const savedChartModel = {
+    get: jest.fn(async () => chart),
+    delete: jest.fn(async () => ({
+        uuid: 'chart_uuid',
+        projectUuid: 'project_uuid',
+    })),
+};
 
 jest.spyOn(analyticsMock, 'track');
 describe('DashboardService', () => {
@@ -80,12 +74,12 @@ describe('DashboardService', () => {
     const { uuid: dashboardUuid } = dashboard;
     const service = new DashboardService({
         analytics: analyticsMock,
-        dashboardModel,
-        spaceModel,
-        analyticsModel,
-        pinnedListModel,
-        schedulerModel,
-        savedChartModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        analyticsModel: analyticsModel as unknown as AnalyticsModel,
+        pinnedListModel: {} as PinnedListModel,
+        schedulerModel: {} as SchedulerModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
         slackClient: {} as SlackClient,
         schedulerClient: {} as SchedulerClient,
     });

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -1,6 +1,6 @@
 import { LightdashInstallType, LightdashMode } from '@lightdash/common';
 import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
-import { organizationModel } from '../../models/models';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { HealthService } from './HealthService';
 import { BaseResponse, Config } from './HealthService.mock';
 
@@ -8,11 +8,9 @@ jest.mock('../../version', () => ({
     VERSION: '0.1.0',
 }));
 
-jest.mock('../../models/models', () => ({
-    organizationModel: {
-        hasOrgs: jest.fn(async () => true),
-    },
-}));
+const organizationModel = {
+    hasOrgs: jest.fn(async () => true),
+};
 jest.mock('../../clients/DockerHub/DockerHub', () => ({
     getDockerHubVersion: jest.fn(() => '0.2.7'),
 }));
@@ -26,7 +24,7 @@ jest.mock('../../database/database', () => ({
 
 describe('health', () => {
     const healthService = new HealthService({
-        organizationModel,
+        organizationModel: organizationModel as unknown as OrganizationModel,
         lightdashConfig: Config,
     });
 
@@ -62,7 +60,8 @@ describe('health', () => {
     });
     it('Should return localDbtEnabled false when in cloud beta mode', async () => {
         const service = new HealthService({
-            organizationModel,
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
             lightdashConfig: {
                 ...Config,
                 mode: LightdashMode.CLOUD_BETA,

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -1,41 +1,37 @@
 import { LightdashInstallType } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
-import {
-    groupsModel,
-    inviteLinkModel,
-    onboardingModel,
-    organizationAllowedEmailDomainsModel,
-    organizationMemberProfileModel,
-    organizationModel,
-    projectModel,
-    userModel,
-} from '../../models/models';
+import { GroupsModel } from '../../models/GroupsModel';
+import { InviteLinkModel } from '../../models/InviteLinkModel';
+import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { UserModel } from '../../models/UserModel';
 import { OrganizationService } from './OrganizationService';
 import { organization, user } from './OrganizationService.mock';
 
-jest.mock('../../models/models', () => ({
-    projectModel: {
-        hasProjects: jest.fn(async () => true),
-    },
-    organizationModel: {
-        get: jest.fn(async () => organization),
-    },
-    organizationAllowedEmailDomainsModel: {},
-    groupsModel: {},
-}));
+const projectModel = {
+    hasProjects: jest.fn(async () => true),
+};
+const organizationModel = {
+    get: jest.fn(async () => organization),
+};
+
 describe('organization service', () => {
     const organizationService = new OrganizationService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
-        organizationModel,
-        projectModel,
-        onboardingModel,
-        inviteLinkModel,
-        organizationMemberProfileModel,
-        userModel,
-        organizationAllowedEmailDomainsModel,
-        groupsModel,
+        organizationModel: organizationModel as unknown as OrganizationModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        onboardingModel: {} as OnboardingModel,
+        inviteLinkModel: {} as InviteLinkModel,
+        organizationMemberProfileModel: {} as OrganizationMemberProfileModel,
+        userModel: {} as UserModel,
+        organizationAllowedEmailDomainsModel:
+            {} as OrganizationAllowedEmailDomainsModel,
+        groupsModel: {} as GroupsModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -9,18 +9,16 @@ import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
-import {
-    analyticsModel,
-    dashboardModel,
-    jobModel,
-    onboardingModel,
-    projectModel,
-    savedChartModel,
-    spaceModel,
-    sshKeyPairModel,
-    userAttributesModel,
-    userWarehouseCredentialsModel,
-} from '../../models/models';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { JobModel } from '../../models/JobModel/JobModel';
+import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SshKeyPairModel } from '../../models/SshKeyPairModel';
+import { UserAttributesModel } from '../../models/UserAttributesModel';
+import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { METRIC_QUERY, warehouseClientMock } from '../../queryBuilder.mock';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { ProjectService } from './ProjectService';
@@ -48,67 +46,63 @@ import {
     validExplore,
 } from './ProjectService.mock';
 
-jest.mock('../../models/models', () => ({
-    projectModel: {
-        getWithSensitiveFields: jest.fn(async () => projectWithSensitiveFields),
-        get: jest.fn(async () => projectWithSensitiveFields),
-        getSummary: jest.fn(async () => projectSummary),
-        getTablesConfiguration: jest.fn(async () => tablesConfiguration),
-        updateTablesConfiguration: jest.fn(),
-        getExploresFromCache: jest.fn(async () => allExplores),
-        getExploreFromCache: jest.fn(async () => validExplore),
-        lockProcess: jest.fn((projectUuid, fun) => fun()),
-        getWarehouseCredentialsForProject: jest.fn(
-            async () => warehouseClientMock.credentials,
-        ),
-        getWarehouseClientFromCredentials: jest.fn(() => ({
-            ...warehouseClientMock,
-            runQuery: jest.fn(async () => resultsWith1Row),
-        })),
-    },
-    onboardingModel: {
-        getByOrganizationUuid: jest.fn(async () => ({
-            ranQueryAt: new Date(),
-            shownSuccessAt: new Date(),
-        })),
-    },
-    savedChartModel: {
-        getAllSpaces: jest.fn(async () => spacesWithSavedCharts),
-    },
-    jobModel: {
-        get: jest.fn(async () => job),
-    },
-    spaceModel: {
-        getAllSpaces: jest.fn(async () => spacesWithSavedCharts),
-    },
-    sshKeyPairModel: {},
-    userAttributesModel: {
-        getAttributeValuesForOrgMember: jest.fn(async () => ({})),
-    },
-    analyticsModel: {},
-    dashboardModel: {},
-    userWarehouseCredentialsModel: {},
-}));
+const projectModel = {
+    getWithSensitiveFields: jest.fn(async () => projectWithSensitiveFields),
+    get: jest.fn(async () => projectWithSensitiveFields),
+    getSummary: jest.fn(async () => projectSummary),
+    getTablesConfiguration: jest.fn(async () => tablesConfiguration),
+    updateTablesConfiguration: jest.fn(),
+    getExploresFromCache: jest.fn(async () => allExplores),
+    getExploreFromCache: jest.fn(async () => validExplore),
+    lockProcess: jest.fn((projectUuid, fun) => fun()),
+    getWarehouseCredentialsForProject: jest.fn(
+        async () => warehouseClientMock.credentials,
+    ),
+    getWarehouseClientFromCredentials: jest.fn(() => ({
+        ...warehouseClientMock,
+        runQuery: jest.fn(async () => resultsWith1Row),
+    })),
+};
+const onboardingModel = {
+    getByOrganizationUuid: jest.fn(async () => ({
+        ranQueryAt: new Date(),
+        shownSuccessAt: new Date(),
+    })),
+};
+const savedChartModel = {
+    getAllSpaces: jest.fn(async () => spacesWithSavedCharts),
+};
+const jobModel = {
+    get: jest.fn(async () => job),
+};
+const spaceModel = {
+    getAllSpaces: jest.fn(async () => spacesWithSavedCharts),
+};
+
+const userAttributesModel = {
+    getAttributeValuesForOrgMember: jest.fn(async () => ({})),
+};
 
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
     const service = new ProjectService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
-        projectModel,
-        onboardingModel,
-        savedChartModel,
-        jobModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        onboardingModel: onboardingModel as unknown as OnboardingModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        jobModel: jobModel as unknown as JobModel,
         emailClient: new EmailClient({
             lightdashConfig: lightdashConfigWithNoSMTP,
         }),
-        spaceModel,
-        sshKeyPairModel,
-        userAttributesModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        sshKeyPairModel: {} as SshKeyPairModel,
+        userAttributesModel:
+            userAttributesModel as unknown as UserAttributesModel,
         s3CacheClient: {} as S3CacheClient,
-        analyticsModel,
-        dashboardModel,
-        userWarehouseCredentialsModel,
+        analyticsModel: {} as AnalyticsModel,
+        dashboardModel: {} as DashboardModel,
+        userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
         schedulerClient: {} as SchedulerClient,
     });
     afterEach(() => {

--- a/packages/backend/src/services/ShareService/ShareService.test.ts
+++ b/packages/backend/src/services/ShareService/ShareService.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
-import { shareModel } from '../../models/models';
+import { ShareModel } from '../../models/ShareModel';
 import { ShareService } from './ShareService';
 import {
     Config,
@@ -12,17 +12,15 @@ import {
     UserFromAnotherOrg,
 } from './ShareService.mock';
 
-jest.mock('../../models/models', () => ({
-    shareModel: {
-        createSharedUrl: jest.fn(async () => SampleShareUrl),
-        getSharedUrl: jest.fn(async () => SampleShareUrl),
-    },
-}));
+const shareModel = {
+    createSharedUrl: jest.fn(async () => SampleShareUrl),
+    getSharedUrl: jest.fn(async () => SampleShareUrl),
+};
 
 describe('share', () => {
     const shareService = new ShareService({
         analytics: analyticsMock,
-        shareModel,
+        shareModel: shareModel as unknown as ShareModel,
         lightdashConfig: Config,
     });
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -1,50 +1,45 @@
 import { OpenIdIdentityIssuerType } from '@lightdash/common';
-import {
-    emailModel,
-    groupsModel,
-    inviteLinkModel,
-    openIdIdentityModel,
-    organizationAllowedEmailDomainsModel,
-    organizationMemberProfileModel,
-    organizationModel,
-    passwordResetLinkModel,
-    personalAccessTokenModel,
-    sessionModel,
-    userModel,
-    userWarehouseCredentialsModel,
-} from '../models/models';
-
 import { analyticsMock } from '../analytics/LightdashAnalytics.mock';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import { LightdashConfig } from '../config/parseConfig';
+import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
+import { EmailModel } from '../models/EmailModel';
+import { GroupsModel } from '../models/GroupsModel';
+import { InviteLinkModel } from '../models/InviteLinkModel';
+import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
+import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
+import { OrganizationMemberProfileModel } from '../models/OrganizationMemberProfileModel';
+import { OrganizationModel } from '../models/OrganizationModel';
+import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
+import { SessionModel } from '../models/SessionModel';
+import { UserModel } from '../models/UserModel';
+import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { UserService } from './UserService';
 
 jest.mock('../database/database', () => ({}));
 
-jest.mock('../models/models', () => ({
-    userModel: {
-        getOpenIdIssuer: jest.fn(async () => undefined),
-    },
-}));
-
+const userModel = {
+    getOpenIdIssuer: jest.fn(async () => undefined),
+};
 const createUserService = (lightdashConfig: LightdashConfig) =>
     new UserService({
         analytics: analyticsMock,
         lightdashConfig,
-        inviteLinkModel,
-        userModel,
-        groupsModel,
-        sessionModel,
-        emailModel,
-        openIdIdentityModel,
-        passwordResetLinkModel,
+        inviteLinkModel: {} as InviteLinkModel,
+        userModel: userModel as unknown as UserModel,
+        groupsModel: {} as GroupsModel,
+        sessionModel: {} as SessionModel,
+        emailModel: {} as EmailModel,
+        openIdIdentityModel: {} as OpenIdIdentityModel,
+        passwordResetLinkModel: {} as PasswordResetLinkModel,
         emailClient: {} as EmailClient,
-        organizationMemberProfileModel,
-        organizationModel,
-        personalAccessTokenModel,
-        organizationAllowedEmailDomainsModel,
-        userWarehouseCredentialsModel,
+        organizationMemberProfileModel: {} as OrganizationMemberProfileModel,
+        organizationModel: {} as OrganizationModel,
+        personalAccessTokenModel: {} as PersonalAccessTokenModel,
+        organizationAllowedEmailDomainsModel:
+            {} as OrganizationAllowedEmailDomainsModel,
+        userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
     });
 
 jest.spyOn(analyticsMock, 'track');

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -1,13 +1,10 @@
 import { TableSelectionType } from '@lightdash/common';
-import {
-    dashboardModel,
-    projectModel,
-    savedChartModel,
-    spaceModel,
-    validationModel,
-} from '../../models/models';
-
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { ValidationService } from './ValidationService';
 import {
@@ -24,35 +21,33 @@ import {
     tableConfiguration,
 } from './ValidationService.mock';
 
-jest.mock('../../models/models', () => ({
-    savedChartModel: {
-        find: jest.fn(async () => [{}]),
-        get: jest.fn(async () => chart),
-    },
-    projectModel: {
-        getExploresFromCache: jest.fn(async () => [explore]),
-        get: jest.fn(async () => project),
-        getTablesConfiguration: jest.fn(async () => tableConfiguration),
-    },
-    validationModel: {
-        delete: jest.fn(async () => {}),
-        create: jest.fn(async () => {}),
-    },
-    dashboardModel: {
-        getAllByProject: jest.fn(async () => [{}]),
-        getById: jest.fn(async () => dashboard),
-    },
-}));
+const savedChartModel = {
+    find: jest.fn(async () => [{}]),
+    get: jest.fn(async () => chart),
+};
+const projectModel = {
+    getExploresFromCache: jest.fn(async () => [explore]),
+    get: jest.fn(async () => project),
+    getTablesConfiguration: jest.fn(async () => tableConfiguration),
+};
+const validationModel = {
+    delete: jest.fn(async () => {}),
+    create: jest.fn(async () => {}),
+};
+const dashboardModel = {
+    getAllByProject: jest.fn(async () => [{}]),
+    getById: jest.fn(async () => dashboard),
+};
 
 describe('validation', () => {
     const validationService = new ValidationService({
         analytics: analyticsMock,
-        validationModel,
-        projectModel,
-        savedChartModel,
-        dashboardModel,
+        validationModel: validationModel as unknown as ValidationModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
         lightdashConfig: config,
-        spaceModel,
+        spaceModel: {} as SpaceModel,
         schedulerClient: {} as SchedulerClient,
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Stop importing from `models/models.ts`as we are moving the models initialization to the App class.

The only import I haven't moved in this PR is in `slackRouter` as I need to create a new service. 

Changes:
- refactored controllers/routes to use the user service instead of the user model
- create model instances inside seed files
- create model instance inside the 'overrideUserPassword.ts' script
- amended test mocks 

Following PRs:
- refactor `slackRouter` to use a service instead of a model
- move model initialization to App class

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
