### PR TITLE
refactor: rework Config component

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -43,13 +43,13 @@ export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
             />
             {!isAuto && (
                 <Group noWrap spacing="xs">
-                    <Config.SubLabel>Min</Config.SubLabel>
+                    <Config.Label>Min</Config.Label>
                     <TextInput
                         placeholder="Min"
                         defaultValue={min || undefined}
                         onBlur={(e) => setMin(e.currentTarget.value)}
                     />
-                    <Config.SubLabel>Max</Config.SubLabel>
+                    <Config.Label>Max</Config.Label>
                     <TextInput
                         placeholder="Max"
                         defaultValue={max || undefined}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -76,10 +76,10 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
     return (
         <Stack>
             <Config>
-                <Config.Group>
-                    <Config.Label>{`${
+                <Config.Section>
+                    <Config.Heading>{`${
                         dirtyLayout?.flipAxes ? 'Y' : 'X'
-                    }-axis label`}</Config.Label>
+                    }-axis label`}</Config.Heading>
                     <TextInput
                         placeholder="Enter axis label"
                         defaultValue={
@@ -104,7 +104,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     )}
                     <Group spacing="xs">
                         <Group spacing="xs">
-                            <Config.SubLabel>Sort</Config.SubLabel>
+                            <Config.Label>Sort</Config.Label>
                             <SegmentedControl
                                 defaultValue={
                                     dirtyEchartsConfig?.xAxis?.[0]?.inverse
@@ -136,7 +136,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         </Group>
                         {!dirtyLayout?.flipAxes && (
                             <Group noWrap spacing="xs" align="baseline">
-                                <Config.SubLabel>Rotation</Config.SubLabel>
+                                <Config.Label>Rotation</Config.Label>
                                 <NumberInput
                                     type="number"
                                     defaultValue={
@@ -155,16 +155,16 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             </Group>
                         )}
                     </Group>
-                </Config.Group>
+                </Config.Section>
             </Config>
 
             <Config>
-                <Config.Group>
-                    <Config.Label>{`${
+                <Config.Section>
+                    <Config.Heading>{`${
                         dirtyLayout?.flipAxes ? 'X' : 'Y'
                     }-axis label (${
                         dirtyLayout?.flipAxes ? 'bottom' : 'left'
-                    })`}</Config.Label>
+                    })`}</Config.Heading>
 
                     <TextInput
                         placeholder="Enter axis label"
@@ -192,16 +192,16 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             setMax={(newValue) => setYMaxValue(0, newValue)}
                         />
                     )}
-                </Config.Group>
+                </Config.Section>
             </Config>
 
             <Config>
-                <Config.Group>
-                    <Config.Label>{`${
+                <Config.Section>
+                    <Config.Heading>{`${
                         dirtyLayout?.flipAxes ? 'X' : 'Y'
                     }-axis label (${
                         dirtyLayout?.flipAxes ? 'top' : 'right'
-                    })`}</Config.Label>
+                    })`}</Config.Heading>
 
                     <TextInput
                         placeholder="Enter axis label"
@@ -230,12 +230,12 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             setMax={(newValue) => setYMaxValue(1, newValue)}
                         />
                     )}
-                </Config.Group>
+                </Config.Section>
             </Config>
 
             <Config>
-                <Config.Group>
-                    <Config.Label>Show grid</Config.Label>
+                <Config.Section>
+                    <Config.Heading>Show grid</Config.Heading>
 
                     <Stack spacing="xs">
                         <Checkbox
@@ -262,7 +262,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             }}
                         />
                     </Stack>
-                </Config.Group>
+                </Config.Section>
             </Config>
         </Stack>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -160,11 +160,11 @@ export const Layout: FC<Props> = ({ items }) => {
     return (
         <Stack>
             <Config>
-                <Config.Group>
-                    <Config.LabelGroup>
-                        <Config.Label>{`${
+                <Config.Section>
+                    <Config.Group>
+                        <Config.Heading>{`${
                             validConfig?.layout.flipAxes ? 'Y' : 'X'
-                        }-axis`}</Config.Label>
+                        }-axis`}</Config.Heading>
                         <Group spacing="two">
                             <Tooltip variant="xs" label="Flip Axes">
                                 <ActionIcon
@@ -184,7 +184,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                 />
                             )}
                         </Group>
-                    </Config.LabelGroup>
+                    </Config.Group>
                     {dirtyLayout?.xField !== EMPTY_X_AXIS && (
                         <FieldSelect
                             data-testid="x-axis-field-select"
@@ -200,15 +200,15 @@ export const Layout: FC<Props> = ({ items }) => {
                             }
                         />
                     )}
