### PR TITLE
fix: don't destructure root filter groups as they can be 'any' now

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -552,6 +552,39 @@ export const getFiltersFromGroup = (
     }, {} as Filters);
 };
 
+export const deleteFilterRuleFromGroup = (
+    filterGroup: FilterGroup,
+    id: string,
+) => {
+    const items = getItemsFromFilterGroup(filterGroup);
+
+    // If the filter group contains the rule we want to delete, we remove it
+    if (items.some((rule) => rule.id === id)) {
+        return {
+            id: filterGroup.id,
+            [getFilterGroupItemsPropertyName(filterGroup)]: items.filter(
+                (rule) => rule.id !== id,
+            ),
+        } as FilterGroup;
+    }
+
+    const groupGroups = items.filter(isFilterGroup);
+    const groupItems = items.filter(isFilterRule);
+
+    // If the filter group contains nested groups, we recursively call this function on each nested group
+    const newGroups: FilterGroup[] = groupGroups.map((group) =>
+        deleteFilterRuleFromGroup(group, id),
+    );
+
+    return {
+        id: filterGroup.id,
+        [getFilterGroupItemsPropertyName(filterGroup)]: [
+            ...groupItems,
+            ...newGroups,
+        ],
+    } as FilterGroup;
+};
+
 export const getDashboardFilterRulesForTile = (
     tileUuid: string,
     rules: DashboardFilterRule[],

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -376,47 +376,21 @@ export const addFilterRule = ({
     };
 };
 
-export const getFilterRulesByFieldType = (
+export const getInvalidFilterRules = (
     fields: Field[],
     filterRules: FilterRule[],
 ) =>
-    filterRules.reduce<
-        Record<
-            'valid' | 'invalid',
-            Record<'dimensions' | 'metrics' | 'tableCalculations', FilterRule[]>
-        >
-    >(
-        (accumulator, filterRule) => {
-            const fieldInRule = fields.find(
-                (field) => fieldId(field) === filterRule.target.fieldId,
-            );
+    filterRules.reduce<FilterRule[]>((accumulator, filterRule) => {
+        const fieldInRule = fields.find(
+            (field) => fieldId(field) === filterRule.target.fieldId,
+        );
 
-            const updateAccumulator = (
-                key: 'valid' | 'invalid',
-                rule: FilterRule,
-            ) => {
-                if (isDimension(fieldInRule)) {
-                    accumulator[key].dimensions.push(rule);
-                } else if (isTableCalculationField(fieldInRule)) {
-                    accumulator[key].tableCalculations.push(rule);
-                } else {
-                    accumulator[key].metrics.push(rule);
-                }
-            };
+        if (!fieldInRule) {
+            return [...accumulator, filterRule];
+        }
 
-            if (fieldInRule) {
-                updateAccumulator('valid', filterRule);
-            } else {
-                updateAccumulator('invalid', filterRule);
-            }
-
-            return accumulator;
-        },
-        {
-            valid: { dimensions: [], metrics: [], tableCalculations: [] },
-            invalid: { dimensions: [], metrics: [], tableCalculations: [] },
-        },
-    );
+        return accumulator;
+    }, []);
 
 /**
  * Takes a filter group and flattens it by merging nested groups into the parent group if they are the same filter group type

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -1,8 +1,8 @@
 import {
     addFilterRule,
     deleteFilterRuleFromGroup,
-    getFilterRulesByFieldType,
     getFiltersFromGroup,
+    getInvalidFilterRules,
     getTotalFilterRules,
     hasNestedGroups,
     isAndFilterGroup,
@@ -49,14 +49,8 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
     }, [fieldsMap]);
 
     const totalFilterRules = getTotalFilterRules(filters);
-    const { invalid: invalidFilterRulesPerType } = getFilterRulesByFieldType(
-        fields,
-        totalFilterRules,
-    );
-
-    const hasInvalidFilterRules = Object.values(invalidFilterRulesPerType).some(
-        (arr) => arr.length > 0,
-    );
+    const invalidFilterRules = getInvalidFilterRules(fields, totalFilterRules);
+    const hasInvalidFilterRules = invalidFilterRules.length > 0;
 
     const showSimplifiedForm: boolean =
         totalFilterRules.length < 2 && !hasNestedGroups(filters);
@@ -191,49 +185,44 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                 ))}
 
             {hasInvalidFilterRules &&
-                Object.entries(invalidFilterRulesPerType).map(
-                    ([type, rules], index) => (
-                        <Stack
-                            key={type + index}
-                            ml={showSimplifiedForm ? 'none' : 'xl'}
-                            spacing="two"
-                            align="flex-start"
+                invalidFilterRules.map((rule, index) => (
+                    <Stack
+                        key={index}
+                        ml={showSimplifiedForm ? 'none' : 'xl'}
+                        spacing="two"
+                        align="flex-start"
+                    >
+                        <Group
+                            key={rule.id}
+                            spacing="xs"
+                            pl="xs"
+                            sx={(theme) => ({
+                                border: `1px solid ${theme.colors.gray[2]}`,
+                                borderRadius: theme.radius.sm,
+                            })}
                         >
-                            {rules.map((rule) => (
-                                <Group
-                                    key={rule.id}
-                                    spacing="xs"
-                                    pl="xs"
-                                    sx={(theme) => ({
-                                        border: `1px solid ${theme.colors.gray[2]}`,
-                                        borderRadius: theme.radius.sm,
-                                    })}
-                                >
-                                    <MantineIcon icon={IconAlertCircle} />
-                                    <Text color="dimmed" fz="xs">
-                                        Tried to reference field with unknown
-                                        id:{' '}
-                                        <Text span fw={500} c="gray.7">
-                                            {rule.target.fieldId}
-                                        </Text>
-                                    </Text>
-                                    <ActionIcon
-                                        onClick={() =>
-                                            updateFiltersFromGroup(
-                                                deleteFilterRuleFromGroup(
-                                                    rootFilterGroup,
-                                                    rule.id,
-                                                ),
-                                            )
-                                        }
-                                    >
-                                        <MantineIcon icon={IconX} size="sm" />
-                                    </ActionIcon>
-                                </Group>
-                            ))}
-                        </Stack>
-                    ),
-                )}
+                            <MantineIcon icon={IconAlertCircle} />
+                            <Text color="dimmed" fz="xs">
+                                Tried to reference field with unknown id:{' '}
+                                <Text span fw={500} c="gray.7">
+                                    {rule.target.fieldId}
+                                </Text>
+                            </Text>
+                            <ActionIcon
+                                onClick={() =>
+                                    updateFiltersFromGroup(
+                                        deleteFilterRuleFromGroup(
+                                            rootFilterGroup,
+                                            rule.id,
+                                        ),
+                                    )
+                                }
+                            >
+                                <MantineIcon icon={IconX} size="sm" />
+                            </ActionIcon>
+                        </Group>
+                    </Stack>
+                ))}
 
             {isEditMode ? (
                 <Box bg="white" pos="relative" style={{ zIndex: 2 }}>

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -81,12 +81,10 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
 
             setFilters(
                 {
-                    ...filters,
                     dimensions:
                         result.dimensions.length > 0
                             ? {
                                   id: uuidv4(),
-                                  ...filters.dimensions,
                                   and: result.dimensions,
                               }
                             : undefined,
@@ -94,7 +92,6 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                         result.metrics.length > 0
                             ? {
                                   id: uuidv4(),
-                                  ...filters.metrics,
                                   and: result.metrics,
                               }
                             : undefined,
@@ -102,7 +99,6 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                         result.tableCalculations.length > 0
                             ? {
                                   id: uuidv4(),
-                                  ...filters.tableCalculations,
                                   and: result.tableCalculations,
                               }
                             : undefined,
@@ -110,7 +106,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                 false,
             );
         },
-        [fields, filters, setFilters],
+        [fields, setFilters],
     );
 
     const updateFiltersFromGroup = useCallback(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10008

### Description:

The simplified filters form update function was always de-structuring the root filter groups into the new filters.
Since root filters can now be OR type, it would mean that we could end up with a root filter group having both `and` and `or`. The fix was to remove the de-structuring and just add the rules for the simplified form in a AND group - note: the simplified form only shows when theres only 1 filter rule or there's no subgroups, so it can always be AND in that case.

Before:

https://github.com/lightdash/lightdash/assets/22939015/412dcdf4-e8fc-46b7-8f0e-311c337761b5

After:

https://github.com/lightdash/lightdash/assets/22939015/0b2436bd-bf34-4ca6-a6a7-327162c1f533




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
