### PR TITLE
fix: show explore from here button to interactive viewers

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -324,6 +324,14 @@ const SavedChartsHeader: FC = () => {
         savedChart &&
         user.data?.ability?.can('manage', subject('SavedChart', savedChart));
 
+    const userCanManageExplore = user.data?.ability.can(
+        'manage',
+        subject('Explore', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid: savedChart?.projectUuid,
+        }),
+    );
+
     const userCanCreateDeliveriesAndAlerts = user.data?.ability?.can(
         'create',
         subject('ScheduledDeliveries', {
@@ -467,14 +475,18 @@ const SavedChartsHeader: FC = () => {
                     )}
                 </PageTitleAndDetailsContainer>
 
-                {(userCanManageChart || userCanCreateDeliveriesAndAlerts) && (
+                {(userCanManageChart ||
+                    userCanCreateDeliveriesAndAlerts ||
+                    userCanManageExplore) && (
                     <PageActionsContainer>
+                        {userCanManageExplore && !isEditMode && (
+                            <ExploreFromHereButton />
+                        )}
                         {userCanManageChart && (
                             <>
                                 {/* TODO: Extract this into a separate component, depending on the mode: viewing or editing */}
                                 {!isEditMode ? (
                                     <>
-                                        <ExploreFromHereButton />
                                         <Button
                                             variant="default"
                                             size="xs"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9549 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Show "explore from here" button to interactive viewers.

Before:

<img width="1573" alt="Screenshot 2024-03-27 at 15 08 25" src="https://github.com/lightdash/lightdash/assets/9117144/52445b53-c312-453e-82c5-3e268f7d2af6">

After:
<img width="1224" alt="Screenshot 2024-03-27 at 16 27 57" src="https://github.com/lightdash/lightdash/assets/9117144/169ddebe-53a1-4ce6-b57f-886ae0a9b2da">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
