### PR TITLE
fix: page crash when setting date to invalid value

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -76,12 +76,17 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
     if (isCustomDimension(field)) return <></>;
     if (isDateItem(field)) {
         if (isDimension(field) && field.timeInterval) {
+            // Uses the current date if the provided value is invalid
+            const parsedDate = dayjs(value).isValid()
+                ? dayjs(value).toDate()
+                : new Date();
+
             switch (field.timeInterval.toUpperCase()) {
                 case TimeFrames.WEEK:
                     return (
                         <FilterWeekPicker
                             size="sm"
-                            value={dayjs(value).toDate()}
+                            value={parsedDate}
                             firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                             onChange={(dateValue) => {
                                 if (!dateValue) return;
@@ -100,7 +105,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                     return (
                         <FilterMonthAndYearPicker
                             size="sm"
-                            value={dayjs(value).toDate()}
+                            value={parsedDate}
                             onChange={(dateValue: Date) => {
                                 onChange(
                                     formatDate(
@@ -117,7 +122,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                     return (
                         <FilterYearPicker
                             size="sm"
-                            value={dayjs(value).toDate()}
+                            value={parsedDate}
                             onChange={(dateValue: Date) => {
                                 onChange(
                                     formatDate(
@@ -134,7 +139,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
             return (
                 <FilterDatePicker
                     size="sm"
-                    value={dayjs(value).toDate()}
+                    value={parsedDate}
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     onChange={(newValue) => {
                         onChange(formatDate(newValue, TimeFrames.DAY, false));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9423

### Description:

Checks that a date is valid before passing it to the date inputs in a reference line.

To repro the original bug:
- Add a reference line to a chart with a date axis (eg "How many orders we have over time ?" in jaffle shop)
- Set the value of the reference line to something like 'a' on a field that allows it (date input doesnt)
- Switch to the date field 
- 😢 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
