### PR TITLE
fix: missing formatting in model level metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -94,6 +94,11 @@ models:
       joins:
         - join: customers
           sql_on: ${customers.customer_id} = ${orders.customer_id}
+      metrics:
+        completion_percentage:
+          type: number
+          sql: ${total_completed_order_amount}/${total_order_amount}
+          format: percent
     columns:
       - name: order_id
         tests:

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -130,6 +130,11 @@ export enum TableCalculationType {
     TIMESTAMP = 'timestamp',
     BOOLEAN = 'boolean',
 }
+
+// TODO: this type and the TableCalculationField type share
+// most of the same fields -- can we merge them. This mostly
+// needs to add fieldType: FieldType.TABLE_CALCULATION which
+// would make the type checking more robust
 export type TableCalculation = {
     index?: number;
     name: string;
@@ -144,6 +149,12 @@ export type TableCalculationMetadata = {
     name: string;
 };
 
+export enum FieldType {
+    METRIC = 'metric',
+    DIMENSION = 'dimension',
+    TABLE_CALCULATION = 'table_calculation',
+}
+
 export interface TableCalculationField extends Field {
     fieldType: FieldType.TABLE_CALCULATION;
     type: TableCalculationType;
@@ -153,6 +164,8 @@ export interface TableCalculationField extends Field {
     sql: string;
 }
 
+// This type check is a little fragile because it's based on
+// 'displayName'. Ideally these would all have fieldTypes.
 export const isTableCalculation = (
     item: Item | AdditionalMetric | TableCalculationField,
 ): item is TableCalculation =>
@@ -160,18 +173,13 @@ export const isTableCalculation = (
         ? !('binType' in item) &&
           !!item.sql &&
           !('description' in item) &&
-          !('tableName' in item)
+          !('tableName' in item) &&
+          'displayName' in item
         : false;
 
 export type CompiledTableCalculation = TableCalculation & {
     compiledSql: string;
 };
-
-export enum FieldType {
-    METRIC = 'metric',
-    DIMENSION = 'dimension',
-    TABLE_CALCULATION = 'table_calculation',
-}
 
 export type FieldUrl = {
     url: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9779, 

### Description:

Formatting was getting skipped for some metrics defined in yml because they were being treated as table calculations. Our isTableCalculation check is pretty fragile, but I made it a little better to fix this. I added a check for displayName, which is only on table calculations for now. But if someone adds that field to another Item type this could break. Ideally we'd have a fieldType field on all of these types, but it's missing on TableCalculation. I tried adding it there to fix this, but it's not backwards compatible -- any existing table calculations won't have it. So I checked displayName for now. 

I added a model-level metric to test this. 
1. Create a chart
2. add orders.completion_percentage. If it's displayed as a percent this should be working. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
