### PR TITLE
fix: fix joined table with aliases in metric

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -69,6 +69,7 @@ const compileAdditionalMetric = ({
     const compiledMetric = exploreCompiler.compileMetricSql(
         metric,
         explore.tables,
+        {},
     );
     return {
         ...metric,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -70,6 +70,7 @@ export type UncompiledExplore = {
     warehouse?: string;
     ymlPath?: string;
     sqlPath?: string;
+    joinAliases?: Record<string, Record<string, string>>;
 };
 
 export class ExploreCompiler {
@@ -91,6 +92,7 @@ export class ExploreCompiler {
         warehouse,
         ymlPath,
         sqlPath,
+        joinAliases,
     }: UncompiledExplore): Explore {
         // Check that base table and joined tables exist
         if (!tables[baseTable]) {
@@ -140,6 +142,7 @@ export class ExploreCompiler {
                     [join.alias || join.table]: {
                         ...tables[join.table],
                         originalName: tables[join.table].name,
+                        aliases: undefined,
                         name: joinTableName,
                         label: joinTableLabel,
                         hidden: join.hidden,
@@ -205,10 +208,12 @@ export class ExploreCompiler {
                 [tableName]: this.compileTable(
                     includedTables[tableName],
                     includedTables,
+                    joinAliases,
                 ),
             }),
             {},
         );
+
         const compiledJoins: CompiledExploreJoin[] = joinedTables.map((j) =>
             this.compileJoin(j, includedTables),
         );
@@ -228,7 +233,11 @@ export class ExploreCompiler {
         };
     }
 
-    compileTable(table: Table, tables: Record<string, Table>): CompiledTable {
+    compileTable(
+        table: Table,
+        tables: Record<string, Table>,
+        joinAliases: UncompiledExplore['joinAliases'],
+    ): CompiledTable {
         const dimensions: Record<string, CompiledDimension> = Object.keys(
             table.dimensions,
         ).reduce(
@@ -249,6 +258,7 @@ export class ExploreCompiler {
                 [metricKey]: this.compileMetric(
                     table.metrics[metricKey],
                     tables,
+                    joinAliases,
                 ),
             }),
             {},
@@ -273,8 +283,13 @@ export class ExploreCompiler {
     compileMetric(
         metric: Metric,
         tables: Record<string, Table>,
+        joinAliases?: UncompiledExplore['joinAliases'],
     ): CompiledMetric {
-        const compiledMetric = this.compileMetricSql(metric, tables);
+        const compiledMetric = this.compileMetricSql(
+            metric,
+            tables,
+            joinAliases,
+        );
         metric.showUnderlyingValues?.forEach((dimReference) => {
             const { refTable, refName } = getParsedReference(
                 dimReference,
@@ -312,6 +327,7 @@ export class ExploreCompiler {
     compileMetricSql(
         metric: Metric,
         tables: Record<string, Table>,
+        joinAliases: UncompiledExplore['joinAliases'],
     ): { sql: string; tablesReferences: Set<string> } {
         // Metric might have references to other dimensions
         if (!tables[metric.table]) {
@@ -335,7 +351,12 @@ export class ExploreCompiler {
 
                 const compiledReference = isNonAggregateMetric(metric)
                     ? this.compileMetricReference(p1, tables, metric.table)
-                    : this.compileDimensionReference(p1, tables, metric.table);
+                    : this.compileDimensionReference(
+                          p1,
+                          tables,
+                          metric.table,
+                          joinAliases,
+                      );
                 tablesReferences = new Set([
                     ...tablesReferences,
                     ...compiledReference.tablesReferences,
@@ -475,6 +496,7 @@ export class ExploreCompiler {
         ref: string,
         tables: Record<string, Table>,
         currentTable: string,
+        joinAliases?: UncompiledExplore['joinAliases'],
     ): { sql: string; tablesReferences: Set<string> } {
         // Reference to current table
         if (ref === 'TABLE') {
@@ -489,10 +511,18 @@ export class ExploreCompiler {
         const { refTable, refName } = getParsedReference(ref, currentTable);
 
         /** Resolve the table reference through its original name, or via an alias: */
-        const referencedTable = Object.values(tables).find(
-            (table) =>
-                table.name === refTable || table.originalName === refTable,
-        );
+        const referencedTable = Object.values(tables).find((table) => {
+            const nameMatch =
+                table.name === refTable || table.originalName === refTable;
+            if (nameMatch) return true;
+
+            if (!joinAliases?.[currentTable]) return false;
+            // Check if this `refTable` is an alias in its join
+            return Object.entries(joinAliases[currentTable]).some(
+                ([alias, joinTable]) =>
+                    alias === refTable && joinTable === table.name,
+            );
+        });
 
         const referencedDimension = referencedTable?.dimensions[refName];
 
@@ -510,7 +540,7 @@ export class ExploreCompiler {
         return {
             sql: `(${compiledDimension.sql})`,
             tablesReferences: new Set([
-                refTable,
+                referencedTable?.name || refTable,
                 ...compiledDimension.tablesReferences,
             ]),
         };
@@ -520,6 +550,7 @@ export class ExploreCompiler {
         ref: string,
         tables: Record<string, Table>,
         currentTable: string,
+        joinAliases?: UncompiledExplore['joinAliases'],
     ): { sql: string; tablesReferences: Set<string> } {
         // Reference to current table
         if (ref === 'TABLE') {
@@ -542,7 +573,11 @@ export class ExploreCompiler {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const compiledMetric = this.compileMetricSql(referencedMetric, tables);
+        const compiledMetric = this.compileMetricSql(
+            referencedMetric,
+            tables,
+            joinAliases,
+        );
         return {
             sql: `(${compiledMetric.sql})`,
             tablesReferences: new Set([

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -142,7 +142,6 @@ export class ExploreCompiler {
                     [join.alias || join.table]: {
                         ...tables[join.table],
                         originalName: tables[join.table].name,
-                        aliases: undefined,
                         name: joinTableName,
                         label: joinTableLabel,
                         hidden: join.hidden,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -540,6 +540,27 @@ export const convertExplores = async (
     );
 
     const exploreCompiler = new ExploreCompiler(warehouseClient);
+    const joinAliases = validModels.reduce<
+        Record<string, Record<string, string>>
+    >((acc, model) => {
+        const joins = model.config?.meta?.joins;
+        if (joins === undefined) return acc;
+
+        const aliases = joins.reduce<Record<string, string>>((acc2, join) => {
+            if (join.alias && tableLookup[join.join]) {
+                return {
+                    ...acc2,
+                    [join.alias]: join.join,
+                };
+            }
+            return acc2;
+        }, {});
+        return {
+            ...acc,
+            [model.name]: aliases,
+        };
+    }, {});
+
     const explores: (Explore | ExploreError)[] = validModels.map((model) => {
         const meta = model.config?.meta || model.meta; // Config block takes priority, then meta block
         try {
@@ -564,6 +585,7 @@ export const convertExplores = async (
                 warehouse: model.config?.snowflake_warehouse,
                 ymlPath: model.patch_path?.split('://')?.[1],
                 sqlPath: model.path,
+                joinAliases,
             });
         } catch (e) {
             return {

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -88,5 +88,4 @@ export type Table = TableBase & {
     metrics: { [fieldName: string]: Metric }; //
     lineageGraph: LineageGraph; // DAG structure representing the lineage of the table
     source?: Source;
-    aliases?: string[]; // Optional list of aliases for the table
 };

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -88,4 +88,5 @@ export type Table = TableBase & {
     metrics: { [fieldName: string]: Metric }; //
     lineageGraph: LineageGraph; // DAG structure representing the lineage of the table
     source?: Source;
+    aliases?: string[]; // Optional list of aliases for the table
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/9726

### Solution

 Generate a mapping with all the joins tables and aliases so we can evaluate the alias in the dimension reference method 

![Screenshot from 2024-04-22 11-24-28](https://github.com/lightdash/lightdash/assets/1983672/07c8184b-3622-4afd-af91-845492f90363)

### Description:

This PR is only fixing the specified issue with nested joins , alias and sql metric. There are other scenarios that are not covered on this PR , like dimensions, user attributes, etc. THe approach should be similar to this fix though. 

![Screenshot from 2024-04-22 12-21-47](https://github.com/lightdash/lightdash/assets/1983672/505fcf24-afe5-490b-9f71-0e6feaafa8eb)

<!-- Add a description of the changes proposed in the pull request. -->
Before
![Screenshot from 2024-04-22 09-32-33](https://github.com/lightdash/lightdash/assets/1983672/1ad81d84-669c-421d-b24e-80b1f57f600c)

![Screenshot from 2024-04-22 11-49-06](https://github.com/lightdash/lightdash/assets/1983672/e852f52c-0899-44dc-8269-8bc7cfc50d91)


After:


![Screenshot from 2024-04-22 12-21-03 (copy)](https://github.com/lightdash/lightdash/assets/1983672/c101150a-9528-444d-9bd3-7535e4f2a4ec)

![Screenshot from 2024-04-22 12-21-33](https://github.com/lightdash/lightdash/assets/1983672/9aa13ca0-b8b8-47cc-b7dd-7f5ba91ede86)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
