### PR TITLE
feat: table chart config - conditional formatting (3/3)

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationSidebar.tsx
@@ -16,7 +16,7 @@ import { ConfigTabs as BigNumberConfigTabs } from '../../VisualizationConfigs/Bi
 import { ConfigTabs as ChartConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/ConfigTabs';
 import CustomVisConfigTabs from '../../VisualizationConfigs/ChartConfigPanel/CustomVisConfigTabs';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
-import TableConfigTabs from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
+import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
 
 const VisualizationSidebar: FC<{

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -9,7 +9,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Accordion } from '@mantine/core';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useProject } from '../../../../hooks/useProject';
 import { type ReferenceLineField } from '../../../common/ReferenceLine';
@@ -17,31 +17,12 @@ import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/
 import { useVisualizationContext } from '../../../LightdashVisualization/VisualizationProvider';
 import { AddButton } from '../../common/AddButton';
 import { Config } from '../../common/Config';
+import { useControlledAccordion } from '../../common/hooks/useControlledAccordion';
 import { ReferenceLine, type ReferenceLineProps } from './ReferenceLine';
 
 type Props = {
     items: (Field | TableCalculation | CompiledDimension | CustomDimension)[];
     projectUuid: string;
-};
-
-const useControlledAccordion = (defaultOpenItems = []) => {
-    const [openItems, setOpenItems] = useState<string[]>(defaultOpenItems);
-
-    const handleAccordionChange = useCallback((itemValues: string[]) => {
-        setOpenItems(itemValues);
-    }, []);
-
-    const addNewItem = useCallback((index: string) => {
-        setOpenItems((prevOpenItems) => [...prevOpenItems, index]);
-    }, []);
-
-    const removeItem = useCallback((index: string) => {
-        setOpenItems((prevOpenItems) =>
-            prevOpenItems.filter((item) => item !== index),
-        );
-    }, []);
-
-    return { openItems, handleAccordionChange, addNewItem, removeItem };
 };
 
 export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -254,7 +254,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
             >
                 <Group spacing="xs" position="apart">
                     <Group spacing="xs">
-                        <Config.Label>{controlLabel}</Config.Label>
+                        <Config.Heading>{controlLabel}</Config.Heading>
 
                         <Tooltip
                             variant="xs"

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -16,58 +16,57 @@ import {
     type FilterableItem,
 } from '@lightdash/common';
 import {
+    Accordion,
     ActionIcon,
+    Box,
     Button,
-    Collapse,
-    ColorInput,
+    Divider,
     Group,
-    Select,
-    SimpleGrid,
+    SegmentedControl,
     Stack,
-    Text,
     Tooltip,
 } from '@mantine/core';
-import {
-    IconChevronDown,
-    IconChevronUp,
-    IconPercentage,
-    IconPlus,
-    IconX,
-} from '@tabler/icons-react';
+import { useHover } from '@mantine/hooks';
+import { IconPercentage, IconPlus, IconTrash } from '@tabler/icons-react';
 import produce from 'immer';
-import React, { useCallback, useMemo, useState, type FC } from 'react';
+import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import FilterNumberInput from '../../common/Filters/FilterInputs/FilterNumberInput';
 import { FiltersProvider } from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
+import ColorSelector from '../ColorSelector';
+import { Config } from '../common/Config';
 import ConditionalFormattingRule from './ConditionalFormattingRule';
 
