### PR TITLE
fix: override operator dashboard filter

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -88,7 +88,7 @@ describe('overrideChartFilter', () => {
         });
     });
 
-    test('should not override the chart group filter when operator is different', async () => {
+    test('should override the chart group filter when operator is different', async () => {
         const result = overrideChartFilter(
             chartAndFilterGroup,
             dashboardFilterWithSameTargetButDifferentOperator,
@@ -97,11 +97,11 @@ describe('overrideChartFilter', () => {
             id: 'fillter-group-1',
             and: [
                 {
-                    id: '1',
+                    id: '5',
                     target: { fieldId: 'field-1' },
-                    values: ['1'],
+                    values: ['1', '2', '3'],
                     disabled: false,
-                    operator: ConditionalOperator.EQUALS,
+                    operator: ConditionalOperator.NOT_EQUALS,
                 },
                 {
                     id: '2',

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -654,11 +654,7 @@ const findAndOverrideChartFilter = (
     filterRulesList: FilterRule[],
 ): FilterGroupItem => {
     const identicalDashboardFilter = isFilterRule(item)
-        ? filterRulesList.find(
-              (x) =>
-                  x.target.fieldId === item.target.fieldId &&
-                  x.operator === item.operator,
-          )
+        ? filterRulesList.find((x) => x.target.fieldId === item.target.fieldId)
         : undefined;
     return identicalDashboardFilter
         ? {
@@ -670,6 +666,7 @@ const findAndOverrideChartFilter = (
                         settings: identicalDashboardFilter.settings,
                     }
                   : {}),
+              operator: identicalDashboardFilter.operator,
           }
         : item;
 };

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -4,9 +4,7 @@ import {
     fieldId,
     isDimension,
     isField,
-    isTableCalculation,
     MetricType,
-    TableCalculationType,
     type CompiledDimension,
     type CustomDimension,
     type Dimension,
@@ -21,11 +19,8 @@ import {
     type AdditionalMetric,
 } from '../types/metricQuery';
 
-export const isNumericType = (
-    type: DimensionType | MetricType | TableCalculationType,
-) => {
+export const isNumericType = (type: DimensionType | MetricType) => {
     const numericTypes = [
-        TableCalculationType.NUMBER,
         DimensionType.NUMBER,
         MetricType.NUMBER,
         MetricType.PERCENTILE,
@@ -52,10 +47,8 @@ export const isNumericItem = (
         return false;
     }
     if (isCustomDimension(item)) return false;
-    if (isField(item) || isAdditionalMetric(item) || isTableCalculation(item)) {
-        return isNumericType(
-            item.type as DimensionType | MetricType | TableCalculationType,
-        );
+    if (isField(item) || isAdditionalMetric(item)) {
+        return isNumericType(item.type as DimensionType | MetricType);
     }
     return true;
 };

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -4,7 +4,9 @@ import {
     fieldId,
     isDimension,
     isField,
+    isTableCalculation,
     MetricType,
+    TableCalculationType,
     type CompiledDimension,
     type CustomDimension,
     type Dimension,
@@ -19,8 +21,11 @@ import {
     type AdditionalMetric,
 } from '../types/metricQuery';
 
-export const isNumericType = (type: DimensionType | MetricType) => {
+export const isNumericType = (
+    type: DimensionType | MetricType | TableCalculationType,
+) => {
     const numericTypes = [
+        TableCalculationType.NUMBER,
         DimensionType.NUMBER,
         MetricType.NUMBER,
         MetricType.PERCENTILE,
@@ -47,8 +52,10 @@ export const isNumericItem = (
         return false;
     }
     if (isCustomDimension(item)) return false;
-    if (isField(item) || isAdditionalMetric(item)) {
-        return isNumericType(item.type as DimensionType | MetricType);
+    if (isField(item) || isAdditionalMetric(item) || isTableCalculation(item)) {
+        return isNumericType(
+            item.type as DimensionType | MetricType | TableCalculationType,
+        );
     }
     return true;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #9965

### Description:
<!-- Add a description of the changes proposed in the pull request. -->


Have a chart with a date ìs` filter

![image](https://github.com/lightdash/lightdash/assets/1983672/a5711204-fca4-4235-9910-f6ec2bfbc747)

IF I try to override on the dashboard: 


Before: (it creates 2 filters) 

![Screenshot from 2024-05-06 16-58-37](https://github.com/lightdash/lightdash/assets/1983672/059f5698-932b-455b-966d-3695f021c81d)

![Screenshot from 2024-05-06 16-58-27](https://github.com/lightdash/lightdash/assets/1983672/b0789b79-a292-4ac0-ae9e-58429bb3eb4d)

After:

![Screenshot from 2024-05-06 17-09-27](https://github.com/lightdash/lightdash/assets/1983672/792270a9-b68c-4d65-ab7a-5cc4997ee614)

![Screenshot from 2024-05-06 17-09-36](https://github.com/lightdash/lightdash/assets/1983672/949b5e55-adee-4dbc-9227-0994dafb778d)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
