### PR TITLE
fix: treat YEAR_NUM formatting as string

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -9,6 +9,7 @@ import {
     NumberSeparator,
     type CustomFormat,
 } from '../types/field';
+import { TimeFrames } from '../types/timeFrames';
 import {
     applyCustomFormat,
     currencies,
@@ -742,6 +743,16 @@ describe('Formatting', () => {
                     new Date('2021-03-10T00:00:00.000Z'),
                 ),
             ).toEqual('2021-03-10, 00:00:00:000 (+00:00)');
+            expect(
+                formatItemValue(
+                    {
+                        ...dimension,
+                        timeInterval: TimeFrames.YEAR_NUM,
+                        type: DimensionType.NUMBER,
+                    },
+                    2021,
+                ),
+            ).toEqual('2021');
         });
 
         test('formatItemValue should return the right format when field is Metric', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -13,6 +13,7 @@ import {
     type CompactOrAlias,
     type CustomDimension,
     type CustomFormat,
+    type Dimension,
     type Field,
     type TableCalculation,
 } from '../types/field';
@@ -381,6 +382,7 @@ export function applyCustomFormat(
 export function formatItemValue(
     item:
         | Field
+        | Dimension
         | AdditionalMetric
         | TableCalculation
         | CustomDimension
@@ -426,6 +428,15 @@ export function formatItemValue(
                             isDimension(item) ? item.timeInterval : undefined,
                             convertToUTC,
                         );
+                    }
+                    break;
+                case DimensionType.NUMBER:
+                    if (
+                        isDimension(item) &&
+                        item.timeInterval &&
+                        item.timeInterval === TimeFrames.YEAR_NUM // Year number (e.g. 2021) is a number, but should be formatted as a string so there's no separator applied
+                    ) {
+                        return `${value}`;
                     }
                     break;
                 default:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4707 #9536

### Description:

Apply string formatting to `YEAR_NUM` dimension type.

Happy to discuss other ways of improving this (or call it in `formatNumberValue` but that requires passing new arg `item`)

Before:
see screenshots from issues ⬆️ 

After:
<img width="998" alt="Screenshot 2024-04-10 at 16 08 57" src="https://github.com/lightdash/lightdash/assets/7611706/e4df16f9-37e1-462a-8ce4-41461c7abc9e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
