### PR TITLE
fix: add migration to add delete cascade

### DIFF
--- a/packages/backend/src/database/migrations/20240329095412_modify_user_uuid_fk_in_dashboard_tile_comments.ts
+++ b/packages/backend/src/database/migrations/20240329095412_modify_user_uuid_fk_in_dashboard_tile_comments.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+const dashboardTileCommentsTable = 'dashboard_tile_comments';
+const usersTable = 'users';
+const userUuidColumnName = 'user_uuid';
+const constraintName = 'dashboard_tile_comments_user_uuid_foreign';
+
+export async function up(knex: Knex): Promise<void> {
+    // Drop existing
+    await knex.schema.table(dashboardTileCommentsTable, (table) => {
+        table.dropForeign([userUuidColumnName], constraintName);
+    });
+
+    // Re-add foreign key back with on delete cascade
+    await knex.schema.table(dashboardTileCommentsTable, (table) => {
+        table
+            .foreign(userUuidColumnName, constraintName)
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.table(dashboardTileCommentsTable, (table) => {
+        table.dropForeign([userUuidColumnName], constraintName);
+    });
+
+    await knex.schema.table(dashboardTileCommentsTable, (table) => {
+        table
+            .foreign(userUuidColumnName, constraintName)
+            .references('user_uuid')
+            .inTable(usersTable);
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Some users would get this error when deleting another user that had left dashboard comments
```
error: delete from "users" where "user_uuid" = $1 - update or
delete on table "users" violates foreign key constraint
"dashboard_tile_comments_user_uuid_foreign" on table
"dashboard_tile_comments"
```

There's a missing on delete cascade in the `user_uuid` column.
Added a migration that drops current foreign constraint and re-adds it with the on delete
Verified with `psql`

```sql
 "dashboard_tile_comments_user_uuid_foreign" FOREIGN KEY (user_uuid) REFERENCES users(user_uuid) ON DELETE CASCADE
```

bug

https://github.com/lightdash/lightdash/assets/7611706/7681ecdd-b37d-480b-a7eb-c53a7d561b30


fix


https://github.com/lightdash/lightdash/assets/7611706/ea2a964d-7104-43fe-8856-07527cf1db5a



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
