### PR TITLE
fix: week axes not respecting timezone correctly

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -974,7 +974,7 @@ const getEchartAxes = ({
                 case TimeFrames.WEEK:
                     axisConfig.axisLabel = {
                         formatter: (value: any) => {
-                            return formatItemValue(axisItem, value, false);
+                            return formatItemValue(axisItem, value, true);
                         },
                     };
                     axisConfig.axisPointer = {
@@ -983,7 +983,7 @@ const getEchartAxes = ({
                                 return formatItemValue(
                                     axisItem,
                                     value.value,
-                                    false,
+                                    true,
                                 );
                             },
                         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10030

### Description:

In some timezones (US) the week axis wasn't showing the right dates. We were keeping timezone information, then converting to local time. This just forces the times to be treated as utc. 

Jose actually suggested this in code review, but I didn't make the change because I was misunderstanding a bit of a subtlety with dayjs. Since the values all have a timezone included, converting them with dayjs(value).utc() is the same as dayjs.utc(value), which is how you would tell dayjs to treat a value as already utc. What we have now is a bit semantically confusing (we are not really converting them), but it does the right thing. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
