### PR TITLE
fix: dashboard chart from explore from here deleted all current dashboard tiles

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -223,7 +223,12 @@ const Dashboard: FC = () => {
         try {
             const unsavedDashboardTiles = JSON.parse(unsavedDashboardTilesRaw);
             // If there are unsaved tiles, add them to the dashboard
-            setDashboardTiles(unsavedDashboardTiles);
+            setDashboardTiles((currentDashboardTiles) =>
+                appendNewTilesToBottom(
+                    currentDashboardTiles,
+                    unsavedDashboardTiles,
+                ),
+            );
 
             setHaveTilesChanged(!!unsavedDashboardTiles);
         } catch {


### PR DESCRIPTION
Closes: #10039

### Description:

- Saving a dashboard chart from "Explore from here" was overwriting the current tiles in the dashboard

**Before**

https://github.com/lightdash/lightdash/assets/22939015/60779288-2a8c-45e6-aa35-f719ae65cdb5

**After**

https://github.com/lightdash/lightdash/assets/22939015/0efb879f-149c-455f-b1b3-7b274956bfc4

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
