### PR TITLE
fix: preprocess markdown tile content (backend/frontend)

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -10,8 +10,10 @@ import {
     DashboardTileTypes,
     DashboardUnversionedFields,
     DashboardVersionedFields,
+    HTML_SANITIZE_MARKDOWN_TILE_RULES,
     LightdashUser,
     NotFoundError,
+    sanitizeHtml,
     SavedChart,
     SessionUser,
     UnexpectedServerError,
@@ -169,7 +171,10 @@ export class DashboardModel {
                         dashboard_version_id: versionId.dashboard_version_id,
                         dashboard_tile_uuid: insertedTile.dashboard_tile_uuid,
                         title: tile.properties.title,
-                        content: tile.properties.content,
+                        content: sanitizeHtml(
+                            tile.properties.content,
+                            HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                        ),
                     });
                     break;
                 case DashboardTileTypes.LOOM:

--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -1,4 +1,7 @@
-import { sanitizeHtml } from './sanitizeHtml';
+import {
+    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    sanitizeHtml,
+} from './sanitizeHtml';
 
 describe('sanitizeHtml', () => {
     test('empty input', () => {
@@ -27,6 +30,17 @@ describe('sanitizeHtml', () => {
         expect(
             sanitizeHtml('<a href="https://www.lightdash.com/">Lightdash</a>'),
         ).toEqual('<a href="https://www.lightdash.com/">Lightdash</a>');
+    });
+
+    test('iframe tag with markdown tile rule set', () => {
+        expect(
+            sanitizeHtml(
+                '<iframe src="https://google.com" width=400 height="300"></iframe>',
+                HTML_SANITIZE_MARKDOWN_TILE_RULES,
+            ),
+        ).toEqual(
+            '<iframe src="https://google.com" width="400" height="300"></iframe>',
+        );
     });
 
     test('style tag in span is preserved', () => {

--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -32,7 +32,7 @@ describe('sanitizeHtml', () => {
         ).toEqual('<a href="https://www.lightdash.com/">Lightdash</a>');
     });
 
-    test('iframe tag with markdown tile rule set', () => {
+    test('markdown tile rule set', () => {
         expect(
             sanitizeHtml(
                 '<iframe src="https://google.com" width=400 height="300"></iframe>',
@@ -41,6 +41,20 @@ describe('sanitizeHtml', () => {
         ).toEqual(
             '<iframe src="https://google.com" width="400" height="300"></iframe>',
         );
+
+        expect(
+            sanitizeHtml(
+                '<img src="https://google.com" width=400 height="300" />',
+                HTML_SANITIZE_MARKDOWN_TILE_RULES,
+            ),
+        ).toEqual('<img src="https://google.com" width="400" height="300" />');
+
+        expect(
+            sanitizeHtml(
+                '<style>body { content: "hello this is ur bank"; }</style>',
+                HTML_SANITIZE_MARKDOWN_TILE_RULES,
+            ),
+        ).toEqual('');
     });
 
     test('style tag in span is preserved', () => {

--- a/packages/common/src/utils/sanitizeHtml.ts
+++ b/packages/common/src/utils/sanitizeHtml.ts
@@ -20,10 +20,15 @@ export const HTML_SANITIZE_DEFAULT_RULES: sanitize.IOptions = {
  */
 export const HTML_SANITIZE_MARKDOWN_TILE_RULES: sanitize.IOptions = {
     ...HTML_SANITIZE_DEFAULT_RULES,
-    allowedTags: [...(HTML_SANITIZE_DEFAULT_RULES.allowedTags || []), 'iframe'],
+    allowedTags: [
+        ...(HTML_SANITIZE_DEFAULT_RULES.allowedTags || []),
+        'iframe',
+        'img',
+    ],
     allowedAttributes: {
         ...HTML_SANITIZE_DEFAULT_RULES.allowedAttributes,
         iframe: ['width', 'height', 'src', 'name'],
+        img: ['src', 'width', 'height', 'alt', 'style'],
     },
 };
 

--- a/packages/common/src/utils/sanitizeHtml.ts
+++ b/packages/common/src/utils/sanitizeHtml.ts
@@ -4,7 +4,7 @@ import sanitize from 'sanitize-html';
  * If you want to modify sanitization settings, be sure to merge them
  * with the sane defaults pre-included with sanitize-html.
  */
-const HTML_SANITIZE_OPTIONS: sanitize.IOptions = {
+export const HTML_SANITIZE_DEFAULT_RULES: sanitize.IOptions = {
     ...sanitize.defaults,
 
     allowedAttributes: {
@@ -14,5 +14,20 @@ const HTML_SANITIZE_OPTIONS: sanitize.IOptions = {
     },
 };
 
-export const sanitizeHtml = (input: string): string =>
-    sanitize(input, HTML_SANITIZE_OPTIONS);
+/**
+ * Adjusted html sanitization rules for markdown tiles, mainly to
+ * allow iframes to be used.
+ */
+export const HTML_SANITIZE_MARKDOWN_TILE_RULES: sanitize.IOptions = {
+    ...HTML_SANITIZE_DEFAULT_RULES,
+    allowedTags: [...(HTML_SANITIZE_DEFAULT_RULES.allowedTags || []), 'iframe'],
+    allowedAttributes: {
+        ...HTML_SANITIZE_DEFAULT_RULES.allowedAttributes,
+        iframe: ['width', 'height', 'src', 'name'],
+    },
+};
+
+export const sanitizeHtml = (
+    input: string,
+    ruleSet: sanitize.IOptions = HTML_SANITIZE_DEFAULT_RULES,
+): string => sanitize(input, ruleSet);

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -12,6 +12,9 @@ interface MarkdownTileFormProps {
     form: UseFormReturnType<DashboardMarkdownTileProperties['properties']>;
 }
 
+/**
+ * Helper that can be used as a value transformer with Mantine's `useForm` hook.
+ */
 export const markdownTileContentTransform = (
     values: DashboardMarkdownTile['properties'],
 ) => ({

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -1,4 +1,9 @@
-import { type DashboardMarkdownTileProperties } from '@lightdash/common';
+import {
+    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    sanitizeHtml,
+    type DashboardMarkdownTile,
+    type DashboardMarkdownTileProperties,
+} from '@lightdash/common';
 import { Stack, TextInput } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import MDEditor from '@uiw/react-md-editor';
@@ -6,6 +11,13 @@ import MDEditor from '@uiw/react-md-editor';
 interface MarkdownTileFormProps {
     form: UseFormReturnType<DashboardMarkdownTileProperties['properties']>;
 }
+
+export const markdownTileContentTransform = (
+    values: DashboardMarkdownTile['properties'],
+) => ({
+    ...values,
+    content: sanitizeHtml(values.content, HTML_SANITIZE_MARKDOWN_TILE_RULES),
+});
 
 const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => (
     <Stack spacing="md">

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
@@ -4,6 +4,7 @@ import {
     defaultTileSize,
     type Dashboard,
     type DashboardLoomTileProperties,
+    type DashboardMarkdownTile,
     type DashboardMarkdownTileProperties,
 } from '@lightdash/common';
 import {
@@ -20,7 +21,9 @@ import { useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import MantineIcon from '../../common/MantineIcon';
 import LoomTileForm, { getLoomId } from './LoomTileForm';
-import MarkdownTileForm from './MarkdownTileForm';
+import MarkdownTileForm, {
+    markdownTileContentTransform,
+} from './MarkdownTileForm';
 
 type Tile = Dashboard['tiles'][number];
 type TileProperties = Tile['properties'];
@@ -54,6 +57,15 @@ export const TileAddModal: FC<AddProps> = ({
     const form = useForm<TileProperties>({
         validate: getValidators(),
         validateInputOnChange: ['title', 'url', 'content'],
+        transformValues(values) {
+            if (type === DashboardTileTypes.MARKDOWN) {
+                return markdownTileContentTransform(
+                    values as DashboardMarkdownTile['properties'],
+                );
+            }
+
+            return values;
+        },
     });
 
     if (!type) return null;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -3,6 +3,7 @@ import {
     DashboardTileTypes,
     type Dashboard,
     type DashboardLoomTileProperties,
+    type DashboardMarkdownTile,
     type DashboardMarkdownTileProperties,
 } from '@lightdash/common';
 import {
@@ -18,7 +19,9 @@ import { IconMarkdown, IconVideo } from '@tabler/icons-react';
 import produce from 'immer';
 import MantineIcon from '../../common/MantineIcon';
 import LoomTileForm, { getLoomId } from './LoomTileForm';
-import MarkdownTileForm from './MarkdownTileForm';
+import MarkdownTileForm, {
+    markdownTileContentTransform,
+} from './MarkdownTileForm';
 
 type Tile = Dashboard['tiles'][number];
 type TileProperties = Tile['properties'];
@@ -53,6 +56,15 @@ const TileUpdateModal = <T extends Tile>({
         initialValues: { ...tile.properties },
         validate: getValidators(),
         validateInputOnChange: ['title', 'url'],
+        transformValues(values) {
+            if (tile.type === DashboardTileTypes.MARKDOWN) {
+                return markdownTileContentTransform(
+                    values as DashboardMarkdownTile['properties'],
+                );
+            }
+
+            return values;
+        },
     });
 
     const handleConfirm = form.onSubmit(({ ...properties }) => {


### PR DESCRIPTION
### Description:

- Extends `sanitizeHtml` to support a ruleset as an argument
- Adds a new ruleset specifically for markdown tiles (which supports iframes and a subset of attributes)
- Updates the dashboards router (backend) and the tile forms (frontend) to pre-process input

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
