### PR TITLE
fix: add icloud to email provider list

### DIFF
--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -58,6 +58,7 @@ const EMAIL_PROVIDER_LIST = [
     'yahoo.co.jp',
     'sky.com',
     'blueyonder.co.uk',
+    'icloud.com',
 ];
 
 const isEmailProviderDomain = (domain: string): boolean =>


### PR DESCRIPTION
Closes: 

### Description:

I was just testing account invite/signup flow and noticed that icloud is not in the common email domains list.

![CleanShot 2024-03-19 at 22 32 09@2x](https://github.com/lightdash/lightdash/assets/962095/862eee7a-1939-464c-8957-72b8815ffd89)

that list is not ideal and I hope new auth flow fixes the issue associated with "claiming a brand domain name" problem

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
