### PR TITLE
fix: trim project name whitespace on CreateProject

### DIFF
--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -102,6 +102,8 @@ const createNewProject = async (
         projectName = options.create;
     }
 
+    projectName = projectName.trim();
+
     // Create the project
     console.error('');
     const spinner = GlobalState.startSpinner(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Makes sure the Project Name passed in the CLI is trimmed, avoiding any whitespace in the project name that can cause trouble with managing the project.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
