### PR TITLE
fix: fix foreign key constraint error when delete last tab

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -243,6 +243,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         setDeletingTab(false);
 
         if (dashboardTabs.length === 1) {
+            dashboardTiles?.forEach((tile) => {
+                tile.tabUuid = undefined; // set tab uuid back to null to avoid foreign key constraint error
+            });
             return; // keep all tiles if its the last tab
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
issue:
this error would happen when delete last tab:
<img width="538" alt="Screenshot 2024-04-23 at 07 46 58" src="https://github.com/lightdash/lightdash/assets/101873365/9c51e1c7-6137-4123-9058-f2553ff43a34">

and that's happening because the tab uuid referenced in the tiles is gone.

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
