### PR TITLE
fix: Avoid long URLs in SQL Runner

### DIFF
--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -2,12 +2,14 @@ import {
     ApiErrorPayload,
     ApiShareResponse,
     CreateShareUrl,
+    UpdateShareUrl,
 } from '@lightdash/common';
 import {
     Body,
     Get,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Request,
@@ -42,6 +44,30 @@ export class ShareController extends BaseController {
             results: await this.services
                 .getShareService()
                 .getShareUrl(req.user!, nanoId),
+        };
+    }
+
+    /**
+     * Updates a single share, by its NanoID. All parameters are optional.
+     * @param body a full URL used to generate a short url id
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'OK')
+    @Patch('{nanoId}')
+    @OperationId('UpdateShareUrl')
+    async update(
+        @Path() nanoId: string,
+        @Body() body: UpdateShareUrl,
+        @Request() req: express.Request,
+    ): Promise<ApiShareResponse> {
+        this.setStatus(201);
+        const shareUrl = await this.services
+            .getShareService()
+            .updateShareUrl(req.user!, nanoId, body);
+        return {
+            status: 'ok',
+            results: shareUrl,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4989,6 +4989,23 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Partial_CreateShareUrl_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                path: { dataType: 'string' },
+                params: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateShareUrl: {
+        dataType: 'refAlias',
+        type: { ref: 'Partial_CreateShareUrl_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_ShareUrl.path-or-params_': {
         dataType: 'refAlias',
         type: {
@@ -11030,6 +11047,66 @@ export function RegisterRoutes(app: express.Router) {
                     validatedArgs as any,
                 );
                 promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.patch(
+        '/api/v1/share/:nanoId',
+        ...fetchMiddlewares<RequestHandler>(ShareController),
+        ...fetchMiddlewares<RequestHandler>(ShareController.prototype.update),
+
+        async function ShareController_update(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                nanoId: {
+                    in: 'path',
+                    name: 'nanoId',
+                    required: true,
+                    dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateShareUrl',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ShareController>(
+                    ShareController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.update.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
             } catch (err) {
                 return next(err);
             }

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5573,6 +5573,23 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "Partial_CreateShareUrl_": {
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The URL path of the full URL"
+                    },
+                    "params": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpdateShareUrl": {
+                "$ref": "#/components/schemas/Partial_CreateShareUrl_",
+                "description": "Same as above, but allows partial submission for updates."
+            },
             "Pick_ShareUrl.path-or-params_": {
                 "properties": {
                     "path": {
@@ -6714,7 +6731,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1042.4",
+        "version": "0.1045.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -10725,6 +10742,56 @@
                         }
                     }
                 ]
+            },
+            "patch": {
+                "operationId": "UpdateShareUrl",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiShareResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Updates a single share, by its NanoID. All parameters are optional.",
+                "tags": ["Share links"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "nanoId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "a full URL used to generate a short url id",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateShareUrl",
+                                "description": "a full URL used to generate a short url id"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/share": {

--- a/packages/backend/src/models/ShareModel.ts
+++ b/packages/backend/src/models/ShareModel.ts
@@ -33,6 +33,17 @@ export class ShareModel {
         return shareUrl;
     }
 
+    async updateShareUrl(shareUrl: ShareUrl): Promise<ShareUrl> {
+        await this.database(ShareTableName)
+            .where('nanoid', shareUrl.nanoid)
+            .update({
+                path: shareUrl.path ? shareUrl.path : undefined,
+                params: shareUrl.params ? shareUrl.params : undefined,
+            });
+
+        return shareUrl;
+    }
+
     async getSharedUrl(nanoid: string): Promise<ShareUrl> {
         const [row] = await this.database(ShareTableName)
             .leftJoin(

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -4,6 +4,7 @@ import {
     isUserWithOrg,
     SessionUser,
     ShareUrl,
+    UpdateShareUrl,
 } from '@lightdash/common';
 import { nanoid as nanoidGenerator } from 'nanoid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -64,6 +65,31 @@ export class ShareService {
             },
         });
         return this.shareUrlWithHost(shareUrl);
+    }
+
+    async updateShareUrl(
+        user: SessionUser,
+        nanoid: string,
+        updateParams: UpdateShareUrl,
+    ): Promise<ShareUrl> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const shareUrl = await this.getShareUrl(user, nanoid);
+
+        if (shareUrl.createdByUserUuid !== user.userUuid) {
+            throw new ForbiddenError(
+                'User is not original creator of share url',
+            );
+        }
+
+        const updatedShareUrl: ShareUrl = {
+            ...shareUrl,
+            ...updateParams,
+        };
+
+        return this.shareModel.updateShareUrl(updatedShareUrl);
     }
 
     async createShareUrl(

--- a/packages/common/src/types/share.ts
+++ b/packages/common/src/types/share.ts
@@ -30,3 +30,8 @@ export type ShareUrl = {
  * Contains the detail of a full URL to generate a short URL id
  */
 export type CreateShareUrl = Pick<ShareUrl, 'path' | 'params'>;
