### PR TITLE
fix: get invalid filters and allow deletion even in groups

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -119,6 +119,7 @@ const FiltersCard: FC = memo(() => {
                 <>
                     {totalActiveFilters > 0 && !filterIsOpen ? (
                         <Tooltip
+                            variant="xs"
                             arrowOffset={12}
                             label={
                                 <div

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -7,7 +7,7 @@ import {
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Select, Text } from '@mantine/core';
+import { ActionIcon, Box, Menu, Select } from '@mantine/core';
 import { IconDots, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import FieldSelect from '../FieldSelect';
@@ -70,6 +70,10 @@ const FilterRuleForm: FC<Props> = ({
         [activeField, fields, filterRule, onChange],
     );
 
+    if (!activeField) {
+        return null;
+    }
+
     return (
         <div
             style={{
@@ -79,72 +83,62 @@ const FilterRuleForm: FC<Props> = ({
                 flex: 1,
             }}
         >
-            {activeField ? (
-                <>
-                    <FieldSelect
-                        size="xs"
-                        disabled={!isEditMode}
-                        withinPortal={popoverProps?.withinPortal}
-                        onDropdownOpen={popoverProps?.onOpen}
-                        onDropdownClose={popoverProps?.onClose}
-                        hasGrouping
-                        item={activeField}
-                        items={fields}
-                        onChange={(field) => {
-                            if (!field) return;
-                            onFieldChange(getFieldId(field));
-                        }}
-                    />
+            <FieldSelect
+                size="xs"
+                disabled={!isEditMode}
+                withinPortal={popoverProps?.withinPortal}
+                onDropdownOpen={popoverProps?.onOpen}
+                onDropdownClose={popoverProps?.onClose}
+                hasGrouping
+                item={activeField}
+                items={fields}
+                onChange={(field) => {
+                    if (!field) return;
+                    onFieldChange(getFieldId(field));
+                }}
+            />
 
-                    <Select
-                        size="xs"
-                        w="150px"
-                        sx={{ flexShrink: 0 }}
-                        withinPortal={popoverProps?.withinPortal}
-                        onDropdownOpen={popoverProps?.onOpen}
-                        onDropdownClose={popoverProps?.onClose}
-                        disabled={!isEditMode}
-                        value={filterRule.operator}
-                        data={filterOperatorOptions}
-                        onChange={(value) => {
-                            if (!value) return;
+            <Select
+                size="xs"
+                w="150px"
+                sx={{ flexShrink: 0 }}
+                withinPortal={popoverProps?.withinPortal}
+                onDropdownOpen={popoverProps?.onOpen}
+                onDropdownClose={popoverProps?.onClose}
+                disabled={!isEditMode}
+                value={filterRule.operator}
+                data={filterOperatorOptions}
+                onChange={(value) => {
+                    if (!value) return;
 
-                            onChange(
-                                getFilterRuleWithDefaultValue(
-                                    activeField,
-                                    {
-                                        ...filterRule,
-                                        operator:
-                                            value as FilterRule['operator'],
-                                    },
-                                    (filterRule.values?.length || 0) > 0
-                                        ? filterRule.values
-                                        : [1],
-                                ),
-                            );
-                        }}
-                    />
+                    onChange(
+                        getFilterRuleWithDefaultValue(
+                            activeField,
+                            {
+                                ...filterRule,
+                                operator: value as FilterRule['operator'],
+                            },
+                            (filterRule.values?.length || 0) > 0
+                                ? filterRule.values
+                                : [1],
+                        ),
+                    );
+                }}
+            />
 
-                    <FilterInputComponent
-                        filterType={filterType}
-                        field={activeField}
-                        rule={filterRule}
-                        onChange={onChange}
-                        disabled={!isEditMode}
-                        popoverProps={popoverProps}
-                    />
-                </>
-            ) : (
-                <Text color="dimmed">
-                    Tried to reference field with unknown id:{' '}
-                    {filterRule.target.fieldId}
-                </Text>
-            )}
+            <FilterInputComponent
+                filterType={filterType}
+                field={activeField}
+                rule={filterRule}
+                onChange={onChange}
+                disabled={!isEditMode}
+                popoverProps={popoverProps}
+            />
 
             {isEditMode &&
                 (!onConvertToGroup ? (
                     <ActionIcon onClick={onDelete}>
-                        <MantineIcon icon={IconX} size="lg" />
+                        <MantineIcon icon={IconX} size="sm" />
                     </ActionIcon>
                 ) : (
                     <Menu


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9667

### Description:

The issue: 

- When _invalid_ filters (no longer available) are in `Filters` card, we display a message `tried to reference...` 
- This doesn't apply when there's a Filter group - the component doesn't handle it at the moment (see `FilterGroupForm`)

The solution for this is to: 
- Get valid and invalid filter rules in the parent: `FiltersForm` (see Filters/index.ts)
- Improve: `getFilterRulesByFieldType` to return also invalid filters
- Use the invalid filters and render the same component in `FiltersForm` - the parent of  `FilterRuleForm`

Demo: 
https://github.com/lightdash/lightdash/assets/7611706/e815e51f-11d9-4df4-89c9-1bf116ead35a


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
