### PR TITLE
fix: chart labels overlapping on small chart tiles

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -923,6 +923,7 @@ const getEchartAxes = ({
             switch (axisItem.timeInterval) {
                 case TimeFrames.WEEK_NUM:
                     axisConfig.axisLabel = {
+                        hideOverlap: true,
                         formatter: (value: any) => {
                             return formatItemValue(axisItem, value, false);
                         },
@@ -955,6 +956,14 @@ const getEchartAxes = ({
             axisConfig.axisLabel.rotate = rotate;
             axisConfig.nameGap = oppositeSide + 15;
         }
+
+        /**
+         * Prevent axis from visually overlapping if positioned too close together,
+         * particularly on smaller chart tiles.
+         */
+        axisConfig.axisLabel ||= {};
+        axisConfig.axisLabel.hideOverlap = true;
+
         return axisConfig;
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4431 

### Description:

- Force-hides overlapping chart labels (x and y, regardless of axis type).

Before:

<img width="440" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/151b6bee-b552-43dc-944a-01dde73ab128">


After: 
<img width="466" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/adc544a7-d31e-4996-8e1d-59d7331c9a82">


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
