### PR TITLE
fix: keep identical filter settings if they exist when overriding

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -665,6 +665,11 @@ const findAndOverrideChartFilter = (
               ...item,
               id: identicalDashboardFilter.id,
               values: identicalDashboardFilter.values,
+              ...(identicalDashboardFilter.settings
+                  ? {
+                        settings: identicalDashboardFilter.settings,
+                    }
+                  : {}),
           }
         : item;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9840 

### Description:

- Keeps filter settings when overriding chart filter

Date filter value was being overridden but the settings weren't. Because of this the chart filter's `unitOfTime` was kept the same and wasn't overridden with the dashboard filter one

**Before**

https://github.com/lightdash/lightdash/assets/22939015/c09105e0-3a96-4fb9-922a-9d157c2fe61a

**After**

https://github.com/lightdash/lightdash/assets/22939015/51d47f10-93eb-4acd-b41a-1489c6780964

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
