### PR TITLE
fix: fix drill down date discrepancy

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -213,7 +213,11 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     value={
                         rule.values
                             ? parseDate(
-                                  formatDate(rule.values[0], TimeFrames.DAY),
+                                  formatDate(
+                                      rule.values[0],
+                                      TimeFrames.DAY,
+                                      true,
+                                  ),
                                   TimeFrames.DAY,
                               )
                             : null


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
issue:
when i drill down from 02-Feb-2018
filter is showing 01-Feb-2018

https://github.com/lightdash/lightdash/assets/101873365/10068380-83a1-4950-bf67-d2046b63afb7


### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
