### PR TITLE
fix: improve behavior when ordering non-grouped series, cleanup temporary color assignment code 

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -194,12 +194,17 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
         }
     }, [resultsData?.metricQuery, columnOrder]);
 
+    /**
+     * Build a local set of fallback colors, used when dealing with ungrouped series.
+     *
+     * Colors are pre-calculated per-series, and re-calculated when series change.
+     */
     const fallbackColors = useMemo<Record<string, string>>(() => {
         if (!chartConfig?.config || chartConfig.type !== ChartType.CARTESIAN) {
             return {};
         }
 
-        const entries = Object.fromEntries(
+        return Object.fromEntries(
             (chartConfig.config.eChartsConfig.series ?? []).map((series, i) => {
                 return [
                     calculateSeriesLikeIdentifier(series).join('|'),
@@ -207,10 +212,6 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
                 ];
             }),
         );
-
-        console.log(entries);
-
-        return entries;
     }, [chartConfig, colorPalette]);
 
     const handleChartConfigChange = useCallback(
@@ -256,6 +257,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
             return isGroupedSeries(seriesLike)
                 ? calculateSeriesColorAssignment(seriesLike)
                 : fallbackColors[
+                      // Note: we don't use getSeriesId since we may not be dealing with a Series type here
                       calculateSeriesLikeIdentifier(seriesLike).join('|')
                   ];
         },

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -20,19 +20,12 @@ type BasicSeriesConfigurationProps = {
     item: Field | TableCalculation | CustomDimension;
     updateSingleSeries: (series: Series) => void;
     dragHandleProps?: DraggableProvidedDragHandleProps | null;
-
-    /**
-     * Temporary - we need to keep track of the series' index to assign a fallback color
-     * if shared colors are not enabled.
-     */
-    seriesIndex: number;
 };
 
 const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
     isSingle,
     layout,
     series,
-    seriesIndex,
     item,
     updateSingleSeries,
     dragHandleProps,
@@ -55,7 +48,6 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                 layout={layout}
                 series={series}
                 isSingle={isSingle}
-                seriesIndex={seriesIndex}
                 seriesLabel={getItemLabelWithoutTableName(item)}
                 updateSingleSeries={updateSingleSeries}
             />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -134,9 +134,9 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     const onDragEnd = useCallback(
         (result: DropResult) => {
             const allSerieIds = series.map(getSeriesId);
-            const seriesWithColor: Series[] = series.map((s, i) => ({
+            const seriesWithColor: Series[] = series.map((s) => ({
                 ...s,
-                color: getSeriesColor(s, i),
+                color: getSeriesColor(s),
             }));
             const serie = seriesWithColor.find(
                 (s) => getSeriesId(s) === result.draggableId,
@@ -378,7 +378,6 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                                                 dragHandleProps={
                                                                     groupedDragHandleProps
                                                                 }
-                                                                seriesIndex={i}
                                                                 isCollapsable
                                                                 layout={layout}
                                                                 series={

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -35,7 +35,6 @@ import {
 import { IconGripVertical } from '@tabler/icons-react';
 import { createPortal } from 'react-dom';
 import MantineIcon from '../../../common/MantineIcon';
-import { useVisualizationContext } from '../../../LightdashVisualization/VisualizationProvider';
 
 const VALUE_LABELS_OPTIONS = [
     { value: 'hidden', label: 'Hidden' },
@@ -108,7 +107,6 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     updateSeries,
     series,
 }) => {
-    const { getSeriesColor } = useVisualizationContext();
     const [openSeriesId, setOpenSeriesId] = React.useState<
         string | undefined
     >();
@@ -134,11 +132,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     const onDragEnd = useCallback(
         (result: DropResult) => {
             const allSerieIds = series.map(getSeriesId);
-            const seriesWithColor: Series[] = series.map((s) => ({
-                ...s,
-                color: getSeriesColor(s),
-            }));
-            const serie = seriesWithColor.find(
+            const serie = series.find(
                 (s) => getSeriesId(s) === result.draggableId,
             );
             if (!serie) return;
@@ -154,14 +148,14 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                     ? allSerieIds.indexOf(getSeriesId(previousGroupedItem))
                     : 0;
 
-            const sortedSeries = seriesWithColor.filter(
+            const sortedSeries = series.filter(
                 (s) => getSeriesId(s) !== result.draggableId,
             );
             sortedSeries.splice(destinationIndex, 0, serie);
 
             updateSeries(sortedSeries);
         },
-        [series, seriesGroup, updateSeries, getSeriesColor],
+        [series, seriesGroup, updateSeries],
     );
 
     return (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -37,7 +37,6 @@ type Props = {
     isOpen?: boolean;
     toggleIsOpen?: () => void;
     dragHandleProps?: DraggableProvidedDragHandleProps | null;
-    seriesIndex: number;
 };
 
 const SingleSeriesConfiguration: FC<Props> = ({
@@ -51,7 +50,6 @@ const SingleSeriesConfiguration: FC<Props> = ({
     isOpen,
     toggleIsOpen,
     dragHandleProps,
-    seriesIndex,
 }) => {
     const { colorPalette, getSeriesColor } = useVisualizationContext();
     const type =
@@ -89,7 +87,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                     </Box>
                 )}
                 <ColorSelector
-                    color={getSeriesColor(series, seriesIndex)}
+                    color={getSeriesColor(series)}
                     swatches={colorPalette}
                     onColorChange={(color) => {
                         updateSingleSeries({

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -78,9 +78,9 @@ const SeriesTab: FC<Props> = ({ items }) => {
             const reorderedSeries = reorderedSeriesGroups.reduce<Series[]>(
                 (acc, seriesGroup) => [
                     ...acc,
-                    ...seriesGroup.value.map((s, i) => ({
+                    ...seriesGroup.value.map((s) => ({
                         ...s,
-                        color: getSeriesColor(s, i),
+                        color: getSeriesColor(s),
                     })),
                 ],
                 [],
@@ -182,7 +182,6 @@ const SeriesTab: FC<Props> = ({ items }) => {
                                                     <BasicSeriesConfiguration
                                                         item={field}
                                                         layout={dirtyLayout}
-                                                        seriesIndex={i}
                                                         isSingle={
                                                             seriesGroupedByField.length <=
                                                             1

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -298,6 +298,26 @@ const useCartesianChartConfig = ({
     }, []);
 
     const removeSingleSeries = useCallback((index: number) => {
+        setDirtyEchartsConfig((prev) => {
+            /**
+             * Clean up any color data assigned to this series, to prevent confusing
+             * behaviors around reordering and deleting/re-adding series.
+             */
+            if (prev?.series && prev.series[index]) {
+                const newSeries = [...prev.series];
+                newSeries[index] = {
+                    ...newSeries[index],
+                    color: undefined,
+                };
+
+                return {
+                    ...prev,
+                    series: newSeries,
+                };
+            }
+
+            return prev;
+        });
         setDirtyLayout((prev) => ({
             ...prev,
             yField: prev?.yField

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1405,8 +1405,8 @@ const useEchartsCartesianConfig = (
     const stackedSeriesWithColorAssignments = useMemo(() => {
         if (!itemsMap) return;
 
-        const seriesWithValidStack = series.map<EChartSeries>((serie, i) => {
-            const color = getSeriesColor(serie, i);
+        const seriesWithValidStack = series.map<EChartSeries>((serie) => {
+            const color = getSeriesColor(serie);
 
             return {
                 ...serie,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1406,11 +1406,9 @@ const useEchartsCartesianConfig = (
         if (!itemsMap) return;
 
         const seriesWithValidStack = series.map<EChartSeries>((serie) => {
-            const color = getSeriesColor(serie);
-
             return {
                 ...serie,
-                color,
+                color: getSeriesColor(serie),
                 stack: getValidStack(serie),
             };
         });

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -105,11 +105,32 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
     const pivotValuesSubPath =
         yPivotValues && yPivotValues.length > 0 ? `${yPivotValues[0]}` : null;
 
+    /**
+     * When dealing with flipped axis, Echarts will include the pivot value as
+     * part of the field identifier - we want to remove it for the purposes of
+     * color mapping if that's the case, so that we continue to have a mapping
+     * that looks like:
+     *
+     *  basefield->pivot_value
+     *
+     * instead of:
+     *
+     *  basefield.pivot_value -> pivot_value
+     *
+     * (which would be a grouping of 1 per pivot value, causing all values to
+     * be assigned the first color)
+     */
+    const baseFieldPathParts = baseField.split('.');
+    const baseFieldPath =
+        pivotValuesSubPath && baseFieldPathParts.at(-1) === pivotValuesSubPath
+            ? baseFieldPathParts.slice(0, -1).join('.')
+            : baseField;
+
     const completeIdentifier = pivotValuesSubPath
         ? pivotValuesSubPath
-        : baseField;
+        : baseFieldPath;
 
-    return [baseField, completeIdentifier];
+    return [baseFieldPath, completeIdentifier];
 };
 
 export const useChartColorConfig = ({

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -178,23 +178,11 @@ export const useChartColorConfig = ({
     );
 
     const calculateSeriesColorAssignment = useCallback(
-        (
-            series: SeriesLike,
-            options: {
-                groupPrefix?: string;
-            } = {},
-        ) => {
+        (series: SeriesLike) => {
             const [baseField, completeIdentifier] =
                 calculateSeriesLikeIdentifier(series);
 
-            return calculateKeyColorAssignment(
-                /**
-                 * If no group prefix is specified, we treat the base field as the group.
-                 * This allows overriding colors are grouped across different contexts.
-                 */
-                options.groupPrefix ?? baseField,
-                completeIdentifier,
-            );
+            return calculateKeyColorAssignment(baseField, completeIdentifier);
         },
         [calculateKeyColorAssignment],
     );


### PR DESCRIPTION
### Description:

- Cleans up temporary code introduced during the color mapping changes
- Makes color fallback behavior more reliable, and fixes some edge cases around sorting, removing and re-adding series.

Note that this change is not directly related to color mapping (though it uses some of the same code).

- Ensures re-ordering series preserves the "original" color (as well as manually set colors as before)

![Kapture 2024-03-20 at 18 34 25](https://github.com/lightdash/lightdash/assets/382538/deec91de-50ff-4a21-837b-c0a90819dc16)

- Ensures removing and re-adding a series works, and picks up the correct fallback color (this fixes an issue where colors were sticky, and removing a series and re-adding it would re-add it with the old color, which may no longer be in the correct position)

![Kapture 2024-03-20 at 18 36 03](https://github.com/lightdash/lightdash/assets/382538/0ab7e089-0568-48ab-a4db-96717f5e721b)

- Works across different chart types

![Kapture 2024-03-20 at 18 38 08](https://github.com/lightdash/lightdash/assets/382538/ac2c59c9-5d49-4293-acd0-0e5e422ad0c7)



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
