### PR TITLE
fix: fix foreign constraint error when add chart to dashboard

### DIFF
--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -159,12 +159,19 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                     if (!selectedDashboard) {
                         throw new Error('Expected dashboard');
                     }
+                    const firstTab = selectedDashboard.tabs?.[0];
                     await updateDashboard({
                         name: selectedDashboard.name,
                         filters: selectedDashboard.filters,
                         tiles: appendNewTilesToBottom(selectedDashboard.tiles, [
-                            newTile,
+                            firstTab
+                                ? {
+                                      ...newTile,
+                                      tabUuid: firstTab.uuid,
+                                  }
+                                : newTile, // TODO: add to first tab by default, need ux to allow user select tab
                         ]),
+                        tabs: selectedDashboard.tabs,
                     });
                     onClose?.();
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

steps to reproduce:

1.  create a saved chart - c1
2. create a dashboard and add tabs to dashboard - d1
3. click "add to dashboard"  from saved chart

![Screenshot 2024-04-25 at 23 28 47](https://github.com/lightdash/lightdash/assets/101873365/dc7b6e2e-0c99-4f1f-a4ea-b5e54ae0ea53)
4. then you get the error
![Screenshot 2024-04-25 at 23 30 37](https://github.com/lightdash/lightdash/assets/101873365/b2100985-0081-4847-97e6-6f016db066da)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
