### PR TITLE
feat: pylon chat

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -71,6 +71,9 @@ export const lightdashConfigMock: LightdashConfig = {
         appId: '',
         apiBase: '',
     },
+    pylon: {
+        appId: '',
+    },
     lightdashSecret: '',
     logging: {
         level: 'debug',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -154,6 +154,7 @@ export type LightdashConfig = {
     sentry: SentryConfig;
     auth: AuthConfig;
     intercom: IntercomConfig;
+    pylon: PylonConfig;
     siteUrl: string;
     staticIp: string;
     database: {
@@ -229,6 +230,11 @@ export type S3Config = {
 export type IntercomConfig = {
     appId: string;
     apiBase: string;
+};
+
+type PylonConfig = {
+    appId: string;
+    identityVerificationSecret?: string;
 };
 
 export type RudderConfig = {
@@ -510,6 +516,11 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             appId: process.env.INTERCOM_APP_ID || 'zppxyjpp',
             apiBase:
                 process.env.INTERCOM_APP_BASE || 'https://api-iam.intercom.io',
+        },
+        pylon: {
+            appId: process.env.PYLON_APP_ID || '',
+            identityVerificationSecret:
+                process.env.PYLON_IDENTITY_VERIFICATION_SECRET,
         },
         siteUrl,
         staticIp: process.env.STATIC_IP || '',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -1,100 +1,80 @@
-import { LightdashMode, SessionUser } from '@lightdash/common';
-import { LightdashConfig } from '../../config/parseConfig';
+import { HealthState, LightdashMode, SessionUser } from '@lightdash/common';
 
-export const BaseResponse = {
+export const BaseResponse: HealthState = {
     healthy: true,
     version: '0.1.0',
     mode: LightdashMode.DEFAULT,
     isAuthenticated: false,
     requiresOrgRegistration: false,
     localDbtEnabled: true,
-    auth: {
-        disablePasswordAuthentication: false,
-        google: {
-            loginPath: '',
-            oauth2ClientId: '',
-        },
-        okta: {
-            enabled: false,
-            loginPath: '',
-        },
-        oneLogin: {
-            enabled: false,
-            loginPath: '',
-        },
-        azuread: {
-            enabled: false,
-            loginPath: '',
-        },
-        oidc: {
-            enabled: false,
-            loginPath: '',
-        },
-    },
-    defaultProject: undefined,
-    latest: { version: '0.2.7' },
-    hasEmailClient: false,
-    siteUrl: undefined,
-    intercom: undefined,
-    posthog: undefined,
-    rudder: undefined,
-    sentry: {
-        frontend: {
-            dsn: 'frontend-dsn.sentry.io',
-        },
-        environment: 'environment',
-        release: '1234',
-    },
-    hasSlack: false,
-    hasHeadlessBrowser: false,
-    query: undefined,
-    staticIp: undefined,
+    siteUrl: 'https://test.lightdash.cloud',
+    staticIp: '',
+    customVisualizationsEnabled: false,
     hasDbtSemanticLayer: false,
-    hasGroups: false,
+    hasEmailClient: false,
     hasExtendedUsageAnalytics: false,
     hasGithub: false,
-};
-
-export const Config = {
-    mode: LightdashMode.DEFAULT,
+    hasGroups: false,
+    hasHeadlessBrowser: false,
+    hasSlack: false,
     auth: {
         disablePasswordAuthentication: false,
         google: {
+            enabled: false,
             loginPath: '',
-            oauth2ClientId: '',
-            oauth2ClientSecret: '',
-            callbackPath: '',
+            oauth2ClientId: undefined,
+            googleDriveApiKey: undefined,
         },
         okta: {
+            enabled: false,
             loginPath: '',
         },
         oneLogin: {
+            enabled: false,
             loginPath: '',
         },
         azuread: {
+            enabled: false,
             loginPath: '',
         },
         oidc: {
+            enabled: false,
             loginPath: '',
         },
     },
-    groups: {
-        enabled: false,
+    intercom: {
+        apiBase: '',
+        appId: '',
     },
-    extendedUsageAnalytics: {
-        enabled: false,
+    latest: {
+        version: '0.2.7',
+    },
+    pivotTable: {
+        maxColumnLimit: 0,
+    },
+    posthog: {
+        apiHost: '',
+        projectApiKey: '',
+    },
+    pylon: {
+        appId: '',
+    },
+    query: {
+        csvCellsLimit: 100000,
+        maxLimit: 5000,
+    },
+    rudder: {
+        dataPlaneUrl: '',
+        writeKey: '',
     },
     sentry: {
-        backend: {
-            dsn: 'backend-dsn.sentry.io',
-        },
+        environment: '',
         frontend: {
-            dsn: 'frontend-dsn.sentry.io',
+            dsn: '',
         },
-        environment: 'environment',
-        release: '1234',
+        release: '',
     },
-} as LightdashConfig; // TODO: Refactor this to be a mock of the actual configuration, rather than a partial that might contain incorrect properties.
+};
 
 export const userMock = {
     userUuid: 'uuid',

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -1,9 +1,10 @@
 import { LightdashInstallType, LightdashMode } from '@lightdash/common';
 import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { MigrationModel } from '../../models/MigrationModel/MigrationModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { HealthService } from './HealthService';
-import { BaseResponse, Config, userMock } from './HealthService.mock';
+import { BaseResponse, userMock } from './HealthService.mock';
 
 jest.mock('../../version', () => ({
     VERSION: '0.1.0',
@@ -26,7 +27,7 @@ const migrationModel = {
 describe('health', () => {
     const healthService = new HealthService({
         organizationModel: organizationModel as unknown as OrganizationModel,
-        lightdashConfig: Config,
+        lightdashConfig: lightdashConfigMock,
         migrationModel: migrationModel as unknown as MigrationModel,
     });
 
@@ -67,7 +68,7 @@ describe('health', () => {
             organizationModel:
                 organizationModel as unknown as OrganizationModel,
             lightdashConfig: {
-                ...Config,
+                ...lightdashConfigMock,
                 mode: LightdashMode.CLOUD_BETA,
             },
             migrationModel: migrationModel as unknown as MigrationModel,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -6,6 +6,7 @@ import {
     SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
+import { createHmac } from 'crypto';
 import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
 import { LightdashConfig } from '../../config/parseConfig';
 import { MigrationModel } from '../../models/MigrationModel/MigrationModel';
@@ -74,6 +75,20 @@ export class HealthService extends BaseService {
                 release: this.lightdashConfig.sentry.release,
             },
             intercom: this.lightdashConfig.intercom,
+            pylon: {
+                appId: this.lightdashConfig.pylon.appId,
+                verificationHash:
+                    this.lightdashConfig.pylon.identityVerificationSecret &&
+                    user?.email
+                        ? createHmac(
+                              'sha256',
+                              this.lightdashConfig.pylon
+                                  .identityVerificationSecret,
+                          )
+                              .update(user?.email)
+                              .digest('hex')
+                        : undefined,
+            },
             siteUrl: this.lightdashConfig.siteUrl,
             staticIp: this.lightdashConfig.staticIp,
             posthog: this.lightdashConfig.posthog,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -731,6 +731,10 @@ export type HealthState = {
         appId: string;
         apiBase: string;
     };
+    pylon: {
+        appId: string;
+        verificationHash?: string;
+    };
     staticIp: string;
     query: {
         maxLimit: number;

--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -34,12 +34,16 @@ const HelpMenu: FC = () => {
             </Menu.Target>
 
             <Menu.Dropdown>
-                {(isCloudCustomer || true) && (
+                {isCloudCustomer && (
                     <LargeMenuItem
                         onClick={() => {
                             // @ts-ignore
-                            window.Pylon('show');
-                            showIntercom();
+                            if (window.Pylon) {
+                                // @ts-ignore
+                                window.Pylon('show');
+                            } else {
+                                showIntercom();
+                            }
                         }}
                         title="Contact support"
                         description="Drop us a message and we’ll get back to you asap!"

--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -34,9 +34,13 @@ const HelpMenu: FC = () => {
             </Menu.Target>
 
             <Menu.Dropdown>
-                {isCloudCustomer && (
+                {(isCloudCustomer || true) && (
                     <LargeMenuItem
-                        onClick={() => showIntercom()}
+                        onClick={() => {
+                            // @ts-ignore
+                            window.Pylon('show');
+                            showIntercom();
+                        }}
                         title="Contact support"
                         description="Drop us a message and we’ll get back to you asap!"
                         icon={IconMessages}

--- a/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
+++ b/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
@@ -7,32 +7,39 @@ import useSentry from '../hooks/thirdPartyServices/useSentry';
 import { useApp } from './AppProvider';
 
 const Pylon = () => {
-    const appId = ''; // todo: replace with health.data.pylon.appId
-    const { user } = useApp();
+    const { user, health } = useApp();
     useEffect(() => {
-        if (user.data) {
+        if (health.data?.pylon?.appId && user.data) {
             // @ts-ignore
             window.pylon = {
                 chat_settings: {
-                    app_id: appId,
+                    app_id: health.data.pylon.appId,
                     email: user.data.email,
                     name: `${user.data.firstName} ${user.data.lastName}`,
+                    email_hash: health.data.pylon.verificationHash,
                 },
             };
             // @ts-ignore
-            window.Pylon('setNewIssueCustomFields', {
-                user_uuid: user.data.userUuid,
-                org_uuid: user.data.organizationUuid,
-                org_name: user.data.organizationName,
-                user_role: user.data.role,
-            });
+            if (window.Pylon) {
+                // @ts-ignore
+                window.Pylon('setNewIssueCustomFields', {
+                    user_uuid: user.data.userUuid,
+                    org_uuid: user.data.organizationUuid,
+                    org_name: user.data.organizationName,
+                    user_role: user.data.role,
+                });
+            }
         }
-    }, [user]);
+    }, [user, health]);
+
+    if (!health.data?.pylon?.appId) {
+        return null;
+    }
 
     return (
         <Helmet>
             <script type="text/javascript">
-                {`(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${appId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`}
+                {`(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${health.data.pylon.appId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`}
             </script>
         </Helmet>
     );

--- a/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
+++ b/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
@@ -1,9 +1,42 @@
 import { PostHogProvider, usePostHog } from 'posthog-js/react';
-import { type FC } from 'react';
+import { useEffect, type FC } from 'react';
+import { Helmet } from 'react-helmet';
 import { IntercomProvider } from 'react-use-intercom';
 import { Intercom } from '../components/Intercom';
 import useSentry from '../hooks/thirdPartyServices/useSentry';
 import { useApp } from './AppProvider';
+
+const Pylon = () => {
+    const appId = ''; // todo: replace with health.data.pylon.appId
+    const { user } = useApp();
+    useEffect(() => {
+        if (user.data) {
+            // @ts-ignore
+            window.pylon = {
+                chat_settings: {
+                    app_id: appId,
+                    email: user.data.email,
+                    name: `${user.data.firstName} ${user.data.lastName}`,
+                },
+            };
+            // @ts-ignore
+            window.Pylon('setNewIssueCustomFields', {
+                user_uuid: user.data.userUuid,
+                org_uuid: user.data.organizationUuid,
+                org_name: user.data.organizationName,
+                user_role: user.data.role,
+            });
+        }
+    }, [user]);
+
+    return (
+        <Helmet>
+            <script type="text/javascript">
+                {`(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${appId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`}
+            </script>
+        </Helmet>
+    );
+};
 
 const PosthogIdentified: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const { user } = useApp();
@@ -58,6 +91,7 @@ const ThirdPartyServicesEnabledProvider: FC<React.PropsWithChildren<{}>> = ({
             >
                 <PosthogIdentified>
                     <Intercom />
+                    <Pylon />
                     {children}
                 </PosthogIdentified>
             </PostHogProvider>

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -28,6 +28,9 @@ export default function mockHealthResponse(
             appId: '',
             apiBase: '',
         },
+        pylon: {
+            appId: '',
+        },
         siteUrl: 'http://localhost:3000',
         staticIp: '',
         posthog: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-internal-work/issues/1651 <!-- reference the related issue e.g. #150 -->

### Description:

Changes:
- add new env vars
- pass app id and verification hash to frontend
- init pylon if needed
- show pylon chat instead of intercom if initialized

Note:
- We still show intercom chat if pylon chat is not available
- Keep intercom in login and verification pages as Pylon doesn't support chat when user is not authenticated.

How to test:

1. pull branch locally
2. update `HelpMenu.tsx` to have `{isCloudCustomer || true && (`
3. set env vars


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
