### PR TITLE
feat: move ctas in view mode saved chart

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -6,15 +6,11 @@ import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import { Can } from '../../common/Authorization';
 import MantineIcon from '../../common/MantineIcon';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
-import ExploreFromHereButton from '../../ExploreFromHereButton';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import SaveChartButton from '../SaveChartButton';
 
 const ExplorerHeader: FC = memo(() => {
-    const isEditMode = useExplorerContext(
-        (context) => context.state.isEditMode,
-    );
     const savedChart = useExplorerContext(
         (context) => context.state.savedChart,
     );
@@ -48,55 +44,46 @@ const ExplorerHeader: FC = memo(() => {
         };
     }, [getHasDashboardChanges]);
 
-    if (isEditMode) {
-        return (
-            <Group position="apart">
-                <Box>
-                    <RefreshDbtButton />
-                </Box>
-
-                <Group spacing="xs">
-                    {showLimitWarning && (
-                        <Tooltip
-                            width={400}
-                            label={`Query limit of ${limit} reached. There may be additional results that have not been displayed. To see more, increase the query limit or try narrowing filters.`}
-                            multiline
-                            position={'bottom'}
-                        >
-                            <Badge
-                                leftSection={
-                                    <MantineIcon
-                                        icon={IconAlertCircle}
-                                        size={'sm'}
-                                    />
-                                }
-                                color="yellow"
-                                variant="outline"
-                                tt="none"
-                                sx={{ cursor: 'help' }}
-                            >
-                                Results may be incomplete
-                            </Badge>
-                        </Tooltip>
-                    )}
-
-                    <RefreshButton size="xs" />
-
-                    {!savedChart && (
-                        <Can I="manage" a="SavedChart">
-                            <SaveChartButton isExplorer />
-                        </Can>
-                    )}
-                    <ShareShortLinkButton disabled={!isValidQuery} />
-                </Group>
-            </Group>
-        );
-    }
-
     return (
-        <Group position="right" spacing="xs">
-            <ExploreFromHereButton />
-            <ShareShortLinkButton disabled={!isValidQuery} />
+        <Group position="apart">
+            <Box>
+                <RefreshDbtButton />
+            </Box>
+
+            <Group spacing="xs">
+                {showLimitWarning && (
+                    <Tooltip
+                        width={400}
+                        label={`Query limit of ${limit} reached. There may be additional results that have not been displayed. To see more, increase the query limit or try narrowing filters.`}
+                        multiline
+                        position={'bottom'}
+                    >
+                        <Badge
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconAlertCircle}
+                                    size={'sm'}
+                                />
+                            }
+                            color="yellow"
+                            variant="outline"
+                            tt="none"
+                            sx={{ cursor: 'help' }}
+                        >
+                            Results may be incomplete
+                        </Badge>
+                    </Tooltip>
+                )}
+
+                <RefreshButton size="xs" />
+
+                {!savedChart && (
+                    <Can I="manage" a="SavedChart">
+                        <SaveChartButton isExplorer />
+                    </Can>
+                )}
+                <ShareShortLinkButton disabled={!isValidQuery} />
+            </Group>
         </Group>
     );
 });

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -468,6 +468,7 @@ const SavedChartsHeader: FC = () => {
                     <PageActionsContainer>
                         {userCanManageChart && (
                             <>
+                                {/* TODO: Extract this into a separate component, depending on the mode: viewing or editing */}
                                 {!isEditMode ? (
                                     <>
                                         <ExploreFromHereButton />
@@ -526,6 +527,7 @@ const SavedChartsHeader: FC = () => {
                                 )}
                             </>
                         )}
+                        {/* TODO: Refactor this into its own component */}
                         <Menu
                             position="bottom"
                             withArrow

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -77,6 +77,8 @@ import SpaceAndDashboardInfo from '../../common/PageHeader/SpaceAndDashboardInfo
 import { UpdatedInfo } from '../../common/PageHeader/UpdatedInfo';
 import ViewInfo from '../../common/PageHeader/ViewInfo';
 import { ResourceInfoPopup } from '../../common/ResourceInfoPopup/ResourceInfoPopup';
+import ShareShortLinkButton from '../../common/ShareShortLinkButton';
+import ExploreFromHereButton from '../../ExploreFromHereButton';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import SaveChartButton from '../SaveChartButton';
 
@@ -178,6 +180,9 @@ const SavedChartsHeader: FC = () => {
 
     const resultsData = useExplorerContext(
         (context) => context.queryResults.data,
+    );
+    const isValidQuery = useExplorerContext(
+        (context) => context.state.isValidQuery,
     );
 
     const itemsMap = useMemo(() => {
@@ -465,6 +470,7 @@ const SavedChartsHeader: FC = () => {
                             <>
                                 {!isEditMode ? (
                                     <>
+                                        <ExploreFromHereButton />
                                         <Button
                                             variant="default"
                                             size="xs"
@@ -481,6 +487,9 @@ const SavedChartsHeader: FC = () => {
                                         >
                                             Edit chart
                                         </Button>
+                                        <ShareShortLinkButton
+                                            disabled={!isValidQuery}
+                                        />
                                     </>
                                 ) : (
                                     <>

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -24,6 +24,9 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const unsavedChartVersionMetricQuery = useExplorerContext(
             (context) => context.state.unsavedChartVersion.metricQuery,
         );
+        const isEditMode = useExplorerContext(
+            (context) => context.state.isEditMode,
+        );
         const { projectUuid } = useParams<{ projectUuid: string }>();
 
         const { data: projects } = useProjects({ refetchOnMount: false });
@@ -41,7 +44,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 explore={explore}
             >
                 <Stack sx={{ flexGrow: 1 }}>
-                    {!hideHeader && <ExplorerHeader />}
+                    {!hideHeader && isEditMode && <ExplorerHeader />}
 
                     <FiltersCard />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9435 

### Description:

Move CTAs to Chart header when on view mode


https://github.com/lightdash/lightdash/assets/7611706/5cbfa9bd-64c6-40f1-8dbb-17ac417777cf



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
