### PR TITLE
fix: only use enabled openid issuers

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -864,20 +864,17 @@ export class UserModel {
         return row.refresh_token;
     }
 
-    async getOpenIdIssuer(
-        email: string,
-    ): Promise<OpenIdIdentityIssuerType | undefined | null> {
-        const row = await this.database('emails')
+    async getOpenIdIssuers(email: string): Promise<OpenIdIdentityIssuerType[]> {
+        const rows = await this.database('emails')
             .leftJoin(
                 'openid_identities',
                 'emails.user_id',
                 'openid_identities.user_id',
             )
-            .where('emails.email', email)
+            .whereNotNull('openid_identities.issuer_type')
+            .andWhere('emails.email', email)
             .andWhere('emails.is_primary', true)
-            .select('openid_identities.issuer_type')
-            .first();
-
-        return row?.issuer_type;
+            .select('openid_identities.issuer_type');
+        return rows.map((row) => row.issuer_type);
     }
 }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -83,6 +83,7 @@ describe('UserService', () => {
                 disablePasswordAuthentication: false,
                 okta: {
                     ...lightdashConfigMock.auth.okta,
+                    oauth2ClientId: '1',
                     loginPath: '/login/okta',
                 },
             },

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -18,7 +18,7 @@ import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredential
 import { UserService } from './UserService';
 
 const userModel = {
-    getOpenIdIssuer: jest.fn(async () => undefined),
+    getOpenIdIssuers: jest.fn(async () => []),
 };
 const createUserService = (lightdashConfig: LightdashConfig) =>
     new UserService({
@@ -72,8 +72,60 @@ describe('UserService', () => {
         });
     });
     test('should previous logged in sso provider', async () => {
-        (userModel.getOpenIdIssuer as jest.Mock).mockImplementationOnce(
-            async () => OpenIdIdentityIssuerType.OKTA,
+        (userModel.getOpenIdIssuers as jest.Mock).mockImplementationOnce(
+            async () => [OpenIdIdentityIssuerType.OKTA],
+        );
+
+        const service = createUserService({
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                disablePasswordAuthentication: false,
+                okta: {
+                    ...lightdashConfigMock.auth.okta,
+                    oauth2ClientId: '1',
+                    loginPath: '/login/okta',
+                },
+            },
+        });
+
+        expect(await service.getLoginOptions('test@lightdash.com')).toEqual({
+            forceRedirect: true,
+            redirectUri:
+                'https://test.lightdash.cloud/api/v1/login/okta?login_hint=test%40lightdash.com',
+            showOptions: ['okta'],
+        });
+    });
+    test('should not login with previous sso provider if not enabled', async () => {
+        (userModel.getOpenIdIssuers as jest.Mock).mockImplementationOnce(
+            async () => [OpenIdIdentityIssuerType.OKTA],
+        );
+
+        const service = createUserService({
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                disablePasswordAuthentication: false,
+                okta: {
+                    ...lightdashConfigMock.auth.okta,
+                    oauth2ClientId: undefined, // disbled okta
+                    loginPath: '/login/okta',
+                },
+            },
+        });
+
+        expect(await service.getLoginOptions('test@lightdash.com')).toEqual({
+            forceRedirect: false,
+            redirectUri: undefined,
+            showOptions: ['email'],
+        });
+    });
+    test('should previous logged in enabled sso provider', async () => {
+        (userModel.getOpenIdIssuers as jest.Mock).mockImplementationOnce(
+            async () => [
+                OpenIdIdentityIssuerType.GOOGLE,
+                OpenIdIdentityIssuerType.OKTA,
+            ],
         );
 
         const service = createUserService({

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1315,6 +1315,8 @@ export class UserService extends BaseService {
                 OpenIdIdentityIssuerType.OKTA,
             this.lightdashConfig.auth.oneLogin?.oauth2ClientId !== undefined &&
                 OpenIdIdentityIssuerType.ONELOGIN,
+            this.lightdashConfig.auth.oidc.clientId !== undefined &&
+                OpenIdIdentityIssuerType.GENERIC_OIDC,
         ].filter(Boolean) as OpenIdIdentityIssuerType[];
 
         const openIdIssuer = await this.userModel.getOpenIdIssuer(email);

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1318,8 +1318,12 @@ export class UserService extends BaseService {
         ].filter(Boolean) as OpenIdIdentityIssuerType[];
 
         const openIdIssuer = await this.userModel.getOpenIdIssuer(email);
-        // First it checks for existing SSO logins
-        if (openIdIssuer !== null && openIdIssuer !== undefined) {
+        // First it checks for existing enabled SSO logins
+        if (
+            openIdIssuer !== null &&
+            openIdIssuer !== undefined &&
+            enabledOpenIdIssuers.includes(openIdIssuer)
+        ) {
             return {
                 showOptions: [openIdIssuer],
                 forceRedirect: true,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1319,13 +1319,13 @@ export class UserService extends BaseService {
                 OpenIdIdentityIssuerType.GENERIC_OIDC,
         ].filter(Boolean) as OpenIdIdentityIssuerType[];
 
-        const openIdIssuer = await this.userModel.getOpenIdIssuer(email);
+        const openIdIssuers = await this.userModel.getOpenIdIssuers(email);
         // First it checks for existing enabled SSO logins
-        if (
-            openIdIssuer !== null &&
-            openIdIssuer !== undefined &&
-            enabledOpenIdIssuers.includes(openIdIssuer)
-        ) {
+        const activeIssuers = openIdIssuers.filter((issuer) =>
+            enabledOpenIdIssuers.includes(issuer),
+        );
+        if (activeIssuers.length === 1) {
+            const openIdIssuer = activeIssuers[0];
             return {
                 showOptions: [openIdIssuer],
                 forceRedirect: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Question: Is it possible to have 2 existing open_id types linked to the same primary email ? if so we should do the filter in the getOPenIdIssuer model method, or return all (instead of first) and filter them later

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
