### PR TITLE
feat: allow to always join a table

### DIFF
--- a/docs/docs/references/joins.mdx
+++ b/docs/docs/references/joins.mdx
@@ -157,6 +157,22 @@ models:
 
 A full join returns all rows when there is a match in either the left or right table records. Non-matching rows will have `NULL` for columns of the table that lacks a match. For example, if you have a `users` table and a `subscriptions` table, a full join would return all users and all subscriptions, and the subscription information for users who have a subscription.
 
+## Always join a table
+
+If you need a table to always be joined, you can set the `always` field to `true`.
+
+```yaml
+models:
+  - name: messages
+    meta:
+      joins:
+        - join: users
+          sql_on: ${messages.sent_by} = ${users.user_id}
+          always: true
+```
+
+This will make sure that even when you don't select any of the fields from the joined table it will still be joined in the query.
+
 ## Only select a subset of fields from a join
 
 Use the `fields` tag to select a subset of fields from a join. This is useful if you want to join a model but only a

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -407,7 +407,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden_': {
+    'Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -416,6 +416,7 @@ const models: TsoaRoute.Models = {
                 sqlOn: { dataType: 'string', required: true },
                 type: { ref: 'DbtModelJoinType' },
                 hidden: { dataType: 'boolean' },
+                always: { dataType: 'boolean' },
             },
             validators: {},
         },
@@ -426,7 +427,9 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'intersection',
             subSchemas: [
-                { ref: 'Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden_' },
+                {
+                    ref: 'Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_',
+                },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -375,7 +375,7 @@
                 "type": "string",
                 "enum": ["inner", "full", "left", "right"]
             },
-            "Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden_": {
+            "Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_": {
                 "properties": {
                     "table": {
                         "type": "string"
@@ -388,6 +388,9 @@
                     },
                     "hidden": {
                         "type": "boolean"
+                    },
+                    "always": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["table", "sqlOn"],
@@ -397,7 +400,7 @@
             "CompiledExploreJoin": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden_"
+                        "$ref": "#/components/schemas/Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_"
                     },
                     {
                         "properties": {
@@ -6735,7 +6738,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1064.2",
+        "version": "0.1064.5",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -660,7 +660,7 @@ export const buildQuery = ({
     ]);
 
     const sqlJoins = explore.joinedTables
-        .filter((join) => joinedTables.has(join.table))
+        .filter((join) => joinedTables.has(join.table) || join.always)
         .map((join) => {
             const joinTable = explore.tables[join.table].sqlTable;
             const joinType = getJoinType(join.type);

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -678,6 +678,7 @@ export const compiledSimpleJoinedExplore: Explore = {
             compiledSqlOn: '("a".dim1) = ("b".dim1)',
             type: undefined,
             hidden: undefined,
+            always: undefined,
         },
     ],
     tables: {
@@ -869,6 +870,7 @@ export const compiledJoinedExploreOverridingJoinAlias: Explore = {
             compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
             type: undefined,
             hidden: undefined,
+            always: undefined,
         },
     ],
     tables: {
@@ -912,6 +914,7 @@ export const compiledJoinedExploreOverridingAliasAndLabel: Explore = {
             compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
             type: undefined,
             hidden: undefined,
+            always: undefined,
         },
     ],
     tables: {
@@ -955,6 +958,7 @@ export const compiledExploreWithHiddenJoin: Explore = {
             compiledSqlOn: '("a".dim1) = ("b".dim1)',
             type: undefined,
             hidden: true,
+            always: undefined,
         },
     ],
     tables: {
@@ -1061,6 +1065,7 @@ export const compiledJoinedExploreWithJoinAliasAndSubsetOfFieldsThatDontIncludeS
                 compiledSqlOn: '("a".dim1) = ("custom_alias".dim1)',
                 type: undefined,
                 hidden: undefined,
+                always: undefined,
             },
         ],
         tables: {
@@ -1447,6 +1452,7 @@ export const exploreWithRequiredAttributesCompiled: Explore = {
             table: 'b',
             type: undefined,
             hidden: undefined,
+            always: undefined,
         },
     ],
     tables: {

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -1568,3 +1568,28 @@ export const exploreWithRequiredAttributesCompiled: Explore = {
         },
     },
 };
+
+export const simpleJoinedExploreWithAlwaysTrue: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${b.dim1}',
+            always: true,
+        },
+    ],
+};
+
+export const compiledSimpleJoinedExploreWithAlwaysTrue: Explore = {
+    ...compiledSimpleJoinedExplore,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${b.dim1}',
+            compiledSqlOn: '("a".dim1) = ("b".dim1)',
+            type: undefined,
+            hidden: undefined,
+            always: true,
+        },
+    ],
+};

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -10,6 +10,7 @@ import {
     compiledJoinedExploreWithSubsetOfFields,
     compiledJoinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     compiledSimpleJoinedExplore,
+    compiledSimpleJoinedExploreWithAlwaysTrue,
     exploreCircularDimensionReference,
     exploreCircularDimensionShortReference,
     exploreCircularMetricReference,
@@ -40,6 +41,7 @@ import {
     joinedExploreWithSubsetOfFields,
     joinedExploreWithSubsetOfFieldsThatDontIncludeSqlFields,
     simpleJoinedExplore,
+    simpleJoinedExploreWithAlwaysTrue,
     tablesWithMetricsWithFilters,
     warehouseClientMock,
 } from './exploreCompiler.mock';
@@ -298,5 +300,13 @@ describe('Explore with user attributes', () => {
         expect(
             compiler.compileExplore(exploreWithRequiredAttributes),
         ).toStrictEqual(exploreWithRequiredAttributesCompiled);
+    });
+});
+
+describe('Explore with always true join', () => {
+    test('should compile explore with always true join', () => {
+        expect(
+            compiler.compileExplore(simpleJoinedExploreWithAlwaysTrue),
+        ).toStrictEqual(compiledSimpleJoinedExploreWithAlwaysTrue);
     });
 });

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -571,10 +571,12 @@ export class ExploreCompiler {
                 {
                     table: join.alias || join.table,
                     sqlOn: join.sqlOn,
+                    always: join.always,
                 },
                 tables,
             ),
             hidden: join.hidden,
