### PR TITLE
feat: enable grouping on field select in big number config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
@@ -44,6 +44,7 @@ export const Layout: FC = () => {
                             newValue ? getItemId(newValue) : undefined,
                         );
                     }}
+                    hasGrouping
                 />
 
                 <Grid gutter="xs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9409

### Description:

Adds `hasGrouping` to `FieldSelect`s in big number chart config

<img width="408" alt="Screenshot 2024-04-08 at 13 11 56" src="https://github.com/lightdash/lightdash/assets/7611706/fcc82980-db78-45df-9875-e35c2f566ba8">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
