### PR TITLE
chore: fix race condition in dashboard test

### DIFF
--- a/packages/e2e/cypress/e2e/api/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/api/dashboard.cy.ts
@@ -21,6 +21,7 @@ const chartMock: CreateSavedChart = {
     name: 'chart in dashboard',
     tableName: 'orders',
     metricQuery: {
+        exploreName: 'orders',
         dimensions: ['orders_customer_id'],
         metrics: [],
         filters: {},
@@ -163,24 +164,22 @@ describe('Lightdash dashboard', () => {
                     },
                 ).then(({ chart: newChart2, dashboard: updatedDashboard2 }) => {
                     expect(updatedDashboard2.tiles.length).to.eq(2);
-                    const firstTile = updatedDashboard2
-                        .tiles[0] as DashboardChartTile;
-                    const secondTile = updatedDashboard2
-                        .tiles[1] as DashboardChartTile;
-
-                    expect(
-                        firstTile.properties.savedChartUuid,
-                        "Check if first tile didn't change",
-                    ).to.eq(newChart.uuid);
-                    // assert second tile is correct
-                    expect(
-                        secondTile.properties.savedChartUuid,
-                        'Check if second tile is correct',
-                    ).to.eq(newChart2.uuid);
-                    expect(
-                        secondTile.properties.belongsToDashboard,
-                        'Check if second tile belongs to a dashboard',
-                    ).to.eq(true);
+                    const firstTile = updatedDashboard2.tiles.find(
+                        ({ properties }: DashboardChartTile) =>
+                            properties.savedChartUuid === newChart.uuid &&
+                            properties.belongsToDashboard,
+                    );
+                    const secondTile = updatedDashboard2.tiles.find(
+                        ({ properties }: DashboardChartTile) =>
+                            properties.savedChartUuid === newChart2.uuid &&
+                            properties.belongsToDashboard,
+                    );
+                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                    expect(firstTile, "Check if first tile didn't change").to
+                        .not.be.undefined;
+                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                    expect(secondTile, 'Check if second tile is correct').to.not
+                        .be.undefined;
                 });
             });
         });
@@ -198,9 +197,20 @@ describe('Lightdash dashboard', () => {
 
             cy.request(`${apiUrl}/dashboards/${dashboard.uuid}`).then(
                 (dashboardResponse) => {
+                    const tileWithChartInDashboard =
+                        dashboardResponse.body.results.tiles.find(
+                            (tile: DashboardChartTile) =>
+                                tile.properties.belongsToDashboard,
+                        );
+
+                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                    expect(
+                        tileWithChartInDashboard,
+                        'Check dashboard has chart that belongs to dashboard',
+                    ).to.not.be.undefined;
+
                     const chartInDashboard =
-                        dashboardResponse.body.results.tiles[0].properties
-                            .savedChartUuid;
+                        tileWithChartInDashboard.properties.savedChartUuid;
 
                     cy.request<{ results: SavedChart }>({
                         method: 'PATCH',
@@ -239,9 +249,19 @@ describe('Lightdash dashboard', () => {
 
             cy.request(`${apiUrl}/dashboards/${dashboard.uuid}`).then(
                 (dashboardResponse) => {
+                    const tileWithChartInDashboard =
+                        dashboardResponse.body.results.tiles.find(
+                            (tile: DashboardChartTile) =>
+                                tile.properties.belongsToDashboard,
+                        );
+                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                    expect(
+                        tileWithChartInDashboard,
+                        'Check dashboard has chart that belongs to dashboard',
+                    ).to.not.be.undefined;
+
                     const chartInDashboard =
-                        dashboardResponse.body.results.tiles[0].properties
-                            .savedChartUuid;
+                        tileWithChartInDashboard.properties.savedChartUuid;
 
                     cy.request<ApiChartSummaryListResponse>(
                         `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

These tests sometimes fail because we save all the dashboard tiles in parallel so we shouldn't rely on the order of the tiles array. 

Updated the test to find the correct tile instead.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
