### PR TITLE
chore: make bug report description field a textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,42 +2,43 @@ name: Bug report
 description: Create a report to help us improve
 labels: 🐛 bug
 body:
-  - type: input
-    id: description
-    attributes:
-      label: Description
-      description: What happened and what did you expect?
-      placeholder: Selecting a numeric metric on Explore page throws an error "Undefined"
-    validations:
-      required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to Reproduce the Bug or Issue
-      description: Describe the steps we have to take to reproduce the behavior.
-      placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
-        4. See error
-    validations:
-      required: true
-  - type: input
-    id: version
-    attributes:
-      label: version
-      description: What version of Lightdash were you using when you encountered the
-        bug? (App version is available in the footer of the Lightdash homepage)
-      placeholder: v0.1045.0
-    validations:
-      required: false
-  - type: dropdown
-    id: cloud
-    attributes:
-      label: Cloud or self-hosting
-      description: Did you get this bug on Lightdash cloud or self-hosting
-      options:
-        - cloud
-        - self-hosting
-    validations:
-      required: false
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: What happened and what did you expect?
+          placeholder: Selecting a numeric metric on Explore page throws an error "Undefined"
+      validations:
+          required: true
+    - type: textarea
+      id: steps
+      attributes:
+          label: Steps to Reproduce the Bug or Issue
+          description: Describe the steps we have to take to reproduce the behavior.
+          placeholder: |
+              1. Go to '...'
+              2. Click on '....'
+              3. Scroll down to '....'
+              4. See error
+      validations:
+          required: true
+    - type: input
+      id: version
+      attributes:
+          label: version
+          description:
+              What version of Lightdash were you using when you encountered the
+              bug? (App version is available in the footer of the Lightdash homepage)
+          placeholder: v0.1045.0
+      validations:
+          required: false
+    - type: dropdown
+      id: cloud
+      attributes:
+          label: Cloud or self-hosting
+          description: Did you get this bug on Lightdash cloud or self-hosting
+          options:
+              - cloud
+              - self-hosting
+      validations:
+          required: false


### PR DESCRIPTION
### Description:

On the issue report form, makes the description field a textarea (like remaining fields) instead of a single line input. The single line input is awkward to write in (particularly since most useful descriptions will be a couple of lines, or at least a longer single line), and doesn't currently show the full placeholder text.


Field in question as it is now (and the second field is what it'll look like instead):

<img width="692" alt="image" src="https://github.com/lightdash/lightdash/assets/382538/73254660-028a-4b7d-8c00-63239ea71fdf">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
