### PR TITLE
fix: fix add saved chart to tabbed dashbord from explore view error out

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -302,10 +302,11 @@ export const SaveToSpaceOrDashboard: FC<SaveToSpaceOrDashboardProps> = ({
                     description: values.description,
                     dashboardUuid: values.dashboardUuid,
                 });
+                const firstTab = selectedDashboard.tabs?.[0];
                 const newTile: DashboardChartTile = {
                     uuid: uuid4(),
                     type: DashboardTileTypes.SAVED_CHART,
-                    tabUuid: undefined,
+                    tabUuid: firstTab?.uuid,
                     properties: {
                         belongsToDashboard: true,
                         savedChartUuid: savedQuery.uuid,
@@ -318,7 +319,7 @@ export const SaveToSpaceOrDashboard: FC<SaveToSpaceOrDashboardProps> = ({
                     tiles: appendNewTilesToBottom(selectedDashboard.tiles, [
                         newTile,
                     ]),
-                    tabs: [],
+                    tabs: selectedDashboard.tabs,
                 };
                 await updateDashboard(updateFields);
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
issue:
<img width="1334" alt="Screenshot 2024-05-02 at 23 18 22" src="https://github.com/lightdash/lightdash/assets/101873365/d2546e30-f719-4930-9811-1b9f92c16354">

steps to reproduce:
1. created a tabbed dashboard
2. go back to home page and click "Run Query"
3. create a chart 
4. click "save chart"
5. choose tabbed dashboard

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
