### PR TITLE
fix: flaky e2e profile test

### DIFF
--- a/packages/e2e/cypress/e2e/app/settings/profile.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/profile.cy.ts
@@ -22,20 +22,26 @@ describe('Settings - Profile', () => {
         cy.visit('/');
         cy.findByTestId('user-avatar').click();
         cy.findByRole('menuitem', { name: 'User settings' }).click();
-        cy.get('[data-cy="first-name-input"]').should(
-            'have.value',
-            SEED_ORG_1_ADMIN.first_name,
-        ); // wait for form to populate
-        cy.get('[data-cy="first-name-input"]').focus().clear();
-        cy.get('[data-cy="first-name-input"]').should('be.empty');
-        cy.get('[data-cy="first-name-input"]').type('Kevin');
-        cy.get('[data-cy="last-name-input"]').focus().clear();
-        cy.get('[data-cy="last-name-input"]').should('be.empty');
-        cy.get('[data-cy="last-name-input"]').type('Space');
-        cy.get('[data-cy="update-profile-settings"]').click();
+
+        cy.findByPlaceholderText('First name')
+            .should('not.be.disabled')
+            .should('have.value', SEED_ORG_1_ADMIN.first_name);
+        cy.findByPlaceholderText('Last name')
+            .should('not.be.disabled')
+            .should('have.value', SEED_ORG_1_ADMIN.last_name);
+        cy.findByPlaceholderText('Email')
+            .should('not.be.disabled')
+            .should('have.value', SEED_ORG_1_ADMIN_EMAIL.email);
+
+        cy.findByPlaceholderText('First name').clear().type('Kevin');
+        cy.findByPlaceholderText('Last name').clear().type('Space');
+
+        cy.findByRole('button', { name: 'Update' }).click();
+
         cy.findByText('Success! User details were updated.').should(
             'be.visible',
         );
+
         cy.visit('/');
         cy.findByTestId('user-avatar').should('contain', 'KS');
     });

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -107,29 +107,24 @@ const ProfilePanel: FC = () => {
         <form onSubmit={handleOnSubmit}>
             <Stack mt="md">
                 <TextInput
-                    id="first-name-input"
                     placeholder="First name"
                     label="First name"
                     type="text"
                     required
                     disabled={isLoadingUser || isUpdatingUser}
-                    data-cy="first-name-input"
                     {...form.getInputProps('firstName')}
                 />
 
                 <TextInput
-                    id="last-name-input"
                     placeholder="Last name"
                     label="Last name"
                     type="text"
                     required
                     disabled={isLoadingUser || isUpdatingUser}
-                    data-cy="last-name-input"
                     {...form.getInputProps('lastName')}
                 />
 
                 <TextInput
-                    id="email-input"
                     placeholder="Email"
                     label="Email"
                     type="email"
@@ -142,7 +137,6 @@ const ProfilePanel: FC = () => {
                         'description',
                     ]}
                     {...form.getInputProps('email')}
-                    data-cy="email-input"
                     rightSection={
                         isEmailServerConfigured && data?.isVerified ? (
                             <Tooltip label="This e-mail has been verified">
@@ -192,7 +186,6 @@ const ProfilePanel: FC = () => {
                         type="submit"
                         display="block"
                         loading={isLoadingUser || isUpdatingUser}
-                        data-cy="update-profile-settings"
                         disabled={!form.isDirty()}
                     >
                         Update

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -32,22 +32,17 @@ type FormValues = z.infer<typeof validationSchema>;
 
 const ProfilePanel: FC = () => {
     const {
-        user: { data: userData, isInitialLoading: isLoadingUser },
+        user: { data: userData, isLoading: isLoadingUser },
         health,
     } = useApp();
     const { showToastSuccess, showToastError } = useToaster();
 
     const form = useForm<FormValues>({
-        initialValues: {
-            firstName: '',
-            lastName: '',
-            email: '',
-        },
         validate: zodResolver(validationSchema),
     });
 
     useEffect(() => {
-        if (isLoadingUser || !userData) return;
+        if (!userData) return;
 
         const initialValues = {
             firstName: userData.firstName,
@@ -55,11 +50,15 @@ const ProfilePanel: FC = () => {
             email: userData.email,
         };
 
-        form.setInitialValues(initialValues);
-        form.setValues(initialValues);
+        if (form.initialized) {
+            form.setInitialValues(initialValues);
+            form.setValues(initialValues);
+        } else {
+            form.initialize(initialValues);
+        }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isLoadingUser, userData]);
+    }, [userData]);
 
     const isEmailServerConfigured = health.data?.hasEmailClient;
     const { data, isInitialLoading: statusLoading } = useEmailStatus();
@@ -103,6 +102,8 @@ const ProfilePanel: FC = () => {
         updateUser(formValues);
     });
 
+    const isLoading = isLoadingUser || isUpdatingUser || !form.initialized;
+
     return (
         <form onSubmit={handleOnSubmit}>
             <Stack mt="md">
@@ -111,8 +112,9 @@ const ProfilePanel: FC = () => {
                     label="First name"
                     type="text"
                     required
-                    disabled={isLoadingUser || isUpdatingUser}
+                    disabled={isLoading}
                     {...form.getInputProps('firstName')}
+                    value={form.values.firstName ?? ''}
                 />
 
                 <TextInput
@@ -120,8 +122,9 @@ const ProfilePanel: FC = () => {
                     label="Last name"
                     type="text"
                     required
-                    disabled={isLoadingUser || isUpdatingUser}
+                    disabled={isLoading}
                     {...form.getInputProps('lastName')}
+                    value={form.values.lastName ?? ''}
                 />
 
                 <TextInput
@@ -129,7 +132,7 @@ const ProfilePanel: FC = () => {
                     label="Email"
                     type="email"
                     required
-                    disabled={isLoadingUser || isUpdatingUser}
+                    disabled={isLoading}
                     inputWrapperOrder={[
                         'label',
                         'input',
@@ -137,6 +140,7 @@ const ProfilePanel: FC = () => {
                         'description',
                     ]}
                     {...form.getInputProps('email')}
+                    value={form.values.email ?? ''}
                     rightSection={
                         isEmailServerConfigured && data?.isVerified ? (
                             <Tooltip label="This e-mail has been verified">
@@ -185,7 +189,7 @@ const ProfilePanel: FC = () => {
                     <Button
                         type="submit"
                         display="block"
-                        loading={isLoadingUser || isUpdatingUser}
+                        loading={isLoading}
                         disabled={!form.isDirty()}
                     >
                         Update


### PR DESCRIPTION
### Description:

this is something I observed recently and confirmed flakyness locally...

main changes are:
- tests waits for the input boxes to be enabled - they are in disabled state when loading the data
- how form handles setting and resetting default (initial) form state

other changes are cosmetic and using some of the [best practices from cypress 
](https://docs.cypress.io/guides/references/best-practices)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
