### PR TITLE
fix: zIndex issues on dashboard while loading

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -119,14 +119,17 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     : `1px solid ${theme.colors.gray[1]}`,
             })}
         >
-            <LoadingOverlay visible={isLoading ?? false} />
+            <LoadingOverlay
+                visible={isLoading ?? false}
+                zIndex={getDefaultZIndex('modal') - 10}
+            />
 
             <HeaderContainer
                 $isEditMode={isEditMode}
                 $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
                 style={{
                     backgroundColor: 'white',
-                    zIndex: isLoading ? getDefaultZIndex('overlay') + 1 : 3,
+                    zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
                     borderRadius: '5px',
                 }}
             >

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -22,6 +22,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
     return (
         <Menu
             withArrow
+            withinPortal
             shadow="lg"
             position="bottom-start"
             arrowOffset={16}

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -46,6 +46,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     position="bottom-start"
                     arrowOffset={16}
                     offset={-2}
+                    withinPortal
                 >
                     <Menu.Target>
                         <Button


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9974 

### Description:

There were some z-Index issues on dashboard while charts were loading. Here is a before and after

**Before**
![before](https://github.com/lightdash/lightdash/assets/1864179/9c566b73-3380-46f2-afdb-0190c86f495a)

**After***

![after](https://github.com/lightdash/lightdash/assets/1864179/16891b2c-b16e-40cc-8728-dfa5f505d6c9)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
