### PR TITLE
fix: reference line accordion item index

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -241,8 +241,7 @@ export const ReferenceLine: FC<Props> = ({
     >(selectedFieldDefault);
 
     const controlLabel = `Line ${index}`;
-
-    const accordionValue = referenceLine.data.value;
+    const accordionValue = `${index}`;
 
     const { ref, hovered } = useHover<HTMLButtonElement>();
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -134,7 +134,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
             },
         };
         setReferenceLines([...referenceLines, newReferenceLine]);
-        addNewItem(newReferenceLine.data.value);
+        addNewItem(`${referenceLines.length + 1}`);
     }, [addNewItem, isCartesianChart, visualizationConfig.chartConfig]);
 
     const removeReferenceLine = useCallback(
@@ -209,7 +209,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                     >
                         {referenceLines.map((line, index) => (
                             <ReferenceLine
-                                isOpen={openItems.includes(line.data.value)}
+                                isOpen={openItems.includes(`${index + 1}`)}
                                 addNewItem={addNewItem}
                                 removeItem={removeItem}
                                 key={line.data.value}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -124,8 +124,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
     const addReferenceLine = useCallback(() => {
         if (!isCartesianChart) return;
 
-        const { referenceLines, setReferenceLines } =
-            visualizationConfig.chartConfig;
+        const { setReferenceLines } = visualizationConfig.chartConfig;
 
         const newReferenceLine: ReferenceLineField = {
             data: {
@@ -133,8 +132,12 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                 value: uuidv4(),
             },
         };
-        setReferenceLines([...referenceLines, newReferenceLine]);
-        addNewItem(`${referenceLines.length + 1}`);
+        setReferenceLines((prev) => {
+            const newReferenceLines = [...prev, newReferenceLine];
+            addNewItem(`${newReferenceLines.length}`);
+
+            return newReferenceLines;
+        });
     }, [addNewItem, isCartesianChart, visualizationConfig.chartConfig]);
 
     const removeReferenceLine = useCallback(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Use `index` instead of referenceLine's `data.value` to fix this issue: https://lightdash.sentry.io/issues/5131175770/?project=5959292&referrer=slack

`Accordion.Item`s will break if their `value` attribute value is not correct.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
