### PR TITLE
fix: improve color assignment for charts with multiple groups

### DIFF
--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -93,8 +93,8 @@ export const isGroupedSeries = (series: SeriesLike) => {
 
 export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
     const baseField =
-        (series as Series).encode.yRef?.field ??
-        (series as EChartSeries).encode?.x;
+        (series as EChartSeries).pivotReference?.field ??
+        (series as Series).encode.yRef?.field;
 
     const yPivotValues = (
         (series as EChartSeries)?.pivotReference?.pivotValues ??
@@ -123,6 +123,7 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
      * be assigned the first color)
      */
     const baseFieldPathParts = baseField.split('.');
+
     const baseFieldPath =
         pivotValuesSubPath && baseFieldPathParts.at(-1) === pivotValuesSubPath
             ? baseFieldPathParts.slice(0, -1).join('.')

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -103,7 +103,9 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
     ).map(({ value }) => `${value}`);
 
     const pivotValuesSubPath =
-        yPivotValues && yPivotValues.length > 0 ? `${yPivotValues[0]}` : null;
+        yPivotValues && yPivotValues.length > 0
+            ? `${yPivotValues.join('.')}`
+            : null;
 
     /**
      * When dealing with flipped axis, Echarts will include the pivot value as
@@ -130,7 +132,20 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
         ? pivotValuesSubPath
         : baseFieldPath;
 
-    return [baseFieldPath, completeIdentifier];
+    return [
+        `${baseFieldPath}${
+            /**
+             * If we have more than one pivot value, we append the number of pivot values
+             * to the group identifier, giving us a unique group per number of values.
+             *
+             * This is not critical, but gives us better serial color assignment when
+             * switching between number of groups, since we're not tacking each group
+             * configuration on top of eachother (under the same identifier).
+             */
+            yPivotValues.length === 1 ? '' : `${`_n${yPivotValues.length}`}`
+        }`,
+        completeIdentifier,
+    ];
 };
 
 export const useChartColorConfig = ({

--- a/packages/frontend/src/hooks/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig.tsx
@@ -96,15 +96,15 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
         (series as EChartSeries).pivotReference?.field ??
         (series as Series).encode.yRef?.field;
 
-    const yPivotValues = (
+    const pivotValues = (
         (series as EChartSeries)?.pivotReference?.pivotValues ??
         (series as Series)?.encode.yRef.pivotValues ??
         []
     ).map(({ value }) => `${value}`);
 
     const pivotValuesSubPath =
-        yPivotValues && yPivotValues.length > 0
-            ? `${yPivotValues.join('.')}`
+        pivotValues && pivotValues.length > 0
+            ? `${pivotValues.join('.')}`
             : null;
 
     /**
@@ -143,7 +143,7 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
              * switching between number of groups, since we're not tacking each group
              * configuration on top of eachother (under the same identifier).
              */
-            yPivotValues.length === 1 ? '' : `${`_n${yPivotValues.length}`}`
+            pivotValues.length === 1 ? '' : `${`_n${pivotValues.length}`}`
         }`,
         completeIdentifier,
     ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9710

### Description:

- Color mapping groups are now suffixed with its number of groups if >1 (e.g `order_status_n2.shipped`) to improve serial color assignment when switching chart groups, by preventing different combinations of groups from taking colors from a single color pool.
- All pivot values are considered when building color mapping identifiers, so all permutations of groups are assigned a unique color (e.g `[shipped - <some other metric>]` is no longer the same color as just `[shipped]`)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
