### PR TITLE
feat: dashboard override chart filters

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -411,19 +411,10 @@ export class CsvService extends BaseService {
                   )
                 : undefined;
 
-        const isDashboardFilterOverrideEnabled: boolean =
-            await isFeatureFlagEnabled(
-                FeatureFlags.DashboardFilterOverridesChartFilters,
-                {
-                    userUuid: user.userUuid,
-                    organizationUuid: user.organizationUuid,
-                },
-            );
         const metricQueryWithDashboardFilters = dashboardFiltersForTile
             ? addDashboardFiltersToMetricQuery(
                   metricQuery,
                   dashboardFiltersForTile,
-                  isDashboardFilterOverrideEnabled,
               )
             : metricQuery;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1409,19 +1409,11 @@ export class ProjectService extends BaseService {
                 dashboardFilters.tableCalculations,
             ),
         };
-        const isDashboardFilterOverrideEnabled: boolean =
-            await isFeatureFlagEnabled(
-                FeatureFlags.DashboardFilterOverridesChartFilters,
-                {
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                },
-            );
+
         const metricQueryWithDashboardOverrides: MetricQuery = {
             ...addDashboardFiltersToMetricQuery(
                 savedChart.metricQuery,
                 appliedDashboardFilters,
-                isDashboardFilterOverrideEnabled,
             ),
             sorts:
                 dashboardSorts && dashboardSorts.length > 0
@@ -3739,20 +3731,10 @@ export class ProjectService extends BaseService {
               }
             : undefined;
 
-        const isDashboardFilterOverrideEnabled: boolean =
-            await isFeatureFlagEnabled(
-                FeatureFlags.DashboardFilterOverridesChartFilters,
-                {
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                },
-            );
-
         const metricQuery: MetricQuery = appliedDashboardFilters
             ? addDashboardFiltersToMetricQuery(
                   savedChart.metricQuery,
                   appliedDashboardFilters,
-                  isDashboardFilterOverrideEnabled,
               )
             : savedChart.metricQuery;
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -31,9 +31,6 @@ export enum FeatureFlags {
     /* Shows the two-stage login flow */
     newLoginEnabled = 'new-login-enabled',
 
-    /* Dashboard filters will override chart filters */
-    DashboardFilterOverridesChartFilters = 'dashboard-filter-overrides-chart-filters',
-
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 

--- a/packages/common/src/utils/filters.mock.ts
+++ b/packages/common/src/utils/filters.mock.ts
@@ -133,49 +133,6 @@ export const dashboardFilters: DashboardFilters = {
     tableCalculations: [],
 };
 
-export const expectedChartWithMergedDashboardFilters: MetricQuery = {
-    exploreName: 'test',
-    dimensions: ['a_dim1'],
-    limit: 501,
-    metrics: [],
-    sorts: [],
-    tableCalculations: [],
-    filters: {
-        dimensions: {
-            and: [
-                {
-                    id: 'root',
-                    and: [
-                        {
-                            id: '1',
-                            target: {
-                                fieldId: 'a_dim1',
-                            },
-                            operator: FilterOperator.EQUALS,
-                            values: [0],
-                        },
-                    ],
-                },
-                {
-                    id: '4',
-                    target: { fieldId: 'a_dim1' },
-                    operator: ConditionalOperator.EQUALS,
-                    values: ['1', '2', '3'],
-                },
-            ],
-            id: 'uuid',
-        },
-        metrics: {
-            and: [],
-            id: 'uuid',
-        },
-        tableCalculations: {
-            and: [],
-            id: 'uuid',
-        },
-    },
-};
-
 export const expectedChartWithOverrideDashboardFilters: MetricQuery = {
     exploreName: 'test',
     dimensions: ['a_dim1'],

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -9,7 +9,6 @@ import {
     dashboardFilters,
     dashboardFilterWithSameTargetAndOperator,
     dashboardFilterWithSameTargetButDifferentOperator,
-    expectedChartWithMergedDashboardFilters,
     expectedChartWithOverrideDashboardFilters,
     expectedChartWithOverrideDashboardORFilters,
     metricQueryWithAndFilters,
@@ -21,19 +20,10 @@ jest.mock('uuid', () => ({
 }));
 
 describe('addDashboardFiltersToMetricQuery', () => {
-    test('should merge the chart filters with dashboard filters', async () => {
-        const result = addDashboardFiltersToMetricQuery(
-            metricQueryWithAndFilters,
-            dashboardFilters,
-            false,
-        );
-        expect(result).toEqual(expectedChartWithMergedDashboardFilters);
-    });
     test('should override the chart AND filter group with dashboard filters', async () => {
         const result = addDashboardFiltersToMetricQuery(
             metricQueryWithAndFilters,
             dashboardFilters,
-            true,
         );
         expect(result).toEqual(expectedChartWithOverrideDashboardFilters);
     });
@@ -41,7 +31,6 @@ describe('addDashboardFiltersToMetricQuery', () => {
         const result = addDashboardFiltersToMetricQuery(
             metricQueryWithOrFilters,
             dashboardFilters,
-            true,
         );
         expect(result).toEqual(expectedChartWithOverrideDashboardORFilters);
     });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -734,14 +734,6 @@ const overrideFilterGroupWithFilterRules = (
     };
 };
 
-const combineFilterGroupWithFilterRules = (
-    filterGroup: FilterGroup | undefined,
-    filterRules: FilterRule[],
-): FilterGroup => ({
-    id: uuidv4(),
-    and: [...(filterGroup ? [filterGroup] : []), ...filterRules],
-});
-
 const convertDashboardFilterRuleToFilterRule = (
     dashboardFilterRule: DashboardFilterRule,
 ): FilterRule => ({
@@ -762,32 +754,26 @@ const convertDashboardFilterRuleToFilterRule = (
 export const addDashboardFiltersToMetricQuery = (
     metricQuery: MetricQuery,
     dashboardFilters: DashboardFilters,
-    shouldOverride: boolean,
-): MetricQuery => {
-    const mergeStrategy = shouldOverride
-        ? overrideFilterGroupWithFilterRules
-        : combineFilterGroupWithFilterRules;
-    return {
-        ...metricQuery,
-        filters: {
-            dimensions: mergeStrategy(
-                metricQuery.filters?.dimensions,
-                dashboardFilters.dimensions.map(
-                    convertDashboardFilterRuleToFilterRule,
-                ),
+): MetricQuery => ({
+    ...metricQuery,
+    filters: {
+        dimensions: overrideFilterGroupWithFilterRules(
+            metricQuery.filters?.dimensions,
+            dashboardFilters.dimensions.map(
+                convertDashboardFilterRuleToFilterRule,
             ),
-            metrics: mergeStrategy(
-                metricQuery.filters?.metrics,
-                dashboardFilters.metrics.map(
-                    convertDashboardFilterRuleToFilterRule,
-                ),
+        ),
+        metrics: overrideFilterGroupWithFilterRules(
+            metricQuery.filters?.metrics,
+            dashboardFilters.metrics.map(
+                convertDashboardFilterRuleToFilterRule,
             ),
-            tableCalculations: mergeStrategy(
-                metricQuery.filters?.tableCalculations,
-                dashboardFilters.tableCalculations.map(
-                    convertDashboardFilterRuleToFilterRule,
-                ),
+        ),
+        tableCalculations: overrideFilterGroupWithFilterRules(
+            metricQuery.filters?.tableCalculations,
+            dashboardFilters.tableCalculations.map(
+                convertDashboardFilterRuleToFilterRule,
             ),
-        },
-    };
-};
+        ),
+    },
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-internal-work/issues/1680<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Applying breaking change that was announced it here:
https://changelog.lightdash.com/breaking-change-dashboard-filters-will-now-apply-to-all-matching-tiles-by-default-274972

This breaking change as been active in cloud but not for self hosted users. This PR is the final work to remove the old behaviour. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