-interface ConditionalFormattingProps {
-    isDefaultOpen?: boolean;
+type Props = {
+    isOpen: boolean;
     colorPalette: string[];
     index: number;
     fields: FilterableItem[];
     value: ConditionalFormattingConfig;
     onChange: (newConfig: ConditionalFormattingConfig) => void;
     onRemove: () => void;
-}
-
-const ConditionalFormattingRuleLabels = {
-    [ConditionalFormattingConfigType.Single]: 'Single color',
-    [ConditionalFormattingConfigType.Range]: 'Color range',
+    addNewItem: (value: string) => void;
+    removeItem: (value: string) => void;
 };
 
-const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
-    isDefaultOpen = true,
+const ConditionalFormattingRuleLabels = {
+    [ConditionalFormattingConfigType.Single]: 'Single',
+    [ConditionalFormattingConfigType.Range]: 'Range',
+};
+
+export const ConditionalFormattingItem: FC<Props> = ({
     colorPalette,
     index: configIndex,
     fields,
+    isOpen,
     value,
     onChange,
     onRemove,
+    addNewItem,
+    removeItem,
 }) => {
     const [isAddingRule, setIsAddingRule] = useState(false);
-    const [isOpen, setIsOpen] = useState(isDefaultOpen);
     const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
 
     const field = useMemo(
@@ -239,38 +238,46 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
         [handleChange, config],
     );
 
+    const { ref, hovered } = useHover<HTMLButtonElement>();
+    const controlLabel = `Rule ${configIndex}`;
+    const accordionValue = `${configIndex}`;
+
     return (
-        <FiltersProvider>
-            <Stack spacing="xs">
-                <Group noWrap position="apart">
+        <Accordion.Item value={accordionValue}>
+            <Accordion.Control
+                ref={ref}
+                onClick={() =>
+                    isOpen
+                        ? removeItem(accordionValue)
+                        : addNewItem(accordionValue)
+                }
+            >
+                <Group spacing="xs" position="apart">
                     <Group spacing="xs">
-                        <ActionIcon
-                            onClick={() => setIsOpen(!isOpen)}
-                            size="sm"
+                        <Config.Label>{controlLabel}</Config.Label>
+
+                        <Tooltip
+                            variant="xs"
+                            label="Remove rule"
+                            position="left"
+                            withinPortal
                         >
-                            <MantineIcon
-                                icon={isOpen ? IconChevronUp : IconChevronDown}
-                            />
-                        </ActionIcon>
-
-                        <Text fw={500}>Rule {configIndex + 1}</Text>
+                            <ActionIcon
+                                onClick={handleRemove}
+                                sx={{
+                                    visibility: hovered ? 'visible' : 'hidden',
+                                }}
+                            >
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Tooltip>
                     </Group>
-
-                    <Tooltip label="Remove rule" position="left" withinPortal>
-                        <ActionIcon onClick={handleRemove} size="sm">
-                            <MantineIcon icon={IconX} />
-                        </ActionIcon>
-                    </Tooltip>
                 </Group>
-                <Collapse in={isOpen}>
-                    <Stack
-                        bg={'gray.0'}
-                        p="sm"
-                        spacing="sm"
-                        sx={(theme) => ({
-                            borderRadius: theme.radius.sm,
-                        })}
-                    >
+            </Accordion.Control>
+
+            <Accordion.Panel>
+                <Stack spacing="xs">
+                    <FiltersProvider>
                         <FieldSelect
                             label="Select field"
                             clearable
@@ -279,47 +286,60 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                             onChange={handleChangeField}
                         />
 
-                        <Select
-                            label="Select type"
-                            value={getConditionalFormattingConfigType(config)}
-                            data={[
-                                {
-                                    value: ConditionalFormattingConfigType.Single,
-                                    label: ConditionalFormattingRuleLabels[
-                                        ConditionalFormattingConfigType.Single
-                                    ],
-                                },
-                                {
-                                    value: ConditionalFormattingConfigType.Range,
-                                    label: ConditionalFormattingRuleLabels[
-                                        ConditionalFormattingConfigType.Range
-                                    ],
-                                },
-                            ]}
-                            onChange={(
-                                newConfigType: ConditionalFormattingConfigType,
-                            ) => {
-                                handleConfigTypeChange(newConfigType);
-                            }}
-                        />
+                        <Group spacing="xs">
+                            <Config.Label>Color</Config.Label>
+
+                            <SegmentedControl
+                                data={[
+                                    {
+                                        value: ConditionalFormattingConfigType.Single,
+                                        label: ConditionalFormattingRuleLabels[
+                                            ConditionalFormattingConfigType
+                                                .Single
+                                        ],
+                                    },
+                                    {
+                                        value: ConditionalFormattingConfigType.Range,
+                                        label: ConditionalFormattingRuleLabels[
+                                            ConditionalFormattingConfigType
+                                                .Range
+                                        ],
+                                    },
+                                ]}
+                                value={getConditionalFormattingConfigType(
+                                    config,
+                                )}
+                                onChange={(
+                                    newConfigType: ConditionalFormattingConfigType,
+                                ) => {
+                                    handleConfigTypeChange(newConfigType);
+                                }}
+                            />
+
+                            {isConditionalFormattingConfigWithSingleColor(
+                                config,
+                            ) ? (
+                                <ColorSelector
+                                    color={config.color}
+                                    swatches={colorPalette}
+                                    onColorChange={handleChangeSingleColor}
+                                />
+                            ) : null}
+                        </Group>
 
                         {isConditionalFormattingConfigWithSingleColor(
                             config,
                         ) ? (
-                            <>
-                                <ColorInput
-                                    withinPortal={false}
-                                    withEyeDropper={false}
-                                    format="hex"
-                                    swatches={colorPalette}
-                                    swatchesPerRow={8}
-                                    label="Select color"
-                                    value={config.color}
-                                    onChange={handleChangeSingleColor}
-                                />
-
+                            <Box
+                                p="xs"
+                                sx={(theme) => ({
+                                    backgroundColor: theme.colors.gray[1],
+                                    border: `1px solid ${theme.colors.gray[4]}`,
+                                    borderRadius: theme.radius.sm,
+                                })}
+                            >
                                 {config.rules.map((rule, ruleIndex) => (
-                                    <React.Fragment key={ruleIndex}>
+                                    <Fragment key={ruleIndex}>
                                         <ConditionalFormattingRule
                                             isDefaultOpen={
                                                 config.rules.length === 1 ||
@@ -350,51 +370,54 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
 
                                         {ruleIndex !==
                                             config.rules.length - 1 && (
-                                            <Text fz="xs" fw={600}>
-                                                AND
-                                            </Text>
+                                            <Divider
+                                                mt="xs"
+                                                label={
+                                                    <Config.Label>
+                                                        AND
+                                                    </Config.Label>
+                                                }
+                                                labelPosition="center"
+                                            />
                                         )}
-                                    </React.Fragment>
+                                    </Fragment>
                                 ))}
-                            </>
+                            </Box>
                         ) : isConditionalFormattingConfigWithColorRange(
                               config,
                           ) ? (
-                            <SimpleGrid cols={2}>
-                                <ColorInput
-                                    withinPortal={false}
-                                    withEyeDropper={false}
-                                    format="hex"
-                                    swatches={colorPalette}
-                                    swatchesPerRow={8}
-                                    label="Start color"
-                                    value={config.color.start}
-                                    onChange={(newStartColor) =>
-                                        handleChangeColorRangeColor({
-                                            start: newStartColor,
-                                        })
-                                    }
-                                />
-
-                                <ColorInput
-                                    withinPortal={false}
-                                    withEyeDropper={false}
-                                    format="hex"
-                                    swatches={colorPalette}
-                                    swatchesPerRow={8}
-                                    label="End color"
-                                    value={config.color.end}
-                                    onChange={(newEndColor) =>
-                                        handleChangeColorRangeColor({
-                                            end: newEndColor,
-                                        })
-                                    }
-                                />
+                            <Group spacing="xs" noWrap grow>
+                                <Group>
+                                    <Stack spacing="one">
+                                        <Config.Label>Start</Config.Label>
+                                        <ColorSelector
+                                            color={config.color.start}
+                                            swatches={colorPalette}
+                                            onColorChange={(newStartColor) => {
+                                                handleChangeColorRangeColor({
+                                                    start: newStartColor,
+                                                });
+                                            }}
+                                        />
+                                    </Stack>
+                                    <Stack spacing="one">
+                                        <Config.Label>End</Config.Label>
+                                        <ColorSelector
+                                            color={config.color.end}
+                                            swatches={colorPalette}
+                                            onColorChange={(newEndColor) => {
+                                                handleChangeColorRangeColor({
+                                                    end: newEndColor,
+                                                });
+                                            }}
+                                        />
+                                    </Stack>
+                                </Group>
 
                                 {/* FIXME: remove this and use NumberInput from @mantine/core once we upgrade to mantine v7 */}
                                 {/* INFO: mantine v6 NumberInput does not handle decimal values properly */}
                                 <FilterNumberInput
-                                    label="Min value"
+                                    label="Min"
                                     icon={
                                         hasPercentageFormat(field) ? (
                                             <MantineIcon
@@ -402,7 +425,6 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                             />
                                         ) : null
                                     }
-                                    size="sm"
                                     value={config.rule.min}
                                     onChange={(newMin) => {
                                         if (newMin === null) return;
@@ -416,7 +438,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                 {/* FIXME: remove this and use NumberInput from @mantine/core once we upgrade to mantine v7 */}
                                 {/* INFO: mantine v6 NumberInput does not handle decimal values properly */}
                                 <FilterNumberInput
-                                    label="Max value"
+                                    label="Max"
                                     icon={
                                         hasPercentageFormat(field) ? (
                                             <MantineIcon
@@ -424,7 +446,6 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                             />
                                         ) : null
                                     }
-                                    size="sm"
                                     value={config.rule.max}
                                     onChange={(newMax) => {
                                         if (newMax === null) return;
@@ -434,7 +455,7 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                         });
                                     }}
                                 />
-                            </SimpleGrid>
+                            </Group>
                         ) : (
                             assertUnreachable(config, 'Unknown config type')
                         )}
@@ -444,7 +465,6 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                         ) ? (
                             <Button
                                 sx={{ alignSelf: 'start' }}
-                                size="xs"
                                 variant="subtle"
                                 leftIcon={<MantineIcon icon={IconPlus} />}
                                 onClick={handleAddRule}
@@ -452,10 +472,9 @@ const ConditionalFormatting: FC<ConditionalFormattingProps> = ({
                                 Add new condition
                             </Button>
                         ) : null}
-                    </Stack>
-                </Collapse>
-            </Stack>
-        </FiltersProvider>
+                    </FiltersProvider>
+                </Stack>
+            </Accordion.Panel>
+        </Accordion.Item>
     );
 };
-export default ConditionalFormatting;

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -13,7 +13,8 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
+import { useHover } from '@mantine/hooks';
+import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import {
     FilterInputComponent,
@@ -48,32 +49,40 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     onRemoveRule,
     hasRemove,
 }) => {
+    const { ref, hovered } = useHover();
     const [isOpen, setIsOpen] = useState(isDefaultOpen);
 
     return (
-        <Stack spacing="xs">
+        <Stack spacing="xs" ref={ref}>
             <Group noWrap position="apart">
                 <Group spacing="xs">
-                    <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
-                        <MantineIcon
-                            icon={isOpen ? IconChevronUp : IconChevronDown}
-                        />
-                    </ActionIcon>
+                    <Text fw={500} fz="xs">
+                        Condition {ruleIndex + 1}
+                    </Text>
 
-                    <Text fw={500}>Condition {ruleIndex + 1}</Text>
+                    {hasRemove && hovered && (
+                        <Tooltip
+                            variant="xs"
+                            label="Remove condition"
+                            position="left"
+                            withinPortal
+                        >
+                            <ActionIcon onClick={onRemoveRule}>
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
                 </Group>
 
-                {hasRemove && (
-                    <Tooltip label="Remove rule" position="left" withinPortal>
-                        <ActionIcon onClick={onRemoveRule} size="sm">
-                            <MantineIcon icon={IconX} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
+                <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
+                    <MantineIcon
+                        icon={isOpen ? IconChevronUp : IconChevronDown}
+                    />
+                </ActionIcon>
             </Group>
 
             <Collapse in={isOpen}>
-                <Stack spacing="xs">
+                <Group noWrap spacing="xs">
                     <Select
                         value={rule.operator}
                         data={filterOperatorOptions}
@@ -89,7 +98,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                         rule={rule}
                         onChange={onChangeRule}
                     />
-                </Stack>
+                </Group>
             </Collapse>
         </Stack>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
@@ -3,11 +3,10 @@ import {
     Droppable,
     type DraggableStateSnapshot,
 } from '@hello-pangea/dnd';
-import { Box, Group, Text } from '@mantine/core';
-import { IconGripVertical } from '@tabler/icons-react';
+import { Group, Stack, Text } from '@mantine/core';
 import React, { type FC } from 'react';
 import { createPortal } from 'react-dom';
-import MantineIcon from '../../common/MantineIcon';
+import { GrabIcon } from '../common/GrabIcon';
 import ColumnConfiguration from './ColumnConfiguration';
 
 type DraggablePortalHandlerProps = {
@@ -36,76 +35,85 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
     disableReorder,
     placeholder,
 }) => {
+    const hasItems = itemIds.length > 0;
     return (
-        <Droppable droppableId={droppableId}>
-            {(dropProps, droppableSnapshot) => (
-                <Box
-                    {...dropProps.droppableProps}
-                    ref={dropProps.innerRef}
-                    mih={isDragging ? '30px' : undefined}
-                    p="xs"
-                    bg={
-                        droppableSnapshot.isDraggingOver
-                            ? 'gray.1'
-                            : isDragging
-                            ? 'gray.0'
-                            : undefined
-                    }
-                >
-                    {!isDragging && itemIds.length <= 0 ? (
-                        <Text size="xs" color="gray.6" m="xs" ta="center">
-                            {placeholder}
-                        </Text>
-                    ) : null}
-                    {itemIds.map((itemId, index) => (
-                        <Draggable
-                            key={itemId}
-                            draggableId={itemId}
-                            index={index}
-                        >
-                            {(
-                                { draggableProps, dragHandleProps, innerRef },
-                                snapshot,
-                            ) => (
-                                <DraggablePortalHandler snapshot={snapshot}>
-                                    <Group
-                                        noWrap
-                                        spacing="xs"
-                                        mb="xs"
-                                        ref={innerRef}
-                                        {...draggableProps}
-                                        style={{
-                                            visibility:
-                                                isDragging &&
-                                                disableReorder &&
-                                                !snapshot.isDragging
-                                                    ? 'hidden'
-                                                    : undefined,
-                                            ...draggableProps.style,
-                                        }}
-                                    >
-                                        <Box
-                                            {...dragHandleProps}
-                                            sx={{
-                                                opacity: 0.6,
-                                                '&:hover': { opacity: 1 },
+        <Stack
+            spacing="xs"
+            sx={(theme) => ({
+                padding: theme.spacing.xs,
+                backgroundColor: theme.colors.gray['0'],
+                borderRadius: theme.radius.sm,
+            })}
+        >
+            <Droppable droppableId={droppableId}>
+                {(dropProps, droppableSnapshot) => (
+                    <Stack
+                        {...dropProps.droppableProps}
+                        spacing="xs"
+                        ref={dropProps.innerRef}
+                        mih={isDragging ? '30px' : undefined}
+                        bg={
+                            droppableSnapshot.isDraggingOver
+                                ? 'gray.1'
+                                : isDragging
+                                ? 'gray.0'
+                                : undefined
+                        }
+                    >
+                        {!isDragging && !hasItems ? (
+                            <Text size="xs" color="gray.6" m="xs" ta="center">
+                                {placeholder}
+                            </Text>
+                        ) : null}
+                        {itemIds.map((itemId, index) => (
+                            <Draggable
+                                key={itemId}
+                                draggableId={itemId}
+                                index={index}
+                            >
+                                {(
+                                    {
+                                        draggableProps,
+                                        dragHandleProps,
+                                        innerRef,
+                                    },
+                                    snapshot,
+                                ) => (
+                                    <DraggablePortalHandler snapshot={snapshot}>
+                                        <Group
+                                            noWrap
+                                            spacing="xs"
+                                            ref={innerRef}
+                                            {...draggableProps}
+                                            style={{
+                                                visibility:
+                                                    isDragging &&
+                                                    disableReorder &&
+                                                    !snapshot.isDragging
+                                                        ? 'hidden'
+                                                        : undefined,
+                                                ...draggableProps.style,
                                             }}
                                         >
-                                            <MantineIcon
-                                                icon={IconGripVertical}
+                                            <GrabIcon
+                                                dragHandleProps={
+                                                    dragHandleProps
+                                                }
                                             />
-                                        </Box>
 
-                                        <ColumnConfiguration fieldId={itemId} />
-                                    </Group>
-                                </DraggablePortalHandler>
-                            )}
-                        </Draggable>
-                    ))}
-                    {dropProps.placeholder}
-                </Box>
-            )}
-        </Droppable>
+                                            <ColumnConfiguration
+                                                fieldId={itemId}
+                                            />
+                                        </Group>
+                                    </DraggablePortalHandler>
+                                )}
+                            </Draggable>
+                        ))}
+                        {dropProps.placeholder}
+                    </Stack>
+                )}
+            </Droppable>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,10 +1,11 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
 import { getCustomDimensionId } from '@lightdash/common';
-import { Box, Checkbox, Stack, Title, Tooltip } from '@mantine/core';
-import React, { useCallback, useMemo, useState, type FC } from 'react';
+import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine/core';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigTable';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
+import { Config } from '../common/Config';
 import ColumnConfiguration from './ColumnConfiguration';
 import DroppableItemsList from './DroppableItemsList';
 
@@ -161,58 +162,73 @@ const GeneralSettings: FC = () => {
     } = chartConfig;
 
     return (
-        <Stack spacing={0}>
+        <Stack>
             <DragDropContext
                 onDragStart={() => setIsDragging(true)}
                 onDragEnd={onDragEnd}
             >
-                <Title order={6}>Columns</Title>
-                <DroppableItemsList
-                    droppableId={DroppableIds.COLUMNS}
-                    itemIds={columns}
-                    isDragging={isDragging}
-                    disableReorder={false}
-                    placeholder={
-                        'Move dimensions to columns to pivot your table'
-                    }
-                />
-                <Title order={6}>Rows</Title>
-                <DroppableItemsList
-                    droppableId={DroppableIds.ROWS}
-                    itemIds={rows}
-                    isDragging={isDragging}
-                    disableReorder={true}
-                />
+                <Config>
+                    <Config.Section>
+                        <Config.Heading>Columns</Config.Heading>
+                        <DroppableItemsList
+                            droppableId={DroppableIds.COLUMNS}
+                            itemIds={columns}
+                            isDragging={isDragging}
+                            disableReorder={false}
+                            placeholder={
+                                'Drag dimensions into this area to pivot your table'
+                            }
+                        />
+
+                        <Config.Heading>Rows</Config.Heading>
+                        <DroppableItemsList
+                            droppableId={DroppableIds.ROWS}
+                            itemIds={rows}
+                            isDragging={isDragging}
+                            disableReorder={true}
+                            placeholder={
+                                'Drag dimensions into this area to group your data'
+                            }
+                        />
+                    </Config.Section>
+                </Config>
             </DragDropContext>
 
-            <Title order={6}>Metrics</Title>
-            <Tooltip
-                disabled={!!isPivotTableEnabled}
-                label={
-                    'To use metrics as rows, you need to move a dimension to "Columns"'
-                }
-                w={300}
-                multiline
-                withinPortal
-                position="top-start"
-            >
-                <Box my="sm">
-                    <Checkbox
-                        disabled={!isPivotTableEnabled}
-                        label="Show metrics as rows"
-                        checked={metricsAsRows}
-                        onChange={() => handleToggleMetricsAsRows()}
-                    />
-                </Box>
-            </Tooltip>
-            <Stack spacing="xs" mb="md">
+            <Config.Section>
+                <Config.Section>
+                    <Config.Heading>Metrics</Config.Heading>
+                    <Tooltip
+                        disabled={!!isPivotTableEnabled}
+                        label={
+                            'To use metrics as rows, you need to move a dimension to "Columns"'
+                        }
+                        w={300}
+                        multiline
+                        withinPortal
+                        position="top-start"
+                    >
+                        <Box>
+                            <Switch
+                                disabled={!isPivotTableEnabled}
+                                label="Show metrics as rows"
+                                labelPosition="right"
+                                checked={metricsAsRows}
+                                onChange={() => handleToggleMetricsAsRows()}
+                            />
+                        </Box>
+                    </Tooltip>
+                </Config.Section>
+            </Config.Section>
+
+            <Config.Section>
                 {metrics.map((itemId) => (
                     <ColumnConfiguration key={itemId} fieldId={itemId} />
                 ))}
-            </Stack>
+            </Config.Section>
 
-            <Title order={6}>Options</Title>
-            <Stack mt="sm" spacing="xs">
+            <Config.Section>
+                <Config.Heading>Display</Config.Heading>
+
                 <Checkbox
                     label="Show table names"
                     checked={showTableNames}
@@ -220,7 +236,6 @@ const GeneralSettings: FC = () => {
                         setShowTableNames(!showTableNames);
                     }}
                 />
-
                 <Checkbox
                     label="Show row numbers"
                     checked={!hideRowNumbers}
@@ -228,6 +243,10 @@ const GeneralSettings: FC = () => {
                         setHideRowNumbers(!hideRowNumbers);
                     }}
                 />
+            </Config.Section>
+
+            <Config.Section>
+                <Config.Heading>Results</Config.Heading>
                 {isPivotTableEnabled ? (
                     <Checkbox
                         label="Show row totals"
@@ -278,7 +297,7 @@ const GeneralSettings: FC = () => {
                         />
                     </Box>
                 </Tooltip>
-            </Stack>
+            </Config.Section>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,13 +1,17 @@
-import { Tabs } from '@mantine/core';
-import React, { memo } from 'react';
+import { MantineProvider, Tabs } from '@mantine/core';
+import { memo, type FC } from 'react';
+import { themeOverride } from '../mantineTheme';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
-const TableConfigTabs: React.FC = memo(() => {
-    return (
+
+export const ConfigTabs: FC = memo(() => (
+    <MantineProvider inherit theme={themeOverride}>
         <Tabs defaultValue="general" keepMounted={false}>
             <Tabs.List mb="sm">
-                <Tabs.Tab value="general">General</Tabs.Tab>
-                <Tabs.Tab value="conditional-formatting">
+                <Tabs.Tab px="sm" value="general">
+                    General
+                </Tabs.Tab>
+                <Tabs.Tab px="sm" value="conditional-formatting">
                     Conditional formatting
                 </Tabs.Tab>
             </Tabs.List>
@@ -19,7 +23,5 @@ const TableConfigTabs: React.FC = memo(() => {
                 <ConditionalFormattingList />
             </Tabs.Panel>
         </Tabs>
-    );
-});
-
-export default TableConfigTabs;
+    </MantineProvider>
+));

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/index.tsx
@@ -7,8 +7,7 @@ import {
 } from '../../common/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';
-
-import TableConfigTabs from './TableConfigTabs';
+import { ConfigTabs } from './TableConfigTabs';
 
 const TableConfigPanel: React.FC = () => {
     const { resultsData } = useVisualizationContext();
@@ -30,7 +29,7 @@ const TableConfigPanel: React.FC = () => {
 
             <Popover.Dropdown>
                 <Box w={320}>
-                    <TableConfigTabs />
+                    <ConfigTabs />
                 </Box>
             </Popover.Dropdown>
         </Popover>

--- a/packages/frontend/src/components/VisualizationConfigs/common/hooks/useControlledAccordion.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/hooks/useControlledAccordion.tsx
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react';
+
+export const useControlledAccordion = (defaultOpenItems = []) => {
+    const [openItems, setOpenItems] = useState<string[]>(defaultOpenItems);
+
+    const handleAccordionChange = useCallback((itemValues: string[]) => {
+        setOpenItems(itemValues);
+    }, []);
+
+    const addNewItem = useCallback((index: string) => {
+        setOpenItems((prevOpenItems) => [...prevOpenItems, index]);
+    }, []);
+
+    const removeItem = useCallback((index: string) => {
+        setOpenItems((prevOpenItems) =>
+            prevOpenItems.filter((item) => item !== index),
+        );
+    }, []);
+
+    return { openItems, handleAccordionChange, addNewItem, removeItem };
+};


### PR DESCRIPTION
Relates to: #9568 


### Description:

Table config changes to `Conditional Formatting` tab

Single colour
<img width="382" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/9a004c4f-a9fb-4b9f-94a9-0a36fa033d6e">

Range
<img width="385" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/11dcd1b4-760c-4b08-87cb-96512e349850">


- Inputs are smaller
- Color selects are different depending on mode
- It's an accordion now
- Different UI when adding more and more conditions


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
