### PR TITLE
fix: dashboardName missing for dashboard charts in charts endpoint

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -165,10 +165,21 @@ export class SpaceModel {
         const space = await this.getFirstAccessibleSpace(projectUuid, userUuid);
         const savedQueries = await this.database('saved_queries')
             .leftJoin(
-                SpaceTableName,
-                `saved_queries.space_id`,
-                `${SpaceTableName}.space_id`,
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
             )
+            .leftJoin(SpaceTableName, function spaceJoin() {
+                this.on(
+                    `${SavedChartsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                ).orOn(
+                    `${DashboardsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                );
+            })
             .leftJoin(
                 'users',
                 'saved_queries.last_version_updated_by_user_uuid',
@@ -193,11 +204,6 @@ export class SpaceModel {
                 OrganizationTableName,
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
-            )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
             )
             .select<
                 {
@@ -815,10 +821,21 @@ export class SpaceModel {
         let spaceQueriesQuery = this.database('saved_queries')
             .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
             .leftJoin(
-                SpaceTableName,
-                `saved_queries.space_id`,
-                `${SpaceTableName}.space_id`,
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
             )
+            .leftJoin(SpaceTableName, function spaceJoin() {
+                this.on(
+                    `${SavedChartsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                ).orOn(
+                    `${DashboardsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                );
+            })
             .leftJoin(
                 'users',
                 'saved_queries.last_version_updated_by_user_uuid',
@@ -843,11 +860,6 @@ export class SpaceModel {
                 OrganizationTableName,
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
-            )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
             )
             .select<
                 {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#9468](https://github.com/lightdash/lightdash/issues/9468)

### Description:

- Returns dashboard name for dashboard charts on `/charts` endpoint

![image](https://github.com/lightdash/lightdash/assets/22939015/b68e74bf-20e8-453b-92e5-e325a1920963)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
