### PR TITLE
feat: address remaining bits on chart config ui changes

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -76,6 +76,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                                 size="sm"
                                 lighter
                                 defaultValue={value}
+                                placeholder={getItemLabelWithoutTableName(item)}
                                 onChange={(event) => {
                                     setValue(event.currentTarget.value);
                                     updateSingleSeries({

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -156,126 +156,132 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                         {getItemLabelWithoutTableName(item)} (grouped)
                     </Config.Label>
                 </Group>
-                <Group ml="md" noWrap spacing="xs" align="start">
-                    <ChartTypeSelect
-                        chartValue={chartValue}
-                        showMixed={!isChartTypeTheSameForAllSeries}
-                        onChange={(value) => {
-                            const newType =
-                                value === CartesianSeriesType.AREA
-                                    ? CartesianSeriesType.LINE
-                                    : value;
-                            updateAllGroupedSeries(fieldKey, {
-                                type: newType as Series['type'],
-                                areaStyle:
+                <Stack spacing="xs" ml="md">
+                    <Group noWrap spacing="xs" align="start">
+                        <ChartTypeSelect
+                            chartValue={chartValue}
+                            showMixed={!isChartTypeTheSameForAllSeries}
+                            onChange={(value) => {
+                                const newType =
                                     value === CartesianSeriesType.AREA
-                                        ? {}
-                                        : undefined,
-                            });
-                        }}
-                    />
+                                        ? CartesianSeriesType.LINE
+                                        : value;
+                                updateAllGroupedSeries(fieldKey, {
+                                    type: newType as Series['type'],
+                                    areaStyle:
+                                        value === CartesianSeriesType.AREA
+                                            ? {}
+                                            : undefined,
+                                });
+                            }}
+                        />
 
-                    <Select
-                        label="Axis"
-                        value={
-                            isAxisTheSameForAllSeries
-                                ? String(seriesGroup[0].yAxisIndex)
-                                : 'mixed'
-                        }
-                        data={
-                            isAxisTheSameForAllSeries
-                                ? layout?.flipAxes
-                                    ? FLIPPED_AXIS_OPTIONS
-                                    : AXIS_OPTIONS
-                                : [
-                                      ...(layout?.flipAxes
-                                          ? FLIPPED_AXIS_OPTIONS
-                                          : AXIS_OPTIONS),
-                                      {
-                                          value: 'mixed',
-                                          label: 'Mixed',
-                                      },
-                                  ]
-                        }
-                        onChange={(value) => {
-                            updateAllGroupedSeries(fieldKey, {
-                                yAxisIndex: parseInt(value || '0', 10),
-                            });
-                        }}
-                    />
-                    <Select
-                        label="Value labels"
-                        value={
-                            isLabelTheSameForAllSeries
-                                ? seriesGroup[0].label?.position || 'hidden'
-                                : 'mixed'
-                        }
-                        data={
-                            isLabelTheSameForAllSeries
-                                ? VALUE_LABELS_OPTIONS
-                                : [
-                                      ...VALUE_LABELS_OPTIONS,
-                                      {
-                                          value: 'mixed',
-                                          label: 'Mixed',
-                                      },
-                                  ]
-                        }
-                        onChange={(value) => {
-                            updateAllGroupedSeries(fieldKey, {
-                                label:
-                                    value === 'hidden'
-                                        ? { show: false }
-                                        : {
-                                              show: true,
-                                              position: value as any,
+                        <Select
+                            label="Axis"
+                            value={
+                                isAxisTheSameForAllSeries
+                                    ? String(seriesGroup[0].yAxisIndex)
+                                    : 'mixed'
+                            }
+                            data={
+                                isAxisTheSameForAllSeries
+                                    ? layout?.flipAxes
+                                        ? FLIPPED_AXIS_OPTIONS
+                                        : AXIS_OPTIONS
+                                    : [
+                                          ...(layout?.flipAxes
+                                              ? FLIPPED_AXIS_OPTIONS
+                                              : AXIS_OPTIONS),
+                                          {
+                                              value: 'mixed',
+                                              label: 'Mixed',
                                           },
-                            });
-                        }}
-                    />
-                    {seriesGroup[0].stack &&
-                        chartValue === CartesianSeriesType.BAR && (
-                            <Stack spacing="xs" mt="two">
-                                <Config.SubLabel>Total</Config.SubLabel>
-                                <Switch
-                                    checked={seriesGroup[0].stackLabel?.show}
-                                    onChange={() => {
-                                        updateAllGroupedSeries(fieldKey, {
-                                            stackLabel: {
-                                                show: !seriesGroup[0].stackLabel
-                                                    ?.show,
-                                            },
-                                        });
-                                    }}
-                                />
-                            </Stack>
-                        )}
-                </Group>
-                {(chartValue === CartesianSeriesType.LINE ||
-                    chartValue === CartesianSeriesType.AREA) && (
-                    <Group spacing="xs">
-                        <Checkbox
-                            checked={seriesGroup[0].showSymbol ?? true}
-                            label="Show symbol"
-                            onChange={() => {
+                                      ]
+                            }
+                            onChange={(value) => {
                                 updateAllGroupedSeries(fieldKey, {
-                                    showSymbol: !(
-                                        seriesGroup[0].showSymbol ?? true
-                                    ),
+                                    yAxisIndex: parseInt(value || '0', 10),
                                 });
                             }}
                         />
-                        <Checkbox
-                            checked={seriesGroup[0].smooth}
-                            label="Smooth"
-                            onChange={() => {
+                        <Select
+                            label="Value labels"
+                            value={
+                                isLabelTheSameForAllSeries
+                                    ? seriesGroup[0].label?.position || 'hidden'
+                                    : 'mixed'
+                            }
+                            data={
+                                isLabelTheSameForAllSeries
+                                    ? VALUE_LABELS_OPTIONS
+                                    : [
+                                          ...VALUE_LABELS_OPTIONS,
+                                          {
+                                              value: 'mixed',
+                                              label: 'Mixed',
+                                          },
+                                      ]
+                            }
+                            onChange={(value) => {
                                 updateAllGroupedSeries(fieldKey, {
-                                    smooth: !(seriesGroup[0].smooth ?? true),
+                                    label:
+                                        value === 'hidden'
+                                            ? { show: false }
+                                            : {
+                                                  show: true,
+                                                  position: value as any,
+                                              },
                                 });
                             }}
                         />
+                        {seriesGroup[0].stack &&
+                            chartValue === CartesianSeriesType.BAR && (
+                                <Stack spacing="xs" mt="two">
+                                    <Config.SubLabel>Total</Config.SubLabel>
+                                    <Switch
+                                        checked={
+                                            seriesGroup[0].stackLabel?.show
+                                        }
+                                        onChange={() => {
+                                            updateAllGroupedSeries(fieldKey, {
+                                                stackLabel: {
+                                                    show: !seriesGroup[0]
+                                                        .stackLabel?.show,
+                                                },
+                                            });
+                                        }}
+                                    />
+                                </Stack>
+                            )}
                     </Group>
-                )}
+                    {(chartValue === CartesianSeriesType.LINE ||
+                        chartValue === CartesianSeriesType.AREA) && (
+                        <Group spacing="xs">
+                            <Checkbox
+                                checked={seriesGroup[0].showSymbol ?? true}
+                                label="Show symbol"
+                                onChange={() => {
+                                    updateAllGroupedSeries(fieldKey, {
+                                        showSymbol: !(
+                                            seriesGroup[0].showSymbol ?? true
+                                        ),
+                                    });
+                                }}
+                            />
+                            <Checkbox
+                                checked={seriesGroup[0].smooth}
+                                label="Smooth"
+                                onChange={() => {
+                                    updateAllGroupedSeries(fieldKey, {
+                                        smooth: !(
+                                            seriesGroup[0].smooth ?? true
+                                        ),
+                                    });
+                                }}
+                            />
+                        </Group>
+                    )}
+                </Stack>
                 <Box
                     bg="gray.1"
                     p="xxs"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -105,6 +105,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                             <EditableText
                                 disabled={series.hidden}
                                 defaultValue={seriesValue}
+                                placeholder={seriesLabel}
                                 onChange={(event) => {
                                     setSeriesValue(event.currentTarget.value);
                                     updateSingleSeries({
@@ -143,8 +144,8 @@ const SingleSeriesConfiguration: FC<Props> = ({
                 </Group>
             </Group>
             <Collapse in={!isCollapsable || isOpen || false}>
-                <Stack ml={isGrouped ? 'lg' : 'none'} spacing="xs">
-                    <Group ml="lg" spacing="xs" noWrap>
+                <Stack ml="lg" spacing="xs">
+                    <Group spacing="xs" noWrap>
                         <ChartTypeSelect
                             showLabel={!isGrouped}
                             chartValue={type}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/EditableText.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/EditableText.tsx
@@ -38,8 +38,11 @@ export const EditableText: FC<Props> = ({ lighter, ...props }) => {
                             overflow: 'visible',
                             background: theme.colors.gray[lighter ? '1' : '2'],
                         },
+
+                        '::placeholder': {
+                            color: theme.colors.gray[lighter ? '5' : '6'],
+                        },
                     },
-                    rightSection: {},
                 })}
             />
         </Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9528 

### Description:

- Spacing on `Series`- see `Show symbol` checkbox that had a missing margin left

<img width="407" alt="Screenshot 2024-04-02 at 16 17 17" src="https://github.com/lightdash/lightdash/assets/7611706/d0a110fa-933f-4823-b16d-f2b2a46599ec">

- `EditableText` - show placeholder if no value set - it goes back to default value on the chart visualisation so let's keep that. 

<img width="409" alt="Screenshot 2024-04-02 at 16 18 45" src="https://github.com/lightdash/lightdash/assets/7611706/07492a76-95fb-4bc9-b0c0-681c827be9e8">
<img width="400" alt="Screenshot 2024-04-02 at 16 18 59" src="https://github.com/lightdash/lightdash/assets/7611706/57524de0-e59c-4dfb-9bba-296b713437af">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