-                </Config.Group>
+                </Config.Section>
             </Config>
 
             <Config>
-                <Config.Group>
-                    <Config.LabelGroup>
-                        <Config.Label>{`${
+                <Config.Section>
+                    <Config.Group>
+                        <Config.Heading>{`${
                             validConfig?.layout.flipAxes ? 'X' : 'Y'
-                        }-axis`}</Config.Label>
+                        }-axis`}</Config.Heading>
                         {availableYFields.length > 0 && (
                             <AddButton
                                 onClick={() =>
@@ -218,7 +218,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                 }
                             />
                         )}
-                    </Config.LabelGroup>
+                    </Config.Group>
 
                     {yFields.map((field, index) => {
                         const activeField = yActiveField(field);
@@ -249,15 +249,15 @@ export const Layout: FC<Props> = ({ items }) => {
                             />
                         );
                     })}
-                </Config.Group>
+                </Config.Section>
             </Config>
 
             <Config>
-                <Config.Group>
+                <Config.Section>
                     <Stack spacing="xs">
-                        <Config.LabelGroup>
+                        <Config.Group>
                             <Group spacing="one">
-                                <Config.Label>Group</Config.Label>
+                                <Config.Heading>Group</Config.Heading>
                             </Group>
                             {canAddPivot && (
                                 <AddButton
@@ -271,7 +271,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                     }
                                 />
                             )}
-                        </Config.LabelGroup>
+                        </Config.Group>
                         {!chartHasMetricOrTableCalc &&
                             !(pivotDimensions && !!pivotDimensions.length) && (
                                 <FieldSelect
@@ -354,7 +354,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                 disabled={!isXAxisFieldNumeric}
                             >
                                 <Group spacing="xs">
-                                    <Config.SubLabel>Stacking</Config.SubLabel>
+                                    <Config.Label>Stacking</Config.Label>
                                     <SegmentedControl
                                         disabled={isXAxisFieldNumeric}
                                         value={
@@ -374,7 +374,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                 </Group>
                             </Tooltip>
                         )}
-                </Config.Group>
+                </Config.Section>
             </Config>
         </Stack>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -186,11 +186,11 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
 
     return (
         <Config>
-            <Config.Group>
-                <Config.LabelGroup>
-                    <Config.Label>Reference lines</Config.Label>
+            <Config.Section>
+                <Config.Group>
+                    <Config.Heading>Reference lines</Config.Heading>
                     <AddButton onClick={addReferenceLine} />
-                </Config.LabelGroup>
+                </Config.Group>
 
                 {referenceLines && (
                     <Accordion
@@ -227,7 +227,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                         ))}
                     </Accordion>
                 )}
