### PR TITLE
fix: extra week added in week chart axis

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -824,11 +824,12 @@ const getWeekAxisConfig = (
         axisField.timeInterval === TimeFrames.WEEK
     ) {
         const [minX, maxX] = getMinAndMaxValues([axisId], rows || []);
-        const continuousWeekRange = [dayjs.utc(minX).format()];
+
+        const continuousWeekRange = [];
         let nextDate = dayjs.utc(minX);
         while (nextDate.isBefore(dayjs(maxX))) {
-            nextDate = nextDate.add(1, 'week');
             continuousWeekRange.push(nextDate.format());
+            nextDate = nextDate.add(1, 'week');
         }
         continuousWeekRange.push(dayjs.utc(maxX).format());
         return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10003 

### Description:

Fixes adding an extra week at the end when filling gaps in the week axis. 

Oops. 

Repro:
- Make a chart with weeks on the x-axis. There will be a repeated week at the end. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
