### PR TITLE
fix: use snowflake user and password if provided

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -143,11 +143,19 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 credentials.quotedIdentifiersIgnoreCase;
         }
 
+        let authenticator: ConnectionOptions['authenticator'] | undefined;
+
+        if (credentials.user && credentials.password) {
+            authenticator = 'SNOWFLAKE';
+        } else if (decodedPrivateKey) {
+            authenticator = 'SNOWFLAKE_JWT';
+        }
+
         this.connectionOptions = {
             account: credentials.account,
             username: credentials.user,
             password: credentials.password,
-            authenticator: decodedPrivateKey ? 'SNOWFLAKE_JWT' : undefined,
+            authenticator,
             privateKey: decodedPrivateKey,
             database: credentials.database,
             schema: credentials.schema,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -143,20 +143,24 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 credentials.quotedIdentifiersIgnoreCase;
         }
 
-        let authenticator: ConnectionOptions['authenticator'] | undefined;
+        let authenticationOptions: Partial<ConnectionOptions> = {};
 
-        if (credentials.user && credentials.password) {
-            authenticator = 'SNOWFLAKE';
+        if (credentials.password) {
+            authenticationOptions = {
+                password: credentials.password,
+                authenticator: 'SNOWFLAKE',
+            };
         } else if (decodedPrivateKey) {
-            authenticator = 'SNOWFLAKE_JWT';
+            authenticationOptions = {
+                privateKey: decodedPrivateKey,
+                authenticator: 'SNOWFLAKE_JWT',
+            };
         }
 
         this.connectionOptions = {
             account: credentials.account,
             username: credentials.user,
-            password: credentials.password,
-            authenticator,
-            privateKey: decodedPrivateKey,
+            ...authenticationOptions,
             database: credentials.database,
             schema: credentials.schema,
             warehouse: credentials.warehouse,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8480

### Description:

If user provides `password` then the `authenticator` method is `SNOWFLAKE` - the default
If the user provides a `decodedPrivateKey`, then it should use `SNOWFLAKE_JWT`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
