### PR TITLE
fix: ui layout issues with big number comparison label

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -2,6 +2,7 @@ import { ComparisonDiffTypes } from '@lightdash/common';
 import {
     Center,
     Flex,
+    Group,
     Stack,
     Text,
     Tooltip,
@@ -218,39 +219,35 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                     display="inline-flex"
                     wrap="wrap"
                     style={{ flexShrink: 1 }}
-                    mt="lg"
+                    mt={labelFontSize / 2}
                 >
                     <Tooltip withinPortal label={comparisonTooltip}>
-                        <BigNumberText
-                            span
-                            fz={comparisonFontSize}
-                            c={comparisonValueColor}
-                        >
-                            {comparisonValue}
+                        <Group spacing="two" mr={comparisonLabel ? 'xs' : '0'}>
+                            <BigNumberText
+                                span
+                                fz={comparisonFontSize}
+                                c={comparisonValueColor}
+                            >
+                                {comparisonValue}
+                            </BigNumberText>
 
                             {comparisonDiff === ComparisonDiffTypes.POSITIVE ? (
                                 <MantineIcon
                                     icon={IconArrowUpRight}
-                                    size={18}
-                                    style={{
-                                        display: 'inline',
-                                        margin: '0 7px 0 0',
-                                    }}
+                                    display="inline"
+                                    color={comparisonValueColor}
+                                    size={comparisonFontSize}
                                 />
                             ) : comparisonDiff ===
                               ComparisonDiffTypes.NEGATIVE ? (
                                 <MantineIcon
                                     icon={IconArrowDownRight}
-                                    size={18}
-                                    style={{
-                                        display: 'inline',
-                                        margin: '0 7px 0 0',
-                                    }}
+                                    display="inline"
+                                    color={comparisonValueColor}
+                                    size={comparisonFontSize}
                                 />
-                            ) : (
-                                <span style={{ margin: '0 7px 0 0' }} />
-                            )}
-                        </BigNumberText>
+                            ) : null}
+                        </Group>
                     </Tooltip>
 
                     {comparisonLabel ? (


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/9506

### Description:

the only "visual bug" remaining is that there's an extra empty `xs` space after the arrow icon only when the comparison label wraps.

tests with different sizes:

![CleanShot 2024-03-22 at 18 38 19@2x](https://github.com/lightdash/lightdash/assets/962095/65bada1b-45fb-49f2-b72c-0dfad5105432)

![CleanShot 2024-03-22 at 18 41 05@2x](https://github.com/lightdash/lightdash/assets/962095/8c4b7c4c-2487-42c9-b5ab-ec8f215da90e)

![CleanShot 2024-03-22 at 18 44 43@2x](https://github.com/lightdash/lightdash/assets/962095/55086fe3-e668-404a-85ce-db98f0e8cce1)

![CleanShot 2024-03-22 at 18 44 54@2x](https://github.com/lightdash/lightdash/assets/962095/866fdb48-075c-4812-bf5a-880bb5fa86e0)

![CleanShot 2024-03-22 at 18 44 49@2x](https://github.com/lightdash/lightdash/assets/962095/edab40a6-6352-4114-9d6f-d2194cfda125)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
