### PR TITLE
fix: replace escaped newlines in credentials values

### DIFF
--- a/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
@@ -167,7 +167,16 @@ export const getBigqueryCredentialsFromServiceAccountJson = async (
         bigqueryServiceAccountJsonSchema,
     );
     if (validate(target)) {
-        return target.keyfile_json as Record<string, string>;
+        return Object.entries(target.keyfile_json).reduce<
+            Record<string, string>
+        >((acc, [key, value]) => {
+            if (typeof value === 'string') {
+                acc[key] = value.replaceAll(/\\n/gm, '\n'); // replace escaped newlines. Prevents error: Error: error:1E08010C:DECODER routines::unsupported
+            } else {
+                acc[key] = value;
+            }
+            return acc;
+        }, {});
     }
     const lineErrorMessages = (validate.errors || [])
         .map((err) => `Field at ${err.instancePath} ${err.message}`)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Some users experiencing errors `Error: error:1E08010C:DECODER routines::unsupported` when using env vars in their dbt profile.
This thread explains why this may happen and how to fix it. 
https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
