### PR TITLE
feat: allow common properties for text styling in markdown tile html tags

### DIFF
--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -32,62 +32,147 @@ describe('sanitizeHtml', () => {
         ).toEqual('<a href="https://www.lightdash.com/">Lightdash</a>');
     });
 
-    test('markdown tile rule set', () => {
-        expect(
-            sanitizeHtml(
-                '<iframe src="https://google.com" width=400 height="300"></iframe>',
-                HTML_SANITIZE_MARKDOWN_TILE_RULES,
-            ),
-        ).toEqual(
-            '<iframe src="https://google.com" width="400" height="300"></iframe>',
-        );
-
-        expect(
-            sanitizeHtml(
-                '<img src="https://google.com" width=400 height="300" />',
-                HTML_SANITIZE_MARKDOWN_TILE_RULES,
-            ),
-        ).toEqual('<img src="https://google.com" width="400" height="300" />');
-
-        expect(
-            sanitizeHtml(
-                '<style>body { content: "hello this is ur bank"; }</style>',
-                HTML_SANITIZE_MARKDOWN_TILE_RULES,
-            ),
-        ).toEqual('');
-    });
-
-    test('style tag in span is preserved', () => {
-        expect(
-            sanitizeHtml('<span style="color:red;font-size:24px">@Foo</span>'),
-        ).toEqual('<span style="color:red;font-size:24px">@Foo</span>');
-    });
-
     test('style tag in paragraph is discarded', () => {
         expect(
             sanitizeHtml('<p style="color:red;font-size:24px">@Foo</p>'),
         ).toEqual('<p>@Foo</p>');
     });
 
