### PR TITLE
feat: allow intrinsic user attributes

### DIFF
--- a/docs/docs/references/sql-variables.mdx
+++ b/docs/docs/references/sql-variables.mdx
@@ -9,3 +9,9 @@ reusable
 - `${lightdash.attributes.my_attr_1}` - a user attribute called `my_attr_1`
   - (optional) `ld` as an alias for `lightdash`
   - (optional) `attribute` or `attr` as an alias for `attributes`
+- `${lightdash.user.<intrinsic_attribute>}` - reference an `intrinsic_attribute` of the current Lightdash user
+  - (optional) `ld` as an alias for `lightdash`
+  - available intrinsic user attributes:
+    - `email`
+    - `first_name`
+    - `last_name`

--- a/docs/docs/references/user-attributes.mdx
+++ b/docs/docs/references/user-attributes.mdx
@@ -69,6 +69,12 @@ When referencing user attributes in SQL you can use the following [SQL variables
 - `${lightdash.attributes.my_attr_1}` - a user attribute called `my_attr_1`
   - (optional) `ld` as an alias for `lightdash`
   - (optional) `attribute` or `attr` as an alias for `attributes`
+- `${lightdash.user.<intrinsic_attribute>}` - reference an `intrinsic_attribute` of the current Lightdash user
+  - (optional) `ld` as an alias for `lightdash`
+  - available intrinsic user attributes:
+    - `email`
+    - `first_name`
+    - `last_name`
 
 ### Row filtering with `sql_filter`
 
@@ -138,6 +144,12 @@ columns:
           team_name: ['HR', 'C-Suite']
 ```
 
+:::info
+
+Column filtering using `required_attributes` does not take into account intrinsic attributes of a user - `email`, `first_name`, `last_name`.
+
+:::
+
 ### Table filtering with `required_attributes`
 
 You can use `user attributes` to limit some tables to some users.
@@ -154,6 +166,12 @@ models:
 ```
 
 Similar to [columns filtering](#column-filtering-with-required_attributes), you can add multiple attributes for a single table.
+
+:::info
+
+Table filtering using `required_attributes` does not take into account intrinsic attributes of a user - `email`, `first_name`, `last_name`.
+
+:::
 
 ### Filtering joins with `sql_on`
 

--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -8,6 +8,7 @@ import {
     Explore,
     FieldType,
     FilterOperator,
+    IntrinsicUserAttributes,
     MetricType,
     SupportedDbtAdapter,
     WarehouseClient,
@@ -1307,3 +1308,9 @@ SELECT * FROM table_calculations WHERE ((
 ))
 ORDER BY "table1_metric1" DESC
 LIMIT 10`;
+
+export const INTRINSIC_USER_ATTRIBUTES: IntrinsicUserAttributes = {
+    email: 'mock@lightdash.com',
+    first_name: 'Mock',
+    last_name: 'User',
+};

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -440,6 +440,36 @@ describe('replaceUserAttributes', () => {
             ),
         ).toEqual('${lightdash.foo.test} > 1');
     });
+
+    it('should replace `email` intrinsic user attribute', async () => {
+        expect(
+            replaceUserAttributes(
+                '${lightdash.user.email} = "mock@lightdash.com"',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('(\'mock@lightdash.com\' = "mock@lightdash.com")');
+    });
+
+    it('should replace `first_name` intrinsic user attribute', async () => {
+        expect(
+            replaceUserAttributes(
+                '${lightdash.user.first_name} = "Mock"',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('(\'Mock\' = "Mock")');
+    });
+
+    it('should replace `last_name` intrinsic user attribute', async () => {
+        expect(
+            replaceUserAttributes(
+                '${lightdash.user.last_name} = "User"',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('(\'User\' = "User")');
+    });
 });
 
 describe('assertValidDimensionRequiredAttribute', () => {

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -13,6 +13,7 @@ import {
     EXPLORE_BIGQUERY,
     EXPLORE_JOIN_CHAIN,
     EXPLORE_WITH_SQL_FILTER,
+    INTRINSIC_USER_ATTRIBUTES,
     METRIC_QUERY,
     METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL,
     METRIC_QUERY_JOIN_CHAIN,
@@ -60,6 +61,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -70,6 +72,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_BIGQUERY,
                 compiledMetricQuery: METRIC_QUERY,
                 warehouseClient: bigqueryClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL_BIGQUERY);
     });
@@ -80,6 +83,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_TWO_TABLES_SQL);
     });
@@ -90,6 +94,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_TABLE_REFERENCE_SQL);
     });
@@ -100,6 +105,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_SQL);
     });
@@ -110,6 +116,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_JOIN_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_JOIN_CHAIN_SQL);
     });
@@ -120,6 +127,7 @@ describe('Query builder', () => {
                 explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
                 compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL);
     });
@@ -130,6 +138,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL);
     });
@@ -140,6 +149,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_DISABLED_FILTER_SQL);
     });
@@ -151,6 +161,7 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL);
     });
@@ -161,6 +172,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL);
     });
@@ -171,6 +183,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_SQL);
     });
@@ -181,6 +194,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_METRIC_FILTER_SQL);
     });
@@ -192,6 +206,7 @@ describe('Query builder', () => {
                 compiledMetricQuery:
                     METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(
             METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM_SQL,
@@ -204,6 +219,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_NESTED_METRIC_FILTERS_SQL);
     });
@@ -214,6 +230,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL);
     });
@@ -224,6 +241,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_FILTER_SQL);
     });
@@ -234,6 +252,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL);
     });
@@ -244,6 +263,7 @@ describe('Query builder', () => {
                 explore: EXPLORE,
                 compiledMetricQuery: METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
                 warehouseClient: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER_SQL);
     });
@@ -256,6 +276,7 @@ describe('Query builder', () => {
                     compiledMetricQuery: METRIC_QUERY,
                     warehouseClient: warehouseClientMock,
                     userAttributes: {},
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                 }).query,
         ).toThrowError(ForbiddenError);
     });
@@ -269,6 +290,7 @@ describe('Query builder', () => {
                 userAttributes: {
                     country: ['EU'],
                 },
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(METRIC_QUERY_WITH_SQL_FILTER);
     });
@@ -276,32 +298,56 @@ describe('Query builder', () => {
 
 describe('replaceUserAttributes', () => {
     it('method with no user attribute should return same sqlFilter', async () => {
-        expect(replaceUserAttributes('${dimension} > 1', {})).toEqual(
-            '${dimension} > 1',
-        );
-        expect(replaceUserAttributes('${table.dimension} = 1', {})).toEqual(
-            '${table.dimension} = 1',
-        );
         expect(
-            replaceUserAttributes('${dimension} = ${TABLE}.dimension', {}),
+            replaceUserAttributes(
+                '${dimension} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('${dimension} > 1');
+        expect(
+            replaceUserAttributes(
+                '${table.dimension} = 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('${table.dimension} = 1');
+        expect(
+            replaceUserAttributes(
+                '${dimension} = ${TABLE}.dimension',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
         ).toEqual('${dimension} = ${TABLE}.dimension');
     });
 
     it('method with missing user attribute should throw error', async () => {
         expect(() =>
-            replaceUserAttributes('${lightdash.attribute.test} > 1', {}),
+            replaceUserAttributes(
+                '${lightdash.attribute.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
         ).toThrowError(ForbiddenError);
 
         expect(() =>
-            replaceUserAttributes('${ld.attr.test} > 1', {}),
+            replaceUserAttributes(
+                '${ld.attr.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
         ).toThrowError(ForbiddenError);
     });
 
     it('method with no user attribute value should throw error', async () => {
         expect(() =>
-            replaceUserAttributes('${lightdash.attribute.test} > 1', {
-                test: [],
-            }),
+            replaceUserAttributes(
+                '${lightdash.attribute.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {
+                    test: [],
+                },
+            ),
         ).toThrowError(ForbiddenError);
     });
 
@@ -311,20 +357,29 @@ describe('replaceUserAttributes', () => {
         expect(
             replaceUserAttributes(
                 '${lightdash.attribute.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
                 userAttributes,
             ),
         ).toEqual(expected);
 
         expect(
-            replaceUserAttributes('${ld.attr.test} > 1', userAttributes),
+            replaceUserAttributes(
+                '${ld.attr.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                userAttributes,
+            ),
         ).toEqual(expected);
     });
 
     it('method should replace sqlFilter with user attribute with multiple values', async () => {
         expect(
-            replaceUserAttributes("'1' IN (${lightdash.attribute.test})", {
-                test: ['1', '2'],
-            }),
+            replaceUserAttributes(
+                "'1' IN (${lightdash.attribute.test})",
+                INTRINSIC_USER_ATTRIBUTES,
+                {
+                    test: ['1', '2'],
+                },
+            ),
         ).toEqual("('1' IN ('1', '2'))");
     });
 
@@ -333,36 +388,57 @@ describe('replaceUserAttributes', () => {
         const sqlFilter =
             '${dimension} IS NOT NULL OR (${lightdash.attribute.test} > 1 AND ${lightdash.attribute.another} = 2)';
         const expected = "(${dimension} IS NOT NULL OR ('1' > 1 AND '2' = 2))";
-        expect(replaceUserAttributes(sqlFilter, userAttributes)).toEqual(
-            expected,
-        );
+        expect(
+            replaceUserAttributes(
+                sqlFilter,
+                INTRINSIC_USER_ATTRIBUTES,
+                userAttributes,
+            ),
+        ).toEqual(expected);
     });
 
     it('method should replace sqlFilter using short aliases', async () => {
         const userAttributes = { test: ['1'], another: ['2'] };
         const expected = "('1' > 1)";
         expect(
-            replaceUserAttributes('${ld.attribute.test} > 1', userAttributes),
+            replaceUserAttributes(
+                '${ld.attribute.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                userAttributes,
+            ),
         ).toEqual(expected);
         expect(
-            replaceUserAttributes('${lightdash.attr.test} > 1', userAttributes),
+            replaceUserAttributes(
+                '${lightdash.attr.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                userAttributes,
+            ),
         ).toEqual(expected);
         expect(
-            replaceUserAttributes('${ld.attr.test} > 1', userAttributes),
+            replaceUserAttributes(
+                '${ld.attr.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                userAttributes,
+            ),
         ).toEqual(expected);
 
         expect(
             replaceUserAttributes(
                 '${lightdash.attributes.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
                 userAttributes,
             ),
         ).toEqual(expected);
     });
 
     it('method should not replace any invalid attribute', async () => {
-        expect(replaceUserAttributes('${lightdash.foo.test} > 1', {})).toEqual(
-            '${lightdash.foo.test} > 1',
-        );
+        expect(
+            replaceUserAttributes(
+                '${lightdash.foo.test} > 1',
+                INTRINSIC_USER_ATTRIBUTES,
+                {},
+            ),
+        ).toEqual('${lightdash.foo.test} > 1');
     });
 });
 
@@ -515,6 +591,7 @@ ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range
                 compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_DIMENSION,
                 warehouseClient: bigqueryClientMock,
                 userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(`WITH  age_range_cte AS (
                     SELECT
@@ -561,6 +638,7 @@ LIMIT 10`);
                 },
                 warehouseClient: bigqueryClientMock,
                 userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(`SELECT
   "table1".dim1 AS \`table1_dim1\`,
@@ -599,6 +677,7 @@ LIMIT 10`);
 
                 warehouseClient: bigqueryClientMock,
                 userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(`WITH  age_range_cte AS (
                     SELECT
@@ -683,6 +762,7 @@ ELSE 2
 
                 warehouseClient: bigqueryClientMock,
                 userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(`WITH  age_range_cte AS (
                     SELECT
@@ -735,6 +815,7 @@ LIMIT 10`);
                 },
                 warehouseClient: warehouseClientMock,
                 userAttributes: {},
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             }).query,
         ).toStrictEqual(`SELECT
   "table1".dim1 AS "table1_dim1",

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -154,6 +154,7 @@ export const replaceUserAttributes = (
     const intrinsicUserAttributeRegex =
         /\$\{(?:lightdash|ld)\.(?:user)\.(\w+)\}/g;
 
+    // Replace user attributes in the SQL filter
     const replacedSqlFilter = replaceAttributes(
         userAttributeRegex,
         sqlFilter,
@@ -162,6 +163,7 @@ export const replaceUserAttributes = (
         filter,
     );
 
+    // Replace intrinsic user attributes in the SQL filter
     return replaceAttributes(
         intrinsicUserAttributeRegex,
         replacedSqlFilter,

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -22,6 +22,7 @@ import {
     getFilterRulesFromGroup,
     getMetrics,
     getSqlForTruncatedDate,
+    IntrinsicUserAttributes,
     isAndFilterGroup,
     isFilterGroup,
     ItemsMap,
@@ -30,11 +31,11 @@ import {
     renderTableCalculationFilterRuleSql,
     SortField,
     SupportedDbtAdapter,
-    TableCalculation,
     UserAttributeValueMap,
     WarehouseClient,
     WeekDay,
 } from '@lightdash/common';
+import { isArray } from 'lodash';
 import { hasUserAttribute } from './services/UserAttributesService/UserAttributeUtils';
 
 const getDimensionFromId = (
@@ -94,15 +95,14 @@ const getMetricFromId = (
     return metric;
 };
 
-export const replaceUserAttributes = (
+const replaceAttributes = (
+    regex: RegExp,
     sqlFilter: string,
-    userAttributes: UserAttributeValueMap,
-    stringQuoteChar: string = "'",
-    filter: string = 'sql_filter',
+    userAttributes: UserAttributeValueMap | IntrinsicUserAttributes,
+    stringQuoteChar: string,
+    filter: string,
 ): string => {
-    const userAttributeRegex =
-        /\$\{(?:lightdash|ld)\.(?:attribute|attributes|attr)\.(\w+)\}/g;
-    const sqlAttributes = sqlFilter.match(userAttributeRegex);
+    const sqlAttributes = sqlFilter.match(regex);
 
     if (sqlAttributes === null || sqlAttributes.length === 0) {
         return sqlFilter;
@@ -110,9 +110,8 @@ export const replaceUserAttributes = (
 
     const replacedUserAttributesSql = sqlAttributes.reduce<string>(
         (acc, sqlAttribute) => {
-            const attribute = sqlAttribute.replace(userAttributeRegex, '$1');
-            const attributeValues: string[] | undefined =
-                userAttributes[attribute];
+            const attribute = sqlAttribute.replace(regex, '$1');
+            const attributeValues = userAttributes[attribute];
 
             if (attributeValues === undefined) {
                 throw new ForbiddenError(
@@ -125,21 +124,51 @@ export const replaceUserAttributes = (
                 );
             }
 
-            return acc.replace(
-                sqlAttribute,
-                attributeValues
-                    .map(
-                        (attributeValue) =>
-                            `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
-                    )
-                    .join(', '),
-            );
+            const valueString = isArray(attributeValues)
+                ? attributeValues
+                      .map(
+                          (attributeValue) =>
+                              `${stringQuoteChar}${attributeValue}${stringQuoteChar}`,
+                      )
+                      .join(', ')
+                : `${stringQuoteChar}${attributeValues}${stringQuoteChar}`;
+
+            return acc.replace(sqlAttribute, valueString);
         },
         sqlFilter,
     );
 
     // NOTE: Wrap the replaced user attributes in parentheses to avoid issues with AND/OR operators
     return `(${replacedUserAttributesSql})`;
+};
+
+export const replaceUserAttributes = (
+    sqlFilter: string,
+    intrinsicUserAttributes: IntrinsicUserAttributes,
+    userAttributes: UserAttributeValueMap,
+    stringQuoteChar: string = "'",
+    filter: string = 'sql_filter',
+): string => {
+    const userAttributeRegex =
+        /\$\{(?:lightdash|ld)\.(?:attribute|attributes|attr)\.(\w+)\}/g;
+    const intrinsicUserAttributeRegex =
+        /\$\{(?:lightdash|ld)\.(?:user)\.(\w+)\}/g;
+
+    const replacedSqlFilter = replaceAttributes(
+        userAttributeRegex,
+        sqlFilter,
+        userAttributes,
+        stringQuoteChar,
+        filter,
+    );
+
+    return replaceAttributes(
+        intrinsicUserAttributeRegex,
+        replacedSqlFilter,
+        intrinsicUserAttributes,
+        stringQuoteChar,
+        filter,
+    );
 };
 
 export const assertValidDimensionRequiredAttribute = (
@@ -179,6 +208,7 @@ export type BuildQueryProps = {
     compiledMetricQuery: CompiledMetricQuery;
     warehouseClient: WarehouseClient;
     userAttributes?: UserAttributeValueMap;
+    intrinsicUserAttributes: IntrinsicUserAttributes;
 };
 
 const getJoinType = (type: DbtModelJoinType = 'left') => {
@@ -512,6 +542,7 @@ export const buildQuery = ({
     explore,
     compiledMetricQuery,
     warehouseClient,
+    intrinsicUserAttributes,
     userAttributes = {},
 }: BuildQueryProps): CompiledQuery => {
     let hasExampleMetric: boolean = false;
@@ -669,6 +700,7 @@ export const buildQuery = ({
             const alias = join.table;
             const parsedSqlOn = replaceUserAttributes(
                 join.compiledSqlOn,
+                intrinsicUserAttributes,
                 userAttributes,
                 stringQuoteChar,
                 'sql_on',
@@ -805,6 +837,7 @@ export const buildQuery = ({
         ? [
               replaceUserAttributes(
                   baseTableSqlWhere,
+                  intrinsicUserAttributes,
                   userAttributes,
                   stringQuoteChar,
               ),

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -98,7 +98,7 @@ const getMetricFromId = (
 const replaceAttributes = (
     regex: RegExp,
     sqlFilter: string,
-    userAttributes: UserAttributeValueMap | IntrinsicUserAttributes,
+    userAttributes: Record<string, string | string[]>,
     stringQuoteChar: string,
     filter: string,
 ): string => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -49,9 +49,11 @@ import {
     getDimensions,
     getFields,
     getFilterRulesFromGroup,
+    getIntrinsicUserAttributes,
     getItemId,
     getMetrics,
     hasIntersection,
+    IntrinsicUserAttributes,
     isDateItem,
     isExploreError,
     isFilterableDimension,
@@ -913,6 +915,7 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery,
         explore: Explore,
         warehouseClient: WarehouseClient,
+        intrinsicUserAttributes: IntrinsicUserAttributes,
         userAttributes: UserAttributeValueMap,
         granularity?: DateGranularity,
     ): Promise<[CompiledQuery, CompiledQuery]> {
@@ -998,6 +1001,7 @@ export class ProjectService extends BaseService {
             explore: exploreWithOverride,
             compiledMetricQuery: compiledMetricQueryWithoutTableCalculations,
             warehouseClient,
+            intrinsicUserAttributes,
             userAttributes,
         });
 
@@ -1027,6 +1031,7 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery,
         explore: Explore,
         warehouseClient: WarehouseClient,
+        intrinsicUserAttributes: IntrinsicUserAttributes,
         userAttributes: UserAttributeValueMap,
         granularity?: DateGranularity,
     ): Promise<CompiledQuery> {
@@ -1047,6 +1052,7 @@ export class ProjectService extends BaseService {
             explore: exploreWithOverride,
             compiledMetricQuery,
             warehouseClient,
+            intrinsicUserAttributes,
             userAttributes,
         });
 
@@ -1125,10 +1131,14 @@ export class ProjectService extends BaseService {
                 organizationUuid,
                 userUuid: user.userUuid,
             });
+
+        const intrinsicUserAttributes = getIntrinsicUserAttributes(user);
+
         const compiledQuery = await ProjectService._compileQuery(
             metricQuery,
             explore,
             warehouseClient,
+            intrinsicUserAttributes,
             userAttributes,
         );
         await sshTunnel.disconnect();
@@ -1863,6 +1873,9 @@ export class ProjectService extends BaseService {
                             },
                         );
 
+                    const intrinsicUserAttributes =
+                        getIntrinsicUserAttributes(user);
+
                     /**
                      * Note: most of this is temporary while testing out in-memory table calculations,
                      * so that we can more cleanly handle the feature-flagged behavior fork below.
@@ -1878,6 +1891,7 @@ export class ProjectService extends BaseService {
                         metricQueryWithLimit,
                         explore,
                         warehouseClient,
+                        intrinsicUserAttributes,
                         userAttributes,
                         granularity,
                     ] as const;
@@ -2202,10 +2216,14 @@ export class ProjectService extends BaseService {
                 organizationUuid,
                 userUuid: user.userUuid,
             });
+
+        const intrinsicUserAttributes = getIntrinsicUserAttributes(user);
+
         const { query } = await ProjectService._compileQuery(
             metricQuery,
             explore,
             warehouseClient,
+            intrinsicUserAttributes,
             userAttributes,
         );
 
@@ -3494,6 +3512,8 @@ export class ProjectService extends BaseService {
                 userUuid: user.userUuid,
             });
 
+        const intrinsicUserAttributes = getIntrinsicUserAttributes(user);
+
         const totalQuery: MetricQuery = {
             ...metricQuery,
             limit: 1,
@@ -3508,6 +3528,7 @@ export class ProjectService extends BaseService {
             totalQuery,
             explore,
             warehouseClient,
+            intrinsicUserAttributes,
             userAttributes,
         );
 
@@ -3912,7 +3933,7 @@ export class ProjectService extends BaseService {
                     chartUrl: `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${chart.uuid}/view`,
                 })),
             ];
-            console.log('metrics', metrics);
+
             return metrics;
         }, []);
     }

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -114,3 +114,13 @@ export type ApiGetLoginOptionsResponse = {
     status: 'ok';
     results: LoginOptions;
 };
+
+export type IntrinsicUserAttributes = Record<string, string>;
+
+export const getIntrinsicUserAttributes = (
+    user: LightdashUser,
+): IntrinsicUserAttributes => ({
+    email: user.email ?? '',
+    first_name: user.firstName,
+    last_name: user.lastName,
+});

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -115,7 +115,11 @@ export type ApiGetLoginOptionsResponse = {
     results: LoginOptions;
 };
 
-export type IntrinsicUserAttributes = Record<string, string>;
+export type IntrinsicUserAttributes = {
+    email: string;
+    first_name: string;
+    last_name: string;
+};
 
 export const getIntrinsicUserAttributes = (
     user: LightdashUser,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#6955](https://github.com/lightdash/lightdash/issues/6955)

### Description:

- Allows to reference  user intrinsic attributes in `filters` and `join` on clauses via `${lightdash.user.<attribute>}`
- Available attributes are - `email`, `first_name`, `last_name`

- join `sql_on`
![image](https://github.com/lightdash/lightdash/assets/22939015/fd940dd0-ec15-49b4-b30a-dd01b6c9598e)
![image](https://github.com/lightdash/lightdash/assets/22939015/2eaed2de-bc47-4439-b22c-3b7d7dc93ea1)

- models `sql_filter`
![image](https://github.com/lightdash/lightdash/assets/22939015/52cf967a-bb0b-4369-98f6-6b73dd97a160)
![image](https://github.com/lightdash/lightdash/assets/22939015/689ad601-b299-4d5e-96d1-740773f0a801)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
