### PR TITLE
fix: can remove all users access from space

### DIFF
--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -274,13 +274,6 @@ export class SpaceService {
             throw new ForbiddenError();
         }
 
-        if (
-            space.access.filter((userUuid) => userUuid !== shareWithUserUuid)
-                .length === 0
-        ) {
-            throw new Error('There must be at least 1 user in this space');
-        }
-
         await this.spaceModel.removeSpaceAccess(spaceUuid, shareWithUserUuid);
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9555 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before we show an error when we try to remove the last user with direct access from a space. Even though there are org/project admins with inherited access.

<img width="690" alt="Screenshot 2024-03-27 at 16 51 16" src="https://github.com/lightdash/lightdash/assets/9117144/b2cd7c7e-70c1-4d0f-bdb1-7ad72eeb42db">



Now we can remove them. We don't need this check as there will always be an org admin with access.

<img width="639" alt="Screenshot 2024-03-27 at 16 49 35" src="https://github.com/lightdash/lightdash/assets/9117144/f58b7af2-8ce1-4a26-a6a1-10168d887f51">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
