### PR TITLE
fix: force chart tiles into a vertical stack in mobile minimal view

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -36,4 +36,10 @@ export enum FeatureFlags {
 
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
+
+    /** Collapse dashboard into a simple vertical stack on mobile */
+    DashboardMobileVerticalStack = 'dashboard-mobile-vertical-stack',
+
+    /** */
+    LazyLoadDashboardTiles = 'lazy-load-dashboard-tiles',
 }

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     DashboardTileTypes,
+    FeatureFlags,
     isDashboardScheduler,
 } from '@lightdash/common';
 import { useMemo, type FC } from 'react';
@@ -19,6 +20,7 @@ import {
 } from './Dashboard';
 
 import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
+import { useFeatureFlagEnabled } from '../hooks/useFeatureFlagEnabled';
 import '../styles/react-grid.css';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -28,6 +30,9 @@ const MinimalDashboard: FC = () => {
     const schedulerUuid = useSearchParams('schedulerUuid');
     const sendNowchedulerFilters = useSearchParams('sendNowchedulerFilters');
     const dateZoom = useDateZoomGranularitySearch();
+    const stackVerticallyOnSmallestBreakpoint = useFeatureFlagEnabled(
+        FeatureFlags.DashboardMobileVerticalStack,
+    );
 
     const {
         data: dashboard,
@@ -82,7 +87,9 @@ const MinimalDashboard: FC = () => {
             dateZoom={dateZoom}
         >
             <ResponsiveGridLayout
-                {...getResponsiveGridLayoutProps(false)}
+                {...getResponsiveGridLayoutProps({
+                    stackVerticallyOnSmallestBreakpoint,
+                })}
                 layouts={layouts}
             >
                 {dashboard.tiles.map((tile) => (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9655

### Description:

- Introduces a new feature flag (`DashboardMobileVerticalStack`)
- Refactors `getResponsiveGridLayoutProps` to accept options based on the feature flag above
- If the feature flag is enabled, stacks tiles vertically (single column) on the smallest (mobile) breakpoint.

Before:
<img width="480" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/17c663be-efb2-4502-add1-2f5b3d4053f2">

After (same dashboard):

![Kapture 2024-04-09 at 16 49 32](https://github.com/lightdash/lightdash/assets/382538/30b35f2c-28be-4739-88b3-4ea0883a3193)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
