### PR TITLE
fix: only show option to move tab when there are multiple tabs available

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -236,22 +236,26 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                     </Menu.Item>
                                                 ) : (
                                                     <>
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
+                                                        {tabs &&
+                                                            tabs.length > 1 && (
+                                                                <Menu.Item
                                                                     icon={
-                                                                        IconArrowAutofitContent
+                                                                        <MantineIcon
+                                                                            icon={
+                                                                                IconArrowAutofitContent
+                                                                            }
+                                                                        />
                                                                     }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                setIsMovingTabs(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Move to another tab
-                                                        </Menu.Item>
+                                                                    onClick={() =>
+                                                                        setIsMovingTabs(
+                                                                            true,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Move to
+                                                                    another tab
+                                                                </Menu.Item>
+                                                            )}
                                                         <Menu.Divider />
                                                         <Menu.Item
                                                             color="red"

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
@@ -60,10 +60,13 @@ const MoveTileToTabModal: FC<Props> = ({
                     <Select
                         label="Select tab to move this tile to"
                         value={selectedTabId}
-                        data={tabs.map((tab) => ({
-                            value: tab.uuid,
-                            label: tab.name,
-                        }))}
+                        placeholder="Pick a tab"
+                        data={tabs
+                            .filter((tab) => tab.uuid !== tile.tabUuid)
+                            .map((tab) => ({
+                                value: tab.uuid,
+                                label: tab.name,
+                            }))}
                         withinPortal
                         onChange={(value) => setSelectedTabId(value)}
                     />
@@ -76,7 +79,9 @@ const MoveTileToTabModal: FC<Props> = ({
                         Cancel
                     </Button>
 
-                    <Button onClick={handleConfirm}>Move</Button>
+                    <Button onClick={handleConfirm} disabled={!selectedTabId}>
+                        Move
+                    </Button>
                 </Group>
             </Stack>
         </Modal>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9827<!-- reference the related issue e.g. #150 -->
Closes: #9657 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- Only show option to move tab when there are multiple tabs available.
- Don't show current tab as an option.
- Disable button until they select a tab


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
