### PR TITLE
fix: fix missing scheduled job error

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -632,6 +632,8 @@ export class SchedulerModel {
             .orderBy('scheduled_time', 'desc')
             .returning('*');
 
+        if (jobs.length === 0) throw new NotFoundError('Job not found');
+
         const job = jobs.sort(
             (a, b) =>
                 statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status),

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -140,6 +140,14 @@ export class SchedulerClient {
                 maxAttempts: 1,
             },
         );
+        await this.schedulerModel.logSchedulerJob({
+            task: 'handleScheduledDelivery',
+            schedulerUuid,
+            jobGroup: id,
+            jobId: id,
+            scheduledTime: date,
+            status: SchedulerJobStatus.SCHEDULED,
+        });
         this.analytics.track({
             event: 'scheduler_job.created',
             anonymousId: LightdashAnalytics.anonymousId,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/9994

### What the issue was

We were creating the job, but didn't add the `scheduled` job status , so if the scheduler was busy, we were trying to fetch a missing job log from the job id

This PR ensures we create the `scheduled` job log on `send now`

### Description:

Before:
![image](https://github.com/lightdash/lightdash/assets/1983672/d6a6d5f6-3c48-484f-a73b-b7b4ba769f7f)


After:

![Screenshot from 2024-05-07 15-24-15](https://github.com/lightdash/lightdash/assets/1983672/058bfef4-1078-4713-822c-6e0869af6ffe)


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
