### PR TITLE
fix: return empty data if metric doesn't exist in results for pie chart

### DIFF
--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -243,6 +243,14 @@ const usePieChartConfig: PieChartConfigFn = (
             return [];
         }
 
+        const isMetricPresentInResults = resultsData?.rows.some(
+            (r) => r[metricId],
+        );
+
+        if (!isMetricPresentInResults) {
+            return [];
+        }
+
         const mappedData = resultsData.rows.map((row) => {
             const name = groupFieldIds
                 .map((groupFieldId) => row[groupFieldId]?.value?.formatted)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9613 

Steps to reproduce:

1. Create a pie chart with a custom metric
2. Remove the metric from the results table
3. Click run query

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
