### PR TITLE
chore: run dangerjs for internal PRs only

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -20,9 +20,14 @@ jobs:
             - name: Install packages
               run: yarn install --frozen-lockfile
             - name: Run dangerjs
-              # Ensure the dangerjs check only runs on pull requests, while allowing
+              # Ensure the dangerjs check only runs on internal pull requests, while allowing
               # us to reuse the remainder of the setup for this workflow:
-              if: github.event_name == 'pull_request'
+              #
+              # If we ever migrate this away from this action, `pull_request_target` solves for
+              # this problem out of the gate, and is a cleaner solution.
+              if: |
+                  github.event_name == 'pull_request' &&
+                  ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
               run: yarn danger ci --use-github-checks
               env:
                   GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -28,7 +28,7 @@ jobs:
               if: |
                   github.event_name == 'pull_request' &&
                   ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-              run: yarn danger-cli-lint
+              run: yarn danger-ci-lint
               env:
                   GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
             - name: Lint all packages

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -20,14 +20,7 @@ jobs:
             - name: Install packages
               run: yarn install --frozen-lockfile
             - name: Run dangerjs
-              # Ensure the dangerjs check only runs on internal pull requests, while allowing
-              # us to reuse the remainder of the setup for this workflow:
-              #
-              # If we ever migrate this away from this action, `pull_request_target` solves for
-              # this problem out of the gate, and is a cleaner solution.
-              if: |
-                  github.event_name == 'pull_request' &&
-                  ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+              if: github.event_name == 'pull_request'
               run: yarn danger-ci-lint
               env:
                   GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -28,7 +28,7 @@ jobs:
               if: |
                   github.event_name == 'pull_request' &&
                   ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-              run: yarn danger ci --use-github-checks
+              run: yarn danger-cli-lint
               env:
                   GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
             - name: Lint all packages

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
         "prepare": "husky install",
         "load:env": "dotenv -c -e .env.development.local",
         "generate-api": "yarn common-build && yarn workspace backend generate-api && yarn workspace backend formatter --write ./src/generated",
-        "danger-local-lint": "danger -b main -f"
+        "danger-local-lint": "danger -b main -f",
+        "danger-ci-lint": "[[ -n $GITHUB_TOKEN ]] && danger ci --use-github-checks || echo 'Skipped - no GITHUB_TOKEN' present"
     },
     "lint-staged": {
         "docs/**/*.(md|mdx|yml|yaml)": [


### PR DESCRIPTION
### Description:

Prevents issues around missing github tokens. `pull_request_target` is a better way to achieve this, but this way is easier if we want to reuse the existing project setup.

Checks if `GITHUB_TOKEN` is set when running `danger-ci-lint`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
