### PR TITLE
chore: poc common modal component

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal.tsx
@@ -7,10 +7,8 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
-    Button,
     Group,
     Input,
-    Modal,
     Select,
     Stack,
     Text,
@@ -30,6 +28,7 @@ import {
     useSpaceSummaries,
 } from '../../../hooks/useSpaces';
 import MantineIcon from '../MantineIcon';
+import CommonModal from './Modal';
 
 interface ChartCreateModalProps {
     savedData: CreateSavedChartVersion;
@@ -177,24 +176,26 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     if (isLoadingSpaces || !spaces) return null;
 
     return (
-        <Modal
+        <CommonModal
             opened={isOpen}
             onClose={onClose}
             keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
-                    <Text fw={600}>
-                        {fromDashboard
-                            ? `Save chart to ${fromDashboard}`
-                            : 'Save chart'}
-                    </Text>
-                </Group>
+            leftTitleIcon={
+                <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
             }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
-                body: { padding: 0 },
-            })}
+            title={
+                fromDashboard ? `Save chart to ${fromDashboard}` : 'Save chart'
+            }
+            confirmButtonProps={{
+                type: 'submit',
+                disabled:
+                    isCreating ||
+                    isCreatingSpace ||
+                    !form.values.name ||
+                    (!fromDashboard &&
+                        showSpaceInput &&
+                        !form.values.newSpaceName),
+            }}
         >
             <form
                 onSubmit={form.onSubmit((values) => {
@@ -272,36 +273,8 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                         </Stack>
                     )}
                 </Stack>
-
-                <Group
-                    position="right"
-                    w="100%"
-                    sx={(theme) => ({
-                        borderTop: `1px solid ${theme.colors.gray[4]}`,
-                        bottom: 0,
-                        padding: theme.spacing.md,
-                    })}
-                >
-                    <Button onClick={onClose} variant="outline">
-                        Cancel
-                    </Button>
-
-                    <Button
-                        type="submit"
-                        disabled={
-                            isCreating ||
-                            isCreatingSpace ||
-                            !form.values.name ||
-                            (!fromDashboard &&
-                                showSpaceInput &&
-                                !form.values.newSpaceName)
-                        }
-                    >
-                        Save
-                    </Button>
-                </Group>
             </form>
-        </Modal>
+        </CommonModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -1,15 +1,4 @@
-import {
-    Alert,
-    Anchor,
-    Button,
-    Group,
-    List,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Alert, Anchor, List, Text, type ModalProps } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router-dom';
@@ -19,6 +8,7 @@ import {
     useSavedQueryDeleteMutation,
 } from '../../../hooks/useSavedQuery';
 import MantineIcon from '../MantineIcon';
+import CommonModal, { Intent } from './Modal';
 
 interface ChartDeleteModalProps extends ModalProps {
     uuid: string;
@@ -54,64 +44,50 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
     };
 
     return (
-        <Modal title={<Title order={4}>Delete Chart</Title>} {...modalProps}>
-            <Stack spacing="lg" pt="sm">
-                <Text>
-                    Are you sure you want to delete the chart{' '}
-                    <Text span fw={600}>
-                        "{chart.name}"
-                    </Text>
-                    ?
+        <CommonModal
+            title="Delete Chart"
+            intent={Intent.DELETE}
+            onConfirm={handleConfirm}
+            isLoading={isDeleting}
+            {...modalProps}
+        >
+            <Text>
+                Are you sure you want to delete the chart{' '}
+                <Text span fw={600}>
+                    "{chart.name}"
                 </Text>
+                ?
+            </Text>
 
-                {relatedDashboards.length > 0 && (
-                    <>
-                        <Alert
-                            icon={<MantineIcon icon={IconAlertCircle} />}
-                            title={
-                                <Text fw={600}>
-                                    This action will remove a chart tile from{' '}
-                                    {relatedDashboards.length} dashboard
-                                    {relatedDashboards.length > 1 ? 's' : ''}:
-                                </Text>
-                            }
-                        >
-                            <List fz="sm">
-                                {relatedDashboards.map((dashboard) => (
-                                    <List.Item key={dashboard.uuid}>
-                                        <Anchor
-                                            component={Link}
-                                            target="_blank"
-                                            to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}
-                                        >
-                                            {dashboard.name}
-                                        </Anchor>
-                                    </List.Item>
-                                ))}
-                            </List>
-                        </Alert>
-                    </>
-                )}
-
-                <Group position="right" mt="sm">
-                    <Button
-                        color="dark"
-                        variant="outline"
-                        onClick={modalProps.onClose}
+            {relatedDashboards.length > 0 && (
+                <>
+                    <Alert
+                        icon={<MantineIcon icon={IconAlertCircle} />}
+                        title={
+                            <Text fw={600}>
+                                This action will remove a chart tile from{' '}
+                                {relatedDashboards.length} dashboard
+                                {relatedDashboards.length > 1 ? 's' : ''}:
+                            </Text>
+                        }
                     >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        loading={isDeleting}
-                        color="red"
-                        onClick={handleConfirm}
-                    >
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+                        <List fz="sm">
+                            {relatedDashboards.map((dashboard) => (
+                                <List.Item key={dashboard.uuid}>
+                                    <Anchor
+                                        component={Link}
+                                        target="_blank"
+                                        to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}
+                                    >
+                                        {dashboard.name}
+                                    </Anchor>
+                                </List.Item>
+                            ))}
+                        </List>
+                    </Alert>
+                </>
+            )}
+        </CommonModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -1,21 +1,11 @@
 import { hasChartsInDashboard, isChartTile } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    List,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
