### PR TITLE
feat: let dashboard filter overrides chart filter when its not required

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -141,7 +141,9 @@ export const isAndFilterGroup = (
 export const isFilterGroup = (value: FilterGroupItem): value is FilterGroup =>
     isOrFilterGroup(value) || isAndFilterGroup(value);
 
-export const isFilterRule = (value: ConditionalRule): value is FilterRule =>
+export const isFilterRule = (
+    value: ConditionalRule | FilterGroupItem,
+): value is FilterRule =>
     'id' in value && 'target' in value && 'operator' in value;
 
 export const getFilterRules = (filters: Filters): FilterRule[] => {

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -7,7 +7,7 @@ import {
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Select, Text } from '@mantine/core';
+import { ActionIcon, Box, Menu, Select, Switch, Text } from '@mantine/core';
 import { IconDots, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import FieldSelect from '../FieldSelect';
@@ -140,6 +140,29 @@ const FilterRuleForm: FC<Props> = ({
                     {filterRule.target.fieldId}
                 </Text>
             )}
+
+            <div style={{ display: 'flex', gap: 10 }}>
+                <Text size="sm" color="dimmed">
+                    Required:{' '}
+                </Text>
+                <Switch
+                    disabled={!isEditMode}
+                    checked={filterRule.settings.required}
+                    onLabel="ON"
+                    offLabel="OFF"
+                    size="sm"
+                    labelPosition="left"
+                    onChange={(value) => {
+                        onChange({
+                            ...filterRule,
+                            settings: {
+                                ...filterRule.settings,
+                                required: value.target.checked,
+                            },
+                        });
+                    }}
+                />
+            </div>
 
             {isEditMode &&
                 (!onConvertToGroup ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
https://github.com/lightdash/lightdash/issues/7268
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

let dashboard filter override chart filter when 
1. chart filter is not marked as required
2. chart filter and dashboard filter has same target and operator value

Test:
<img width="1362" alt="Screenshot 2024-03-21 at 15 26 10" src="https://github.com/lightdash/lightdash/assets/101873365/602b4a75-8191-4ec6-be00-c49f82783cfb">
<img width="1365" alt="Screenshot 2024-03-21 at 15 26 36" src="https://github.com/lightdash/lightdash/assets/101873365/aa1fe162-7ae8-4cac-bd1d-91b8ef73989b">
<img width="1364" alt="Screenshot 2024-03-21 at 15 25 48" src="https://github.com/lightdash/lightdash/assets/101873365/5791c254-d605-4f1a-b12d-aa260c129466">



<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
