### PR TITLE
feat: table chart config - general settings (2/3)

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
@@ -16,7 +16,7 @@ import { ConfigTabs as BigNumberConfigTabs } from '../../VisualizationConfigs/Bi
 import { ConfigTabs as ChartConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/ConfigTabs';
 import CustomVisConfigTabs from '../../VisualizationConfigs/ChartConfigPanel/CustomVisConfigTabs';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
-import TableConfigTabs from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
+import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
 
 const VisualizationSidebar: FC<{

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
@@ -3,11 +3,10 @@ import {
     Droppable,
     type DraggableStateSnapshot,
 } from '@hello-pangea/dnd';
-import { Box, Group, Text } from '@mantine/core';
-import { IconGripVertical } from '@tabler/icons-react';
+import { Group, Stack, Text } from '@mantine/core';
 import React, { type FC } from 'react';
 import { createPortal } from 'react-dom';
-import MantineIcon from '../../common/MantineIcon';
+import { GrabIcon } from '../common/GrabIcon';
 import ColumnConfiguration from './ColumnConfiguration';
 
 type DraggablePortalHandlerProps = {
@@ -36,76 +35,85 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
     disableReorder,
     placeholder,
 }) => {
+    const hasItems = itemIds.length > 0;
     return (
-        <Droppable droppableId={droppableId}>
-            {(dropProps, droppableSnapshot) => (
-                <Box
-                    {...dropProps.droppableProps}
-                    ref={dropProps.innerRef}
-                    mih={isDragging ? '30px' : undefined}
-                    p="xs"
-                    bg={
-                        droppableSnapshot.isDraggingOver
-                            ? 'gray.1'
-                            : isDragging
-                            ? 'gray.0'
-                            : undefined
-                    }
-                >
-                    {!isDragging && itemIds.length <= 0 ? (
-                        <Text size="xs" color="gray.6" m="xs" ta="center">
-                            {placeholder}
-                        </Text>
-                    ) : null}
-                    {itemIds.map((itemId, index) => (
-                        <Draggable
-                            key={itemId}
-                            draggableId={itemId}
-                            index={index}
-                        >
-                            {(
-                                { draggableProps, dragHandleProps, innerRef },
-                                snapshot,
-                            ) => (
-                                <DraggablePortalHandler snapshot={snapshot}>
-                                    <Group
-                                        noWrap
-                                        spacing="xs"
-                                        mb="xs"
-                                        ref={innerRef}
-                                        {...draggableProps}
-                                        style={{
-                                            visibility:
-                                                isDragging &&
-                                                disableReorder &&
-                                                !snapshot.isDragging
-                                                    ? 'hidden'
-                                                    : undefined,
-                                            ...draggableProps.style,
-                                        }}
-                                    >
-                                        <Box
-                                            {...dragHandleProps}
-                                            sx={{
-                                                opacity: 0.6,
-                                                '&:hover': { opacity: 1 },
+        <Stack
+            spacing="xs"
+            sx={(theme) => ({
+                padding: theme.spacing.xs,
+                backgroundColor: theme.colors.gray['0'],
+                borderRadius: theme.radius.sm,
+            })}
+        >
+            <Droppable droppableId={droppableId}>
+                {(dropProps, droppableSnapshot) => (
+                    <Stack
+                        {...dropProps.droppableProps}
+                        spacing="xs"
+                        ref={dropProps.innerRef}
+                        mih={isDragging ? '30px' : undefined}
+                        bg={
+                            droppableSnapshot.isDraggingOver
+                                ? 'gray.1'
+                                : isDragging
+                                ? 'gray.0'
+                                : undefined
+                        }
+                    >
+                        {!isDragging && !hasItems ? (
+                            <Text size="xs" color="gray.6" m="xs" ta="center">
+                                {placeholder}
+                            </Text>
+                        ) : null}
+                        {itemIds.map((itemId, index) => (
+                            <Draggable
+                                key={itemId}
+                                draggableId={itemId}
+                                index={index}
+                            >
+                                {(
+                                    {
+                                        draggableProps,
+                                        dragHandleProps,
+                                        innerRef,
+                                    },
+                                    snapshot,
+                                ) => (
+                                    <DraggablePortalHandler snapshot={snapshot}>
+                                        <Group
+                                            noWrap
+                                            spacing="xs"
+                                            ref={innerRef}
+                                            {...draggableProps}
+                                            style={{
+                                                visibility:
+                                                    isDragging &&
+                                                    disableReorder &&
+                                                    !snapshot.isDragging
+                                                        ? 'hidden'
+                                                        : undefined,
+                                                ...draggableProps.style,
                                             }}
                                         >
-                                            <MantineIcon
-                                                icon={IconGripVertical}
+                                            <GrabIcon
+                                                dragHandleProps={
+                                                    dragHandleProps
+                                                }
                                             />
-                                        </Box>
 
-                                        <ColumnConfiguration fieldId={itemId} />
-                                    </Group>
-                                </DraggablePortalHandler>
-                            )}
-                        </Draggable>
-                    ))}
-                    {dropProps.placeholder}
-                </Box>
-            )}
-        </Droppable>
+                                            <ColumnConfiguration
+                                                fieldId={itemId}
+                                            />
+                                        </Group>
+                                    </DraggablePortalHandler>
+                                )}
+                            </Draggable>
+                        ))}
+                        {dropProps.placeholder}
+                    </Stack>
+                )}
+            </Droppable>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,10 +1,11 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
 import { getCustomDimensionId } from '@lightdash/common';
-import { Box, Checkbox, Stack, Title, Tooltip } from '@mantine/core';
-import React, { useCallback, useMemo, useState, type FC } from 'react';
+import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine/core';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigTable';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
+import { Config } from '../common/Config';
 import ColumnConfiguration from './ColumnConfiguration';
 import DroppableItemsList from './DroppableItemsList';
 
@@ -161,58 +162,73 @@ const GeneralSettings: FC = () => {
     } = chartConfig;
 
     return (
-        <Stack spacing={0}>
+        <Stack>
             <DragDropContext
                 onDragStart={() => setIsDragging(true)}
                 onDragEnd={onDragEnd}
             >
-                <Title order={6}>Columns</Title>
-                <DroppableItemsList
-                    droppableId={DroppableIds.COLUMNS}
-                    itemIds={columns}
-                    isDragging={isDragging}
-                    disableReorder={false}
-                    placeholder={
-                        'Move dimensions to columns to pivot your table'
-                    }
-                />
-                <Title order={6}>Rows</Title>
-                <DroppableItemsList
-                    droppableId={DroppableIds.ROWS}
-                    itemIds={rows}
-                    isDragging={isDragging}
-                    disableReorder={true}
-                />
+                <Config>
+                    <Config.Section>
+                        <Config.Heading>Columns</Config.Heading>
+                        <DroppableItemsList
+                            droppableId={DroppableIds.COLUMNS}
+                            itemIds={columns}
+                            isDragging={isDragging}
+                            disableReorder={false}
+                            placeholder={
+                                'Drag dimensions into this area to pivot your table'
+                            }
+                        />
+
+                        <Config.Heading>Rows</Config.Heading>
+                        <DroppableItemsList
+                            droppableId={DroppableIds.ROWS}
+                            itemIds={rows}
+                            isDragging={isDragging}
+                            disableReorder={true}
+                            placeholder={
+                                'Drag dimensions into this area to group your data'
+                            }
+                        />
+                    </Config.Section>
+                </Config>
             </DragDropContext>
 
-            <Title order={6}>Metrics</Title>
-            <Tooltip
-                disabled={!!isPivotTableEnabled}
-                label={
-                    'To use metrics as rows, you need to move a dimension to "Columns"'
-                }
-                w={300}
-                multiline
-                withinPortal
-                position="top-start"
-            >
-                <Box my="sm">
-                    <Checkbox
-                        disabled={!isPivotTableEnabled}
-                        label="Show metrics as rows"
-                        checked={metricsAsRows}
-                        onChange={() => handleToggleMetricsAsRows()}
-                    />
-                </Box>
-            </Tooltip>
-            <Stack spacing="xs" mb="md">
+            <Config.Section>
+                <Config.Section>
+                    <Config.Heading>Metrics</Config.Heading>
+                    <Tooltip
+                        disabled={!!isPivotTableEnabled}
+                        label={
+                            'To use metrics as rows, you need to move a dimension to "Columns"'
+                        }
+                        w={300}
+                        multiline
+                        withinPortal
+                        position="top-start"
+                    >
+                        <Box>
+                            <Switch
+                                disabled={!isPivotTableEnabled}
+                                label="Show metrics as rows"
+                                labelPosition="right"
+                                checked={metricsAsRows}
+                                onChange={() => handleToggleMetricsAsRows()}
+                            />
+                        </Box>
+                    </Tooltip>
+                </Config.Section>
+            </Config.Section>
+
+            <Config.Section>
                 {metrics.map((itemId) => (
                     <ColumnConfiguration key={itemId} fieldId={itemId} />
                 ))}
-            </Stack>
+            </Config.Section>
 
-            <Title order={6}>Options</Title>
-            <Stack mt="sm" spacing="xs">
+            <Config.Section>
+                <Config.Heading>Display</Config.Heading>
+
                 <Checkbox
                     label="Show table names"
                     checked={showTableNames}
@@ -220,7 +236,6 @@ const GeneralSettings: FC = () => {
                         setShowTableNames(!showTableNames);
                     }}
                 />
-
                 <Checkbox
                     label="Show row numbers"
                     checked={!hideRowNumbers}
@@ -228,6 +243,10 @@ const GeneralSettings: FC = () => {
                         setHideRowNumbers(!hideRowNumbers);
                     }}
                 />
+            </Config.Section>
+
+            <Config.Section>
+                <Config.Heading>Results</Config.Heading>
                 {isPivotTableEnabled ? (
                     <Checkbox
                         label="Show row totals"
@@ -278,7 +297,7 @@ const GeneralSettings: FC = () => {
                         />
                     </Box>
                 </Tooltip>
-            </Stack>
+            </Config.Section>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,13 +1,17 @@
-import { Tabs } from '@mantine/core';
-import React, { memo } from 'react';
+import { MantineProvider, Tabs } from '@mantine/core';
+import { memo, type FC } from 'react';
+import { themeOverride } from '../mantineTheme';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
-const TableConfigTabs: React.FC = memo(() => {
-    return (
+
+export const ConfigTabs: FC = memo(() => (
+    <MantineProvider inherit theme={themeOverride}>
         <Tabs defaultValue="general" keepMounted={false}>
             <Tabs.List mb="sm">
-                <Tabs.Tab value="general">General</Tabs.Tab>
-                <Tabs.Tab value="conditional-formatting">
+                <Tabs.Tab px="sm" value="general">
+                    General
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="conditional-formatting">
                     Conditional formatting
                 </Tabs.Tab>
             </Tabs.List>
@@ -19,7 +23,5 @@ const TableConfigTabs: React.FC = memo(() => {
                 <ConditionalFormattingList />
             </Tabs.Panel>
         </Tabs>
-    );
-});
-
-export default TableConfigTabs;
+    </MantineProvider>
+));

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
@@ -7,8 +7,7 @@ import {
 } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-
-import TableConfigTabs from './TableConfigTabs';
+import { ConfigTabs } from './TableConfigTabs';
 
 const TableConfigPanel: React.FC = () => {
     const { resultsData } = useVisualizationContext();
@@ -30,7 +29,7 @@ const TableConfigPanel: React.FC = () => {
 
             <Popover.Dropdown>
                 <Box w={320}>
-                    <TableConfigTabs />
+                    <ConfigTabs />
                 </Box>
             </Popover.Dropdown>
         </Popover>


### PR DESCRIPTION

Relates to: #9568 


### Description:

Table config changes to `General Settings` tab

<img width="404" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/59810a11-d5ae-4bbb-8d8c-d2e21fe1aa45">

- Inputs are smaller
- Lighter droppable areas - their text inputs have a placeholder if you leave the input empty (default label)
- Grouped checkboxes by intent


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
