### PR TITLE
fix: use gh cli and build common before frontend

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -19,7 +19,9 @@ jobs:
                   cache: 'yarn'
             - name: Install packages
               run: yarn install --frozen-lockfile
-            - name: Build
+            - name: Build common
+              run: yarn common-build
+            - name: Build frontend
               run: yarn workspace frontend build
             - name: List output files - debugging
               run: ls -R ./packages/frontend/build/assets/

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -56,13 +56,9 @@ jobs:
       - name: Trigger Sentry release
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          curl -X POST \
+          gh api --method POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.CI_GITHUB_TOKEN }}" \
-            -d '{
-                  "ref": "main",
-                  "inputs": {
-                    "version": "${{ steps.semantic.outputs.new_release_version }}",
-                  }
-                }' \
-            https://api.github.com/repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches \
+            -f "ref=main" \
+            -f "inputs[version]=${{ steps.semantic.outputs.new_release_version }}"

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -55,6 +55,8 @@ jobs:
             https://api.github.com/repos/lightdash/helm-charts/action/workflows/increment-lightdash-app-version.yml/dispatches
       - name: Trigger Sentry release
         if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         run: |
           gh api --method POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #9918 

### Description:

Uses `gh` cli to help with posting the workflow dispatch. Tested this locally and was able to trigger this run: https://github.com/lightdash/lightdash/actions/runs/8907197505/job/24460632498 - with this error I found that we should also build `common` before building `frontend`.

Use this as reference: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
and this: https://josh-ops.com/posts/gh-auth-login-in-actions/

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