-            </Config.Group>
+            </Config.Section>
         </Config>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -60,7 +60,7 @@ const PositionConfiguration: FC<MarginConfigurationProps> = ({
 
     return (
         <Config>
-            <Config.Group>
+            <Config.Section>
                 <Switch
                     labelPosition="left"
                     label={`Custom position`}
@@ -83,7 +83,7 @@ const PositionConfiguration: FC<MarginConfigurationProps> = ({
                         defaultConfig={defaultConfig}
                     />
                 )}
-            </Config.Group>
+            </Config.Section>
         </Config>
     );
 };
@@ -116,9 +116,9 @@ export const Legend: FC<Props> = ({ items }) => {
     return (
         <Stack>
             <Config>
-                <Config.Group>
+                <Config.Section>
                     <Group spacing="xs" align="center">
-                        <Config.Label>Legend</Config.Label>
+                        <Config.Heading>Legend</Config.Heading>
                         <Switch
                             checked={legendConfig.show ?? showDefault}
                             onChange={(e) =>
@@ -130,9 +130,7 @@ export const Legend: FC<Props> = ({ items }) => {
                     <Collapse in={legendConfig.show ?? showDefault}>
                         <Stack spacing="xs">
                             <Group spacing="xs">
-                                <Config.SubLabel>
-                                    Scroll behavior
-                                </Config.SubLabel>
+                                <Config.Label>Scroll behavior</Config.Label>
                                 <SegmentedControl
                                     value={dirtyEchartsConfig?.legend?.type}
                                     data={[
@@ -145,7 +143,7 @@ export const Legend: FC<Props> = ({ items }) => {
                                 />
                             </Group>
                             <Group spacing="xs">
-                                <Config.SubLabel>Orientation</Config.SubLabel>
+                                <Config.Label>Orientation</Config.Label>
                                 <SegmentedControl
                                     name="orient"
                                     value={legendConfig.orient ?? 'horizontal'}
@@ -170,7 +168,7 @@ export const Legend: FC<Props> = ({ items }) => {
                             />
                         </Stack>
                     </Collapse>
-                </Config.Group>
+                </Config.Section>
             </Config>
             <ReferenceLines items={items} projectUuid={projectUuid} />
         </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -46,7 +46,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
 
     return (
         <Config>
-            <Config.Group>
+            <Config.Section>
                 <Group noWrap spacing="two">
                     <GrabIcon dragHandleProps={dragHandleProps} />
 
@@ -61,9 +61,9 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                         }}
                     />
                     {isSingle ? (
-                        <Config.Label>
+                        <Config.Heading>
                             {getItemLabelWithoutTableName(item)}
-                        </Config.Label>
+                        </Config.Heading>
                     ) : (
                         <Box
                             style={{
@@ -96,7 +96,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                     updateSingleSeries={updateSingleSeries}
                     getSingleSeries={getSingleSeries}
                 />
-            </Config.Group>
+            </Config.Section>
         </Config>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -148,13 +148,13 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
 
     return (
         <Config>
-            <Config.Group>
+            <Config.Section>
                 <Group noWrap spacing="two">
                     <GrabIcon dragHandleProps={dragHandleProps} />
 
-                    <Config.Label>
+                    <Config.Heading>
                         {getItemLabelWithoutTableName(item)} (grouped)
-                    </Config.Label>
+                    </Config.Heading>
                 </Group>
                 <Stack spacing="xs" ml="md">
                     <Group noWrap spacing="xs" align="start">
@@ -237,7 +237,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         {seriesGroup[0].stack &&
                             chartValue === CartesianSeriesType.BAR && (
                                 <Stack spacing="xs" mt="two">
-                                    <Config.SubLabel>Total</Config.SubLabel>
+                                    <Config.Label>Total</Config.Label>
                                     <Switch
                                         checked={
                                             seriesGroup[0].stackLabel?.show
@@ -402,7 +402,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         </Droppable>
                     </DragDropContext>
                 </Box>
-            </Config.Group>
+            </Config.Section>
         </Config>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/Config.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/Config.tsx
@@ -2,35 +2,35 @@ import { Box, Group as MantineGroup, Stack, Text } from '@mantine/core';
 import { type FC, type PropsWithChildren } from 'react';
 
 interface ConfigComponent extends FC<PropsWithChildren> {
+    Section: FC<PropsWithChildren>;
+    Heading: FC<PropsWithChildren>;
     Group: FC<PropsWithChildren>;
     Label: FC<PropsWithChildren>;
-    LabelGroup: FC<PropsWithChildren>;
-    SubLabel: FC<PropsWithChildren>;
 }
 
 export const Config: ConfigComponent = ({ children }) => <Box>{children}</Box>;
 
-const Group: FC<PropsWithChildren> = ({ children }) => (
+const Section: FC<PropsWithChildren> = ({ children }) => (
     <Stack spacing="xs">{children}</Stack>
 );
 
-const Label: FC<PropsWithChildren> = ({ children }) => (
+const Heading: FC<PropsWithChildren> = ({ children }) => (
     <Text c="gray.8" fz="sm" fw={600}>
         {children}
     </Text>
 );
 
-const SubLabel: FC<PropsWithChildren> = ({ children }) => (
+const Label: FC<PropsWithChildren> = ({ children }) => (
     <Text fw={500} size="xs" color="gray.6">
         {children}
     </Text>
 );
 
-const LabelGroup: FC<PropsWithChildren> = ({ children }) => (
+const Group: FC<PropsWithChildren> = ({ children }) => (
     <MantineGroup position="apart">{children}</MantineGroup>
 );
 
+Config.Section = Section;
+Config.Heading = Heading;
 Config.Group = Group;
 Config.Label = Label;
-Config.LabelGroup = LabelGroup;
-Config.SubLabel = SubLabel;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

From discussion here: https://github.com/lightdash/lightdash/pull/9528#discussion_r1546580576

Rework the `Config` component to have its _sub-components_ with clearer namings

```
Config.Section - was Config.Group before
Config.Heading - was Label before
Config.Group - was GroupLabel before
Config.Label - was SubLabel before
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
