### PR TITLE
fix: incorrect default table calc type

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -347,7 +347,7 @@ export const renderTableCalculationFilterRuleSql = (
         case TableCalculationType.BOOLEAN:
             return renderBooleanFilterSql(fieldSql, filterRule);
         default:
-        // Try with format.type for backwards compatibility
+        // Do nothing here. This will try with format.type for backwards compatibility
     }
 
     switch (field.format?.type) {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -79,6 +79,7 @@ const getLabelFromField = (fields: ItemsMap, key: string | undefined) => {
 
 const getAxisTypeFromField = (item?: ItemsMap[string]): string => {
     if (item && isCustomDimension(item)) return 'category';
+    if (item && isTableCalculation(item) && !item.type) return 'value';
     if (item && (isField(item) || isTableCalculation(item))) {
         switch (item.type) {
             case TableCalculationType.NUMBER:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9885 

### Description:

For table calculations return numeric type as the default

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
