### PR TITLE
fix: return to dashboard tooltip overflow

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -507,6 +507,8 @@ const SavedChartsHeader: FC = () => {
                                             <Tooltip
                                                 offset={-1}
                                                 label="Return to dashboard"
+                                                withinPortal
+                                                position="bottom"
                                             >
                                                 <ActionIcon
                                                     variant="default"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fix a small issue with return to dashboard tooltip

Before
<img width="332" alt="Screenshot 2024-04-03 at 16 17 21" src="https://github.com/lightdash/lightdash/assets/1864179/be0bcf23-6c41-4fa2-9b70-822aaa987536">

After
<img width="368" alt="Screenshot 2024-04-03 at 16 17 03" src="https://github.com/lightdash/lightdash/assets/1864179/e9e14211-c29f-4020-ac5e-543afdf007cd">
