### PR TITLE
fix: handle disabled filter change correctly

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -2,7 +2,6 @@ import {
     assertUnreachable,
     createDashboardFilterRuleFromField,
     fieldId,
-    FilterOperator,
     isField,
     isFilterableField,
     matchFieldByType,
@@ -35,6 +34,7 @@ import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 import {
     getFilterRuleRevertableObject,
+    hasFilterValueSet,
     hasSavedFilterValueChanged,
     isFilterEnabled,
 } from './utils';
@@ -136,24 +136,10 @@ const FilterConfiguration: FC<Props> = ({
 
     const handleChangeFilterRule = useCallback(
         (newFilterRule: DashboardFilterRule) => {
-            setDraftFilterRule((oldFilterRule) => {
-                // TODO: Maybe this isn't the best place to do this.
-                // All this says is if a filter *was* disabled and had no
-                // value but now has a value, enable it. Also enable it if
-                // The operator requires no value (null/not null)
-                // This is a way of keeping disabled and 'no value' in sync.
-                let isNewFilterDisabled = newFilterRule.disabled;
-                if (
-                    (oldFilterRule &&
-                        oldFilterRule.disabled &&
-                        !oldFilterRule.values?.length &&
-                        newFilterRule.values?.length) ||
-                    newFilterRule.operator === FilterOperator.NULL ||
-                    newFilterRule.operator === FilterOperator.NOT_NULL
-                ) {
-                    isNewFilterDisabled = false;
-                }
-
+            setDraftFilterRule(() => {
+                // When a disabled filter has a value set, it should be enabled by setting it to false
+                const isNewFilterDisabled =
+                    newFilterRule.disabled && !hasFilterValueSet(newFilterRule);
                 return { ...newFilterRule, disabled: isNewFilterDisabled };
             });
         },
@@ -300,6 +286,7 @@ const FilterConfiguration: FC<Props> = ({
                                 items={fields}
                                 onChange={(newField) => {
                                     if (!newField) return;
+
                                     handleChangeField(newField);
                                 }}
                             />
@@ -380,6 +367,7 @@ const FilterConfiguration: FC<Props> = ({
                             disabled={isApplyDisabled}
                             onClick={() => {
                                 setSelectedTabId(FilterTabs.SETTINGS);
+
                                 if (!!draftFilterRule) onSave(draftFilterRule);
                             }}
                         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

To reproduce: 
- Go to a dashboard ([internal dashboard](https://analytics.lightdash.cloud/projects/21eef0b9-5bae-40f3-851e-9554588e71a6/dashboards/7fa4c980-f9ad-43ca-9a7c-31ef15ae8c49/view))
- Click on `disabled` filter
- Search for a result (has to be a long list, that goes above the max limit - currently 100 for us) 
**Now use your keyboard**
- Select value with `Enter` key
- Press `Escape`
- Click `Apply`
- Filter does not get _enabled_

This PR uses the `hasFilterValueSet` util to check if a filter has a value set depending on its operator & type.


How I replicated this locally: 
seeded `raw_payments.csv`
```csv
130,99,cash,901
131,97,mobile_payment,455
132,92,mobile_payment,1543
133,98,cash,1985
134,97,mobile_payment,232
135,94,cash,1046
136,93,check,1266
137,99,check,1295
138,93,cash,731
139,96,mobile_payment,1054
140,94,mobile_payment,1490
141,93,debit_card,649
142,96,cash,521
143,97,cash,1733
144,92,mobile_payment,1047
145,98,debit_card,1817
146,99,paypal,2237
147,93,mobile_payment,2069
148,94,cash,1798
149,93,cash,2965
150,95,mobile_payment,1387
151,98,debit_card,1723
152,93,mobile_payment,550
153,92,paypal,1180
154,98,cash,1776
155,93,cash,1853
156,96,debit_card,2734
157,92,paypal,896
158,95,check,306
159,99,paypal,1109
160,96,cash,358
161,92,debit_card,642
162,96,check,2734
163,98,cash,1689
164,98,paypal,788
165,98,cash,405
166,97,mobile_payment,284
167,99,mobile_payment,1101
168,93,check,230
169,94,cash,751
170,92,paypal,1243
171,99,check,2804
172,95,mobile_payment,2777
173,93,debit_card,216
174,95,paypal,2386
175,99,paypal,2370
176,92,paypal,1984
177,93,mobile_payment,561
178,93,paypal,1144
179,99,cash,2497
180,94,debit_card,718
181,92,cash,2383
182,95,mobile_payment,2469
183,94,cash,209
184,98,cash,184
185,99,debit_card,1121
186,98,paypal,2472
187,92,check,2373
188,95,check,2206
189,97,paypal,1940
190,97,debit_card,905
191,96,paypal,1111
192,95,paypal,1698
193,96,check,2049
194,98,check,921
195,95,paypal,422
196,92,mobile_payment,2266
197,98,debit_card,1482
198,98,mobile_payment,2950
199,92,debit_card,1917
200,95,check,2762
201,94,mobile_payment,1148
202,97,cash,1222
203,98,check,2187
204,92,mobile_payment,1616
205,93,check,2845
206,98,cash,2123
207,94,mobile_payment,2444
208,99,check,1278
209,93,debit_card,1089
210,95,mobile_payment,2613
211,98,paypal,1479
212,92,cash,445
213,93,paypal,1958
214,95,cash,851
215,92,paypal,2720
216,99,debit_card,1800
217,93,debit_card,1296
218,99,cash,789
219,98,cash,2678
220,98,mobile_payment,2481
221,97,cash,349
222,99,mobile_payment,1386
223,95,paypal,2691
224,93,cash,874
225,96,debit_card,1557
226,94,paypal,1150
227,97,mobile_payment,905
228,93,mobile_payment,1575
229,99,debit_card,336

```

made this change to `orders.sql`
```sql

{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card', 'debit_card', 'paypal', 'cash', 'mobile_payment', 'check'] %}
```

made this change to `schema.yml`
```yml
  - name: payment_method
        tests:
          - accepted_values:
              values:
                - credit_card
                - coupon
                - bank_transfer
                - gift_card
                - debit_card
                - paypal
                - cash
                - mobile_payment
                - check
 ```

set `limit` to `2` in `getFieldValues` in `useFieldValues`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
