### PR TITLE
feat: enable field grouping in cartesian chart config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -198,6 +198,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                     }}
                                 />
                             }
+                            hasGrouping
                         />
                     )}
                 </Config.Section>
@@ -246,6 +247,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                         />
                                     )
                                 }
+                                hasGrouping
                             />
                         );
                     })}
@@ -338,6 +340,7 @@ export const Layout: FC<Props> = ({ items }) => {
                                                     />
                                                 )
                                             }
+                                            hasGrouping
                                         />
                                     </Group>
                                 );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -355,6 +355,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                                     field: newField,
                                 });
                         }}
+                        hasGrouping
                     />
 
                     <Group noWrap grow align="baseline">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9409

### Description:

Adds `hasGrouping` to `FieldSelect`s in cartesian chart config

<img width="210" alt="Screenshot 2024-04-08 at 13 00 38" src="https://github.com/lightdash/lightdash/assets/7611706/d393a65b-8f41-4440-a6e9-a685e5beda68">

<img width="401" alt="Screenshot 2024-04-08 at 13 00 31" src="https://github.com/lightdash/lightdash/assets/7611706/92b5c016-ce03-4752-81ba-c51ec54ed48c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
