### PR TITLE
chore: add support for local/repo dangerfile checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ venv/
 dbt_modules/
 logs/
 /.envrc
+
+# dangerfile
+dangerfile.development.ts


### PR DESCRIPTION
Follow-up to: #9428 

### Description:
- Allows for repo or local dangerfiles just by creating `dangerfile.repo.ts` or `dangerfile.development.ts` files in the root of the repo.
- `dangerfile.development.ts` is excluded via `.gitignore`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
