### PR TITLE
fix: custom metric long name

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -112,6 +112,7 @@ export const CustomMetricModal = () => {
                 if (!item) return null;
 
                 const metricName = getCustomMetricName(
+                    item.table,
                     label,
                     isEditing &&
                         isAdditionalMetric(item) &&

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -40,8 +40,17 @@ export const addFieldIdToMetricFilterRule = (
     },
 });
 
-export const getCustomMetricName = (label: string, dimensionName: string) =>
-    `${dimensionName}_${snakeCaseName(label)}`;
+export const getCustomMetricName = (
+    table: string,
+    label: string,
+    dimensionName: string,
+) => {
+    // Some warehouses don't support long names, so we need to truncate these custom metrics
+    return `${dimensionName}_${snakeCaseName(label)}`.slice(
+        0,
+        62 - table.length,
+    );
+};
 
 const getCustomMetricDescription = (
     metricType: MetricType,
@@ -166,6 +175,7 @@ export const prepareCustomMetricData = ({
         filters: customMetricFilters.length > 0 ? customMetricFilters : [],
         label: customMetricLabel,
         name: getCustomMetricName(
+            item.table,
             customMetricLabel,
             isEditingCustomMetric &&
                 isAdditionalMetric(item) &&

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -45,11 +45,17 @@ export const getCustomMetricName = (
     label: string,
     dimensionName: string,
 ) => {
-    // Some warehouses don't support long names, so we need to truncate these custom metrics
-    return `${dimensionName}_${snakeCaseName(label)}`.slice(
-        0,
-        62 - table.length,
-    );
+    // Some warehouses don't support long names, so we need to truncate these custom metrics if the name is too long
+    if (table.length + dimensionName.length + label.length <= 62) {
+        return `${dimensionName}_${snakeCaseName(label)}`;
+    }
+
+    // 64 (max characters in postgres) - 3 (underscores) - 14 (timestamp length) = 47
+    const maxPartLength = Math.floor((47 - table.length) / 2);
+    // If the name is still too long, we truncate each part and add a timestamp to the end to make it unique
+    return `${dimensionName.slice(0, maxPartLength)}_${snakeCaseName(
+        label,
+    ).slice(0, maxPartLength)}_${new Date().getTime()}`;
 };
 
 const getCustomMetricDescription = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7759

### Description:

This PR fixes the issue with custom metrics, where they are too long , 
this fix should be backwards compatible and straightforward, we are just making a shorter name for the custom metric. 

it doesn't fix the max column name on dbt, that will require a bigger fix

I'm using 64 as the max limit because that's the lowest limit (from postgres) , other database have higher limits.  

Before and after
![Screenshot from 2024-04-01 17-56-48](https://github.com/lightdash/lightdash/assets/1983672/12b070b8-6c80-45c4-bbf5-0f60d469aea4)


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
