### PR TITLE
fix: apply viewport child block display

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -93,7 +93,12 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                 onChange={(e) => setSearch(e.target.value)}
             />
 
-            <ScrollArea variant="primary" offsetScrollbars scrollbarSize={8}>
+            <ScrollArea
+                variant="primary"
+                className="only-vertical"
+                offsetScrollbars
+                scrollbarSize={8}
+            >
                 {tableTrees.length > 0 ? (
                     tableTrees.map((table, index) => (
                         <TableTree

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -114,7 +114,7 @@ export const getMantineThemeOverride = (overrides?: {
                             },
                     },
                     viewport: {
-                        '& > div': {
+                        '.only-vertical & > div': {
                             display: 'block !important', // Only way to override the display value (from `table`) of the Viewport's child element
                         },
                     },

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -113,6 +113,11 @@ export const getMantineThemeOverride = (overrides?: {
                                 ),
                             },
                     },
+                    viewport: {
+                        '& > div': {
+                            display: 'block !important', // Only way to override the display value (from `table`) of the Viewport's child element
+                        },
+                    },
                 }),
             },
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9551

### Description:

Fixed by overriding the `viewport`'s child element `display` value from `table` to `block`. Couldn't find a selector with higher specificity than the inline styling that radix x Mantine apply to the `viewport`'s child

https://github.com/lightdash/lightdash/assets/7611706/05a144cd-f58c-49fb-84cd-799c7e451877



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
