### PR TITLE
fix: wrong chart icon in pinned list

### DIFF
--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -95,7 +95,7 @@ const getCharts = async (
             updatedAt: row.updated_at,
             views: row.views,
             firstViewedAt: row.first_viewed_at,
-            chartType: row.chart_kind,
+            chartKind: row.chart_kind,
             updatedByUser: row.updated_by_user_uuid && {
                 userUuid: row.updated_by_user_uuid,
                 firstName: row.updated_by_user_first_name,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This started happening after https://github.com/lightdash/lightdash/pull/9418/files#diff-97f739a09ecb82dabeb72908a35fe8e622e4d81c213616bc90df3a38d065e23f got merged. we stopped returning `chartType` as `chartKind` in the queries + handling of the frontend icons now used `chartKind` which this endpoint didn't return.

Before:

![image](https://github.com/lightdash/lightdash/assets/22939015/12523e67-5c3c-43b1-a82c-bdd01190be61)


After:

![image](https://github.com/lightdash/lightdash/assets/22939015/15f52cf7-4929-43c1-933b-882c1492ce12)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
