### PR TITLE
fix: space admins can update other space admins access

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -283,16 +283,30 @@ export const ShareSpaceUserList: FC<ShareSpaceUserListProps> = ({
                 unshareSpaceMutation(sharedUser.userUuid);
             } else {
                 if (
-                    sharedUser.inheritedRole === 'member' ||
-                    sharedUser.inheritedRole === 'viewer'
+                    sharedUser.inheritedRole === ProjectMemberRole.ADMIN &&
+                    userAccessOption !== UserAccessAction.ADMIN
                 ) {
+                    showToastError({
+                        title: `Failed to update user access`,
+                        subtitle: `An admin can not be a space ${userAccessOption}`,
+                    });
+                    return;
+                }
+
+                if (sharedUser.inheritedRole === ProjectMemberRole.VIEWER) {
                     if (
-                        userAccessOption == 'editor' ||
-                        userAccessOption == 'admin'
+                        userAccessOption === UserAccessAction.EDITOR ||
+                        userAccessOption === UserAccessAction.ADMIN
                     ) {
                         showToastError({
-                            title: `Failed to share space`,
-                            subtitle: `Project ${sharedUser.inheritedRole} can not be a space ${userAccessOption}`,
+                            title: `Failed to update user access`,
+                            subtitle: `A${
+                                sharedUser.inheritedFrom === 'organization'
+                                    ? 'n'
+                                    : ''
+                            } ${sharedUser.inheritedFrom} ${
+                                sharedUser.inheritedRole
+                            } can not be a space ${userAccessOption}`,
                         });
                         return;
                     }

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -207,8 +207,9 @@ const UserAccessList: FC<UserAccessListProps> = ({
                                 </Text>
                             </Group>
                             {isSessionUser ||
-                            sharedUser.inheritedRole ===
-                                ProjectMemberRole.ADMIN ? (
+                            (!sharedUser.hasDirectAccess &&
+                                sharedUser.inheritedRole ===
+                                    ProjectMemberRole.ADMIN) ? (
                                 <Badge
                                     size="xs"
                                     color="gray.6"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9553 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before a space admin could not edit another space admin access.
<img width="617" alt="Screenshot 2024-03-27 at 15 26 34" src="https://github.com/lightdash/lightdash/assets/9117144/5777c13d-7baa-4d18-b7b9-19b403ad20b5">



Now it can

<img width="609" alt="Screenshot 2024-03-27 at 16 38 18" src="https://github.com/lightdash/lightdash/assets/9117144/65310da7-0337-43e9-ac59-4f90270bb1ea">

(inherited admins still can't be changed)
<img width="608" alt="Screenshot 2024-03-27 at 16 39 11" src="https://github.com/lightdash/lightdash/assets/9117144/56366c9c-46af-4432-82c1-609fab39c880">

If we try to edit a org/project admin to another role we should throw an error.

<img width="475" alt="Screenshot 2024-03-27 at 17 28 20" src="https://github.com/lightdash/lightdash/assets/9117144/53e29873-c404-4f3a-9ef7-fb70a43de860">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
