### PR TITLE
fix: custom sql dimension alias

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -1,5 +1,6 @@
 import {
     BinType,
+    CompiledCustomSqlDimension,
     CompiledDimension,
     CompiledMetricQuery,
     CompiledTable,
@@ -1390,3 +1391,14 @@ export const WEEK_NAME_SORT_SQL = `(
         ELSE 0
     END
 )`;
+
+export const CUSTOM_SQL_DIMENSION: CompiledCustomSqlDimension = {
+    id: 'is_adult',
+    name: 'Is adult',
+    table: 'table1',
+    type: CustomDimensionType.SQL,
+    sql: '${table1.dim1} < 18',
+    dimensionType: DimensionType.BOOLEAN,
+    compiledSql: '"table1".dim1 < 18',
+    tablesReferences: ['table1'],
+};

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -9,6 +9,7 @@ import {
     assertValidDimensionRequiredAttribute,
     buildQuery,
     getCustomBinDimensionSql,
+    getCustomSqlDimensionSql,
     replaceUserAttributes,
     sortDayOfWeekName,
     sortMonthName,
@@ -18,6 +19,7 @@ import {
     COMPILED_DIMENSION,
     COMPILED_MONTH_NAME_DIMENSION,
     COMPILED_WEEK_NAME_DIMENSION,
+    CUSTOM_SQL_DIMENSION,
     EXPLORE,
     EXPLORE_ALL_JOIN_TYPES_CHAIN,
     EXPLORE_BIGQUERY,
@@ -530,6 +532,18 @@ describe('with custom dimensions', () => {
                 sorts: [],
             }),
         ).toStrictEqual(undefined);
+    });
+
+    it('getCustomSqlDimensionSql with custom sql dimension', () => {
+        expect(
+            getCustomSqlDimensionSql({
+                warehouseClient: bigqueryClientMock,
+                customDimensions: [CUSTOM_SQL_DIMENSION],
+            }),
+        ).toStrictEqual({
+            selects: ['  ("table1".dim1 < 18) AS `is_adult`'],
+            tables: ['table1'],
+        });
     });
 
     it('getCustomDimensionSql with custom dimension', () => {

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -277,17 +277,19 @@ export const sortDayOfWeekName = (
 };
 
 export const getCustomSqlDimensionSql = ({
+    warehouseClient,
     customDimensions,
 }: {
+    warehouseClient: WarehouseClient;
     customDimensions: CompiledCustomSqlDimension[] | undefined;
 }): { selects: string[]; tables: string[] } | undefined => {
     if (customDimensions === undefined || customDimensions.length === 0) {
         return undefined;
     }
-
+    const fieldQuoteChar = getFieldQuoteChar(warehouseClient.credentials.type);
     const selects = customDimensions.map<string>(
         (customDimension) =>
-            `  (${customDimension.compiledSql}) AS ${customDimension.id}`,
+            `  (${customDimension.compiledSql}) AS ${fieldQuoteChar}${customDimension.id}${fieldQuoteChar}`,
     );
 
     return {
@@ -682,6 +684,7 @@ export const buildQuery = ({
         sorts,
     });
     const customSqlDimensionSql = getCustomSqlDimensionSql({
+        warehouseClient,
         customDimensions: compiledCustomDimensions?.filter(
             isCompiledCustomSqlDimension,
         ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add quotes to the custom dimension alias so the warehouses (usually snowflake) don't return column as uppercase in the results. 

Before:

```
(month("users".user_created_at)) AS month,
```

After

```
(month("users".user_created_at)) AS "month",
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
