### PR TITLE
feat: table chart config - tabs (1/3)

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
@@ -16,7 +16,7 @@ import { ConfigTabs as BigNumberConfigTabs } from '../../VisualizationConfigs/Bi
 import { ConfigTabs as ChartConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/ConfigTabs';
 import CustomVisConfigTabs from '../../VisualizationConfigs/ChartConfigPanel/CustomVisConfigTabs';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
-import TableConfigTabs from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
+import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
 
 const VisualizationSidebar: FC<{

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,13 +1,17 @@
-import { Tabs } from '@mantine/core';
-import React, { memo } from 'react';
+import { MantineProvider, Tabs } from '@mantine/core';
+import { memo, type FC } from 'react';
+import { themeOverride } from '../mantineTheme';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
-const TableConfigTabs: React.FC = memo(() => {
-    return (
+
+export const ConfigTabs: FC = memo(() => (
+    <MantineProvider inherit theme={themeOverride}>
         <Tabs defaultValue="general" keepMounted={false}>
             <Tabs.List mb="sm">
-                <Tabs.Tab value="general">General</Tabs.Tab>
-                <Tabs.Tab value="conditional-formatting">
+                <Tabs.Tab px="sm" value="general">
+                    General
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="conditional-formatting">
                     Conditional formatting
                 </Tabs.Tab>
             </Tabs.List>
@@ -19,7 +23,5 @@ const TableConfigTabs: React.FC = memo(() => {
                 <ConditionalFormattingList />
             </Tabs.Panel>
         </Tabs>
-    );
-});
-
-export default TableConfigTabs;
+    </MantineProvider>
+));

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
@@ -7,8 +7,7 @@ import {
 } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-
-import TableConfigTabs from './TableConfigTabs';
+import { ConfigTabs } from './TableConfigTabs';
 
 const TableConfigPanel: React.FC = () => {
     const { resultsData } = useVisualizationContext();
@@ -30,7 +29,7 @@ const TableConfigPanel: React.FC = () => {
 
             <Popover.Dropdown>
                 <Box w={320}>
-                    <TableConfigTabs />
+                    <ConfigTabs />
                 </Box>
             </Popover.Dropdown>
         </Popover>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9568 

### Description:

Focuses on `Tabs` for table config chart

Moves `mantineTheme` to the root vis folder

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
