### PR TITLE
style: fix vertical offset vis sidebar

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -3,11 +3,9 @@ import {
     getHiddenTableFields,
     NotFoundError,
 } from '@lightdash/common';
-import { memo, useCallback, useMemo, useState, type FC } from 'react';
-
 import { useDisclosure } from '@mantine/hooks';
+import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { downloadCsv } from '../../../api/csv';
-import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { type EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
@@ -89,8 +87,6 @@ const VisualizationCard: FC<{
 
     const [echartsClickEvent, setEchartsClickEvent] =
         useState<EchartsClickEvent>();
-
-    const { getIsEditingDashboardChart } = useDashboardStorage();
 
     const [isSidebarOpen, { open: openSidebar, close: closeSidebar }] =
         useDisclosure();
@@ -191,7 +187,6 @@ const VisualizationCard: FC<{
                                         unsavedChartVersion.chartConfig.type
                                     }
                                     savedChart={savedChart}
-                                    isEditingDashboardChart={getIsEditingDashboardChart()}
                                     isProjectPreview={isProjectPreview}
                                     isOpen={isSidebarOpen}
                                     onOpen={openSidebar}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { memo, useMemo, type FC } from 'react';
 import { COLLAPSABLE_CARD_BUTTON_PROPS } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
+import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../../NavBar';
 import BigNumberConfigTabs from '../../VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs';
 import ChartConfigTabs from '../../VisualizationConfigs/ChartConfigPanel/ChartConfigTabs';
 import CustomVisConfigTabs from '../../VisualizationConfigs/ChartConfigPanel/CustomVisConfigTabs';
@@ -22,24 +23,25 @@ const VisualizationSidebar: FC<{
     chartType: ChartType;
     savedChart?: SavedChart;
     isProjectPreview?: boolean;
-    isEditingDashboardChart?: boolean;
     isOpen: boolean;
     onClose: () => void;
     onOpen: () => void;
 }> = memo(
-    ({
-        chartType,
-        savedChart,
-        isProjectPreview,
-        isEditingDashboardChart,
-        isOpen,
-        onOpen,
-        onClose,
-    }) => {
-        const sidebarVerticalOffset =
-            (isProjectPreview && !isEditingDashboardChart ? 35 : 0) + // Preview header
-            (isEditingDashboardChart ? 35 : 50) + // Normal header or dashboardChart header
-            (savedChart === undefined ? 0 : 80); // Include the saved chart header or not
+    ({ chartType, savedChart, isProjectPreview, isOpen, onOpen, onClose }) => {
+        const sidebarVerticalOffset = useMemo(() => {
+            let offset = NAVBAR_HEIGHT;
+
+            if (isProjectPreview) {
+                offset += BANNER_HEIGHT;
+            }
+
+            const isQueryingFromTables = savedChart === undefined;
+            if (!isQueryingFromTables) {
+                offset += 65;
+            }
+
+            return offset;
+        }, [isProjectPreview, savedChart]);
 
         const ConfigTab = useMemo(() => {
             switch (chartType) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Now that the saved chart header is shorter, we should also fix the offset height of the visualization Drawer

This also refines the logic and utilizes constants where possible.

Tested this with every possible scenario

1. preview-edit-chart-within-dashboard
<img width="1296" alt="preview-edit-chart-within-dashboard" src="https://github.com/lightdash/lightdash/assets/7611706/aa263efa-9bbd-46eb-aaad-f5eea246a8de">

2. preview-create-chart-within-dashboard
<img width="1282" alt="preview-create-chart-within-dashboard" src="https://github.com/lightdash/lightdash/assets/7611706/ea2c2115-5569-4cfc-bf35-01c045a3c0c0">

3. preview-saved-chart
<img width="627" alt="preview-saved-chart" src="https://github.com/lightdash/lightdash/assets/7611706/6b9ca485-81a3-44ec-88e6-0427d7562e96">

4. preview-query-from-tables
<img width="1298" alt="preview-query-from-tables" src="https://github.com/lightdash/lightdash/assets/7611706/0071b6e2-e50e-46bc-bec4-933943bd7648">

5. edit-chart-within-dashboard
<img width="1000" alt="edit-chart-within-dashboard" src="https://github.com/lightdash/lightdash/assets/7611706/ce4c17dc-4670-4845-b214-457656f5769d">

6. create-chart-within-dashboard
<img width="1187" alt="create-chart-within-dashboard" src="https://github.com/lightdash/lightdash/assets/7611706/b1a0a61d-cfdc-4289-8a49-d73e03653daf">

7. query-from-tables
<img width="1291" alt="query-from-tables" src="https://github.com/lightdash/lightdash/assets/7611706/48a59056-d87f-4bad-9c30-0224b9c141d0">

8. saved-chart
<img width="1293" alt="saved-chart" src="https://github.com/lightdash/lightdash/assets/7611706/c62f2f99-7e46-4905-bbea-ef535afac161">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
