### PR TITLE
fix: Delete last tab should not delete tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -325,8 +325,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                                 )
                                                             }
                                                         >
-                                                            Remove Tab
-                                                            Components
+                                                            Remove Tabs
+                                                            Component
                                                         </Menu.Item>
                                                     ) : (
                                                         <Menu.Item

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -437,7 +437,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                         tab={activeTab}
                         dashboardTiles={dashboardTiles}
                         onClose={() => setDeletingTab(false)}
-                        opened={isDeletingTab && dashboardTabs.length > 1}
+                        opened={isDeletingTab && dashboardTabs?.length > 1}
                         onDeleteTab={(uuid) => {
                             handleDeleteTab(uuid);
                         }}

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -192,6 +192,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     order: 0,
                 };
                 newTabs.push(firstTab);
+                dashboardTiles?.forEach((tile) => {
+                    tile.tabUuid = firstTab.uuid; // move all tiles to default tab
+                });
             }
             const lastOrd = newTabs.sort((a, b) => b.order - a.order)[0].order;
             const newTab = {
@@ -239,15 +242,15 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         setHaveTabsChanged(true);
         setDeletingTab(false);
 
-        if (dashboardTabs.length === 0) {
-            console.log('Do nothing, keep all tiles');
-        } else {
-            const tilesToDelete = dashboardTiles?.filter(
-                (tile) => tile.tabUuid == tabUuid,
-            );
-            if (tilesToDelete) {
-                handleBatchDeleteTiles(tilesToDelete);
-            }
+        if (dashboardTabs.length === 1) {
+            return; // keep all tiles if its the last tab
+        }
+
+        const tilesToDelete = dashboardTiles?.filter(
+            (tile) => tile.tabUuid == tabUuid,
+        );
+        if (tilesToDelete) {
+            handleBatchDeleteTiles(tilesToDelete);
         }
     };
 
@@ -314,13 +317,28 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                     >
                                                         Rename Tab
                                                     </Menu.Item>
-                                                    <Menu.Item
-                                                        onClick={() =>
-                                                            setDeletingTab(true)
-                                                        }
-                                                    >
-                                                        Remove Tab
-                                                    </Menu.Item>
+                                                    {sortedTabs.length === 1 ? (
+                                                        <Menu.Item
+                                                            onClick={() =>
+                                                                handleDeleteTab(
+                                                                    tab.uuid,
+                                                                )
+                                                            }
+                                                        >
+                                                            Remove Tab
+                                                            Components
+                                                        </Menu.Item>
+                                                    ) : (
+                                                        <Menu.Item
+                                                            onClick={() =>
+                                                                setDeletingTab(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            Remove Tab
+                                                        </Menu.Item>
+                                                    )}
                                                 </Menu.Dropdown>
                                             </Menu>
                                         ) : null}
@@ -419,7 +437,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                         tab={activeTab}
                         dashboardTiles={dashboardTiles}
                         onClose={() => setDeletingTab(false)}
-                        opened={isDeletingTab}
+                        opened={isDeletingTab && dashboardTabs.length > 1}
                         onDeleteTab={(uuid) => {
                             handleDeleteTab(uuid);
                         }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
[9832](https://github.com/lightdash/lightdash/issues/9832)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
fix: 
- update all tiles with default tile uuid when first time creating tabs.
- rename "Remove Tab" to "Remove Tabs Component" when only one tab exists.
- delete tab directly instead of opening a modal when deleting last tab.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