-import { IconTrash } from '@tabler/icons-react';
+import { List, Stack, Text, type ModalProps } from '@mantine/core';
 import { type FC } from 'react';
 import {
     useDashboardDeleteMutation,
     useDashboardQuery,
 } from '../../../hooks/dashboard/useDashboard';
-import MantineIcon from '../MantineIcon';
+import CommonModal, { Intent } from './Modal';
 
 interface DashboardDeleteModalProps extends ModalProps {
     uuid: string;
@@ -45,66 +35,43 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
     );
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconTrash} color="red" size="lg" />
-                    <Title order={4}>Delete dashboard</Title>
-                </Group>
-            }
+        <CommonModal
+            title="Delete dashboard"
+            intent={Intent.DELETE}
+            confirmButtonProps={{
+                onClick: handleConfirm,
+                loading: isDeleting,
+            }}
             {...modalProps}
         >
-            <Stack>
-                {hasChartsInDashboard(dashboard) ? (
-                    <Stack>
-                        <Text>
-                            Are you sure you want to delete the dashboard{' '}
-                            <b>"{dashboard.name}"</b>?
-                        </Text>
-                        <Text>
-                            This action will also permanently delete the
-                            following charts that were created from within it:
-                        </Text>
-                        <List size="sm">
-                            {chartsInDashboardTiles.map(
-                                (tile) =>
-                                    isChartTile(tile) && (
-                                        <List.Item key={tile.uuid}>
-                                            <Text>
-                                                {tile.properties.chartName}
-                                            </Text>
-                                        </List.Item>
-                                    ),
-                            )}
-                        </List>
-                    </Stack>
-                ) : (
+            {hasChartsInDashboard(dashboard) ? (
+                <Stack>
                     <Text>
                         Are you sure you want to delete the dashboard{' '}
                         <b>"{dashboard.name}"</b>?
                     </Text>
-                )}
-
-                <Group position="right" spacing="xs">
-                    <Button
-                        color="dark"
-                        variant="outline"
-                        onClick={modalProps.onClose}
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        color="red"
-                        loading={isDeleting}
-                        onClick={handleConfirm}
-                        type="submit"
-                    >
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+                    <Text>
+                        This action will also permanently delete the following
+                        charts that were created from within it:
+                    </Text>
+                    <List size="sm">
+                        {chartsInDashboardTiles.map(
+                            (tile) =>
+                                isChartTile(tile) && (
+                                    <List.Item key={tile.uuid}>
+                                        <Text>{tile.properties.chartName}</Text>
+                                    </List.Item>
+                                ),
+                        )}
+                    </List>
+                </Stack>
+            ) : (
+                <Text>
+                    Are you sure you want to delete the dashboard{' '}
+                    <b>"{dashboard.name}"</b>?
+                </Text>
+            )}
+        </CommonModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/Modal.tsx
+++ b/packages/frontend/src/components/common/modal/Modal.tsx
@@ -1,0 +1,118 @@
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Title,
+    type ButtonProps,
+    type ModalProps,
+} from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import React, { type FC, type ReactNode } from 'react';
+import MantineIcon from '../MantineIcon';
+
+export enum Intent {
+    INFO = 'info',
+    DELETE = 'delete',
+}
+
+interface CommonModalProps extends ModalProps {
+    title: ReactNode;
+    leftTitleIcon?: ReactNode;
+    intent?: Intent;
+    onConfirm?: () => void;
+    confirmText?: string;
+    confirmButtonProps?: ButtonProps &
+        React.ButtonHTMLAttributes<HTMLButtonElement>;
+    children?: ReactNode;
+}
+
+const CommonModal: FC<CommonModalProps> = ({
+    size = 'lg',
+    title,
+    leftTitleIcon,
+    intent = Intent.INFO,
+    onConfirm,
+    confirmButtonProps = {},
+    confirmText = 'Confirm',
+    opened,
+    onClose,
+    children,
+}) => {
+    const isDeleteIntent = intent === 'delete';
+
+    return (
+        <>
+            <Modal.Root
+                size={size}
+                opened={opened}
+                onClose={onClose}
+                withinPortal
+                styles={(theme) => ({
+                    header: {
+                        borderBottom: `1px solid ${theme.colors.gray[3]}`,
+                    },
+                    body: { padding: 0 },
+                })}
+            >
+                <Modal.Overlay />
+                <Modal.Content>
+                    <Modal.Header>
+                        <Modal.Title>
+                            <Group spacing="xs">
+                                {isDeleteIntent && (
+                                    <MantineIcon
+                                        icon={IconTrash}
+                                        color="red"
+                                        size="lg"
+                                    />
+                                )}
+                                {leftTitleIcon}
+                                <Title order={4}>{title}</Title>
+                            </Group>
+                        </Modal.Title>
+                        <Modal.CloseButton />
+                    </Modal.Header>
+                    <Modal.Body>
+                        <Stack spacing="lg" p="md" pb="xl">
+                            {children}
+                        </Stack>
+                        <Group
+                            position="right"
+                            sx={(theme) => ({
+                                borderTop: `1px solid ${theme.colors.gray[3]}`,
+                                bottom: 0,
+                                padding: theme.spacing.sm,
+                            })}
+                        >
+                            <Button
+                                color="dark"
+                                variant="outline"
+                                size="xs"
+                                onClick={onClose}
+                            >
+                                Cancel
+                            </Button>
+                            {isDeleteIntent && (
+                                <Button
+                                    color="red"
+                                    size="xs"
+                                    onClick={onConfirm}
+                                >
+                                    Delete
+                                </Button>
+                            )}
+                            {!isDeleteIntent && (
+                                <Button size="xs" {...confirmButtonProps}>
+                                    {confirmText}
+                                </Button>
+                            )}
+                        </Group>
+                    </Modal.Body>
+                </Modal.Content>
+            </Modal.Root>
+        </>
+    );
+};
+
+export default CommonModal;


