### PR TITLE
fix: bignumber context menu position

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { IconArrowDownRight, IconArrowUpRight } from '@tabler/icons-react';
 import clamp from 'lodash/clamp';
-import { useMemo, type FC, type HTMLAttributes } from 'react';
+import { forwardRef, useMemo, type FC, type HTMLAttributes } from 'react';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import MantineIcon from '../common/MantineIcon';
 import { TILE_HEADER_HEIGHT } from '../DashboardTiles/TileBase/TileBase.styles';
@@ -63,22 +63,25 @@ const calculateFontSize = (
     return fontSize;
 };
 
-const BigNumberText: FC<TextProps> = ({ children, ...textProps }) => {
-    return (
-        <Text
-            c="dark.4"
-            align="center"
-            fw={500}
-            {...textProps}
-            style={{
-                transition: 'font-size 0.1s ease-in-out',
-                ...textProps.style,
-            }}
-        >
-            {children}
-        </Text>
-    );
-};
+const BigNumberText: FC<TextProps> = forwardRef<HTMLDivElement, TextProps>(
+    ({ children, ...textProps }, ref) => {
+        return (
+            <Text
+                ref={ref}
+                c="dark.4"
+                align="center"
+                fw={500}
+                {...textProps}
+                style={{
+                    transition: 'font-size 0.1s ease-in-out',
+                    ...textProps.style,
+                }}
+            >
+                {children}
+            </Text>
+        );
+    },
+);
 
 const SimpleStatistic: FC<SimpleStatisticsProps> = ({
     minimal = false,


### PR DESCRIPTION
Closes: #9516 

### Description:

before:

![image](https://github.com/lightdash/lightdash/assets/962095/8883d31a-caa2-492f-b16a-d3c170ad9d60)

after:
![CleanShot 2024-03-25 at 19 51 52@2x](https://github.com/lightdash/lightdash/assets/962095/f4b948a2-642b-4f00-8792-32e87b349e4e)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
