### PR TITLE
fix: display label and if so remove time interval

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -6,6 +6,7 @@ models:
         description: ""
         meta:
           dimension:
+            label: 'Timestamp (with timezone)'
             type: timestamp
             time_intervals:
               - RAW

--- a/packages/common/src/index.mock.ts
+++ b/packages/common/src/index.mock.ts
@@ -12,7 +12,7 @@ export const dateDayDimension: Dimension = {
     type: DimensionType.DATE,
     timeInterval: TimeFrames.DAY,
     name: 'date',
-    label: 'date',
+    label: 'date day',
     table: 'table',
     tableLabel: 'tableLabel',
     sql: 'sql',
@@ -21,12 +21,20 @@ export const dateDayDimension: Dimension = {
 export const dateMonthDimension: Dimension = {
     ...dateDayDimension,
     timeInterval: TimeFrames.MONTH,
+    label: 'date month',
 };
 
 export const dateYearDimension: Dimension = {
     ...dateDayDimension,
     timeInterval: TimeFrames.YEAR,
+    label: 'date year',
 };
+
+export const dateDayDimensionWithGroup: Dimension = {
+    ...dateDayDimension,
+    group: 'date group',
+};
+
 export const emptyValueFilter: FilterRule = {
     id: '1234',
     target: { fieldId: 'table.date' },

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,7 +1,12 @@
 import moment from 'moment';
-import { getFilterRuleWithDefaultValue, getPasswordSchema } from '.';
+import {
+    getDateGroupLabel,
+    getFilterRuleWithDefaultValue,
+    getPasswordSchema,
+} from '.';
 import {
     dateDayDimension,
+    dateDayDimensionWithGroup,
     dateMonthDimension,
     dateYearDimension,
     emptyValueFilter,
@@ -139,5 +144,35 @@ describe('Password Validation', () => {
                 );
             }
         });
+    });
+});
+
+describe('getDateGroupLabel', () => {
+    test('returns undefined if not a date dimension', () => {
+        expect(getDateGroupLabel(stringDimension)).toBeUndefined();
+    });
+
+    test('returns undefined if no group', () => {
+        expect(getDateGroupLabel(dateDayDimension)).toBeUndefined();
+    });
+
+    test('removes time interval from end of label', () => {
+        expect(getDateGroupLabel(dateDayDimensionWithGroup)).toEqual('date');
+
+        expect(
+            getDateGroupLabel({
+                ...dateDayDimensionWithGroup,
+                label: 'month dayday month date year day',
+            }),
+        ).toEqual('month dayday month date year'); // only replaces time frame at the end of string
+    });
+
+    test('returns friendly label if it cant recognise time interval', () => {
+        expect(
+            getDateGroupLabel({
+                ...dateDayDimensionWithGroup,
+                label: 'day date (day)',
+            }),
+        ).toEqual('Day date day'); // doesn't recognize (day) as a valid time frame
     });
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -113,6 +113,7 @@ import {
 import { type UserWarehouseCredentials } from './types/userWarehouseCredentials';
 import { type ValidationResponse } from './types/validation';
 
+import { TimeFrames } from './types/timeFrames';
 import { convertAdditionalMetric } from './utils/additionalMetrics';
 import { getFields } from './utils/fields';
 import { formatItemValue } from './utils/formatting';
@@ -770,9 +771,23 @@ export const getDateGroupLabel = (axisItem: ItemsMap[string]) => {
     if (
         isDimension(axisItem) &&
         [DimensionType.DATE, DimensionType.TIMESTAMP].includes(axisItem.type) &&
-        axisItem.group
-    )
-        return friendlyName(axisItem.group);
+        axisItem.group &&
+        axisItem.label &&
+        axisItem.timeInterval
+    ) {
+        const timeFrame =
+            TimeFrames[axisItem.timeInterval]?.toLowerCase() || '';
+
+        if (timeFrame && axisItem.label.endsWith(` ${timeFrame}`)) {
+            // Remove the time frame from the end of the label - e.g. from 'Order created day' to 'Order created'.
+            return getItemLabelWithoutTableName(axisItem).replace(
+                new RegExp(`\\s+${timeFrame}$`),
+                '',
+            );
+        }
+
+        return friendlyName(axisItem.label);
+    }
 
     return undefined;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9298 

### Description:

After this: https://github.com/lightdash/lightdash/issues/8094, we've removed the `date granularity` from the date group labels on the x axis, but we don't respect the `label` set on the yml.

This PR uses proposal 2, which originally was: 
`Use date label only (e.g. Order created) - and if no label specified, then just generate the friendly name` in https://github.com/lightdash/lightdash/issues/9298#issuecomment-2003813784. 

What this PR does is: 
- if it's in a `group`, then check its `timeInterval`, and display the `label` without the `time interval`
- if the `time interval` - for any reason - is invalid, then use the friendly name


I'm open to suggestions on doing this differently... 

This is an example `axisItem`:

```json
{
    "sql": "DATE_TRUNC('DAY', ${TABLE}.timestamp_tz)",
    "name": "timestamp_tz_day",
    "type": "date",
    "group": "timestamp_tz",
    "index": 0,
    "label": "Timestamp (with timezone) day",
    "table": "events",
    "hidden": false,
    "fieldType": "dimension",
    "tableLabel": "Events",
    "compiledSql": "DATE_TRUNC('DAY', \"events\".timestamp_tz)",
    "description": "",
    "timeInterval": "DAY",
    "tablesReferences": [
        "events"
    ]
}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-cli test-frontend test-backend