### PR DESCRIPTION
### Description:

After trying out Mantine's `Modals Manager`: #9433 , this code creates, instead, a common Modal component. 

This is what I considered: 
- have full control of Mantine's Modal component using the compound components approach: https://v6.mantine.dev/core/modal/#compound-components
- have an enum of `intents`, rendering different elements depending on its value
- Share styles across different intents (borders, sizing of title, paddings)

This PR has examples of: 
 - delete chart modal
 - delete dashboard modal
 - create chart 
For example, these 2 delete modals didn't share the same `Title` template: one had the icon, another one didn't.

Considerations after this: 
- I can see it being easy to migrate other modals
- Thought about overriding the Mantine's theme to apply different styles depending on a `variant`, but we might not want this applied globally
- With everything common, what is the _ideal_ prop configuration? 
- What intents do we have? `delete`, `info`, `alert`?


Screenshots:
<img width="400" alt="Screenshot 2024-03-18 at 16 51 27" src="https://github.com/lightdash/lightdash/assets/7611706/36c11c4f-1d40-4b22-aba2-2adc9142d0ca">
<img width="400" alt="Screenshot 2024-03-18 at 16 51 41" src="https://github.com/lightdash/lightdash/assets/7611706/3a830be0-ec3d-48f5-8819-82e0d67c1b32">
<img width="400" alt="Screenshot 2024-03-18 at 16 51 17" src="https://github.com/lightdash/lightdash/assets/7611706/25463748-1114-4c8d-b1ac-2d24f058265b">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
