### PR TITLE
fix: The tab delete modal should be more explicit about which tiles/c…

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -317,13 +317,15 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                     >
                                                         Rename Tab
                                                     </Menu.Item>
-                                                    {sortedTabs.length === 1 ? (
+                                                    {sortedTabs.length === 1 ||
+                                                    !currentTabHasTiles ? (
                                                         <Menu.Item
-                                                            onClick={() =>
+                                                            onClick={(e) => {
                                                                 handleDeleteTab(
                                                                     tab.uuid,
-                                                                )
-                                                            }
+                                                                );
+                                                                e.stopPropagation();
+                                                            }}
                                                         >
                                                             Remove Tabs
                                                             Component
@@ -414,6 +416,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     }
                     isEditMode={isEditMode}
                     setAddingTab={setAddingTab}
+                    activeTabUuid={activeTab?.uuid}
                 />
             )}
             <TabAddModal

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -327,8 +327,10 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                                 e.stopPropagation();
                                                             }}
                                                         >
-                                                            Remove Tabs
-                                                            Component
+                                                            {sortedTabs.length ===
+                                                            1
+                                                                ? 'Remove Tabs Component'
+                                                                : 'Remove Tab'}
                                                         </Menu.Item>
                                                     ) : (
                                                         <Menu.Item

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -31,9 +31,15 @@ import { TileAddModal } from './TileForms/TileAddModal';
 type Props = {
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
+    activeTabUuid?: string;
 } & Pick<ButtonProps, 'disabled'>;
 
-const AddTileButton: FC<Props> = ({ onAddTiles, setAddingTab, disabled }) => {
+const AddTileButton: FC<Props> = ({
+    onAddTiles,
+    setAddingTab,
+    disabled,
+    activeTabUuid,
+}) => {
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
@@ -95,6 +101,7 @@ const AddTileButton: FC<Props> = ({ onAddTiles, setAddingTab, disabled }) => {
                                 haveFiltersChanged,
                                 dashboard?.uuid,
                                 dashboard?.name,
+                                activeTabUuid,
                             );
                             history.push(`/projects/${projectUuid}/tables`);
                         }}

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -23,6 +23,7 @@ interface SavedChartsAvailableProps {
     emptyContainerType?: 'dashboard' | 'tab';
     isEditMode: boolean;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
+    activeTabUuid?: string;
 }
 
 const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
@@ -30,6 +31,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     emptyContainerType = 'dashboard',
     isEditMode,
     setAddingTab,
+    activeTabUuid,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
@@ -70,6 +72,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
                                 <AddTileButton
                                     onAddTiles={onAddTiles}
                                     setAddingTab={setAddingTab}
+                                    activeTabUuid={activeTabUuid}
                                 />
                             ) : undefined
                         }

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -67,6 +67,7 @@ type DashboardHeaderProps = {
     isFullscreen: boolean;
     isPinned: boolean;
     oldestCacheTime?: Date;
+    activeTabUuid?: string;
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     onCancel: () => void;
     onSaveDashboard: () => void;
@@ -89,6 +90,7 @@ const DashboardHeader = ({
     isFullscreen,
     isPinned,
     oldestCacheTime,
+    activeTabUuid,
     onAddTiles,
     onCancel,
     onSaveDashboard,
@@ -248,6 +250,7 @@ const DashboardHeader = ({
                         onAddTiles={onAddTiles}
                         disabled={isSaving}
                         setAddingTab={setAddingTab}
+                        activeTabUuid={activeTabUuid}
                     />
                     <Tooltip
                         fz="xs"

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -76,6 +76,7 @@ export const SaveToDashboard: FC<Props> = ({
         clearIsEditingDashboardChart,
         getUnsavedDashboardTiles,
         setUnsavedDashboardTiles,
+        getDashboardActiveTabUuid,
     } = useDashboardStorage();
     const unsavedDashboardTiles = getUnsavedDashboardTiles();
     const form = useForm<FormValues>({
@@ -85,6 +86,8 @@ export const SaveToDashboard: FC<Props> = ({
         },
         validate: zodResolver(validationSchema),
     });
+
+    const activeTabUuid = getDashboardActiveTabUuid();
 
     const handleSaveChartInDashboard = useCallback(
         async (values: SaveToDashboardFormValues) => {
@@ -101,7 +104,7 @@ export const SaveToDashboard: FC<Props> = ({
             const newTile: CreateDashboardChartTile = {
                 uuid: uuid4(),
                 type: DashboardTileTypes.SAVED_CHART,
-                tabUuid: undefined,
+                tabUuid: activeTabUuid ?? undefined,
                 properties: {
                     belongsToDashboard: true,
                     savedChartUuid: chart.uuid,
@@ -132,6 +135,7 @@ export const SaveToDashboard: FC<Props> = ({
             projectUuid,
             showToastSuccess,
             dashboardName,
+            activeTabUuid,
         ],
     );
     return (

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -60,7 +60,7 @@ const useDashboardStorage = () => {
     }, []);
 
     const getDashboardActiveTabUuid = useCallback(() => {
-        return sessionStorage.getItem('activeTabUuid') ?? '';
+        return sessionStorage.getItem('activeTabUuid') ?? undefined;
     }, []);
 
     const clearDashboardStorage = useCallback(() => {
@@ -102,7 +102,9 @@ const useDashboardStorage = () => {
                 'hasDashboardChanges',
                 JSON.stringify(haveTilesChanged || haveFiltersChanged),
             );
-            sessionStorage.setItem('activeTabUuid', activeTabUuid ?? '');
+            if (activeTabUuid) {
+                sessionStorage.setItem('activeTabUuid', activeTabUuid);
+            }
             // Trigger storage event to update NavBar
             window.dispatchEvent(new Event('storage'));
         },

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -60,7 +60,7 @@ const useDashboardStorage = () => {
     }, []);
 
     const getDashboardActiveTabUuid = useCallback(() => {
-        return sessionStorage.getItem('activeTabUuid') ?? undefined;
+        return sessionStorage.getItem('activeTabUuid');
     }, []);
 
     const clearDashboardStorage = useCallback(() => {

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -59,6 +59,10 @@ const useDashboardStorage = () => {
         );
     }, []);
 
+    const getDashboardActiveTabUuid = useCallback(() => {
+        return sessionStorage.getItem('activeTabUuid') ?? '';
+    }, []);
+
     const clearDashboardStorage = useCallback(() => {
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
@@ -77,6 +81,7 @@ const useDashboardStorage = () => {
             haveFiltersChanged: boolean,
             dashboardUuid?: string,
             dashboardName?: string,
+            activeTabUuid?: string,
         ) => {
             sessionStorage.setItem('fromDashboard', dashboardName ?? '');
             sessionStorage.setItem('dashboardUuid', dashboardUuid ?? '');
@@ -97,6 +102,7 @@ const useDashboardStorage = () => {
                 'hasDashboardChanges',
                 JSON.stringify(haveTilesChanged || haveFiltersChanged),
             );
+            sessionStorage.setItem('activeTabUuid', activeTabUuid ?? '');
             // Trigger storage event to update NavBar
             window.dispatchEvent(new Event('storage'));
         },
@@ -132,6 +138,7 @@ const useDashboardStorage = () => {
         getHasDashboardChanges,
         getUnsavedDashboardTiles,
         setUnsavedDashboardTiles,
+        getDashboardActiveTabUuid,
     };
 };
 

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -605,6 +605,7 @@ const Dashboard: FC = () => {
                         oldestCacheTime={oldestCacheTime}
                         isFullscreen={isFullscreen}
                         isPinned={isPinned}
+                        activeTabUuid={activeTab?.uuid}
                         onToggleFullscreen={handleToggleFullscreen}
                         hasDashboardChanged={
                             haveTilesChanged ||


### PR DESCRIPTION
…harts you will delete

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
[](https://github.com/lightdash/lightdash/issues/9870)

1. when there's saved charts that only belongs to dashboard

<img width="871" alt="Screenshot 2024-04-24 at 13 23 42" src="https://github.com/lightdash/lightdash/assets/101873365/7be2ac2e-f072-4338-854d-f16262303f8b">

2. when there's no saved chart created within dashboard

<img width="842" alt="Screenshot 2024-04-24 at 13 23 57" src="https://github.com/lightdash/lightdash/assets/101873365/a7aac002-6090-476a-a215-46c7650a7f12">

3. when tab has no tiles it will just delete the tab without open the modal

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
