### PR TITLE
chore: transformers

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,7 +26,7 @@
         "pegjs": "^0.10.0",
         "sanitize-html": "^2.12.1",
         "uuid": "^8.3.2",
-        "zod": "^3.22.3"
+        "zod": "^3.22.5"
     },
     "scripts": {
         "dev": "tsc --build --watch --preserveWatchOutput tsconfig.json",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -130,6 +130,7 @@ export * from './compiler/translator';
 export * from './dbt/validation';
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';
 export * from './templating/template';
+export * from './transformers';
 export * from './types/analytics';
 export * from './types/api';
 export * from './types/api/comments';

--- a/packages/common/src/transformers/README.md
+++ b/packages/common/src/transformers/README.md
@@ -9,3 +9,30 @@ At the moment there are 3 types of transformers:
 -   **Viz library**: Transforms the viz configuration into a viz library specific configuration
 
 The viz configuration and viz library transformers instances should **ONLY** be created via their factory.
+
+## Usage
+
+To render a visualisation, you need to chain all the transformers together. Here is an example of how to do it:
+
+```typescript
+const results = {}; // this would be the data from the backend after running a query (explore/sql runner/semanticlayer)
+
+// Create a results transformer
+const resultsTransformer = new ExplorerResultsTransformer({ data: results });
+
+const barVizConfig = {}; // example of a bar chart viz config
+// Create a Viz config transformer
+const vizConfigTransformer =
+    VizConfigTransformerFactory.createVizConfigTransformer({
+        vizConfig: barVizConfig,
+        resultsTransformer,
+    });
+
+// Create a Viz lib transformer
+const vizLib = VizLibTransformerFactory.createVizLibTransformer({
+    vizConfigTransformer,
+});
+
+// Get the data & configuration for the viz library
+vizLib.getConfig();
+```

--- a/packages/common/src/transformers/README.md
+++ b/packages/common/src/transformers/README.md
@@ -4,8 +4,8 @@ This directory contains classes that are used to transform the data between each
 
 At the moment there are 3 types of transformers:
 
-- **Results**: Transforms data related the query and results
-- **Viz configuration**: Validates, manages and transforms the viz configuration
-- **Viz library**: Transforms the viz configuration into a viz library specific configuration
+-   **Results**: Transforms data related the query and results
+-   **Viz configuration**: Validates, manages and transforms the viz configuration
+-   **Viz library**: Transforms the viz configuration into a viz library specific configuration
 
 The viz configuration and viz library transformers instances should **ONLY** be created via their factory.

--- a/packages/common/src/transformers/README.md
+++ b/packages/common/src/transformers/README.md
@@ -1,0 +1,11 @@
+# Transformers overview
+
+This directory contains classes that are used to transform the data between each layer of the application.
+
+At the moment there are 3 types of transformers:
+
+- **Results**: Transforms data related the query and results
+- **Viz configuration**: Validates, manages and transforms the viz configuration
+- **Viz library**: Transforms the viz configuration into a viz library specific configuration
+
+The viz configuration and viz library transformers instances should **ONLY** be created via their factory.

--- a/packages/common/src/transformers/ResultTransformers/AbstractResultTransformer.ts
+++ b/packages/common/src/transformers/ResultTransformers/AbstractResultTransformer.ts
@@ -1,0 +1,18 @@
+import { type ResultRow } from '../../types/results';
+
+export abstract class AbstractResultTransformer {
+    /**
+     * Unique identifier for the results transformer
+     */
+    abstract type: string;
+
+    /**
+     * Get the rows from the results transformer
+     */
+    abstract getRows(): ResultRow[];
+
+    /**
+     * Get the field options from the results transformer
+     */
+    abstract getFieldOptions(): string[];
+}

--- a/packages/common/src/transformers/ResultTransformers/ExplorerResultsTransformer.ts
+++ b/packages/common/src/transformers/ResultTransformers/ExplorerResultsTransformer.ts
@@ -1,0 +1,28 @@
+import { type ApiQueryResults } from '../../index';
+import { AbstractResultTransformer } from './AbstractResultTransformer';
+
+type ExplorerResultTransformerArguments = {
+    data: ApiQueryResults;
+};
+
+export class ExplorerResultsTransformer extends AbstractResultTransformer {
+    public type = 'explorer' as const;
+
+    private readonly data: ApiQueryResults;
+
+    constructor(args: ExplorerResultTransformerArguments) {
+        super();
+        this.data = args.data;
+    }
+
+    public getFieldOptions() {
+        return [
+            ...this.data.metricQuery.dimensions,
+            ...this.data.metricQuery.metrics,
+        ];
+    }
+
+    public getRows() {
+        return this.data.rows;
+    }
+}

--- a/packages/common/src/transformers/ResultTransformers/index.ts
+++ b/packages/common/src/transformers/ResultTransformers/index.ts
@@ -1,0 +1,2 @@
+export * from './AbstractResultTransformer';
+export * from './ExplorerResultsTransformer';

--- a/packages/common/src/transformers/VizConfigTransformers/AbstractVizConfigTransformer.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/AbstractVizConfigTransformer.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { type AbstractResultTransformer } from '../ResultTransformers';
+
+export const vizConfigSchema = z.object({
+    type: z.string(),
+});
+
+export type VizConfig = z.infer<typeof vizConfigSchema>;
+
+export interface VizConfigTransformerArguments {
+    vizConfig: VizConfig;
+    resultsTransformer: AbstractResultTransformer;
+}
+
+export abstract class AbstractVizConfigTransformer<
+    T extends VizConfig = VizConfig,
+> {
+    /**
+     * Unique identifier for the vizConfig transformer
+     */
+    static type: string;
+
+    protected readonly resultsTransformer: AbstractResultTransformer;
+
+    protected vizConfig: T;
+
+    constructor(args: VizConfigTransformerArguments) {
+        this.resultsTransformer = args.resultsTransformer;
+        this.vizConfig = args.vizConfig as T;
+    }
+
+    /**
+     * Transforms and returns the data necessary based on the type of vizConfig
+     */
+    public getRows() {
+        return this.resultsTransformer.getRows();
+    }
+
+    /**
+     * Returns the valid vizConfig object
+     */
+    public getVizConfig() {
+        return this.vizConfig;
+    }
+}

--- a/packages/common/src/transformers/VizConfigTransformers/Cartisean/AbstractCartiseanConfigTransformer.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/Cartisean/AbstractCartiseanConfigTransformer.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import {
+    AbstractVizConfigTransformer,
+    vizConfigSchema,
+    type VizConfigTransformerArguments,
+} from '../AbstractVizConfigTransformer';
+
+const axisTickSchema = z.object({
+    tickInterval: z.number(),
+    formatterName: z.string(),
+});
+
+const axisSchema = z.object({
+    fieldId: z.string(),
+    type: z.enum(['categorical', 'time', 'linear', 'log']),
+    label: z.string(),
+    sort: z.enum(['asc', 'desc']).optional(),
+    position: z.enum(['left', 'right']).optional(),
+    gridLines: z.boolean(),
+    axisTicks: z.array(axisTickSchema),
+});
+
+const cartesianVizConfigSeriesSchema = z.object({
+    type: z.enum(['bar', 'line', 'scatter']),
+    label: z.string(),
+    xAxisFieldId: z.string(),
+    yAxisFieldId: z.string(),
+});
+
+export const cartesianVizConfigSchema = vizConfigSchema.extend({
+    xAxis: axisSchema,
+    yAxis: z.array(axisSchema),
+    series: z.array(cartesianVizConfigSeriesSchema),
+});
+
+export type CartesianVizConfig = z.infer<typeof cartesianVizConfigSchema>;
+
+export abstract class AbstractCartesianConfigTransformer<
+    T extends CartesianVizConfig = CartesianVizConfig,
+> extends AbstractVizConfigTransformer<T> {
+    /**
+     * Default series type
+     * @protected
+     */
+    protected defaultSeriesType: string = 'bar';
+
+    constructor(args: VizConfigTransformerArguments) {
+        super(args);
+        this.vizConfig = this.validVizConfig(args.vizConfig as T);
+    }
+
+    protected validVizConfig(config: T): T {
+        return {
+            ...config,
+            type: config.type || this.defaultSeriesType,
+            xAxis: config.xAxis,
+            yAxis: config.yAxis,
+            series: config.series,
+        };
+    }
+
+    public getXAxisOptions() {
+        return this.resultsTransformer.getFieldOptions();
+    }
+
+    public getYAxisOptions() {
+        return this.resultsTransformer.getFieldOptions();
+    }
+}

--- a/packages/common/src/transformers/VizConfigTransformers/Cartisean/BarConfigTransformer.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/Cartisean/BarConfigTransformer.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import {
+    AbstractCartesianConfigTransformer,
+    cartesianVizConfigSchema,
+} from './AbstractCartiseanConfigTransformer';
+
+const barVizConfigSchema = cartesianVizConfigSchema.extend({
+    type: z.literal('bar'),
+});
+
+export type BarVizConfig = z.infer<typeof barVizConfigSchema>;
+
+export class BarConfigTransformer extends AbstractCartesianConfigTransformer<BarVizConfig> {
+    static type = 'bar';
+
+    protected defaultSeriesType: string = 'bar';
+}

--- a/packages/common/src/transformers/VizConfigTransformers/Table/TableConfigTransformer.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/Table/TableConfigTransformer.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import {
+    AbstractVizConfigTransformer,
+    vizConfigSchema,
+    type VizConfigTransformerArguments,
+} from '../AbstractVizConfigTransformer';
+
+const columnSchema = z.object({
+    visible: z.boolean().optional(),
+    name: z.string().optional(),
+    frozen: z.boolean().optional(),
+});
+
+export const tableConfigSchema = vizConfigSchema.extend({
+    type: z.literal('table'),
+    showColumnCalculation: z.boolean().optional(),
+    showRowCalculation: z.boolean().optional(),
+    showTableNames: z.boolean().optional(),
+    hideRowNumbers: z.boolean().optional(),
+    showResultsTotal: z.boolean().optional(),
+    showSubtotals: z.boolean().optional(),
+    columns: z.record(z.string(), columnSchema),
+});
+
+export type TableConfig = z.infer<typeof tableConfigSchema>;
+
+export class TableConfigTransformer<
+    T extends TableConfig = TableConfig,
+> extends AbstractVizConfigTransformer<T> {
+    static type = 'table';
+
+    constructor(args: VizConfigTransformerArguments) {
+        super(args);
+        this.vizConfig = this.validVizConfig(args.vizConfig as T);
+    }
+
+    /**
+     * Returns a valid table config
+     */
+    protected validVizConfig(config: T): T {
+        return {
+            ...config,
+            showColumnCalculation: config.showColumnCalculation,
+            showRowCalculation: config.showRowCalculation,
+            showTableNames: config.showTableNames,
+            hideRowNumbers: config.hideRowNumbers,
+            showResultsTotal: config.showResultsTotal,
+            showSubtotals: config.showSubtotals,
+            columns: this.getColumns(config.columns),
+        };
+    }
+
+    /**
+     * Get valid columns based on existing configuration and results transformer
+     * @param currentColumns
+     * @private
+     */
+    private getColumns(
+        currentColumns?: TableConfig['columns'],
+    ): TableConfig['columns'] {
+        return this.resultsTransformer
+            .getFieldOptions()
+            .reduce<TableConfig['columns']>((acc, field) => {
+                acc[field] = {
+                    visible: true,
+                    name: field,
+                    frozen: false,
+                    ...(currentColumns ?? {})[field],
+                };
+                return acc;
+            }, {});
+    }
+}

--- a/packages/common/src/transformers/VizConfigTransformers/VizConfigTransformerFactory.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/VizConfigTransformerFactory.ts
@@ -1,0 +1,38 @@
+import {
+    type AbstractVizConfigTransformer,
+    type VizConfigTransformerArguments,
+} from './AbstractVizConfigTransformer';
+import { BarConfigTransformer } from './Cartisean/BarConfigTransformer';
+import { TableConfigTransformer } from './Table/TableConfigTransformer';
+
+/**
+ * List of available viz libraries
+ */
+const VIZ_CONFIGS = [BarConfigTransformer, TableConfigTransformer] as const;
+
+/**
+ * Factory class to create VizConfigTransformer objects
+ */
+export class VizConfigTransformerFactory {
+    /**
+     * Returns the list of supported vizConfig types
+     */
+    static listVizConfigs(): string[] {
+        return VIZ_CONFIGS.map((c) => c.type);
+    }
+
+    /**
+     * Creates a new VizConfigTransformer object based on the type
+     */
+    static createVizConfigTransformer(
+        args: VizConfigTransformerArguments,
+    ): AbstractVizConfigTransformer {
+        const { type } = args.vizConfig;
+        const Transformer = VIZ_CONFIGS.find((c) => c.type === type);
+
+        if (Transformer) {
+            return new Transformer(args);
+        }
+        throw new Error(`Unsupported viz config: ${type}`);
+    }
+}

--- a/packages/common/src/transformers/VizConfigTransformers/index.ts
+++ b/packages/common/src/transformers/VizConfigTransformers/index.ts
@@ -1,0 +1,5 @@
+export * from './AbstractVizConfigTransformer';
+export * from './Cartisean/AbstractCartiseanConfigTransformer';
+export * from './Cartisean/BarConfigTransformer';
+export * from './Table/TableConfigTransformer';
+export * from './VizConfigTransformerFactory';

--- a/packages/common/src/transformers/VizLibTransformers/AbstractVizLibTransformer.ts
+++ b/packages/common/src/transformers/VizLibTransformers/AbstractVizLibTransformer.ts
@@ -1,0 +1,38 @@
+import { type AbstractVizConfigTransformer } from '../VizConfigTransformers';
+
+export interface AbstractVizLibTransformerArguments<
+    V extends AbstractVizConfigTransformer = AbstractVizConfigTransformer,
+> {
+    vizConfigTransformer: V;
+}
+
+export abstract class AbstractVizLibTransformer<
+    V extends AbstractVizConfigTransformer = AbstractVizConfigTransformer,
+> {
+    /**
+     * Unique identifier for the vizLib transformer
+     */
+    static type: string;
+
+    /**
+     * List of supported viz config types
+     * Example: ['bar', 'table', 'pie']
+     */
+    static supportedVizTypes: string[];
+
+    protected readonly vizConfigTransformer: V;
+
+    constructor(args: AbstractVizLibTransformerArguments<V>) {
+        this.vizConfigTransformer = args.vizConfigTransformer;
+    }
+
+    /**
+     * Returns the type of the vizLib transformer
+     */
+    abstract getType(): string;
+
+    /**
+     * Returns all the necessary data to render the visualization
+     */
+    abstract getConfig(): unknown;
+}

--- a/packages/common/src/transformers/VizLibTransformers/LibTransformer.mock.ts
+++ b/packages/common/src/transformers/VizLibTransformers/LibTransformer.mock.ts
@@ -1,0 +1,117 @@
+import { type ApiQueryResults } from '../../index';
+import { type MetricQuery } from '../../types/metricQuery';
+import { type BarVizConfig, type TableConfig } from '../VizConfigTransformers';
+
+export const mockRows = [
+    {
+        orders_status: {
+            value: {
+                raw: 'completed',
+                formatted: 'Completed',
+            },
+        },
+        orders_order_date_week: {
+            value: {
+                raw: 1,
+                formatted: '1',
+            },
+        },
+        orders_average_order_size: {
+            value: {
+                raw: 5,
+                formatted: '5',
+            },
+        },
+    },
+    {
+        orders_status: {
+            value: {
+                raw: 'incomplete',
+                formatted: 'Incomplete',
+            },
+        },
+        orders_order_date_week: {
+            value: {
+                raw: 3,
+                formatted: '3',
+            },
+        },
+        orders_average_order_size: {
+            value: {
+                raw: 7,
+                formatted: '7',
+            },
+        },
+    },
+];
+
+export const metricQuery: MetricQuery = {
+    limit: 25,
+    sorts: [],
+    filters: {},
+    exploreName: 'orders',
+    dimensions: ['orders_status', 'orders_order_date_week'],
+    metrics: ['orders_average_order_size'],
+    tableCalculations: [],
+    customDimensions: [],
+};
+
+export const results: ApiQueryResults = {
+    metricQuery,
+    rows: mockRows,
+    fields: {},
+    cacheMetadata: {
+        cacheHit: false,
+    },
+};
+
+export const barVizConfig: BarVizConfig = {
+    type: 'bar',
+    xAxis: {
+        type: 'categorical', // We should decide how rigorous to be with this. Vega uses nominal by default.
+        fieldId: 'orders_status',
+        label: 'Orders Status',
+        sort: 'asc',
+        position: 'left',
+        gridLines: true,
+        axisTicks: [],
+    },
+    yAxis: [
+        {
+            type: 'linear',
+            fieldId: 'orders_average_order_size',
+            label: 'Orders average order size',
+            sort: 'asc',
+            position: 'left',
+            gridLines: true,
+            axisTicks: [],
+        },
+    ],
+    series: [],
+};
+
+export const TableVizConfig: TableConfig = {
+    type: 'table',
+    showColumnCalculation: false,
+    showRowCalculation: false,
+    showTableNames: false,
+    hideRowNumbers: true,
+    showResultsTotal: false,
+    columns: {
+        orders_status: {
+            visible: true,
+            name: 'Orders Status',
+            frozen: false,
+        },
+        orders_order_date_week: {
+            visible: true,
+            name: 'Orders Order Date Week',
+            frozen: false,
+        },
+        orders_average_order_size: {
+            visible: true,
+            name: 'Orders Average Order Size',
+            frozen: false,
+        },
+    },
+};

--- a/packages/common/src/transformers/VizLibTransformers/Table/TableTransformer.test.ts
+++ b/packages/common/src/transformers/VizLibTransformers/Table/TableTransformer.test.ts
@@ -1,0 +1,84 @@
+import { ExplorerResultsTransformer } from '../../ResultTransformers';
+import { VizConfigTransformerFactory } from '../../VizConfigTransformers';
+import { results, TableVizConfig } from '../LibTransformer.mock';
+import { VizLibTransformerFactory } from '../VizLibTransformerFactory';
+
+describe('TableTransformer', () => {
+    it('should return a valid table config', async () => {
+        const resultsTransformer = new ExplorerResultsTransformer({
+            data: results,
+        });
+
+        const vizConfigTransformer =
+            VizConfigTransformerFactory.createVizConfigTransformer({
+                vizConfig: TableVizConfig,
+                resultsTransformer,
+            });
+
+        const vizLib = VizLibTransformerFactory.createVizLibTransformer({
+            vizConfigTransformer,
+        });
+
+        expect(vizLib.getConfig()).toEqual({
+            columns: {
+                orders_status: {
+                    frozen: false,
+                    name: 'Orders Status',
+                    visible: true,
+                },
+                orders_order_date_week: {
+                    frozen: false,
+                    name: 'Orders Order Date Week',
+                    visible: true,
+                },
+                orders_average_order_size: {
+                    frozen: false,
+                    name: 'Orders Average Order Size',
+                    visible: true,
+                },
+            },
+            rows: [
+                {
+                    orders_average_order_size: {
+                        value: {
+                            formatted: '5',
+                            raw: 5,
+                        },
+                    },
+                    orders_order_date_week: {
+                        value: {
+                            formatted: '1',
+                            raw: 1,
+                        },
+                    },
+                    orders_status: {
+                        value: {
+                            formatted: 'Completed',
+                            raw: 'completed',
+                        },
+                    },
+                },
+                {
+                    orders_average_order_size: {
+                        value: {
+                            formatted: '7',
+                            raw: 7,
+                        },
+                    },
+                    orders_order_date_week: {
+                        value: {
+                            formatted: '3',
+                            raw: 3,
+                        },
+                    },
+                    orders_status: {
+                        value: {
+                            formatted: 'Incomplete',
+                            raw: 'incomplete',
+                        },
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/packages/common/src/transformers/VizLibTransformers/Table/TableTransformer.ts
+++ b/packages/common/src/transformers/VizLibTransformers/Table/TableTransformer.ts
@@ -1,0 +1,31 @@
+import {
+    type TableConfig,
+    type TableConfigTransformer,
+} from '../../VizConfigTransformers';
+import { AbstractVizLibTransformer } from '../AbstractVizLibTransformer';
+
+export class TableTransformer extends AbstractVizLibTransformer<TableConfigTransformer> {
+    static type = 'table' as const;
+
+    static supportedVizTypes = ['table'];
+
+    // eslint-disable-next-line class-methods-use-this
+    public getType() {
+        return TableTransformer.type;
+    }
+
+    public getConfig() {
+        return {
+            rows: this.getRows(),
+            columns: this.getColumns(),
+        };
+    }
+
+    private getColumns(): TableConfig['columns'] {
+        return this.vizConfigTransformer.getVizConfig().columns;
+    }
+
+    private getRows() {
+        return this.vizConfigTransformer.getRows();
+    }
+}

--- a/packages/common/src/transformers/VizLibTransformers/Vega/VegaTransformer.test.ts
+++ b/packages/common/src/transformers/VizLibTransformers/Vega/VegaTransformer.test.ts
@@ -1,0 +1,63 @@
+import { ExplorerResultsTransformer } from '../../ResultTransformers';
+import { VizConfigTransformerFactory } from '../../VizConfigTransformers';
+import { barVizConfig, results } from '../LibTransformer.mock';
+import { VizLibTransformerFactory } from '../VizLibTransformerFactory';
+
+describe('VegaTransformer', () => {
+    it('should return a valid vega bar chart', async () => {
+        const resultsTransformer = new ExplorerResultsTransformer({
+            data: results,
+        });
+        const vizConfigTransformer =
+            VizConfigTransformerFactory.createVizConfigTransformer({
+                vizConfig: barVizConfig,
+                resultsTransformer,
+            });
+        const vizLib = VizLibTransformerFactory.createVizLibTransformer({
+            vizConfigTransformer,
+        });
+
+        expect(vizLib.getConfig()).toEqual({
+            autosize: {
+                type: 'fit',
+                contains: 'padding',
+                resize: true,
+            },
+            width: 'container',
+            height: 'container',
+            mark: {
+                type: 'bar',
+                color: '#7162ff',
+            },
+            encoding: {
+                x: {
+                    field: 'orders_status',
+                    title: 'Orders Status',
+                    type: 'nominal',
+                    axis: {
+                        labelAngle: 0,
+                    },
+                },
+                y: {
+                    field: 'orders_average_order_size',
+                    title: 'Orders average order size',
+                    type: 'quantitative',
+                },
+            },
+            data: {
+                values: [
+                    {
+                        orders_status: 'completed',
+                        orders_order_date_week: 1,
+                        orders_average_order_size: 5,
+                    },
+                    {
+                        orders_status: 'incomplete',
+                        orders_order_date_week: 3,
+                        orders_average_order_size: 7,
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/common/src/transformers/VizLibTransformers/Vega/VegaTransformer.ts
+++ b/packages/common/src/transformers/VizLibTransformers/Vega/VegaTransformer.ts
@@ -1,0 +1,73 @@
+import { type AbstractCartesianConfigTransformer } from '../../VizConfigTransformers';
+import { AbstractVizLibTransformer } from '../AbstractVizLibTransformer';
+
+export class VegaTransformer extends AbstractVizLibTransformer<AbstractCartesianConfigTransformer> {
+    static type = 'vega' as const;
+
+    static supportedVizTypes = ['bar'];
+
+    // eslint-disable-next-line class-methods-use-this
+    public getType() {
+        return VegaTransformer.type;
+    }
+
+    public getConfig() {
+        return {
+            ...this.getLayoutProps(),
+            mark: this.getMark(),
+            encoding: this.getEncoding(),
+            data: { values: this.getDataSet() },
+        };
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private getLayoutProps() {
+        return {
+            autosize: {
+                type: 'fit',
+                contains: 'padding',
+                resize: true,
+            },
+            width: 'container',
+            height: 'container',
+        };
+    }
+
+    private getMark() {
+        return {
+            type: this.vizConfigTransformer.getVizConfig().type,
+            color: '#7162ff',
+        };
+    }
+
+    private getEncoding() {
+        const vizConfig = this.vizConfigTransformer.getVizConfig();
+
+        return {
+            x: {
+                field: vizConfig.xAxis.fieldId,
+                title: vizConfig.xAxis.label,
+                type: 'nominal', // TODO
+                axis: { labelAngle: 0 },
+            },
+            y: {
+                field: vizConfig.yAxis?.[0].fieldId,
+                title: vizConfig.yAxis?.[0].label,
+                type: 'quantitative', // TODO
+            },
+        };
+    }
+
+    private getDataSet() {
+        return this.vizConfigTransformer
+            .getRows()
+            .map((row) =>
+                Object.fromEntries(
+                    Object.entries(row).map(([key, rowValue]) => [
+                        key,
+                        rowValue.value.raw,
+                    ]),
+                ),
+            );
+    }
+}

--- a/packages/common/src/transformers/VizLibTransformers/VizLibTransformerFactory.ts
+++ b/packages/common/src/transformers/VizLibTransformers/VizLibTransformerFactory.ts
@@ -1,0 +1,54 @@
+import {
+    type AbstractVizLibTransformer,
+    type AbstractVizLibTransformerArguments,
+} from './AbstractVizLibTransformer';
+import { TableTransformer } from './Table/TableTransformer';
+import { VegaTransformer } from './Vega/VegaTransformer';
+
+/**
+ * List of all supported viz libraries
+ */
+const VIZ_LIBS = [VegaTransformer, TableTransformer] as const;
+
+type LibType = typeof VIZ_LIBS[number]['type'];
+
+/**
+ * Factory class to create VizLib transformers
+ */
+export class VizLibTransformerFactory {
+    /**
+     * Returns the viz lib class based on the viz type and existing lib type
+     */
+    static getVizLib(vizType: string, libType?: LibType) {
+        const libsThatSupportViz = VIZ_LIBS.filter((c) =>
+            c.supportedVizTypes.includes(vizType),
+        );
+        if (libsThatSupportViz.length === 0) {
+            throw new Error(`Unsupported viz type: ${vizType}`);
+        }
+        const lib = libsThatSupportViz.find((c) => c.type === libType);
+        if (lib) {
+            return lib;
+        }
+        return libsThatSupportViz[0];
+    }
+
+    /**
+     * Creates a VizLib transformer based on the viz config transformer
+     */
+    static createVizLibTransformer(
+        args: AbstractVizLibTransformerArguments & {
+            libType?: LibType;
+        },
+    ): AbstractVizLibTransformer {
+        const { libType, ...rest } = args;
+        const { type } = rest.vizConfigTransformer.getVizConfig();
+        const Transformer = VizLibTransformerFactory.getVizLib(type, libType);
+
+        if (Transformer) {
+            // @ts-ignore TODO: we need to fix typing to for viz lib classes handle invalid viz configs
+            return new Transformer(rest);
+        }
+        throw new Error(`Unsupported viz config: ${type}`);
+    }
+}

--- a/packages/common/src/transformers/VizLibTransformers/index.ts
+++ b/packages/common/src/transformers/VizLibTransformers/index.ts
@@ -1,0 +1,4 @@
+export * from './AbstractVizLibTransformer';
+export * from './Table/TableTransformer';
+export * from './Vega/VegaTransformer';
+export * from './VizLibTransformerFactory';

--- a/packages/common/src/transformers/index.ts
+++ b/packages/common/src/transformers/index.ts
@@ -1,0 +1,3 @@
+export * from './ResultTransformers';
+export * from './VizConfigTransformers';
+export * from './VizLibTransformers';

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -92,7 +92,7 @@
         "uuid": "^8.3.2",
         "vega": "^5.26.0",
         "vega-lite": "^5.16.1",
-        "zod": "^3.22.3"
+        "zod": "^3.22.5"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22171,15 +22171,15 @@ zod-to-json-schema@^3.22.3:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.22.5.tgz#3646e81cfc318dbad2a22519e5ce661615418673"
   integrity sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==
 
-zod@^3.22.3:
-  version "3.22.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.3.tgz#2fbc96118b174290d94e8896371c95629e87a060"
-  integrity sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==
-
 zod@^3.22.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+
+zod@^3.22.5:
+  version "3.22.5"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.5.tgz#b9b09db03f6700b0d0b75bf0dbf0c5fc46155220"
+  integrity sha512-HqnGsCdVZ2xc0qWPLdO25WnseXThh0kEYKIdV5F/hTHO75hNZFp8thxSeHhiPrHZKrFTo1SOgkAj9po5bexZlw==
 
 zrender@5.4.4:
   version "5.4.4"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Transformer classes + docs

# Transformers overview

This directory contains classes that are used to transform the data between each layer of the application.

At the moment there are 3 types of transformers:

-   **Results**: Transforms data related the query and results
-   **Viz configuration**: Validates, manages and transforms the viz configuration
-   **Viz library**: Transforms the viz configuration into a viz library specific configuration

The viz configuration and viz library transformers instances should **ONLY** be created via their factory.

## Usage

To render a visualisation, you need to chain all the transformers together. Here is an example of how to do it:

```typescript
const results = {}; // this would be the data from the backend after running a query (explore/sql runner/semanticlayer)

// Create a results transformer
const resultsTransformer = new ExplorerResultsTransformer({ data: results });

const barVizConfig = {}; // example of a bar chart viz config
// Create a Viz config transformer
const vizConfigTransformer =
    VizConfigTransformerFactory.createVizConfigTransformer({
        vizConfig: barVizConfig,
        resultsTransformer,
    });

// Create a Viz lib transformer
const vizLib = VizLibTransformerFactory.createVizLibTransformer({
    vizConfigTransformer,
});

// Get the data & configuration for the viz library
vizLib.getConfig();
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
