### PR TITLE
feat: allow pinning from chart and dashboard pages

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -36,6 +36,8 @@ import {
     IconHistory,
     IconLayoutGridAdd,
     IconPencil,
+    IconPin,
+    IconPinnedOff,
     IconSend,
     IconTrash,
 } from '@tabler/icons-react';
@@ -154,7 +156,15 @@ const useCreatePullRequestForChartFieldsMutation = (
     );
 };
 
-const SavedChartsHeader: FC = () => {
+type SavedChartsHeaderProps = {
+    isPinned: boolean;
+    onTogglePin: () => void;
+};
+
+const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
+    isPinned,
+    onTogglePin,
+}) => {
     const { search } = useLocation();
     const { projectUuid } = useParams<{
         projectUuid: string;
@@ -339,6 +349,14 @@ const SavedChartsHeader: FC = () => {
     const userCanCreateDeliveriesAndAlerts = user.data?.ability?.can(
         'create',
         subject('ScheduledDeliveries', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
+    const userCanPinChart = user.data?.ability.can(
+        'manage',
+        subject('PinnedItems', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
         }),
@@ -604,6 +622,27 @@ const SavedChartsHeader: FC = () => {
                                             Move to space
                                         </Menu.Item>
                                     )}
+
+                                {!chartBelongsToDashboard && userCanPinChart && (
+                                    <Menu.Item
+                                        component="button"
+                                        role="menuitem"
+                                        icon={
+                                            isPinned ? (
+                                                <MantineIcon
+                                                    icon={IconPinnedOff}
+                                                />
+                                            ) : (
+                                                <MantineIcon icon={IconPin} />
+                                            )
+                                        }
+                                        onClick={onTogglePin}
+                                    >
+                                        {isPinned
+                                            ? 'Unpin from homepage'
+                                            : 'Pin to homepage'}
+                                    </Menu.Item>
+                                )}
 
                                 {userCanManageChart &&
                                     !chartBelongsToDashboard && (

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -25,6 +25,8 @@ import {
     IconFolders,
     IconInfoCircle,
     IconPencil,
+    IconPin,
+    IconPinnedOff,
     IconPlus,
     IconSend,
     IconTrash,
@@ -63,6 +65,7 @@ type DashboardHeaderProps = {
     isEditMode: boolean;
     isSaving: boolean;
     isFullscreen: boolean;
+    isPinned: boolean;
     oldestCacheTime?: Date;
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     onCancel: () => void;
@@ -73,6 +76,7 @@ type DashboardHeaderProps = {
     onExport: () => void;
     onToggleFullscreen: () => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
+    onTogglePin: () => void;
 };
 
 const DashboardHeader = ({
@@ -83,6 +87,7 @@ const DashboardHeader = ({
     isEditMode,
     isSaving,
     isFullscreen,
+    isPinned,
     oldestCacheTime,
     onAddTiles,
     onCancel,
@@ -93,6 +98,7 @@ const DashboardHeader = ({
     onExport,
     onToggleFullscreen,
     setAddingTab,
+    onTogglePin,
 }: DashboardHeaderProps) => {
     const { search } = useLocation();
     const { projectUuid, dashboardUuid } = useParams<{
@@ -136,6 +142,14 @@ const DashboardHeader = ({
     const userCanExportData = user.data?.ability.can(
         'manage',
         subject('ExportCsv', { organizationUuid, projectUuid }),
+    );
+
+    const userCanPinDashboard = user.data?.ability.can(
+        'manage',
+        subject('PinnedItems', {
+            organizationUuid,
+            projectUuid,
+        }),
     );
 
     return (
@@ -472,6 +486,27 @@ const DashboardHeader = ({
                                             </Menu>
                                         </Menu.Item>
                                     </>
+                                )}
+
+                                {userCanPinDashboard && (
+                                    <Menu.Item
+                                        component="button"
+                                        role="menuitem"
+                                        icon={
+                                            isPinned ? (
+                                                <MantineIcon
+                                                    icon={IconPinnedOff}
+                                                />
+                                            ) : (
+                                                <MantineIcon icon={IconPin} />
+                                            )
+                                        }
+                                        onClick={onTogglePin}
+                                    >
+                                        {isPinned
+                                            ? 'Unpin from homepage'
+                                            : 'Pin to homepage'}
+                                    </Menu.Item>
                                 )}
 
                                 {!!userCanCreateDeliveries && (

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -29,6 +29,9 @@ export const useChartPinningMutation = () => {
                     savedChart.projectUuid,
                     savedChart.spaceUuid,
                 ]);
+                await queryClient.invalidateQueries([
+                    'most-popular-and-recently-updated',
+                ]);
                 if (savedChart.pinnedListUuid) {
                     showToastSuccess({
                         title: 'Success! Chart was pinned to homepage',

--- a/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
@@ -29,6 +29,9 @@ export const useDashboardPinningMutation = () => {
                     dashboard.projectUuid,
                     dashboard.spaceUuid,
                 ]);
+                await queryClient.invalidateQueries([
+                    'most-popular-and-recently-updated',
+                ]);
 
                 if (dashboard.pinnedListUuid) {
                     showToastSuccess({

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import {
     DashboardTileTypes,
     FeatureFlags,
     isDashboardChartTileType,
+    ResourceViewItemType,
     type Dashboard as IDashboard,
     type DashboardTab,
     type DashboardTile,
@@ -170,7 +171,7 @@ const Dashboard: FC = () => {
         return Boolean(
             pinnedItems?.some(
                 (item) =>
-                    item.type === 'dashboard' &&
+                    item.type === ResourceViewItemType.DASHBOARD &&
                     item.data.uuid === dashboardUuid,
             ),
         );

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -33,6 +33,8 @@ import {
 } from '../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
+import { useDashboardPinningMutation } from '../hooks/pinning/useDashboardPinningMutation';
+import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
 import useToaster from '../hooks/toaster/useToaster';
 import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
@@ -154,6 +156,25 @@ const Dashboard: FC = () => {
     const [isExportDashboardModalOpen, exportDashboardModalHandlers] =
         useDisclosure();
     const [isSaveWarningModalOpen, saveWarningModalHandlers] = useDisclosure();
+    const { mutate: toggleDashboardPinning } = useDashboardPinningMutation();
+    const { data: pinnedItems } = usePinnedItems(
+        projectUuid,
+        dashboard?.pinnedListUuid ?? undefined,
+    );
+
+    const handleDashboardPinning = useCallback(() => {
+        toggleDashboardPinning({ uuid: dashboardUuid });
+    }, [dashboardUuid, toggleDashboardPinning]);
+
+    const isPinned = useMemo(() => {
+        return Boolean(
+            pinnedItems?.some(
+                (item) =>
+                    item.type === 'dashboard' &&
+                    item.data.uuid === dashboardUuid,
+            ),
+        );
+    }, [dashboardUuid, pinnedItems]);
 
     // tabs state
     const [activeTab, setActiveTab] = useState<DashboardTab | undefined>();
@@ -582,6 +603,7 @@ const Dashboard: FC = () => {
                         isSaving={isSaving}
                         oldestCacheTime={oldestCacheTime}
                         isFullscreen={isFullscreen}
+                        isPinned={isPinned}
                         onToggleFullscreen={handleToggleFullscreen}
                         hasDashboardChanged={
                             haveTilesChanged ||
@@ -617,6 +639,7 @@ const Dashboard: FC = () => {
                         onDelete={deleteModalHandlers.open}
                         onExport={exportDashboardModalHandlers.open}
                         setAddingTab={setAddingTab}
+                        onTogglePin={handleDashboardPinning}
                     />
                 }
             >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#9782](https://github.com/lightdash/lightdash/issues/9782)

### Description:

- Allows pinning dashboard from the dashboard page
- Allows pinning chart from the chart page, doesn't display this option for dashboard charts


https://github.com/lightdash/lightdash/assets/22939015/21bd5d3c-c4f0-46ca-8cad-13f7086dd13c



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
