### PR TITLE
fix: apply dashboard filters to underlying data query

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -221,7 +221,7 @@ const UnderlyingDataModalContent: FC<Props> = () => {
                 id: uuidv4(),
                 and: combinedFilters,
             },
-            fieldsInQuery,
+            allFields,
         );
 
         const showUnderlyingTable: string | undefined = isField(item)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10006 

### Description:

Apply dashboard filters to view underlying query. 

We were leaving out filters on fields that weren't part of the chart display. 

To test:
- Apply a new filter to a dashboard
- View underlying data on a chart in the dashboard that is affected by the filter
- Make sure the new filter is reflected in the underlying data query

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
