### PR TITLE
fix: add withinPortal to FiltersProvider in card

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -163,6 +163,9 @@ const FiltersCard: FC = memo(() => {
                 startOfWeek={
                     project.data?.warehouseConnection?.startOfWeek ?? undefined
                 }
+                popoverProps={{
+                    withinPortal: true,
+                }}
             >
                 <FiltersForm
                     isEditMode={isEditMode}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9734

### Description:

pass `withinPortal: true` to `FiltersProvider` in `FilterCard` - we do that in Dashboard filters as well - was just missing here

before

https://github.com/lightdash/lightdash/assets/7611706/9b7db2c2-15d3-494b-a54d-09fe885319e1

after

https://github.com/lightdash/lightdash/assets/7611706/52cca399-6e2d-49a8-b64d-cefaf1b7aed8



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
