### PR TITLE
feat: create sentry release and publish sourcemaps

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -10,6 +10,12 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: '20'
+                  cache: 'yarn'
+            - name: Install packages
+              run: yarn install --frozen-lockfile
             - name: Build
               run: yarn workspace frontend build
             - name: List output files - debugging

--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -1,0 +1,26 @@
+name: Create Sentry release
+on:
+    repository_dispatch:
+        types: [sentry-release]
+
+jobs:
+    create-sentry-release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Build
+              run: yarn workspace frontend build
+            - name: List output files - debugging
+              run: ls -R ./packages/frontend/build/assets/
+            - name: Create Sentry release
+              uses: getsentry/action-release@v1
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: lightdash
+                  SENTRY_PROJECT: lightdash-frontend
+              with:
+                  environment: ${{ github.event.client_payload.environment }}
+                  version: ${{ github.event.client_payload.version }}
+                  sourcemaps: './packages/frontend/build/assets/'

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -53,3 +53,11 @@ jobs:
             -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
             -d '{"ref": "main", "inputs": {"lightdash-version": "${{ steps.semantic.outputs.new_release_version }}"}}' \
             https://api.github.com/repos/lightdash/helm-charts/action/workflows/increment-lightdash-app-version.yml/dispatches
+            - name: Trigger Sentry release
+            if: steps.semantic.outputs.new_release_published == 'true'
+            run: |
+                curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -d '{"event_type": "sentry-release", "client_payload": {"version": "${{ steps.semantic.outputs.new_release_version }}", "environment": "production"}}' \
+                https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9918 

### Description:

When `release-on-merge` is successful, and when there's a new version created, then trigger a new workflow: `Create Sentry release` to: 
- build frontend assets
- create Sentry release with `getsentry/action-release@v1` https://github.com/marketplace/actions/sentry-release
- push sourcemaps to that release

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
