### PR TITLE
feat: show error ID for unexpected errors

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -396,6 +396,10 @@ export default class App {
                         name: errorResponse.name,
                         message: errorResponse.message,
                         data: errorResponse.data,
+                        id:
+                            errorResponse.statusCode === 500
+                                ? Sentry.lastEventId()
+                                : undefined,
                     },
                 });
             },

--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -13,5 +13,6 @@ export const errorHandler = (error: Error): LightdashError => {
     if (error instanceof LightdashError) {
         return error;
     }
-    return new UnexpectedServerError(`${error}`);
+    // Return a generic error to avoid exposing internal details
+    return new UnexpectedServerError();
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -638,11 +638,12 @@ export type ApiResponse<T extends ApiResults = ApiResults> = {
     results: T;
 };
 
-type ApiErrorDetail = {
+export type ApiErrorDetail = {
     name: string;
     statusCode: number;
     message: string;
     data: { [key: string]: string };
+    id?: string;
 };
 export type ApiError = {
     status: 'error';

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -107,17 +107,6 @@ export class MissingCatalogEntryError extends LightdashError {
     }
 }
 
-export class NoServerRunningError extends LightdashError {
-    constructor(message: string) {
-        super({
-            message,
-            name: 'NoServerRunningError',
-            statusCode: 500,
-            data: {},
-        });
-    }
-}
-
 export class MissingWarehouseCredentialsError extends LightdashError {
     constructor(message: string) {
         super({
@@ -131,7 +120,7 @@ export class MissingWarehouseCredentialsError extends LightdashError {
 
 export class UnexpectedServerError extends LightdashError {
     constructor(
-        message = 'Unexpected error in Lightdash server',
+        message = 'Unexpected error in Lightdash server.',
         data: { [key: string]: any } = {},
     ) {
         super({
@@ -151,7 +140,7 @@ export class UnexpectedGitError extends LightdashError {
         super({
             message,
             name: 'UnexpectedGitError',
-            statusCode: 500,
+            statusCode: 400,
             data,
         });
     }
@@ -159,7 +148,7 @@ export class UnexpectedGitError extends LightdashError {
 
 export class UnexpectedDatabaseError extends LightdashError {
     constructor(
-        message = 'Unexpected error in Lightdash database',
+        message = 'Unexpected error in Lightdash database.',
         data: { [key: string]: any } = {},
     ) {
         super({
@@ -179,7 +168,7 @@ export class ParseError extends LightdashError {
         super({
             message,
             name: 'ParseError',
-            statusCode: 500,
+            statusCode: 400,
             data,
         });
     }
@@ -193,7 +182,7 @@ export class CompileError extends LightdashError {
         super({
             message,
             name: 'CompileError',
-            statusCode: 500,
+            statusCode: 400,
             data,
         });
     }
@@ -213,20 +202,6 @@ export class FieldReferenceError extends LightdashError {
     }
 }
 
-export class NetworkError extends LightdashError {
-    constructor(
-        message = 'Error connecting to external service',
-        data: { [key: string]: any } = {},
-    ) {
-        super({
-            message,
-            name: 'NetworkError',
-            statusCode: 500,
-            data,
-        });
-    }
-}
-
 export class DbtError extends LightdashError {
     logs: DbtLog[] | undefined;
 
@@ -234,21 +209,10 @@ export class DbtError extends LightdashError {
         super({
             message,
             name: 'DbtError',
-            statusCode: 500,
+            statusCode: 400,
             data: {},
         });
         this.logs = logs;
-    }
-}
-
-export class RetryableNetworkError extends LightdashError {
-    constructor(message: string) {
-        super({
-            message,
-            name: 'RetryableNetworkError',
-            statusCode: 503,
-            data: {},
-        });
     }
 }
 
@@ -268,7 +232,7 @@ export class WarehouseConnectionError extends LightdashError {
         super({
             message,
             name: 'WarehouseConnectionError',
-            statusCode: 500, // TODO: is this a server error? could be credentials
+            statusCode: 400,
             data: {},
         });
     }
@@ -279,7 +243,7 @@ export class WarehouseQueryError extends LightdashError {
         super({
             message,
             name: 'WarehouseQueryError',
-            statusCode: 500, // TODO: is this a server error? usually syntax error
+            statusCode: 400,
             data: {},
         });
     }

--- a/packages/frontend/src/components/CustomSqlPanel/CreateCustomMetricsPullRequestModal.tsx
+++ b/packages/frontend/src/components/CustomSqlPanel/CreateCustomMetricsPullRequestModal.tsx
@@ -30,7 +30,7 @@ const createCustomMetricsPullRequest = async (
     });
 
 const useCreateCustomMetricsPullRequest = (projectUuid: string) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<
         PullRequestCreated,
@@ -54,10 +54,10 @@ const useCreateCustomMetricsPullRequest = (projectUuid: string) => {
                 },
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create pull request`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -127,7 +127,7 @@ const useCreatePullRequestForChartFieldsMutation = (
         () => createPullRequestForChartFields(projectUuid, chartUuid!),
 
     );*/
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<PullRequestCreated, ApiError>(
         () => createPullRequestForChartFields(projectUuid, chartUuid!),
@@ -146,10 +146,10 @@ const useCreatePullRequestForChartFieldsMutation = (
                     },
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create pull request`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshHooks.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshHooks.ts
@@ -6,7 +6,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 export const useCreateSshKeyPair = (
     options: UseMutationOptions<ApiSshKeyPairResponse['results'], ApiError>,
 ) => {
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<ApiSshKeyPairResponse['results'], ApiError>(
         async () =>
             lightdashApi({
@@ -16,10 +16,10 @@ export const useCreateSshKeyPair = (
             }),
         {
             mutationKey: ['activeSshKeypair'],
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to create SSH keypair',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
             ...options,

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -42,7 +42,7 @@ const deleteGithubInstallation = async () =>
     });
 
 const useDeleteGithubInstallationMutation = () => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
     return useMutation<null, ApiError>(
         ['delete_github_installation'],
@@ -56,10 +56,10 @@ const useDeleteGithubInstallationMutation = () => {
                         'You have successfully deleted your GitHub integration.',
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to delete GitHub integration',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
@@ -26,7 +26,7 @@ const validationSchema = (hasCurrentPassword: boolean) => {
 
 const PasswordPanel: FC = () => {
     const { data: hasPassword } = useUserHasPassword();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     const form = useForm({
         initialValues: {
@@ -46,9 +46,9 @@ const PasswordPanel: FC = () => {
                 window.location.href = '/login';
             },
             onError: ({ error }) => {
-                showToastError({
+                showToastApiError({
                     title: 'Failed to update password',
-                    subtitle: error.message,
+                    apiError: error,
                 });
             },
         });

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -35,7 +35,7 @@ const ProfilePanel: FC = () => {
         user: { data: userData, isLoading: isLoadingUser },
         health,
     } = useApp();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     const form = useForm<FormValues>({
         validate: zodResolver(validationSchema),
@@ -78,11 +78,10 @@ const ProfilePanel: FC = () => {
                     title: 'Success! User details were updated.',
                 });
             },
-            onError: (error: ApiError) => {
-                const [title, ...rest] = error.error.message.split('\n');
-                showToastError({
-                    title,
-                    subtitle: rest.join('\n'),
+            onError: ({ error }: ApiError) => {
+                showToastApiError({
+                    title: 'Failed to update user details',
+                    apiError: error,
                 });
             },
         });

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,6 +1,7 @@
-import { type LightdashError } from '@lightdash/common';
+import { type ApiErrorDetail } from '@lightdash/common';
+import { Text } from '@mantine/core';
 import { IconAlertCircle, IconLock } from '@tabler/icons-react';
-import { useMemo, type ComponentProps, type FC } from 'react';
+import React, { useMemo, type ComponentProps, type FC } from 'react';
 import SuboptimalState from '../SuboptimalState/SuboptimalState';
 
 const DEFAULT_ERROR_PROPS: ComponentProps<typeof SuboptimalState> = {
@@ -10,7 +11,7 @@ const DEFAULT_ERROR_PROPS: ComponentProps<typeof SuboptimalState> = {
 };
 
 const ErrorState: FC<{
-    error?: LightdashError | null;
+    error?: ApiErrorDetail | null;
     hasMarginTop?: boolean;
 }> = ({ error, hasMarginTop = true }) => {
     const props = useMemo<ComponentProps<typeof SuboptimalState>>(() => {
@@ -18,30 +19,40 @@ const ErrorState: FC<{
             return DEFAULT_ERROR_PROPS;
         }
         try {
+            const description = (
+                <Text maw={400}>
+                    <span>{error.message}</span>
+                    <br />
+                    {error.id && (
+                        <span>
+                            Please contact support with the error ID: {error.id}
+                        </span>
+                    )}
+                </Text>
+            );
             switch (error.name) {
                 case 'ForbiddenError':
                     return {
                         icon: IconLock,
                         title: 'You need access',
-                        description: error.message,
+                        description,
                     };
                 case 'AuthorizationError':
                     return {
                         icon: IconLock,
-
                         title: 'Authorization error',
-                        description: error.message,
+                        description,
                     };
                 case 'NotExistsError':
                     return {
                         icon: IconAlertCircle,
                         title: 'Not found',
-                        description: error.message,
+                        description,
                     };
                 default:
                     return {
                         ...DEFAULT_ERROR_PROPS,
-                        description: error.message,
+                        description,
                     };
             }
         } catch {

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -20,15 +20,14 @@ const ErrorState: FC<{
         }
         try {
             const description = (
-                <Text maw={400}>
-                    <span>{error.message}</span>
-                    <br />
+                <>
+                    <Text maw={400}>{error.message}</Text>
                     {error.id && (
-                        <span>
+                        <Text maw={400} weight="bold">
                             Please contact support with the error ID: {error.id}
-                        </span>
+                        </Text>
                     )}
-                </Text>
+                </>
             );
             switch (error.name) {
                 case 'ForbiddenError':

--- a/packages/frontend/src/features/export/hooks/useExportToGoogleSheet.tsx
+++ b/packages/frontend/src/features/export/hooks/useExportToGoogleSheet.tsx
@@ -14,7 +14,7 @@ const useExportToGoogleSheetStart = ({
 }: {
     getGsheetLink: () => Promise<ApiScheduledDownloadCsv>;
 }) => {
-    const { showToastError, showToastInfo } = useToaster();
+    const { showToastApiError, showToastInfo } = useToaster();
 
     return useMutation<ApiScheduledDownloadCsv | undefined, ApiError>(
         ['google-sheets-start'],
@@ -29,11 +29,11 @@ const useExportToGoogleSheetStart = ({
                     autoClose: false,
                 });
             },
-            onError: (error) => {
+            onError: ({ error }) => {
                 notifications.hide('exporting-gsheets');
-                showToastError({
+                showToastApiError({
                     title: `Unable to upload to Google Sheets`,
-                    subtitle: error?.error?.message,
+                    apiError: error,
                 });
             },
         },
@@ -45,7 +45,7 @@ export const useExportToGoogleSheet = ({
 }: {
     getGsheetLink: () => Promise<ApiScheduledDownloadCsv>;
 }) => {
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
 
     const exportToGoogleSheetStartMutation = useExportToGoogleSheetStart({
         getGsheetLink,
@@ -68,11 +68,12 @@ export const useExportToGoogleSheet = ({
                           "Couldn't create scheduler job for google sheets export",
                       ),
                   }),
-        retry: (failureCount) => {
+        retry: (failureCount, { error }) => {
             if (failureCount === 5) {
                 resetStartGoogleSheetExport();
-                showToastError({
+                showToastApiError({
                     title: 'Unable to export to Google Sheets',
+                    apiError: error,
                 });
                 return false;
             }

--- a/packages/frontend/src/features/scheduler/hooks/useChartSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useChartSchedulers.ts
@@ -32,7 +32,7 @@ const createChartScheduler = async (
 
 export const useChartSchedulerCreateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         SchedulerAndTargets,
         ApiError,
@@ -48,10 +48,10 @@ export const useChartSchedulerCreateMutation = () => {
                 title: `Success! Scheduled delivery was created.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create scheduled delivery`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/features/scheduler/hooks/useDashboardSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useDashboardSchedulers.ts
@@ -32,7 +32,7 @@ const createDashboardScheduler = async (
 
 export const useDashboardSchedulerCreateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         SchedulerAndTargets,
         ApiError,
@@ -51,10 +51,10 @@ export const useDashboardSchedulerCreateMutation = () => {
                     title: `Success! Scheduled delivery was created.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create scheduled delivery`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -95,7 +95,12 @@ export const pollJobStatus = async (jobId: string) => {
 
 export const useSendNowScheduler = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastInfo, showToastSuccess } = useToaster();
+    const {
+        showToastError,
+        showToastInfo,
+        showToastSuccess,
+        showToastApiError,
+    } = useToaster();
 
     const sendNowMutation = useMutation<
         ApiTestSchedulerResponse['results'],
@@ -114,10 +119,10 @@ export const useSendNowScheduler = () => {
         {
             mutationKey: ['sendNowScheduler'],
             onSuccess: () => {},
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to process job',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -184,7 +189,7 @@ export const useSendNowScheduler = () => {
                     );
                 }
             },
-            onError: async (error: { error: Error }) => {
+            onError: async ({ error }) => {
                 showToastError({
                     title: 'Error polling job status',
                     subtitle: error?.error?.message,

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -130,7 +130,10 @@ export const useSendNowScheduler = () => {
 
     const { data: sendNowData } = sendNowMutation;
 
-    const { data: scheduledDeliveryJobStatus } = useQuery(
+    const { data: scheduledDeliveryJobStatus } = useQuery<
+        ApiJobStatusResponse['results'] | undefined,
+        ApiError
+    >(
         ['jobStatus', sendNowData?.jobId],
         () => {
             if (!sendNowData?.jobId) return;
@@ -190,9 +193,9 @@ export const useSendNowScheduler = () => {
                 }
             },
             onError: async ({ error }) => {
-                showToastError({
+                showToastApiError({
                     title: 'Error polling job status',
-                    subtitle: error?.error?.message,
+                    apiError: error,
                 });
 
                 setTimeout(

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
@@ -12,7 +12,7 @@ const deleteScheduler = async (uuid: string) =>
 
 export const useSchedulersDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteScheduler, {
         mutationKey: ['delete_scheduler'],
         onSuccess: async () => {
@@ -22,10 +22,10 @@ export const useSchedulersDeleteMutation = () => {
                 title: `Success! Scheduled delivery was deleted`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete scheduled delivery`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulersUpdateMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulersUpdateMutation.ts
@@ -19,7 +19,7 @@ const updateScheduler = async (
 
 export const useSchedulersUpdateMutation = (schedulerUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         SchedulerAndTargets,
         ApiError,
@@ -34,10 +34,10 @@ export const useSchedulersUpdateMutation = (schedulerUuid: string) => {
                 title: `Success! Scheduled delivery was updated.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to update scheduled delivery`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -52,7 +52,7 @@ const updateSchedulerEnabled = async (uuid: string, enabled: boolean) =>
 
 export const useSchedulersEnabledUpdateMutation = (schedulerUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<SchedulerAndTargets, ApiError, boolean>(
         (enabled) => updateSchedulerEnabled(schedulerUuid, enabled),
         {
@@ -61,10 +61,10 @@ export const useSchedulersEnabledUpdateMutation = (schedulerUuid: string) => {
                 await queryClient.invalidateQueries(['chart_schedulers']);
                 await queryClient.invalidateQueries(['dashboard_schedulers']);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update scheduled delivery`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -42,7 +42,7 @@ const Login: FC<{}> = () => {
     const { identify } = useTracking();
     const location = useLocation<{ from?: Location } | undefined>();
 
-    const { showToastError } = useToaster();
+    const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
     useEffect(() => {
         if (flashMessages.data?.error) {
@@ -95,10 +95,10 @@ const Login: FC<{}> = () => {
             identify({ id: data.userUuid });
             window.location.href = redirectUrl;
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to login`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -104,7 +104,7 @@ export const useDashboardQuery = (
 };
 
 export const useExportDashboard = () => {
-    const { showToastSuccess, showToastError, showToastInfo } = useToaster();
+    const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
     return useMutation<
         string,
         ApiError,
@@ -144,13 +144,13 @@ export const useExportDashboard = () => {
                     });
                 }
             },
-            onError: (error, data) => {
-                showToastError({
+            onError: ({ error }, data) => {
+                showToastApiError({
                     key: 'dashboard_export_toast',
                     title: data.isPreview
                         ? `Failed to generate preview for ${data.dashboard.name}`
                         : `Failed to export ${data.dashboard.name}`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -165,7 +165,7 @@ const exportCsvDashboard = async (id: string, filters: DashboardFilters) =>
     });
 
 export const useExportCsvDashboard = () => {
-    const { showToastSuccess, showToastError, showToastInfo } = useToaster();
+    const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
     return useMutation<
         string,
         ApiError,
@@ -192,11 +192,11 @@ export const useExportCsvDashboard = () => {
                 });
             }
         },
-        onError: (error, data) => {
-            showToastError({
+        onError: ({ error }, data) => {
+            showToastApiError({
                 key: 'dashboard_export_toast',
                 title: `Failed to export ${data.dashboard.name}`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -209,7 +209,7 @@ export const useUpdateDashboard = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<Dashboard, ApiError, UpdateDashboard>(
         (data) => {
             if (id === undefined) {
@@ -250,10 +250,10 @@ export const useUpdateDashboard = (
                         : undefined,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update dashboard`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -264,7 +264,7 @@ export const useMoveDashboardMutation = () => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         Dashboard,
         ApiError,
@@ -296,10 +296,10 @@ export const useMoveDashboardMutation = () => {
                     },
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to move dashboard`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -311,7 +311,7 @@ export const useCreateMutation = (
     showRedirectButton: boolean = false,
 ) => {
     const history = useHistory();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
     return useMutation<Dashboard, ApiError, CreateDashboard>(
         (data) => createDashboard(projectUuid, data),
@@ -339,10 +339,10 @@ export const useCreateMutation = (
                         : undefined,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create dashboard`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -359,7 +359,7 @@ export const useDuplicateDashboardMutation = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         Dashboard,
         ApiError,
@@ -395,10 +395,10 @@ export const useDuplicateDashboardMutation = (
                         : undefined,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to duplicate dashboard`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -407,7 +407,7 @@ export const useDuplicateDashboardMutation = (
 
 export const useDashboardDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteDashboard, {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['dashboards']);
@@ -424,10 +424,10 @@ export const useDashboardDeleteMutation = () => {
                 title: `Deleted! Dashboard was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete dashboard`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/dashboard/useDashboards.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboards.tsx
@@ -85,7 +85,7 @@ const updateMultipleDashboard = async (
 
 export const useUpdateMultipleDashboard = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, UpdateMultipleDashboards[]>(
         (data) => updateMultipleDashboard(projectUuid, data),
         {
@@ -111,10 +111,10 @@ export const useUpdateMultipleDashboard = (projectUuid: string) => {
                     title: `Success! Dashboards were updated.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update dashboard`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
+++ b/packages/frontend/src/hooks/dbtCloud/useProjectDbtCloudSettings.ts
@@ -52,7 +52,7 @@ const deleteDbtProject = async (projectUuid: string) =>
 
 export const useProjectDbtCloudDeleteMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     if (projectUuid === undefined) {
         throw new Error(
             'Must use useProjectDbtCloudDeleteMutation hook under react-router path with projectUuid available',
@@ -68,10 +68,10 @@ export const useProjectDbtCloudDeleteMutation = (projectUuid: string) => {
                     title: `Success! Integration to dbt Cloud was deleted.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to delete integration`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -80,7 +80,7 @@ export const useProjectDbtCloudDeleteMutation = (projectUuid: string) => {
 
 export const useProjectDbtCloudUpdateMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     if (projectUuid === undefined) {
         throw new Error(
             'Must use useProjectDbtCloudUpdateMutation hook under react-router path with projectUuid available',
@@ -97,10 +97,10 @@ export const useProjectDbtCloudUpdateMutation = (projectUuid: string) => {
                 title: `Success! Integration to dbt Cloud was updated.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to update integration`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/health/useHealth.tsx
+++ b/packages/frontend/src/hooks/health/useHealth.tsx
@@ -24,23 +24,17 @@ const useHealth = (
         ...useQueryOptions,
     });
 
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
 
     useEffect(() => {
         if (health.error) {
-            const [first, ...rest] = health.error.error.message.split('\n');
-            showToastError({
-                key: first,
-                subtitle: (
-                    <div style={{ color: 'white' }}>
-                        <b>{first}</b>
-                        <p>{rest.join('\n')}</p>
-                    </div>
-                ),
+            showToastApiError({
+                key: 'health',
                 autoClose: false,
+                apiError: health.error.error,
             });
         }
-    }, [health, showToastError]);
+    }, [health, showToastApiError]);
 
     return health;
 };

--- a/packages/frontend/src/hooks/organization/useAllowedDomains.ts
+++ b/packages/frontend/src/hooks/organization/useAllowedDomains.ts
@@ -31,7 +31,7 @@ export const useAllowedEmailDomains = () =>
 
 export const useUpdateAllowedEmailDomains = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<
         AllowedEmailDomains,
         ApiError,
@@ -44,10 +44,10 @@ export const useUpdateAllowedEmailDomains = () => {
                 title: 'Success! Allowed email domains were updated',
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: 'Failed to update allowed email domains',
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/organization/useOrganizationDeleteMultation.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationDeleteMultation.ts
@@ -11,15 +11,15 @@ const deleteDashboard = async (id: string) =>
     });
 
 export const useDeleteOrganizationMutation = () => {
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteDashboard, {
         onSuccess: async () => {
             window.location.href = '/register';
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete organization`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/organization/useOrganizationUpdateMutation.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationUpdateMutation.ts
@@ -12,7 +12,7 @@ const updateOrgQuery = async (data: UpdateOrganization) =>
 
 export const useOrganizationUpdateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, UpdateOrganization>(updateOrgQuery, {
         mutationKey: ['organization_update'],
         onSuccess: async () => {
@@ -21,10 +21,10 @@ export const useOrganizationUpdateMutation = () => {
                 title: 'Success! Organization was updated',
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: 'Failed to update organization',
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -12,7 +12,7 @@ const updateChartPinning = async (data: { uuid: string }) =>
 
 export const useChartPinningMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<SavedChart, ApiError, { uuid: string }>(
         updateChartPinning,
         {
@@ -42,10 +42,10 @@ export const useChartPinningMutation = () => {
                     });
                 }
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to pin chart',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
@@ -12,7 +12,7 @@ const updateDashboardPinning = async (data: { uuid: string }) =>
 
 export const useDashboardPinningMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<Dashboard, ApiError, { uuid: string }>(
         updateDashboardPinning,
         {
@@ -43,10 +43,10 @@ export const useDashboardPinningMutation = () => {
                     });
                 }
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to pin dashboard',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/pinning/usePinnedItems.ts
+++ b/packages/frontend/src/hooks/pinning/usePinnedItems.ts
@@ -38,7 +38,7 @@ export const usePinnedItems = (
 
 export const useReorder = (projectUuid: string, pinnedlistUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<PinnedItems, ApiError, PinnedItems>(
         (pinnedItems) => {
             queryClient.setQueryData(
@@ -65,9 +65,10 @@ export const useReorder = (projectUuid: string, pinnedlistUuid: string) => {
                     pinnedlistUuid,
                 ]);
             },
-            onError: (error) => {
-                showToastError({
-                    title: `Could not re-order pinned items. Please try again. Error: ${error.error}`,
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: `Could not re-order pinned items`,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/pinning/useSpaceMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useSpaceMutation.ts
@@ -12,7 +12,7 @@ const updateSpacePinning = async (projectUuid: string, spaceUuid: string) =>
 
 export const useSpacePinningMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<Space, ApiError, string>(
         (spaceUuid) => updateSpacePinning(projectUuid, spaceUuid),
         {
@@ -47,10 +47,10 @@ export const useSpacePinningMutation = (projectUuid: string) => {
                     });
                 }
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Failed to pin space',
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -35,7 +35,7 @@ const deleteSlack = async () =>
 
 export const useDeleteSlack = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, undefined>(deleteSlack, {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['slack']);
@@ -44,10 +44,10 @@ export const useDeleteSlack = () => {
                 title: `Deleted! Slack integration was deleted`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete Slack integration`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -78,7 +78,7 @@ const updateSlackNotificationChannel = async (channelId: string | null) =>
 
 export const useUpdateSlackNotificationChannelMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, { channelId: string | null }>(
         ({ channelId }) => updateSlackNotificationChannel(channelId),
         {
@@ -89,10 +89,10 @@ export const useUpdateSlackNotificationChannelMutation = () => {
                     title: `Success! Slack notification channel updated`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update Slack notification channel`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,15 +1,26 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Button, Stack, type ButtonProps } from '@mantine/core';
+import {
+    ActionIcon,
+    Button,
+    CopyButton,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+    type ButtonProps,
+} from '@mantine/core';
 import { notifications, type NotificationProps } from '@mantine/notifications';
 import { type PolymorphicComponentProps } from '@mantine/utils';
 import {
     IconAlertTriangleFilled,
+    IconCheck,
     IconCircleCheckFilled,
+    IconCopy,
     IconInfoCircleFilled,
     type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { useCallback, useRef, type ReactNode } from 'react';
+import React, { useCallback, useRef, type ReactNode } from 'react';
 import { v4 as uuid } from 'uuid';
 import MantineIcon from '../../components/common/MantineIcon';
 
@@ -152,14 +163,37 @@ const useToaster = () => {
         ) => {
             const title: ReactNode | undefined = props.title ?? 'Error';
             const subtitle: ReactNode = props.apiError.id ? (
-                <p>
-                    <span>{props.apiError.message}</span>
-                    <br />
-                    <span style={{ fontWeight: 'bold' }}>
-                        Please contact support with the error ID:{' '}
-                        {props.apiError.id}
-                    </span>
-                </p>
+                <>
+                    <Text mb={0}>{props.apiError.message}</Text>
+                    <Text mb={0} weight="bold">
+                        Please contact support with the error ID:
+                    </Text>
+                    <Group>
+                        <Text mb={0} weight="bold">
+                            {props.apiError.id}
+                        </Text>
+                        <CopyButton value={props.apiError.id}>
+                            {({ copied, copy }) => (
+                                <Tooltip
+                                    label={copied ? 'Copied' : 'Copy error ID'}
+                                    withArrow
+                                    position="right"
+                                >
+                                    <ActionIcon
+                                        size="xs"
+                                        onClick={copy}
+                                        variant={'transparent'}
+                                    >
+                                        <MantineIcon
+                                            color={'white'}
+                                            icon={copied ? IconCheck : IconCopy}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </CopyButton>
+                    </Group>
+                </>
             ) : (
                 props.apiError.message
             );

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,3 +1,4 @@
+import type { ApiErrorDetail } from '@lightdash/common';
 import { Button, Stack, type ButtonProps } from '@mantine/core';
 import { notifications, type NotificationProps } from '@mantine/notifications';
 import { type PolymorphicComponentProps } from '@mantine/utils';
@@ -8,7 +9,7 @@ import {
     type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, type ReactNode } from 'react';
 import { v4 as uuid } from 'uuid';
 import MantineIcon from '../../components/common/MantineIcon';
 
@@ -17,7 +18,7 @@ type NotificationData = Omit<
     'message' | 'key'
 > & {
     key?: string;
-    subtitle?: string | JSX.Element;
+    subtitle?: string | ReactNode;
     action?: PolymorphicComponentProps<'button', ButtonProps> & {
         icon?: Icon;
     };
@@ -68,7 +69,14 @@ const useToaster = () => {
                                     }}
                                 />
                             ) : (
-                                subtitle
+                                <div
+                                    style={{
+                                        color: toastColor ? 'white' : undefined,
+                                        fontSize: '12px',
+                                    }}
+                                >
+                                    {subtitle}
+                                </div>
                             )}
 
                             {action && (
@@ -136,6 +144,38 @@ const useToaster = () => {
         [showToast],
     );
 
+    const showToastApiError = useCallback(
+        (
+            props: Omit<NotificationData, 'subtitle'> & {
+                apiError: ApiErrorDetail;
+            },
+        ) => {
+            let title: ReactNode | undefined = props.title ?? 'Error';
+            let subtitle: ReactNode = props.apiError.id ? (
+                <p>
+                    <span>{props.apiError.message}</span>
+                    <br />
+                    <span style={{ fontSize: '8px' }}>
+                        Error ID: {props.apiError.id}
+                    </span>
+                </p>
+            ) : (
+                props.apiError.message
+            );
+
+            showToast({
+                color: 'red',
+                bg: 'red',
+                icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
+                autoClose: 60000,
+                title,
+                subtitle,
+                ...props,
+            });
+        },
+        [showToast],
+    );
+
     const showToastInfo = useCallback(
         (props: NotificationData) => {
             showToast({
@@ -172,6 +212,7 @@ const useToaster = () => {
 
     return {
         showToastSuccess,
+        showToastApiError,
         showToastError,
         showToastInfo,
         showToastPrimary,

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -150,8 +150,8 @@ const useToaster = () => {
                 apiError: ApiErrorDetail;
             },
         ) => {
-            let title: ReactNode | undefined = props.title ?? 'Error';
-            let subtitle: ReactNode = props.apiError.id ? (
+            const title: ReactNode | undefined = props.title ?? 'Error';
+            const subtitle: ReactNode = props.apiError.id ? (
                 <p>
                     <span>{props.apiError.message}</span>
                     <br />

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -155,8 +155,9 @@ const useToaster = () => {
                 <p>
                     <span>{props.apiError.message}</span>
                     <br />
-                    <span style={{ fontSize: '8px' }}>
-                        Error ID: {props.apiError.id}
+                    <span style={{ fontWeight: 'bold' }}>
+                        Please contact support with the error ID:{' '}
+                        {props.apiError.id}
                     </span>
                 </p>
             ) : (

--- a/packages/frontend/src/hooks/useAccessToken.ts
+++ b/packages/frontend/src/hooks/useAccessToken.ts
@@ -54,7 +54,7 @@ export const useAccessToken = (
 
 export const useCreateAccessToken = () => {
     const queryClient = useQueryClient();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<
         ApiCreateUserTokenResults,
         ApiError,
@@ -65,10 +65,10 @@ export const useCreateAccessToken = () => {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['personal_access_tokens']);
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create token`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -76,7 +76,7 @@ export const useCreateAccessToken = () => {
 
 export const useDeleteAccessToken = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteAccessToken, {
         mutationKey: ['personal_access_tokens'],
         onSuccess: async () => {
@@ -85,10 +85,10 @@ export const useDeleteAccessToken = () => {
                 title: `Success! Your token was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete token`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/useEmailVerification.tsx
+++ b/packages/frontend/src/hooks/useEmailVerification.tsx
@@ -36,7 +36,7 @@ export const useEmailStatus = (enabled = true) =>
 
 export const useOneTimePassword = () => {
     const queryClient = useQueryClient();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<EmailStatusExpiring, ApiError>(
         () => sendOneTimePasscodeQuery(),
         {
@@ -44,10 +44,10 @@ export const useOneTimePassword = () => {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['email_status']);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `We couldn't send a verification e-mail to your inbox.`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -47,18 +47,17 @@ export const useInviteLink = (inviteCode: string) =>
 
 export const useCreateInviteLinkMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<
         InviteLink,
         ApiError,
         Omit<CreateInviteLink, 'expiresAt'>
     >(createInviteWith3DayExpiryQuery, {
         mutationKey: ['invite_link'],
-        onError: (error1) => {
-            const [title, ...rest] = error1.error.message.split('\n');
-            showToastError({
-                title,
-                subtitle: rest.join('\n'),
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create invite link',
+                apiError: error,
             });
         },
         onSuccess: async () => {

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -69,7 +69,7 @@ const createGroupQuery = async (data: CreateGroup) =>
 
 export const useGroupCreateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<Group, ApiError, CreateGroup>(
         (data) => createGroupQuery(data),
         {
@@ -82,10 +82,10 @@ export const useGroupCreateMutation = () => {
                     title: `Success! Group was created.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create group`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -106,7 +106,7 @@ const updateGroupQuery = async (
 
 export const useGroupUpdateMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         Group,
         ApiError,
@@ -120,10 +120,10 @@ export const useGroupUpdateMutation = () => {
                 title: `Success! Group '${group.name}' was updated.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to update group`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -138,7 +138,7 @@ const deleteGroupQuery = async (data: Group) =>
 
 export const useGroupDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<Group, ApiError, Group>(
         (data) => deleteGroupQuery(data),
         {
@@ -151,10 +151,10 @@ export const useGroupDeleteMutation = () => {
                     title: `Success! Group '${deletedGroup.name}' was deleted.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to delete group`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -62,7 +62,7 @@ export const useOrganizationUsers = (params?: {
 
 export const useDeleteOrganizationUserMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteUserQuery, {
         mutationKey: ['organization_users_delete'],
         onSuccess: async () => {
@@ -71,10 +71,10 @@ export const useDeleteOrganizationUserMutation = () => {
                 title: `Success! User was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete user`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -83,7 +83,7 @@ export const useDeleteOrganizationUserMutation = () => {
 export const useUpdateUserMutation = (userUuid: string) => {
     const queryClient = useQueryClient();
     const { user } = useApp();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, OrganizationMemberProfileUpdate>(
         (data) => {
             if (userUuid) {
@@ -102,10 +102,10 @@ export const useUpdateUserMutation = (userUuid: string) => {
                     title: `Success! User was updated.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update user's permissions`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/usePasswordReset.ts
+++ b/packages/frontend/src/hooks/usePasswordReset.ts
@@ -37,7 +37,7 @@ export const usePasswordResetLink = (code: string) =>
     });
 
 export const usePasswordResetLinkMutation = () => {
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, CreatePasswordResetLink>(
         sendPasswordResetLinkQuery,
         {
@@ -47,10 +47,10 @@ export const usePasswordResetLinkMutation = () => {
                     title: 'Password recovery email sent successfully',
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to send password recovery email`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -58,7 +58,7 @@ export const usePasswordResetLinkMutation = () => {
 };
 
 export const usePasswordResetMutation = () => {
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, PasswordReset>(resetPasswordQuery, {
         mutationKey: ['reset_password'],
         onSuccess: async () => {
@@ -66,10 +66,10 @@ export const usePasswordResetMutation = () => {
                 title: 'Password updated successfully',
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to reset password`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -47,7 +47,7 @@ export const useProject = (id: string | undefined) => {
 export const useUpdateMutation = (id: string) => {
     const queryClient = useQueryClient();
     const { setActiveJobId } = useActiveJob();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, UpdateProject>(
         (data) => updateProject(id, data),
         {
@@ -61,10 +61,10 @@ export const useUpdateMutation = (id: string) => {
                 await queryClient.invalidateQueries(['queryResults']);
                 await queryClient.invalidateQueries(['status']);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update project`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -73,7 +73,7 @@ export const useUpdateMutation = (id: string) => {
 
 export const useCreateMutation = () => {
     const { setActiveJobId } = useActiveJob();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, CreateProject>(
         (data) => createProject(data),
         {
@@ -82,10 +82,10 @@ export const useCreateMutation = () => {
             onSuccess: (data) => {
                 setActiveJobId(data.jobUuid);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create project`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useProjectAccess.tsx
+++ b/packages/frontend/src/hooks/useProjectAccess.tsx
@@ -37,7 +37,7 @@ const removeProjectAccessQuery = async (
 
 export const useRevokeProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(
         (data) => removeProjectAccessQuery(projectUuid, data),
         {
@@ -48,10 +48,10 @@ export const useRevokeProjectAccessMutation = (projectUuid: string) => {
                     title: `Revoked project access`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to revoke project access`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -70,7 +70,7 @@ const createProjectAccessQuery = async (
 
 export const useCreateProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, CreateProjectMember>(
         (data) => createProjectAccessQuery(projectUuid, data),
         {
@@ -81,11 +81,10 @@ export const useCreateProjectAccessMutation = (projectUuid: string) => {
                     title: 'Created new project access',
                 });
             },
-            onError: async (error1) => {
-                const [title, ...rest] = error1.error.message.split('\n');
-                showToastError({
-                    title,
-                    subtitle: rest.join('\n'),
+            onError: async ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to create project access',
+                    apiError: error,
                 });
             },
         },
@@ -105,7 +104,7 @@ const updateProjectAccessQuery = async (
 
 export const useUpdateProjectAccessMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<
         null,
         ApiError,
@@ -121,11 +120,10 @@ export const useUpdateProjectAccessMutation = (projectUuid: string) => {
                     title: 'Updated project access role',
                 });
             },
-            onError: async (error1) => {
-                const [title, ...rest] = error1.error.message.split('\n');
-                showToastError({
-                    title,
-                    subtitle: rest.join('\n'),
+            onError: async ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update project access role',
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useProjectTablesConfiguration.ts
+++ b/packages/frontend/src/hooks/useProjectTablesConfiguration.ts
@@ -31,7 +31,7 @@ export const useProjectTablesConfiguration = (projectUuid: string) => {
 };
 
 export const useUpdateProjectTablesConfiguration = (projectUuid: string) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
     return useMutation<TablesConfiguration, ApiError, TablesConfiguration>(
         (data) => updateProjectTablesConfigurationQuery(projectUuid, data),
@@ -47,10 +47,10 @@ export const useUpdateProjectTablesConfiguration = (projectUuid: string) => {
                     title: `Saved project configuration`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to save tables configuration`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -64,7 +64,7 @@ const deleteProjectQuery = async (id: string) =>
 
 export const useDeleteProjectMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteProjectQuery, {
         mutationKey: ['organization_project_delete'],
         onSuccess: async () => {
@@ -73,10 +73,10 @@ export const useDeleteProjectMutation = () => {
                 title: `Deleted! Project was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete project`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -15,7 +15,7 @@ const useQueryError = ({
 }: opts = {}): Dispatch<SetStateAction<ApiError | undefined>> => {
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<ApiError | undefined>();
-    const { showToastError } = useToaster();
+    const { showToastError, showToastApiError } = useToaster();
     useEffect(() => {
         (async function doIfError() {
             const { error } = errorResponse || {};
@@ -29,9 +29,9 @@ const useQueryError = ({
                     // we will handle this on pages showing a nice message
 
                     if (forceToastOnForbidden) {
-                        showToastError({
+                        showToastApiError({
                             title: forbiddenToastTitle ?? 'Forbidden',
-                            subtitle: error.message,
+                            apiError: error,
                         });
                     }
                 } else if (statusCode === 401) {
@@ -64,19 +64,9 @@ const useQueryError = ({
                         });
                     }
                 } else {
-                    const { message } = error;
-                    if (message !== '') {
-                        const [first, ...rest] = message.split('\n');
-                        showToastError({
-                            title: first,
-                            subtitle: rest.join('\n'),
-                        });
-                    } else {
-                        showToastError({
-                            title: `An unknown error happened`,
-                            subtitle: JSON.stringify(error),
-                        });
-                    }
+                    showToastApiError({
+                        apiError: error,
+                    });
                 }
             }
         })();
@@ -86,6 +76,7 @@ const useQueryError = ({
         forceToastOnForbidden,
         queryClient,
         showToastError,
+        showToastApiError,
     ]);
     return setErrorResponse;
 };

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -301,15 +301,15 @@ export const useChartVersionResultsMutation = (
     chartUuid: string,
     versionUuid?: string,
 ) => {
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     const mutation = useMutation<ApiQueryResults, ApiError>(
         () => getChartVersionResults(chartUuid, versionUuid!),
         {
             mutationKey: ['chartVersionResults', chartUuid, versionUuid],
-            onError: (result) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Error running query',
-                    subtitle: result.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -112,17 +112,17 @@ export const useRefreshServer = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
     const { setActiveJobId } = useActiveJob();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<ApiRefreshResults, ApiError>({
         mutationKey: ['refresh', projectUuid],
         mutationFn: () => refresh(projectUuid),
         onSettled: async () =>
             queryClient.setQueryData(['status', projectUuid], 'loading'),
         onSuccess: (data) => setActiveJobId(data.jobUuid),
-        onError: (result) =>
-            showToastError({
+        onError: ({ error }) =>
+            showToastApiError({
                 title: 'Error syncing dbt project',
-                subtitle: result.error.message,
+                apiError: error,
             }),
     });
 };

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -163,7 +163,7 @@ export const useChartVersionRollbackMutation = (
         'mutationFn'
     >,
 ) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(
         (versionUuid: string) => rollbackChartQuery(chartUuid, versionUuid),
         {
@@ -175,10 +175,10 @@ export const useChartVersionRollbackMutation = (
                 });
                 useMutationOptions?.onSuccess?.(...args);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to revert chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -187,7 +187,7 @@ export const useChartVersionRollbackMutation = (
 
 export const useSavedQueryDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(
         async (data) => {
             queryClient.removeQueries(['savedChartResults', data]);
@@ -207,10 +207,10 @@ export const useSavedQueryDeleteMutation = () => {
                     title: `Success! Chart was deleted.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to delete chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -230,7 +230,7 @@ const updateMultipleSavedQuery = async (
 
 export const useUpdateMultipleMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<SavedChart[], ApiError, UpdateMultipleSavedChart[]>(
         (data) => {
@@ -254,10 +254,10 @@ export const useUpdateMultipleMutation = (projectUuid: string) => {
                     title: `Success! Charts were updated.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to save chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -270,7 +270,7 @@ export const useUpdateMutation = (
 ) => {
     const history = useHistory();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<
         SavedChart,
@@ -311,10 +311,10 @@ export const useUpdateMutation = (
                         : undefined,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to save chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -331,7 +331,7 @@ export const useMoveChartMutation = (
     const history = useHistory();
     const queryClient = useQueryClient();
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<
         SavedChart,
@@ -361,10 +361,10 @@ export const useMoveChartMutation = (
             });
             options?.onSuccess?.(data, _, __);
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to move chart`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -374,7 +374,7 @@ export const useCreateMutation = () => {
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<SavedChart, ApiError, CreateSavedChart>(
         (data) => createSavedQuery(projectUuid, data),
         {
@@ -388,10 +388,10 @@ export const useCreateMutation = () => {
                     pathname: `/projects/${projectUuid}/saved/${data.uuid}/view`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to save chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -410,7 +410,7 @@ export const useDuplicateChartMutation = (
     const history = useHistory();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         SavedChart,
         ApiError,
@@ -455,10 +455,10 @@ export const useDuplicateChartMutation = (
                         : undefined,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to duplicate chart`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -470,7 +470,7 @@ export const useAddVersionMutation = () => {
     const queryClient = useQueryClient();
     const dashboardUuid = useSearchParams('fromDashboard');
 
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         SavedChart,
         ApiError,
@@ -507,10 +507,10 @@ export const useAddVersionMutation = () => {
                 });
             }
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to update chart`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -73,7 +73,7 @@ const deleteQuery = async (projectUuid: string, spaceUuid: string) =>
     });
 
 export const useSpaceDeleteMutation = (projectUuid: string) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<null, ApiError, string>(
@@ -91,10 +91,10 @@ export const useSpaceDeleteMutation = (projectUuid: string) => {
                     title: `Success! Space was deleted.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to delete space`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -113,7 +113,7 @@ const updateSpace = async (
     });
 
 export const useUpdateMutation = (projectUuid: string, spaceUuid: string) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<Space, ApiError, UpdateSpace>(
@@ -137,10 +137,10 @@ export const useUpdateMutation = (projectUuid: string, spaceUuid: string) => {
                     title: `Success! Space was updated.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update space`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -160,7 +160,7 @@ export const useCreateMutation = (
         onSuccess?: (space: Space) => void;
     },
 ) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<Space, ApiError, CreateSpace>(
@@ -180,10 +180,10 @@ export const useCreateMutation = (
                     title: `Success! Space was created.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create space`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -206,7 +206,7 @@ export const useAddSpaceShareMutation = (
     projectUuid: string,
     spaceUuid: string,
 ) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<Space, ApiError, [string, string]>(
@@ -226,10 +226,10 @@ export const useAddSpaceShareMutation = (
                     title: `Success! Space access updated!`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update space access`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -251,7 +251,7 @@ export const useDeleteSpaceShareMutation = (
     projectUuid: string,
     spaceUuid: string,
 ) => {
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
 
     return useMutation<null, ApiError, string>(
@@ -270,10 +270,10 @@ export const useDeleteSpaceShareMutation = (
                     title: `Success! Space access updated!`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update space access`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useSqlQuery.ts
+++ b/packages/frontend/src/hooks/useSqlQuery.ts
@@ -13,15 +13,15 @@ const runSqlQuery = async (projectUuid: string, sql: string) =>
 
 export const useSqlQueryMutation = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     return useMutation<ApiSqlQueryResults, ApiError, string>(
         (sql) => runSqlQuery(projectUuid, sql),
         {
             mutationKey: ['run_sql_query', projectUuid],
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to run sql query`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useUserAttributes.ts
+++ b/packages/frontend/src/hooks/useUserAttributes.ts
@@ -33,7 +33,7 @@ const createUserAttributes = async (data: CreateUserAttribute) =>
 
 export const useCreateUserAtributesMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<null, ApiError, CreateUserAttribute>(
         createUserAttributes,
@@ -45,10 +45,10 @@ export const useCreateUserAtributesMutation = () => {
                     title: `Success! user attribute was created.`,
                 });
             },
-            onError: (error: { error: Error }) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to create user attribute`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -67,7 +67,7 @@ const updateUserAttributes = async (
 
 export const useUpdateUserAtributesMutation = (userAttributeUuuid?: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<null, ApiError, CreateUserAttribute>(
         (data) => updateUserAttributes(userAttributeUuuid || '', data),
@@ -80,10 +80,10 @@ export const useUpdateUserAtributesMutation = (userAttributeUuuid?: string) => {
                     title: `Success! user attribute was updated.`,
                 });
             },
-            onError: (error: { error: Error }) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update user attribute`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -99,7 +99,7 @@ const deleteUserAttributes = async (uuid: string) =>
 
 export const useUserAttributesDeleteMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteUserAttributes, {
         mutationKey: ['delete_user_attributes'],
         onSuccess: async () => {
@@ -108,10 +108,10 @@ export const useUserAttributesDeleteMutation = () => {
                 title: `Success! user attribute was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete user attribute`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/user/useOpenIdentity.ts
+++ b/packages/frontend/src/hooks/user/useOpenIdentity.ts
@@ -16,7 +16,7 @@ const deleteOpenIdentity = async (data: DeleteOpenIdentity) =>
 
 export const useDeleteOpenIdentityMutation = () => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, DeleteOpenIdentity>(deleteOpenIdentity, {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['user_identities']);
@@ -24,10 +24,10 @@ export const useDeleteOpenIdentityMutation = () => {
                 title: `Deleted! Social login was deleted.`,
             });
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to delete social login`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/hooks/userWarehouseCredentials/useProjectUserWarehouseCredentialsPreference.ts
+++ b/packages/frontend/src/hooks/userWarehouseCredentials/useProjectUserWarehouseCredentialsPreference.ts
@@ -54,7 +54,7 @@ export const useProjectUserWarehouseCredentialsPreferenceMutation = (
     options?: UseMutationOptions<null, ApiError, UpdateCredentialsPreference>,
 ) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, UpdateCredentialsPreference>(
         ({ projectUuid, userWarehouseCredentialsUuid }) =>
             updateProjectUserWarehouseCredentialsPreference(
@@ -72,10 +72,10 @@ export const useProjectUserWarehouseCredentialsPreferenceMutation = (
                 });
                 options?.onSuccess?.(...args);
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to save credentials preference`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
             ...options,

--- a/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
+++ b/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
@@ -47,7 +47,7 @@ export const useUserWarehouseCredentialsCreateMutation = (
     >,
 ) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         UserWarehouseCredentials,
         ApiError,
@@ -62,10 +62,10 @@ export const useUserWarehouseCredentialsCreateMutation = (
             });
             useMutationOptions?.onSuccess?.(data, payload, undefined);
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create warehouse connection`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });
@@ -83,7 +83,7 @@ const updateUserWarehouseCredentials = async (
 
 export const useUserWarehouseCredentialsUpdateMutation = (uuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, UpsertUserWarehouseCredentials>(
         (data) => updateUserWarehouseCredentials(uuid, data),
         {
@@ -97,10 +97,10 @@ export const useUserWarehouseCredentialsUpdateMutation = (uuid: string) => {
                     title: `Success! Warehouse connection was updated.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to update warehouse connection`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },
@@ -116,7 +116,7 @@ const deleteUserWarehouseCredentials = async (uuid: string) =>
 
 export const useUserWarehouseCredentialsDeleteMutation = (uuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError>(
         () => deleteUserWarehouseCredentials(uuid),
         {
@@ -130,10 +130,10 @@ export const useUserWarehouseCredentialsDeleteMutation = (uuid: string) => {
                     title: `Success! Warehouse connection was deleted.`,
                 });
             },
-            onError: (error) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: `Failed to delete warehouse connection`,
-                    subtitle: error.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -73,7 +73,8 @@ export const useValidationMutation = (
     onComplete: () => void,
 ) => {
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError } = useToaster();
+    const { showToastSuccess, showToastError, showToastApiError } =
+        useToaster();
 
     return useMutation<ApiJobScheduledResponse['results'], ApiError>({
         mutationKey: ['validation', projectUuid],
@@ -96,11 +97,10 @@ export const useValidationMutation = (
                     });
                 });
         },
-        onError: (error) => {
-            const [title, ...rest] = error.error.message.split('\n');
-            showToastError({
-                title,
-                subtitle: rest.join('\n'),
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update validation',
+                apiError: error,
             });
         },
     });
@@ -154,7 +154,7 @@ const deleteValidation = async (
 
 export const useDeleteValidation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<null, ApiError, number>(
         (validationId) => deleteValidation(projectUuid, validationId),
         {
@@ -165,11 +165,10 @@ export const useDeleteValidation = (projectUuid: string) => {
                     title: 'Validation dismissed',
                 });
             },
-            onError: async (error1) => {
-                const [title, ...rest] = error1.error.message.split('\n');
-                showToastError({
-                    title,
-                    subtitle: rest.join('\n'),
+            onError: async ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to dismiss validation',
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -102,7 +102,7 @@ const createUserQuery = async (data: ActivateUserWithInviteCode) =>
 const Invite: FC = () => {
     const { inviteCode } = useParams<{ inviteCode: string }>();
     const { health } = useApp();
-    const { showToastError } = useToaster();
+    const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
 
     useEffect(() => {
@@ -127,10 +127,10 @@ const Invite: FC = () => {
             identify({ id: data.userUuid });
             window.location.href = redirectUrl;
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create user`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -53,7 +53,7 @@ const loginQuery = async (data: LoginParams) =>
 const LoginContent: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
     const { health } = useApp();
-    const { showToastError } = useToaster();
+    const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
 
     useEffect(() => {
@@ -93,11 +93,11 @@ const LoginContent: FC = () => {
             identify({ id: data.userUuid });
             window.location.href = redirectUrl;
         },
-        onError: (error) => {
+        onError: ({ error }) => {
             form.reset();
-            showToastError({
+            showToastApiError({
                 title: `Failed to login`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/pages/MetricFlow.tsx
+++ b/packages/frontend/src/pages/MetricFlow.tsx
@@ -42,7 +42,7 @@ import { useApp } from '../providers/AppProvider';
 const MOCK_TABLE_NAME = 'metricflow';
 
 const MetricFlowPage = () => {
-    const { showToastError } = useToaster();
+    const { showToastApiError } = useToaster();
     const { user, health } = useApp();
     const { data: org } = useOrganization();
     const { activeProjectUuid } = useActiveProjectUuid();
@@ -56,10 +56,10 @@ const MetricFlowPage = () => {
         activeProjectUuid,
         selectedMetrics,
         {
-            onError: (err) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Error fetching dimensions',
-                    subtitle: err.error.message,
+                    apiError: error,
                 });
                 setSelectedMetrics({});
             },
@@ -69,10 +69,10 @@ const MetricFlowPage = () => {
         activeProjectUuid,
         selectedDimensions,
         {
-            onError: (err) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Error fetching metrics',
-                    subtitle: err.error.message,
+                    apiError: error,
                 });
                 setSelectedDimensions({});
             },
@@ -85,18 +85,18 @@ const MetricFlowPage = () => {
             dimensions: selectedDimensions,
         },
         {
-            onError: (err) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Error generating query',
-                    subtitle: err.error.message,
+                    apiError: error,
                 });
             },
         },
         {
-            onError: (err) => {
-                showToastError({
+            onError: ({ error }) => {
+                showToastApiError({
                     title: 'Error fetching results',
-                    subtitle: err.error.message,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -37,7 +37,7 @@ const registerQuery = async (data: CreateUserArgs) =>
 const Register: FC = () => {
     const location = useLocation<{ from?: Location } | undefined>();
     const { health } = useApp();
-    const { showToastError } = useToaster();
+    const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
 
     useEffect(() => {
@@ -64,10 +64,10 @@ const Register: FC = () => {
             identify({ id: data.userUuid });
             window.location.href = redirectUrl;
         },
-        onError: (error) => {
-            showToastError({
+        onError: ({ error }) => {
+            showToastApiError({
                 title: `Failed to create user`,
-                subtitle: error.error.message,
+                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/providers/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJobProvider.tsx
@@ -42,7 +42,7 @@ export const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({
     const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
     const [activeJobId, setActiveJobId] = useState();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastError, showToastInfo } = useToaster();
+    const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
 
     const toastJobStatus = useCallback(
         async (job: Job | undefined) => {
@@ -90,11 +90,11 @@ export const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({
         [showToastInfo, showToastSuccess, queryClient, isJobsDrawerOpen],
     );
 
-    const toastJobError = (error: ApiError) => {
-        showToastError({
+    const toastJobError = ({ error }: ApiError) => {
+        showToastApiError({
             key: TOAST_KEY_FOR_REFRESH_JOB,
             title: 'Failed to refresh server',
-            subtitle: error.error.message,
+            apiError: error,
         });
     };
     const { data: activeJob } = useJob(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9917 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- update multiple errors status code from 500 to 400
- stop exposing internal details on unexpected errors
- return error id when error has status code 500
- show error id in 90% of the toasts ( the last % needs more work and can be updated as we go )

Left comments on the important changes. 


Before it would expose SQL error.
<img width="467" alt="Screenshot 2024-04-29 at 18 44 20" src="https://github.com/lightdash/lightdash/assets/9117144/75fee410-d31f-411a-a017-4797cebf5875">


Now shows generic message + error id

<img width="372" alt="Screenshot 2024-04-29 at 19 09 31" src="https://github.com/lightdash/lightdash/assets/9117144/b39a7f7e-f8e6-48d4-bdab-914697b0f369">



Toast shows can now show error id

<img width="471" alt="Screenshot 2024-04-29 at 19 00 36" src="https://github.com/lightdash/lightdash/assets/9117144/813b5e89-fa75-4b5d-afd9-d735c3eef4d8">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
