### PR TITLE
fix: fix tile insert error when duplicate tabbed dashboard

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -412,7 +412,7 @@ export class DashboardService extends BaseService {
                 {
                     tiles: [...updatedTiles],
                     filters: newDashboard.filters,
-                    tabs: [], // todo copy tabs over
+                    tabs: newDashboard.tabs,
                 },
                 user,
                 projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
issue:
<img width="1563" alt="Screenshot 2024-05-01 at 15 03 20" src="https://github.com/lightdash/lightdash/assets/101873365/dda983c2-7fe0-4431-82af-daf25030e1c9">


steps to reproduce:
1. created a tabbed dashboard
2. create a new tab
3. create a 'new chart' tile in the new tab
4. duplicate the dashboard

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
