### PR TITLE
fix: use correct dispatch params to trigger sentry release workflow

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -1,16 +1,19 @@
 name: Create Sentry release
 on:
-    repository_dispatch:
-        types: [sentry-release]
+    workflow_dispatch:
+        inputs:
+            version:
+                required: true
+                description: 'Release version number'
 
 jobs:
     create-sentry-release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20'
                   cache: 'yarn'
@@ -27,6 +30,6 @@ jobs:
                   SENTRY_ORG: lightdash
                   SENTRY_PROJECT: lightdash-frontend
               with:
-                  environment: ${{ github.event.client_payload.environment }}
-                  version: ${{ github.event.client_payload.version }}
+                  version: ${{ github.event.inputs.version }}
+                  environment: 'cloud-beta'
                   sourcemaps: './packages/frontend/build/assets/'

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.CI_GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
             -d '{
                   "ref": "main",
                   "inputs": {

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -57,7 +57,12 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           curl -X POST \
-            -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -d '{"event_type": "sentry-release", "client_payload": {"version": "${{ steps.semantic.outputs.new_release_version }}", "environment": "production"}}' \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.CI_GITHUB_TOKEN }}" \
+            -d '{
+                  "ref": "main",
+                  "inputs": {
+                    "version": "${{ steps.semantic.outputs.new_release_version }}",
+                  }
+                }' \
             https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9918 

### Description:

After this error: https://github.com/lightdash/lightdash/actions/runs/8897910487/job/24433880988

```
Run curl -X POST \
  curl -X POST \
    -H "Authorization: token ***" \
    -H "Accept: application/vnd.github.v3+json" \
    -d '{"event_type": "sentry-release", "client_payload": {"version": "0.1081.1", "environment": "production"}}' \
    https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches
  shell: /usr/bin/bash -e {0}
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   334  100   [2](https://github.com/lightdash/lightdash/actions/runs/8897910487/job/24433880988#step:9:2)30  100   104   1457    659 --:--:-- --:--:-- --:--:--  2127
{
  "message": "Invalid request.\n\n\"client_payload\", \"event_type\" are not permitted keys.\n\"ref\" wasn't supplied.",
  "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event"
}
```

Followed these instructions: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event and these: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch to pass the correct params to the cURL request.

Then... 
Changed the workflow dispatch trigger event + used the version from the inputs.

Have also changed the `environment` to be `cloud-beta`. Happy to pass this to the curl request instead if necessary.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