-    test('valid tag with surrounding + inner text', () => {
-        expect(
-            sanitizeHtml('Here is some text <p>And a paragraph.</p><br />'),
-        ).toEqual('Here is some text <p>And a paragraph.</p><br />');
-    });
-
-    test('double sanitization (with invalid tags)', () => {
-        expect(
-            sanitizeHtml(
+    describe('as part of markdown tiles', () => {
+        test('markdown tile rule set', () => {
+            expect(
                 sanitizeHtml(
-                    '<script>console.log("boo");</script><p><span style="color: red">@Foo</span></p>',
+                    '<iframe src="https://google.com" width=400 height="300"></iframe>',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
                 ),
-            ),
-        ).toEqual('<p><span style="color:red">@Foo</span></p>');
-    });
+            ).toEqual(
+                '<iframe src="https://google.com" width="400" height="300"></iframe>',
+            );
 
-    test('malformed tag', () => {
-        expect(sanitizeHtml('<span style="color:red">@Foo')).toEqual(
-            '<span style="color:red">@Foo</span>',
-        );
+            expect(
+                sanitizeHtml(
+                    '<img src="https://google.com" width=400 height="300" />',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual(
+                '<img src="https://google.com" width="400" height="300" />',
+            );
+
+            expect(
+                sanitizeHtml(
+                    '<style>body { content: "hello this is ur bank"; }</style>',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual('');
+        });
+
+        test('style tag in span is preserved', () => {
+            expect(
+                sanitizeHtml(
+                    '<span style="color:red;font-size:24px">@Foo</span>',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual('<span style="color:red;font-size:24px">@Foo</span>');
+        });
+
+        test('valid tag with surrounding + inner text', () => {
+            expect(
+                sanitizeHtml(
+                    'Here is some text <p>And a paragraph.</p><br />',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual('Here is some text <p>And a paragraph.</p><br />');
+        });
+
+        test('double sanitization (with invalid tags)', () => {
+            expect(
+                sanitizeHtml(
+                    sanitizeHtml(
+                        '<script>console.log("boo");</script><p><span style="color: red">@Foo</span></p>',
+                        HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                    ),
+                ),
+            ).toEqual('<p><span style="color:red">@Foo</span></p>');
+        });
+
+        test('malformed tag', () => {
+            expect(
+                sanitizeHtml(
+                    '<span style="color:red">@Foo',
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual('<span style="color:red">@Foo</span>');
+        });
+
+        test('valid style attribute in allowed tags', () => {
+            const allowedTags = [
+                '<span style="color:red">Text</span>',
+                '<a href="#" style="font-size:16px">Link</a>',
+                '<p style="font-weight:bold">Paragraph</p>',
+            ];
+
+            allowedTags.forEach((tag) => {
+                expect(
+                    sanitizeHtml(tag, HTML_SANITIZE_MARKDOWN_TILE_RULES),
+                ).toEqual(tag);
+            });
+        });
+
+        test('invalid style attributes in allowed tags', () => {
+            const invalidTags = [
+                [
+                    '<span style="background-image:url(\'https://example.com/image.jpg\');">Text</span>',
+                    '<span>Text</span>',
+                ],
+                [
+                    '<a href="#" style="border:1px solid black">Link</a>',
+                    '<a href="#">Link</a>',
+                ],
+                [
+                    '<p style="text-align:right;background: red;">Paragraph</p>',
+                    '<p style="text-align:right">Paragraph</p>',
+                ],
+            ];
+
+            invalidTags.forEach(([tag, expected]) => {
+                expect(
+                    sanitizeHtml(tag, HTML_SANITIZE_MARKDOWN_TILE_RULES),
+                ).toEqual(expected);
+            });
+        });
+
+        test('valid style attribute in allowed tags with multiple styles', () => {
+            const tag = '<span style="color:red;font-weight:bold">Text</span>';
+            expect(
+                sanitizeHtml(tag, HTML_SANITIZE_MARKDOWN_TILE_RULES),
+            ).toEqual(tag);
+        });
+
+        test('invalid style attributes in allowed tags with multiple styles', () => {
+            expect(
+                sanitizeHtml(
+                    `<span style="color:red;font-weight:bold;text-align:right;background: url('foo.jpg')">Text</span>`,
+                    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                ),
+            ).toEqual(
+                '<span style="color:red;font-weight:bold;text-align:right">Text</span>',
+            );
+        });
+
+        test('style attributes in disallowed tags', () => {
+            const disallowedTags = [
+                ['<div style="color:red;">Text</div>', '<div>Text</div>'],
+                [
+                    '<table style="border:1px solid black;"><tr><td>Cell</td></tr></table>',
+                    '<table><tr><td>Cell</td></tr></table>',
+                ],
+            ];
+
+            disallowedTags.forEach(([tag, expected]) => {
+                expect(
+                    sanitizeHtml(tag, HTML_SANITIZE_MARKDOWN_TILE_RULES),
+                ).toEqual(expected);
+            });
+        });
     });
 });

--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -132,6 +132,15 @@ describe('sanitizeHtml', () => {
                     '<p style="text-align:right;background: red;">Paragraph</p>',
                     '<p style="text-align:right">Paragraph</p>',
                 ],
+                [
+                    '<p style="color:rgba(1,1,1,0)">Paragraph</p>',
+                    '<p>Paragraph</p>',
+                ],
+                ['<p style="color:#0000">Paragraph</p>', '<p>Paragraph</p>'],
+                [
+                    '<p style="color:#00000000">Paragraph</p>',
+                    '<p>Paragraph</p>',
+                ],
             ];
 
             invalidTags.forEach(([tag, expected]) => {

--- a/packages/common/src/utils/sanitizeHtml.ts
+++ b/packages/common/src/utils/sanitizeHtml.ts
@@ -38,8 +38,12 @@ const allowedTextStylingProperties: NonNullable<
     'word-spacing': [/^\d+(?:px|em|rem|%)$/], // 1px, 0.2em, 10%
     'text-align': [/^(?:left|right|center|justify)$/], //  left, right, center, justify
     'text-decoration': [/^(?:none|underline|overline|line-through)$/], //  none, underline, overline, line-through
-    'text-shadow': [/.+/],
-    color: [/.+/],
+    color: [
+        /^[a-zA-Z]+$/, // Color names: red, blue, green, etc.
+        /^#[0-9a-fA-F]{3}$/, // Hex colors: #000 Note: we don't allow alpha hex colors (4 digits)
+        /^#[0-9a-fA-F]{6}$/, // Hex colors: #000000 Note: we don't allow alpha hex colors (8 digits)
+        /^rgb\(\d{1,3},\s*\d{1,3},\s*\d{1,3}\)$/, // RGB colors: rgb(0, 0, 0) Note: we don't allow rgba
+    ],
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9976

### Description:

Adds support for common text styling/formatting CSS properties, with basic value validations, as part of the `sanitize-html` configuration. This is applied only for sanitization with the markdown tile rule-set.

Updates the existing `sanitizeHtml` utility test suite to match!

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
