### PR TITLE
feat: use hovercard instead of popover

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -13,8 +13,8 @@ import {
 import {
     Group,
     Highlight,
+    HoverCard,
     NavLink,
-    Popover,
     Text,
     Tooltip,
 } from '@mantine/core';
@@ -149,8 +149,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
             onMouseLeave={() => toggleHover(false)}
             label={
                 <Group noWrap>
-                    <Popover
-                        opened={isHover}
+                    <HoverCard
+                        openDelay={300}
                         keepMounted={false}
                         shadow="sm"
                         withinPortal
@@ -160,7 +160,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         /** Ensures the hover card does not overlap with the right-hand menu. */
                         offset={isFiltered ? 80 : 40}
                     >
-                        <Popover.Target>
+                        <HoverCard.Target>
                             <Highlight
                                 component={Text}
                                 truncate
@@ -169,8 +169,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             >
                                 {label}
                             </Highlight>
-                        </Popover.Target>
-                        <Popover.Dropdown
+                        </HoverCard.Target>
+                        <HoverCard.Dropdown
                             p="xs"
                             /**
                              * Takes up space to the right, so it's OK to go fairly wide in the interest
@@ -191,8 +191,8 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                                     description={description}
                                 />
                             )}
-                        </Popover.Dropdown>
-                    </Popover>
+                        </HoverCard.Dropdown>
+                    </HoverCard>
 
                     {isFiltered ? (
                         <Tooltip withinPortal label="This field is filtered">

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -171,6 +171,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             </Highlight>
                         </HoverCard.Target>
                         <HoverCard.Dropdown
+                            hidden={!isHover}
                             p="xs"
                             /**
                              * Takes up space to the right, so it's OK to go fairly wide in the interest


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9408

### Description:

Uses `HoverCard` instead of Popover and adds a small `openDelay`


https://github.com/lightdash/lightdash/assets/7611706/30ee295b-c41d-4325-a838-8a288a20db66



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
