### PR TITLE
fix: allow schema in profiles.yml for bigquery

### DIFF
--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -113,6 +113,6 @@ export const convertBigquerySchema = async (
     );
 
     throw new ParseError(
-        `Couldn't read profiles.yml file for ${target.type}:\n  ${errs}`,
+        `Couldn't read profiles.yml file for ${target.type}:\n${errs}`,
     );
 };

--- a/packages/cli/src/dbt/targets/snowflake.ts
+++ b/packages/cli/src/dbt/targets/snowflake.ts
@@ -4,6 +4,7 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 import { JSONSchemaType } from 'ajv';
+import betterAjvErrors from 'better-ajv-errors';
 import { promises as fs } from 'fs';
 import { ajv } from '../../ajv';
 import { Target } from '../types';
@@ -131,10 +132,14 @@ export const convertSnowflakeSchema = async (
             queryTag: target.query_tag,
         };
     }
-    const lineErrorMessages = (validate.errors || [])
-        .map((err) => `Field at ${err.instancePath} ${err.message}`)
-        .join('\n');
+
+    const errs = betterAjvErrors(
+        snowflakeSchema,
+        target,
+        validate.errors || [],
+    );
+
     throw new ParseError(
-        `Couldn't read profiles.yml file for ${target.type}:\n  ${lineErrorMessages}`,
+        `Couldn't read profiles.yml file for ${target.type}:\n${errs}`,
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9427

### Description:

- Allows `bigquery` profiles to have `schema` instead of `dataset` for CLI by passing it as `dataset` in `convertBigquerySchema`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
