### PR TITLE
fix: disconnect browser instead of closing (feature flag)

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -27,6 +27,7 @@ export enum FeatureFlags {
     /**/
     PuppeteerScrollElementIntoView = 'puppeteer-scroll-element-into-view',
     PuppeteerSetViewportDynamically = 'puppeteer-set-viewport-dynamically',
+    PuppeteerDisconnectBrowser = 'puppeteer-disconnect-browser',
 
     /* Shows the two-stage login flow */
     newLoginEnabled = 'new-login-enabled',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9962

### Description:

See ticket description for more detail

Adds feature flag `puppeteer-disconnect-browser`
Closes `page` and disconnects from `browser` instead of closing the browser if that FF is enabled.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
