### PR TITLE
fix: init sentry before express handlers

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -225,7 +225,10 @@ export default class App {
             App.initNodeProcessMonitor();
         }
 
-        await this.initExpress();
+        const expressApp = express();
+        // NOTE: Sentry must be initialized before any other handlers or middleware so that it can capture requests accordingly
+        await this.initSentry(expressApp);
+        await this.initExpress(expressApp);
 
         this.initSlack().catch((e) => {
             Logger.error('Error starting slack bot', e);
@@ -235,11 +238,7 @@ export default class App {
         }
     }
 
-    private async initExpress() {
-        const expressApp = express();
-
-        this.initSentry(expressApp);
-
+    private async initExpress(expressApp: Express) {
         const KnexSessionStore = connectSessionKnex(expressSession);
 
         const store = new KnexSessionStore({

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -225,8 +225,8 @@ export default class App {
             App.initNodeProcessMonitor();
         }
 
-        const expressApp = await this.initExpress();
-        this.initSentry(expressApp);
+        await this.initExpress();
+
         this.initSlack().catch((e) => {
             Logger.error('Error starting slack bot', e);
         });
@@ -237,6 +237,8 @@ export default class App {
 
     private async initExpress() {
         const expressApp = express();
+
+        this.initSentry(expressApp);
 
         const KnexSessionStore = connectSessionKnex(expressSession);
 

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -226,7 +226,7 @@ export default class App {
         }
 
         const expressApp = express();
-        // NOTE: Sentry must be initialized before any other handlers or middleware so that it can capture requests accordingly
+        // NOTE: Sentry must be initialized before any other handlers or middleware so that it can capture requests
         await this.initSentry(expressApp);
         await this.initExpress(expressApp);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Initialise Sentry before any other express handlers/middleware

```
The Sentry request handler middleware must be added before any other handlers
app.use(Sentry.Handlers.requestHandler());
```
From the guide here: https://docs.sentry.io/platforms/javascript/guides/express/


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
