### PR TITLE
feat: enable field grouping in pie chart config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -111,6 +111,7 @@ export const Layout: React.FC = () => {
                                         groupRemove(dimensionId);
                                     }
                                 }}
+                                hasGrouping
                             />
                         );
                     })}
@@ -142,6 +143,7 @@ export const Layout: React.FC = () => {
                                         metricChange(newField.name);
                                     else metricChange(null);
                                 }}
+                                hasGrouping
                             />
                         </Box>
                     </Tooltip>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9409

### Description:

Adds `hasGrouping` to `FieldSelect`s in pie chart config

<img width="398" alt="Screenshot 2024-04-08 at 13 03 48" src="https://github.com/lightdash/lightdash/assets/7611706/83b710eb-e6e3-4d13-b19b-393e40b8b7ea">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
