### PR TITLE
feat: add report URL to charts' google syncs

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -153,7 +153,7 @@ export class GoogleDriveClient {
             ],
             ['Update frequency:', updateFrequency],
             ['Time of last sync:', new Date().toLocaleString()],
-            ['Report URL:', reportUrl || ''],
+            ...(reportUrl ? [['Report URL:', reportUrl]] : []),
             ...tabsUpdated,
         ];
 

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -131,6 +131,7 @@ export class GoogleDriveClient {
         fileId: string,
         updateFrequency: string,
         tabs?: string[],
+        reportUrl?: string,
     ) {
         if (!this.isEnabled) {
             throw new Error('Google Drive is not enabled');
@@ -152,6 +153,7 @@ export class GoogleDriveClient {
             ],
             ['Update frequency:', updateFrequency],
             ['Time of last sync:', new Date().toLocaleString()],
+            ['Report URL:', reportUrl || ''],
             ...tabsUpdated,
         ];
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1285,10 +1285,14 @@ export default class SchedulerTask {
                 const refreshToken = await this.userService.getRefreshToken(
                     scheduler.createdBy,
                 );
+
+                const reportUrl = `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view?scheduler_uuid=${schedulerUuid}&isSync=true`;
                 await this.googleDriveClient.uploadMetadata(
                     refreshToken,
                     gdriveId,
                     getHumanReadableCronExpression(scheduler.cron),
+                    undefined,
+                    reportUrl,
                 );
 
                 await this.googleDriveClient.appendToSheet(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [9682](https://github.com/lightdash/lightdash/issues/9682)

### Description:

Adds report URL to meta tab for Charts' google sheets syncs

<img width="1374" alt="Screenshot 2024-04-12 at 14 49 42" src="https://github.com/lightdash/lightdash/assets/7611706/c28f3d3e-5d5a-4bbb-988e-ed5fb3064fc4">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
