### PR TITLE
fix: apply formatting to table calculations in axes

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -167,7 +167,7 @@ export interface TableCalculationField extends Field {
 // This type check is a little fragile because it's based on
 // 'displayName'. Ideally these would all have fieldTypes.
 export const isTableCalculation = (
-    item?: Item | AdditionalMetric | TableCalculationField,
+    item: Item | AdditionalMetric | TableCalculationField,
 ): item is TableCalculation =>
     item
         ? !('binType' in item) &&

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -167,7 +167,7 @@ export interface TableCalculationField extends Field {
 // This type check is a little fragile because it's based on
 // 'displayName'. Ideally these would all have fieldTypes.
 export const isTableCalculation = (
-    item: Item | AdditionalMetric | TableCalculationField,
+    item?: Item | AdditionalMetric | TableCalculationField,
 ): item is TableCalculation =>
     item
         ? !('binType' in item) &&

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1801,7 +1801,6 @@ const useEchartsCartesianConfig = (
     ) {
         return undefined;
     }
-    // console.log('eChartsOptions', eChartsOptions);
 
     return eChartsOptions;
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -907,7 +907,7 @@ const getEchartAxes = ({
         const hasFormattingConfig =
             (isField(axisItem) &&
                 (axisItem.format || axisItem.round || axisItem.compact)) ||
-            (isTableCalculation(axisItem) && axisItem.format);
+            (axisItem && isTableCalculation(axisItem) && axisItem.format);
         const axisMinInterval =
             isDimension(axisItem) &&
             axisItem.timeInterval &&

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -904,8 +904,9 @@ const getEchartAxes = ({
         defaultNameGap?: number;
     }) => {
         const hasFormattingConfig =
-            isField(axisItem) &&
-            (axisItem.format || axisItem.round || axisItem.compact);
+            (isField(axisItem) &&
+                (axisItem.format || axisItem.round || axisItem.compact)) ||
+            (isTableCalculation(axisItem) && axisItem.format);
         const axisMinInterval =
             isDimension(axisItem) &&
             axisItem.timeInterval &&
@@ -1800,6 +1801,8 @@ const useEchartsCartesianConfig = (
     ) {
         return undefined;
     }
+    // console.log('eChartsOptions', eChartsOptions);
+
     return eChartsOptions;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9967 

### Description:

Apply formatters to table calculations. We were skipping formatting because they aren't considered fields. I think these days they are more like fields and we *could* clean up some of these checks. But I think this is the right fix for this bug. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
