### PR TITLE
chore: only run dangerjs on the pull_request event

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -20,6 +20,9 @@ jobs:
             - name: Install packages
               run: yarn install --frozen-lockfile
             - name: Run dangerjs
+              # Ensure the dangerjs check only runs on pull requests, while allowing
+              # us to reuse the remainder of the setup for this workflow:
+              if: github.event_name == 'pull_request'
               run: yarn danger ci --use-github-checks
               env:
                   GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}


### PR DESCRIPTION
### Description:

Allows the dangerjs check to reuse the harness setup for `test-and-build`, while only executing on the `pull_request` github trigger event.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