+            always: join.always,
         };
     }
 }

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -557,6 +557,7 @@ export const convertExplores = async (
                     label: join.label,
                     fields: join.fields,
                     hidden: join.hidden,
+                    always: join.always,
                 })),
                 tables: tableLookup,
                 targetDatabase: adapterType,

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -258,6 +258,9 @@
                             "type": {
                                 "type": "string",
                                 "enum": ["inner", "left", "right", "full"]
+                            },
+                            "always": {
+                                "type": "boolean"
                             }
                         }
                     }

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -51,6 +51,9 @@
                                         },
                                         "sql_on": {
                                             "type": "string"
+                                        },
+                                        "always": {
+                                            "type": "boolean"
                                         }
                                     },
                                     "required": ["join", "sql_on"]

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -76,6 +76,7 @@ type DbtModelJoin = {
     type?: DbtModelJoinType;
     hidden?: boolean;
     fields?: string[];
+    always?: boolean;
 };
 type DbtColumnMetadata = DbtColumnLightdashConfig & {};
 type DbtColumnLightdashConfig = {

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -20,11 +20,12 @@ export type ExploreJoin = {
     label?: string; // Optional UI label override for the underlying table
     hidden?: boolean;
     fields?: string[]; // Optional list of fields to include from the joined table
+    always?: boolean; // Optional flag to always join the table
 };
 
 export type CompiledExploreJoin = Pick<
     ExploreJoin,
-    'table' | 'sqlOn' | 'type' | 'hidden'
+    'table' | 'sqlOn' | 'type' | 'hidden' | 'always'
 > & {
     compiledSqlOn: string; // Sql on clause with template variables resolved
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#6693](https://github.com/lightdash/lightdash/issues/6693)

### Description:

- Adds `always` field to `yaml` joins
- Always join the table when `always` is `true`

**Before**
![image](https://github.com/lightdash/lightdash/assets/22939015/09bfd376-fc3c-4e30-b60f-0dd65570072e)

**After**
- With `always: true`
![image](https://github.com/lightdash/lightdash/assets/22939015/cd2e0d91-38fe-4d41-bef8-caad9258c142)
![image](https://github.com/lightdash/lightdash/assets/22939015/75ad25cd-a6a3-4535-b557-5cab7f038a4a)

- With `always: false`
![image](https://github.com/lightdash/lightdash/assets/22939015/955a5de1-4602-4f17-a901-e7951adcca1d)
![image](https://github.com/lightdash/lightdash/assets/22939015/ba8d4552-d69b-4cee-9921-a59e01648086)


https://github.com/lightdash/lightdash/assets/22939015/5a8d3059-812e-4939-b3ec-cebdabd10a32


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
