### PR TITLE
fix: fix undefiled type table calculation on bignumber

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -268,8 +268,12 @@ const useBigNumberConfig = (
     }, [item, firstRowValueRaw, selectedField, bigNumberStyle, resultsData]);
 
     const unformattedValue = useMemo(() => {
-        return isNumber(item, secondRowValueRaw) &&
-            isNumber(item, firstRowValueRaw)
+        // For backwards compatibility with old table calculations without type
+        const isCalculationTypeUndefined =
+            item && isTableCalculation(item) && item.type === undefined;
+        return (isNumber(item, secondRowValueRaw) &&
+            isNumber(item, firstRowValueRaw)) ||
+            isCalculationTypeUndefined
             ? calculateComparisonValue(
                   Number(firstRowValueRaw),
                   Number(secondRowValueRaw),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10018


### What was the issue: 

new table calculations now have types, but existing table calculations has type as undefined. For undefined table calculations, we assume they are strings (for backwards compatibility) but this assumption is not correct on bignumber.

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2024-05-10 09-08-10](https://github.com/lightdash/lightdash/assets/1983672/ac349682-2fed-465c-9c3c-5355614d6036)

Before:

![Screenshot from 2024-05-10 09-02-22](https://github.com/lightdash/lightdash/assets/1983672/cf510c91-1ac6-4541-a4e6-8cfeab5152ce)

![Screenshot from 2024-05-10 08-55-23](https://github.com/lightdash/lightdash/assets/1983672/7858588c-f598-4e02-bb00-795e513dc32b)

After:

![Screenshot from 2024-05-10 08-58-51](https://github.com/lightdash/lightdash/assets/1983672/53f406ab-9a38-42e3-b22b-310129d0dbdb)

![Screenshot from 2024-05-10 09-02-31](https://github.com/lightdash/lightdash/assets/1983672/fa441c46-26d2-4b78-88ca-903b59ef93f6)

For strings: 

![Screenshot from 2024-05-10 09-03-43](https://github.com/lightdash/lightdash/assets/1983672/db0d78c4-0281-4e02-84a5-77b745896b2a)

(new check type) For table calculation with `string` type:

![Screenshot from 2024-05-10 09-05-20](https://github.com/lightdash/lightdash/assets/1983672/22e5b5cb-9e02-4ec4-9012-4a28d9cd2181)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
