### PR TITLE
feat: align x-axis ticks with data

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -376,7 +376,7 @@ export const timeFrameConfigs: Record<TimeFrames, TimeFrameConfig> = {
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
         getAxisMinInterval: () => null,
-        getAxisLabelFormatter: () => ({ hour: '' }),
+        getAxisLabelFormatter: () => null,
     },
     MONTH: {
         getLabel: () => 'Month',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #3621 

### Description:

The goal of this is to make data line up with the axis labels and ticks better when looking at WEEK timeframe data. 

To do this, I made the week-timeframe use a categorical axis, which gives much more control over axis styles and such. The downside of the categorical axis is it's not continuous -- it doesn't fill holes where there is no data. To handle this, I found the min and max weeks and made the x-axis always a continuous range between them. 

This does a good job of lining up the bars with the ticks, but more could still be done about overlapping labels. 

This is what a week-based chart (with gaps in the data) looked like before:
<img width="1577" alt="Screenshot 2024-05-02 at 15 56 46" src="https://github.com/lightdash/lightdash/assets/1864179/ccdfd738-222d-4289-ae23-961885a7967e">

And here's what it looks like with this change
<img width="1663" alt="Screenshot 2024-05-02 at 15 57 24" src="https://github.com/lightdash/lightdash/assets/1864179/1fc85c9b-f403-48f6-85fa-37a2b642fd7b">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