+
+/**
+ * Same as above, but allows partial submission for updates.
+ */
+export type UpdateShareUrl = Partial<CreateShareUrl>;

--- a/packages/frontend/src/hooks/useShare.ts
+++ b/packages/frontend/src/hooks/useShare.ts
@@ -47,7 +47,7 @@ export const useCreateShareMutation = () => {
     );
 };
 
-export const useUpdateShareMutation = (shareNanoid?: string) => {
+export const useUpdateShareMutation = (shareNanoid: string | null) => {
     return useMutation<ShareUrl, ApiError, UpdateShareUrl>(
         (data) => {
             if (!shareNanoid) {

--- a/packages/frontend/src/hooks/useShare.ts
+++ b/packages/frontend/src/hooks/useShare.ts
@@ -14,7 +14,7 @@ const getShare = async (shareNanoid: string) =>
         body: undefined,
     });
 
-export const useGetShare = (shareNanoid: string | null) =>
+export const useGetShare = (shareNanoid?: string | null) =>
     useQuery<ShareUrl, ApiError>({
         queryKey: ['share', shareNanoid!],
         queryFn: () => getShare(shareNanoid!),

--- a/packages/frontend/src/hooks/useSqlRunnerRoute.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerRoute.ts
@@ -9,6 +9,12 @@ export type SqlRunnerState = {
     sqlRunner: { sql: string } | undefined;
 };
 
+enum SqlRunnerSearchParam {
+    CreateSavedChartVersion = 'create_saved_chart_version',
+    SqlRunnerState = 'sql_runner',
+    SqlRunnerKey = 'sql_runner_id',
+}
+
 const getSqlRunnerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
     sqlRunnerState: SqlRunnerState,
@@ -16,12 +22,15 @@ const getSqlRunnerUrlFromCreateSavedChartVersion = (
     const newParams = new URLSearchParams();
     if (sqlRunnerState.createSavedChart) {
         newParams.set(
-            'create_saved_chart_version',
+            SqlRunnerSearchParam.CreateSavedChartVersion,
             JSON.stringify(sqlRunnerState.createSavedChart),
         );
     }
     if (sqlRunnerState.sqlRunner) {
-        newParams.set('sql_runner', JSON.stringify(sqlRunnerState.sqlRunner));
+        newParams.set(
+            SqlRunnerSearchParam.SqlRunnerState,
+            JSON.stringify(sqlRunnerState.sqlRunner),
+        );
     }
     return {
         pathname: `/projects/${projectUuid}/sqlRunner`,
@@ -54,7 +63,9 @@ export const useSqlRunnerUrlState = (): SqlRunnerState | undefined => {
     return useMemo(() => {
         try {
             const searchParams = new URLSearchParams(search);
-            const sqlRunnerSearchParam = searchParams.get('sql_runner');
+            const sqlRunnerSearchParam = searchParams.get(
+                SqlRunnerSearchParam.SqlRunnerState,
+            );
             const sqlRunner = sqlRunnerSearchParam
                 ? JSON.parse(sqlRunnerSearchParam)
                 : undefined;

--- a/packages/frontend/src/hooks/useSqlRunnerRoute.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerRoute.ts
@@ -1,7 +1,8 @@
 import { type CreateSavedChartVersion } from '@lightdash/common';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { parseExplorerSearchParams } from './useExplorerRoute';
+import { useCreateShareMutation, useGetShare } from './useShare';
 import { generateStateCacheKey, useStateCache } from './useStateCache';
 
 export type SqlRunnerState = {
@@ -12,7 +13,8 @@ export type SqlRunnerState = {
 enum SqlRunnerSearchParam {
     CreateSavedChartVersion = 'create_saved_chart_version',
     SqlRunnerState = 'sql_runner',
-    SqlRunnerKey = 'sql_runner_id',
+    SqlRunnerDraft = 'sql_runner_draft',
+    SqlRunnerId = 'sql_runner_id',
 }
 
 export const useSqlRunnerRoute = () => {
@@ -20,9 +22,13 @@ export const useSqlRunnerRoute = () => {
     const history = useHistory();
     const searchParams = useMemo(() => new URLSearchParams(search), [search]);
 
+    const sqlRunnerShareId = searchParams.get(SqlRunnerSearchParam.SqlRunnerId);
     const sqlRunnerCacheId = searchParams.get(
-        SqlRunnerSearchParam.SqlRunnerKey,
+        SqlRunnerSearchParam.SqlRunnerDraft,
     );
+
+    const { data: shareData } = useGetShare(sqlRunnerShareId);
+    const { mutate: createShare } = useCreateShareMutation();
 
     /**
      * If we don't have a cache key, we generate a brand new one:
@@ -43,6 +49,9 @@ export const useSqlRunnerRoute = () => {
     /**
      * If we're handling legacy search params, we process them as the initial state,
      * and discard them as soon as we receive a new state update.
+     *
+     * If we're using a share nanoID, we instead use that to initialize things, with
+     * a separate search params parser.
      */
     const initialData = useMemo<Partial<SqlRunnerState>>(() => {
         return {
@@ -60,6 +69,66 @@ export const useSqlRunnerRoute = () => {
         initialData,
     });
 
+    useEffect(() => {
+        if (shareData) {
+            const shareParams = new URLSearchParams(shareData.params);
+
+            const hasCreateSavedChartFromParam = shareParams.get(
+                SqlRunnerSearchParam.CreateSavedChartVersion,
+            );
+            const sqlRunnerFromParam = shareParams.get(
+                SqlRunnerSearchParam.SqlRunnerState,
+            );
+
+            setCachedState({
+                createSavedChart: hasCreateSavedChartFromParam
+                    ? parseExplorerSearchParams(shareData.params)
+                    : undefined,
+                sqlRunner: sqlRunnerFromParam
+                    ? JSON.parse(sqlRunnerFromParam)
+                    : undefined,
+            });
+        }
+    }, [shareData, setCachedState]);
+
+    const flushSqlRunnerStateToShare = useCallback(() => {
+        if (cachedState) {
+            /**
+             * Generate a new share with a subset of params, to avoid leaking
+             * from existing search params
+             * */
+            const shareParams = new URLSearchParams({
+                [SqlRunnerSearchParam.CreateSavedChartVersion]:
+                    cachedState.createSavedChart
+                        ? JSON.stringify(cachedState.createSavedChart)
+                        : '',
+                [SqlRunnerSearchParam.SqlRunnerState]: cachedState.sqlRunner
+                    ? JSON.stringify(cachedState.sqlRunner)
+                    : '',
+            });
+
+            createShare(
+                {
+                    params: shareParams.toString(),
+                    path: pathname,
+                },
+                {
+                    onSuccess: (shareUrl) => {
+                        searchParams.set(
+                            SqlRunnerSearchParam.SqlRunnerId,
+                            shareUrl.nanoid,
+                        );
+
+                        history.replace({
+                            pathname,
+                            search: searchParams.toString(),
+                        });
+                    },
+                },
+            );
+        }
+    }, [createShare, cachedState, pathname, searchParams, history]);
+
     const updateSqlRunnerState = useCallback(
         (newState: SqlRunnerState) => {
             const updatedSearchParams = new URLSearchParams(search);
@@ -72,7 +141,7 @@ export const useSqlRunnerRoute = () => {
             );
             updatedSearchParams.delete(SqlRunnerSearchParam.SqlRunnerState);
             updatedSearchParams.set(
-                SqlRunnerSearchParam.SqlRunnerKey,
+                SqlRunnerSearchParam.SqlRunnerDraft,
                 cacheKeyOrGenerated,
             );
 
@@ -87,6 +156,7 @@ export const useSqlRunnerRoute = () => {
 
     return {
         sqlRunnerState: cachedState,
+        flushSqlRunnerStateToShare,
         updateSqlRunnerState,
     };
 };

--- a/packages/frontend/src/hooks/useSqlRunnerRoute.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerRoute.ts
@@ -235,5 +235,6 @@ export const useSqlRunnerRoute = () => {
         flushSqlRunnerStateToShare,
         updateSqlRunnerState,
         isLoading,
+        shareNanoId: shareData?.nanoid,
     };
 };

--- a/packages/frontend/src/hooks/useStateCache.ts
+++ b/packages/frontend/src/hooks/useStateCache.ts
@@ -67,7 +67,7 @@ const cleanupExpiredStateCacheData = (): string[] => {
  *
  * setMyStateData({ ...myStateData, someNewValue: 'foo' });
  */
-export const useStateCache = <CacheDataT>(
+export const useStateCache = <CacheDataT = Record<string, unknown>>(
     /**
      * Unique identifier for a state cache. Should be reasonably unique, like
      * a UUID, but can also be a partial UUID if we treat state caches as

--- a/packages/frontend/src/hooks/useStateCache.ts
+++ b/packages/frontend/src/hooks/useStateCache.ts
@@ -104,19 +104,20 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
     );
 
     /**
-     * Annoyingly, mantine v6 is quite lazy as far as reading cached state during
-     * rendering, so for now we have to handle the first/initial read ourselves:
+     * Annoyingly, mantine v6's version of this hook is quite lazy as far as reading
+     * cached state during rendering, so for now we have to handle the first/initial read ourselves:
      */
-    const defaultValue = useMemo<StateCacheData<CacheDataT>>(() => {
-        const item = localStorage.getItem(fullKey);
-        return item ? JSON.parse(item) : initialData;
-    }, [fullKey, initialData]);
+    const initialStoredValue =
+        useMemo<StateCacheData<CacheDataT> | null>(() => {
+            const item = localStorage.getItem(fullKey);
+            return item ? JSON.parse(item) : null;
+        }, [fullKey]);
 
     const [localStorageCacheData, setCacheDataInLocalStorage] = useLocalStorage<
         StateCacheData<CacheDataT>
     >({
         key: fullKey,
-        defaultValue,
+        defaultValue: initialStoredValue ?? createCacheEntry(initialData),
     });
 
     const setCacheData = useCallback(
@@ -141,7 +142,7 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
     }, [fullKey]);
 
     return [
-        localStorageCacheData.value ?? defaultValue.value,
+        localStorageCacheData.value,
         setCacheData,
 
         /**

--- a/packages/frontend/src/hooks/useStateCache.ts
+++ b/packages/frontend/src/hooks/useStateCache.ts
@@ -137,7 +137,6 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
     );
 
     useEffect(() => {
-        console.log('FLUSH!');
         setCacheDataInLocalStorage(createCacheEntry(debouncedCacheData));
 
         /**

--- a/packages/frontend/src/hooks/useStateCache.ts
+++ b/packages/frontend/src/hooks/useStateCache.ts
@@ -1,5 +1,5 @@
-import { useLocalStorage } from '@mantine/hooks';
-import { useCallback, useMemo } from 'react';
+import { useDebouncedValue, useLocalStorage } from '@mantine/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 /**
  * Static cache key prefix. The number value can be incremented
@@ -80,9 +80,13 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
 
         /* A value in minutes after which this state cache is eligible for deletion. */
         expireAfterMinutes = 1440, // 24 hours
+
+        /* Debounce amount in ms to flush changes to local storage */
+        localStorageDebounceDelay = 250,
     }: {
         initialData: CacheDataT;
         expireAfterMinutes?: number;
+        localStorageDebounceDelay?: number;
     },
 ) => {
     const fullKey = useMemo(
@@ -102,30 +106,46 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
         [expireAfterMinutes],
     );
 
-    const [cacheData, setCacheDataInLocalStorage] = useLocalStorage<
+    /**
+     * This next section can be a bit confusing, so here's a quick explainer:
+     *
+     * - We get a handle to the local storage data for the current key, if any exists. We also
+     *   initialise it with a default value (based on initialData) if needed.
+     * - We use a regular useState for in-flight data, which is what's actually mutated during
+     *   regular component operations.
+     * - We create a debounced reference to that in-flight state using mantine's useDebounced value.
+     * - When changes are flushed to our debounced state, we trigger (using a useEffect hook) a call
+     *   to finally serialize and flush data to localStorage.
+     *
+     * This somewhat convoluted setup allows us to use this hook as state for e.g controlled/high-throughput
+     * components, while still flushing stuff to local storage very frequently.
+     */
+    const [localStorageCacheData, setCacheDataInLocalStorage] = useLocalStorage<
         StateCacheData<CacheDataT>
     >({
         key: fullKey,
         defaultValue: createCacheEntry(initialData),
     });
 
-    /**
-     * Thin wrapper around mantine's local storage setter which calls
-     * createCacheEntry on the data first, and runs the cache cleanup
-     * process.
-     */
-    const setCacheData = useCallback(
-        (data: CacheDataT) => {
-            setCacheDataInLocalStorage(createCacheEntry(data));
-
-            /**
-             * Push this task into a future loop since it's not critical
-             * nor tied to render state:
-             */
-            setTimeout(() => cleanupExpiredStateCacheData(), 0);
-        },
-        [setCacheDataInLocalStorage, createCacheEntry],
+    const [cacheDataInFlight, setCacheData] = useState<CacheDataT>(
+        localStorageCacheData.value,
     );
+
+    const [debouncedCacheData] = useDebouncedValue<CacheDataT>(
+        cacheDataInFlight,
+        localStorageDebounceDelay,
+    );
+
+    useEffect(() => {
+        console.log('FLUSH!');
+        setCacheDataInLocalStorage(createCacheEntry(debouncedCacheData));
+
+        /**
+         * Push this task into a future loop since it's not critical
+         * nor tied to render state:
+         */
+        setTimeout(() => cleanupExpiredStateCacheData(), 0);
+    }, [debouncedCacheData, setCacheDataInLocalStorage, createCacheEntry]);
 
     /**
      * Deletes the underlying local storage entry. Using `setCacheData` with
@@ -136,15 +156,16 @@ export const useStateCache = <CacheDataT = Record<string, unknown>>(
     }, [fullKey]);
 
     return [
-        cacheData.value,
+        cacheDataInFlight,
         setCacheData,
 
         /**
          * Contains metadata that is probably not usually useful to the caller:
          */
         {
-            expireAt: cacheData.expireAt,
+            expireAt: localStorageCacheData.expireAt,
             clearCacheData,
+            hashKey,
         },
     ] as const;
 };

--- a/packages/frontend/src/hooks/useStateLocalCache.ts
+++ b/packages/frontend/src/hooks/useStateLocalCache.ts
@@ -1,0 +1,150 @@
+import { useLocalStorage } from '@mantine/hooks';
+import { useCallback, useMemo } from 'react';
+
+/**
+ * Static cache key prefix. The number value can be incremented
+ * to invalidate previous cache entries.
+ *
+ * Represented as a tuple so that we can use the prefix and version
+ * separately (e.g to find other cache entries by cache key):
+ */
+const stateCacheKeyPrefix: [string, number] = ['ld-state', 1];
+
+interface StateCacheData<CacheDataT> {
+    expireAt: number;
+    value: CacheDataT;
+}
+
+/**
+ * Generates a short, URL-friendly state cache hash-key, out of two
+ * v4 UUID segments.
+ */
+export const generateStateCacheKey = () => {
+    return crypto.randomUUID().split('-').slice(0, 2).join();
+};
+
+/**
+ * Runs through localStorage and removes expired state cache entries, using
+ * the namespace portion of `stateCacheKeyPrefix`.
+ *
+ * Returns a list of keys that were removed.
+ */
+const cleanupExpiredStateCacheData = (): string[] => {
+    const tsNow = Date.now();
+    return Object.keys(localStorage).filter((keyName) => {
+        if (!keyName.startsWith(stateCacheKeyPrefix[0])) {
+            return false;
+        }
+
+        const item = localStorage.getItem(keyName);
+        if (!item) return;
+        try {
+            const cacheData = JSON.parse(item) as StateCacheData<unknown>;
+
+            if (tsNow > cacheData.expireAt) {
+                localStorage.removeItem(keyName);
+                return true;
+            }
+        } catch (_e) {
+            // Do nothing
+        }
+
+        return false;
+    });
+};
+
+/**
+ * Wrapper around mantine's `useLocalStorage` specifically for state caching, with
+ * support for lazy cache expiration.
+ *
+ * Note that multiple tabs using the same cache key will share cache data - this
+ * is cool and useful, but may also have unintended side-effects you have to
+ * account for.
+ *
+ * const [myStateData, setMyStateData] = useStateCache<StateDataT>(generateStateCacheKey(), {
+ *   initialData: myData // StateDataT
+ * });
+ *
+ * setMyStateData({ ...myStateData, someNewValue: 'foo' });
+ */
+export const useStateCache = <CacheDataT>(
+    /**
+     * Unique identifier for a state cache. Should be reasonably unique, like
+     * a UUID, but can also be a partial UUID if we treat state caches as
+     * particularly volatile and short-lived.
+     */
+    hashKey: string,
+    {
+        /* The initial data to be cached; goes directly into local storage */
+        initialData,
+
+        /* A value in minutes after which this state cache is eligible for deletion. */
+        expireAfterMinutes = 1440, // 24 hours
+    }: {
+        initialData: CacheDataT;
+        expireAfterMinutes?: number;
+    },
+) => {
+    const fullKey = useMemo(
+        () => `${stateCacheKeyPrefix.join('-')}/${hashKey}`,
+        [hashKey],
+    );
+
+    /**
+     * Ensures data going into localStorage is properly formatted, including
+     * an expiry timestamp.
+     */
+    const createCacheEntry = useCallback(
+        (data: CacheDataT): StateCacheData<CacheDataT> => ({
+            expireAt: Date.now() + expireAfterMinutes * 60000, // minutes -> ms
+            value: data,
+        }),
+        [expireAfterMinutes],
+    );
+
+    const [cacheData, setCacheDataInLocalStorage] = useLocalStorage<
+        StateCacheData<CacheDataT>
+    >({
+        key: fullKey,
+        defaultValue: createCacheEntry(initialData),
+    });
+
+    /**
+     * Thin wrapper around mantine's local storage setter which calls
+     * createCacheEntry on the data first, and runs the cache cleanup
+     * process.
+     */
+    const setCacheData = useCallback(
+        (data: CacheDataT) => {
+            setCacheDataInLocalStorage(createCacheEntry(data));
+
+            /**
+             * Push this task into a future loop since it's not critical
+             * nor tied to render state:
+             */
+            setTimeout(() => cleanupExpiredStateCacheData(), 0);
+        },
+        [setCacheDataInLocalStorage, createCacheEntry],
+    );
+
+    /**
+     * Deletes the underlying local storage entry. Using `setCacheData` with
+     * the same key at this point will, as you'd expect, recreate the entry.
+     */
+    const clearCacheData = useCallback(() => {
+        localStorage.removeItem(fullKey);
+    }, [fullKey]);
+
+    return [
+        cacheData.value,
+        setCacheData,
+
+        /**
+         * Contains metadata that is probably not usually useful to the caller:
+         */
+        {
+            expireAt: cacheData.expireAt,
+            clearCacheData,
+        },
+    ] as const;
+};

--- a/packages/frontend/src/hooks/useStateLocalCache.ts
+++ b/packages/frontend/src/hooks/useStateLocalCache.ts
@@ -20,7 +20,7 @@ interface StateCacheData<CacheDataT> {
  * v4 UUID segments.
  */
 export const generateStateCacheKey = () => {
-    return crypto.randomUUID().split('-').slice(0, 2).join();
+    return crypto.randomUUID().split('-').slice(0, 2).join('');
 };
 
 /**

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -63,6 +63,7 @@ const SqlRunnerPage = () => {
         sqlRunnerState,
         updateSqlRunnerState,
         flushSqlRunnerStateToShare,
+        shareNanoId,
         isLoading: isLoadingRouteData,
     } = useSqlRunnerRoute();
     const { isInitialLoading: isCatalogLoading, data: catalogData } =
@@ -243,6 +244,7 @@ const SqlRunnerPage = () => {
                         />
                         <ShareShortLinkButton
                             disabled={lastSqlRan === undefined}
+                            shareNanoId={shareNanoId}
                         />
                     </Group>
                 </Group>

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lightdash/common';
 import { Box, Group, Stack, Tabs } from '@mantine/core';
 import { getHotkeyHandler } from '@mantine/hooks';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 
@@ -38,10 +38,6 @@ import {
 } from '../hooks/useProjectCatalogTree';
 import { useSqlQueryMutation } from '../hooks/useSqlQuery';
 import useSqlQueryVisualization from '../hooks/useSqlQueryVisualization';
-import {
-    useSqlRunnerRoute,
-    useSqlRunnerUrlState,
-} from '../hooks/useSqlRunnerRoute';
 import { useApp } from '../providers/AppProvider';
 import { TrackSection } from '../providers/TrackingProvider';
 import { SectionName } from '../types/Events';
@@ -60,12 +56,11 @@ const SqlRunnerPage = () => {
     const { user, health } = useApp();
     const { data: org } = useOrganization();
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const initialState = useSqlRunnerUrlState();
     const sqlQueryMutation = useSqlQueryMutation();
     const { isInitialLoading: isCatalogLoading, data: catalogData } =
         useProjectCatalog();
 
-    const [sql, setSql] = useState<string>(initialState?.sqlRunner?.sql || '');
+    const [sql, setSql] = useState<string>('');
     const [lastSqlRan, setLastSqlRan] = useState<string>();
 
     const [expandedCards, setExpandedCards] = useState(
@@ -92,19 +87,10 @@ const SqlRunnerPage = () => {
         setChartConfig,
         setPivotFields,
     } = useSqlQueryVisualization({
-        initialState: initialState?.createSavedChart,
+        // TODO ---
+        initialState: undefined,
         sqlQueryMutation,
     });
-
-    const sqlRunnerState = useMemo(
-        () => ({
-            createSavedChart,
-            sqlRunner: lastSqlRan ? { sql: lastSqlRan } : undefined,
-        }),
-        [createSavedChart, lastSqlRan],
-    );
-
-    useSqlRunnerRoute(sqlRunnerState);
 
     const handleSubmit = useCallback(() => {
         if (!sql) return;

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -59,7 +59,8 @@ const SqlRunnerPage = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const sqlQueryMutation = useSqlQueryMutation();
 
-    const { sqlRunnerState, updateSqlRunnerState } = useSqlRunnerRoute();
+    const { sqlRunnerState, updateSqlRunnerState, flushSqlRunnerStateToShare } =
+        useSqlRunnerRoute();
     const { isInitialLoading: isCatalogLoading, data: catalogData } =
         useProjectCatalog();
 
@@ -101,7 +102,8 @@ const SqlRunnerPage = () => {
 
         mutate(sql);
         setLastSqlRan(sql);
-    }, [mutate, sql]);
+        flushSqlRunnerStateToShare();
+    }, [mutate, sql, flushSqlRunnerStateToShare]);
 
     useMount(() => {
         handleSubmit();

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -101,8 +101,6 @@ const SqlRunnerPage = () => {
 
         mutate(sql);
         setLastSqlRan(sql);
-
-        // TODO: Flush changes to URL
     }, [mutate, sql]);
 
     useMount(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Part of #4137, does not close it since this change only affects the SQL Runner for now.

The vast majority of this code is reusable for other similar cases, so it's a matter of migrating that over for other cases, once tested & validated.

### Description:

- Introduces `useStateCache` utility
- Introduces `update` action for `ShareUrl` controller, model
- Introduces new `useSqlRunnerRoute` hook to replace existing sql runner route management code. 
  - Loads data from 'legacy' parameters, if present
  - User operations are saved to local storage, under a cache id appended as a query parameter
  - When a user runs a query, the local cache is flushed to a ShareURL, and the url updated accordingly
  - The same share URL is reused across a session
  - Cache writes are debounced
- Introduces `shareNanoId` prop to `ShareShortLinkButton` to reuse an existing share ID when using the permalink/share button on the SQL Runner


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
