### PR TITLE
style: reduce export chart results icon size

### DIFF
--- a/packages/frontend/src/components/ChartDownload.tsx
+++ b/packages/frontend/src/components/ChartDownload.tsx
@@ -6,6 +6,7 @@ import {
     type ApiScheduledDownloadCsv,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Button,
     Popover,
     SegmentedControl,
@@ -21,7 +22,7 @@ import useEchartsCartesianConfig from '../hooks/echarts/useEchartsCartesianConfi
 import { useApp } from '../providers/AppProvider';
 import { Can } from './common/Authorization';
 import {
-    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_ACTION_ICON_PROPS,
     COLLAPSABLE_CARD_POPOVER_PROPS,
 } from './common/CollapsableCard';
 import MantineIcon from './common/MantineIcon';
@@ -279,14 +280,13 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                     position="bottom-end"
                 >
                     <Popover.Target>
-                        <Button
+                        <ActionIcon
                             data-testid="export-csv-button"
-                            {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                            {...COLLAPSABLE_CARD_ACTION_ICON_PROPS}
                             disabled={disabled}
-                            px="xs"
                         >
                             <MantineIcon icon={IconShare2} color="gray" />
-                        </Button>
+                        </ActionIcon>
                     </Popover.Target>
 
                     <Popover.Dropdown>
@@ -337,14 +337,13 @@ export const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                 position="bottom-end"
             >
                 <Popover.Target>
-                    <Button
+                    <ActionIcon
                         data-testid="export-csv-button"
-                        {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                        {...COLLAPSABLE_CARD_ACTION_ICON_PROPS}
                         disabled={disabled}
-                        px="xs"
                     >
                         <MantineIcon icon={IconShare2} color="gray" />
-                    </Button>
+                    </ActionIcon>
                 </Popover.Target>
 
                 <Popover.Dropdown>

--- a/packages/frontend/src/components/DownloadSqlCsvButton/index.tsx
+++ b/packages/frontend/src/components/DownloadSqlCsvButton/index.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@mantine/core';
+import { ActionIcon } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
-import { COLLAPSABLE_CARD_BUTTON_PROPS } from '../common/CollapsableCard';
+import { COLLAPSABLE_CARD_ACTION_ICON_PROPS } from '../common/CollapsableCard';
 import MantineIcon from '../common/MantineIcon';
 
 type Props = {
@@ -14,11 +14,10 @@ const DownloadCsvButton: FC<Props> = memo(({ disabled, getCsvLink }) => {
     const { showToastError } = useToaster();
 
     return (
-        <Button
+        <ActionIcon
             data-testid="export-csv-button"
-            {...COLLAPSABLE_CARD_BUTTON_PROPS}
+            {...COLLAPSABLE_CARD_ACTION_ICON_PROPS}
             disabled={disabled}
-            px="xs"
             onClick={() => {
                 getCsvLink()
                     .then((url) => {
@@ -33,7 +32,7 @@ const DownloadCsvButton: FC<Props> = memo(({ disabled, getCsvLink }) => {
             }}
         >
             <MantineIcon icon={IconShare2} color="gray" />
-        </Button>
+        </ActionIcon>
     );
 });
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Button, Popover } from '@mantine/core';
+import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router-dom';
@@ -13,7 +13,7 @@ import {
 import AddColumnButton from '../../AddColumnButton';
 import { Can } from '../../common/Authorization';
 import CollapsableCard, {
-    COLLAPSABLE_CARD_BUTTON_PROPS,
+    COLLAPSABLE_CARD_ACTION_ICON_PROPS,
     COLLAPSABLE_CARD_POPOVER_PROPS,
 } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
@@ -120,17 +120,16 @@ const ResultsCard: FC = memo(() => {
                                 position="bottom-end"
                             >
                                 <Popover.Target>
-                                    <Button
+                                    <ActionIcon
                                         data-testid="export-csv-button"
-                                        {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                                        {...COLLAPSABLE_CARD_ACTION_ICON_PROPS}
                                         disabled={disabled}
-                                        px="xs"
                                     >
                                         <MantineIcon
                                             icon={IconShare2}
                                             color="gray"
                                         />
-                                    </Button>
+                                    </ActionIcon>
                                 </Popover.Target>
 
                                 <Popover.Dropdown>

--- a/packages/frontend/src/components/common/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard.tsx
@@ -6,6 +6,7 @@ import {
     Group,
     Title,
     Tooltip,
+    type ActionIconProps,
     type ButtonProps,
     type PopoverProps,
 } from '@mantine/core';
@@ -16,6 +17,14 @@ import MantineIcon from './MantineIcon';
 export const COLLAPSABLE_CARD_BUTTON_PROPS: Omit<ButtonProps, 'children'> = {
     variant: 'default',
     size: 'xs',
+};
+
+export const COLLAPSABLE_CARD_ACTION_ICON_PROPS: Pick<
+    ActionIconProps,
+    'variant' | 'size'
+> = {
+    ...COLLAPSABLE_CARD_BUTTON_PROPS,
+    size: 'md',
 };
 
 export const COLLAPSABLE_CARD_POPOVER_PROPS: Omit<PopoverProps, 'children'> = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9430 

### Description:

Uses `ActionIcon` and creates a new var for Action Icon props, since the `size` has to be `md`, instead of `xs`.

Before

<img width="1129" alt="Screenshot 2024-03-22 at 09 37 01" src="https://github.com/lightdash/lightdash/assets/7611706/d2f65349-aed2-461a-953d-61b11b560836">


After

<img width="1133" alt="Screenshot 2024-03-22 at 09 37 35" src="https://github.com/lightdash/lightdash/assets/7611706/724db17b-a63a-44ad-81f5-4214ac789ef2">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
