### PR TITLE
feat: make markdown previews look more like standard tooltips

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -2,6 +2,7 @@ import {
     Anchor,
     Box,
     Group,
+    MantineProvider,
     Popover,
     Text,
     Title,
@@ -19,7 +20,10 @@ import { useItemDetail } from './ItemDetailContext';
  * to avoid markdown styling from completely throwing its surroundings out
  * of whack.
  */
-export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
+export const ItemDetailMarkdown: FC<{
+    source: string;
+    variant?: 'tooltip' | 'default';
+}> = ({ source, variant = 'default' }) => {
     const theme = useMantineTheme();
     return (
         <ReactMarkdownPreview
@@ -31,6 +35,9 @@ export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
                 h3: ({ children }) => <Title order={4}>{children}</Title>,
             }}
             rehypeRewrite={rehypeRemoveHeaderLinks}
+            wrapperElement={{
+                'data-color-mode': variant === 'tooltip' ? 'dark' : undefined,
+            }}
             source={source}
             disallowedElements={['img']}
             style={{
@@ -73,7 +80,7 @@ export const ItemDetailPreview: FC<{
                         : undefined,
                 }}
             >
-                <ItemDetailMarkdown source={description} />
+                <ItemDetailMarkdown source={description} variant="tooltip" />
             </Box>
             {isTruncated && (
                 <Box ta={'center'}>
@@ -111,6 +118,7 @@ export const TableItemDetailPreview = ({
     offset?: number;
 }>) => {
     const { showItemDetail } = useItemDetail();
+    const theme = useMantineTheme();
 
     const onOpenDescriptionView = () => {
         closePreview();
@@ -126,34 +134,38 @@ export const TableItemDetailPreview = ({
     };
 
     return (
-        <Popover
-            opened={showPreview}
-            keepMounted={false}
-            shadow="sm"
-            withinPortal
-            disabled={!description}
-            position="right"
-            withArrow
-            offset={offset}
-        >
-            <Popover.Target>{children}</Popover.Target>
-            <Popover.Dropdown
-                /**
-                 * Takes up space to the right, so it's OK to go fairly wide in the interest
-                 * of readability.
-                 */
-                maw={500}
-                /**
-                 * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
-                 * while interacting with the hovercard.
-                 */
-                onClick={(event) => event.stopPropagation()}
+        <MantineProvider inherit theme={{ colorScheme: 'dark' }}>
+            <Popover
+                opened={showPreview}
+                keepMounted={false}
+                shadow="sm"
+                withinPortal
+                disabled={!description}
+                position="right"
+                withArrow
+                offset={offset}
             >
-                <ItemDetailPreview
-                    onViewDescription={onOpenDescriptionView}
-                    description={description}
-                />
-            </Popover.Dropdown>
-        </Popover>
+                <Popover.Target>{children}</Popover.Target>
+                <Popover.Dropdown
+                    /**
+                     * Takes up space to the right, so it's OK to go fairly wide in the interest
+                     * of readability.
+                     */
+                    maw={500}
+                    /**
+                     * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
+                     * while interacting with the hovercard.
+                     */
+                    onClick={(event) => event.stopPropagation()}
+                    bg={theme.black}
+                    p="xs"
+                >
+                    <ItemDetailPreview
+                        onViewDescription={onOpenDescriptionView}
+                        description={description}
+                    />
+                </Popover.Dropdown>
+            </Popover>
+        </MantineProvider>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -14,9 +14,11 @@ import {
     Group,
     Highlight,
     HoverCard,
+    MantineProvider,
     NavLink,
     Text,
     Tooltip,
+    useMantineTheme,
 } from '@mantine/core';
 import { IconAlertTriangle, IconFilter } from '@tabler/icons-react';
 import { darken, lighten } from 'polished';
@@ -45,6 +47,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
         missingCustomMetrics,
         onItemClick,
     } = useTableTreeContext();
+    const theme = useMantineTheme();
     const { isFilteredField } = useFilters();
     const { showItemDetail } = useItemDetail();
 
@@ -149,51 +152,56 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
             onMouseLeave={() => toggleHover(false)}
             label={
                 <Group noWrap>
-                    <HoverCard
-                        openDelay={300}
-                        keepMounted={false}
-                        shadow="sm"
-                        withinPortal
-                        withArrow
-                        disabled={!description && !isMissing}
-                        position="right"
-                        /** Ensures the hover card does not overlap with the right-hand menu. */
-                        offset={isFiltered ? 80 : 40}
-                    >
-                        <HoverCard.Target>
-                            <Highlight
-                                component={Text}
-                                truncate
-                                sx={{ flexGrow: 1 }}
-                                highlight={searchQuery || ''}
-                            >
-                                {label}
-                            </Highlight>
-                        </HoverCard.Target>
-                        <HoverCard.Dropdown
-                            hidden={!isHover}
-                            p="xs"
-                            /**
-                             * Takes up space to the right, so it's OK to go fairly wide in the interest
-                             * of readability.
-                             */
-                            maw={500}
-                            /**
-                             * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
-                             * while interacting with the hovercard.
-                             */
-                            onClick={(event) => event.stopPropagation()}
+                    <MantineProvider inherit theme={{ colorScheme: 'dark' }}>
+                        <HoverCard
+                            openDelay={300}
+                            keepMounted={false}
+                            shadow="sm"
+                            withinPortal
+                            withArrow
+                            disabled={!description && !isMissing}
+                            position="right"
+                            /** Ensures the hover card does not overlap with the right-hand menu. */
+                            offset={isFiltered ? 80 : 40}
                         >
-                            {isMissing ? (
-                                `This field from '${item.table}' table is no longer available`
-                            ) : (
-                                <ItemDetailPreview
-                                    onViewDescription={onOpenDescriptionView}
-                                    description={description}
-                                />
-                            )}
-                        </HoverCard.Dropdown>
-                    </HoverCard>
+                            <HoverCard.Target>
+                                <Highlight
+                                    component={Text}
+                                    truncate
+                                    sx={{ flexGrow: 1 }}
+                                    highlight={searchQuery || ''}
+                                >
+                                    {label}
+                                </Highlight>
+                            </HoverCard.Target>
+                            <HoverCard.Dropdown
+                                hidden={!isHover}
+                                /**
+                                 * Takes up space to the right, so it's OK to go fairly wide in the interest
+                                 * of readability.
+                                 */
+                                maw={500}
+                                /**
+                                 * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
+                                 * while interacting with the hovercard.
+                                 */
+                                onClick={(event) => event.stopPropagation()}
+                                bg={theme.black}
+                                p="xs"
+                            >
+                                {isMissing ? (
+                                    `This field from '${item.table}' table is no longer available`
+                                ) : (
+                                    <ItemDetailPreview
+                                        onViewDescription={
+                                            onOpenDescriptionView
+                                        }
+                                        description={description}
+                                    />
+                                )}
+                            </HoverCard.Dropdown>
+                        </HoverCard>
+                    </MantineProvider>
 
                     {isFiltered ? (
                         <Tooltip withinPortal label="This field is filtered">

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -153,6 +153,19 @@ export const getMantineThemeOverride = (overrides?: {
             fontWeight: 600,
         },
 
+        /**
+         * Markdown colors for dark mode. Does not account for syntax highlighting.
+         */
+        '[data-color-mode="dark"].wmde-markdown': {
+            '--color-canvas-default': theme.black,
+            '--color-canvas-subtle': theme.colors.dark[7],
+            '--color-border-default': theme.colors.dark[3],
+            '--color-border-muted': theme.colors.dark[3],
+            '--color-fg-default': theme.white,
+            '--color-fg-muted': theme.colors.dark[4],
+            '--color-fg-subtle': theme.colors.dark[2],
+        },
+
         '.react-draggable.react-draggable-dragging .tile-base': {
             border: `1px solid ${theme.colors.blue[5]}`,
         },

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -18,6 +18,24 @@ export default defineConfig({
             forceBuildCDN: true,
             languageWorkers: ['json'],
         }),
+        /**
+         * Disable packaging the CSS styles for react-markdown-preview, in lieu of our own. This
+         * allows us for more control over how it looks alongside our Mantine theme.
+         *
+         * This works by forcing .css imports for this package to be inlined (and immediately discarded).
+         */
+        {
+            name: 'ignore-markdown-preview-css',
+            enforce: 'pre',
+            resolveId: (id) => {
+                if (
+                    id.includes('@uiw/react-markdown-preview') &&
+                    id.endsWith('.css')
+                ) {
+                    return `${id}?inline`;
+                }
+            },
+        },
     ],
     css: {
         transformer: 'lightningcss',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -18,24 +18,6 @@ export default defineConfig({
             forceBuildCDN: true,
             languageWorkers: ['json'],
         }),
-        /**
-         * Disable packaging the CSS styles for react-markdown-preview, in lieu of our own. This
-         * allows us for more control over how it looks alongside our Mantine theme.
-         *
-         * This works by forcing .css imports for this package to be inlined (and immediately discarded).
-         */
-        {
-            name: 'ignore-markdown-preview-css',
-            enforce: 'pre',
-            resolveId: (id) => {
-                if (
-                    id.includes('@uiw/react-markdown-preview') &&
-                    id.endsWith('.css')
-                ) {
-                    return `${id}?inline`;
-                }
-            },
-        },
     ],
     css: {
         transformer: 'lightningcss',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9502 

### Description:
![Kapture 2024-04-03 at 17 07 33](https://github.com/lightdash/lightdash/assets/382538/c8adcfec-1a44-4eac-a382-2b36ae461a33)

Makes markdown preview popovers look more like regular tooltips.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
