### PR TITLE
fix: use github ci token

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -d '{"event_type": "sentry-release", "client_payload": {"version": "${{ steps.semantic.outputs.new_release_version }}", "environment": "production"}}' \
             https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9932 

### Description:

After fixing that step, got an issue with dispatching the workflow here: 

https://github.com/lightdash/lightdash/actions/runs/8895669590/job/24426516663

error

```
Run curl -X POST \
  curl -X POST \
    -H "Authorization: token ***" \
    -H "Accept: application/vnd.github.v3+json" \
    -d '{"event_type": "sentry-release", "client_payload": {"version": "0.1079.[2](https://github.com/lightdash/lightdash/actions/runs/8895669590/job/24426516663#step:9:2)", "environment": "production"}}' \
    https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches
  shell: /usr/bin/bash -e {0}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   268  100   164  100   104   1[3](https://github.com/lightdash/lightdash/actions/runs/8895669590/job/24426516663#step:9:3)38    848 --:--:-- --:--:-- --:--:--  2196
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event"
}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
