### PR TITLE
feat: add "include errors" arg to all explores summaries

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -193,6 +193,10 @@ export const expectedExploreSummaryFilteredByName = [
     expectedAllExploreSummary[0],
 ];
 
+export const expectedAllExploreSummaryWithoutErrors = [
+    expectedAllExploreSummary[0],
+];
+
 export const tablesConfiguration: TablesConfiguration = {
     tableSelection: {
         type: TableSelectionType.ALL,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -27,6 +27,7 @@ import {
     allExplores,
     defaultProject,
     expectedAllExploreSummary,
+    expectedAllExploreSummaryWithoutErrors,
     expectedApiQueryResultsWith1Row,
     expectedApiQueryResultsWith501Rows,
     expectedCatalog,
@@ -219,6 +220,15 @@ describe('ProjectService', () => {
                 true,
             );
             expect(result).toEqual(expectedExploreSummaryFilteredByName);
+        });
+        test('should get all explores summary that do not have errors', async () => {
+            const result = await service.getAllExploresSummary(
+                user,
+                projectUuid,
+                false,
+                false,
+            );
+            expect(result).toEqual(expectedAllExploreSummaryWithoutErrors);
         });
     });
     describe('getJobStatus', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2659,6 +2659,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         filtered: boolean,
+        includeErrors: boolean = true,
     ): Promise<SummaryExplore[]> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -2687,26 +2688,30 @@ export class ProjectService extends BaseService {
         const allExploreSummaries = explores.reduce<SummaryExplore[]>(
             (acc, explore) => {
                 if (isExploreError(explore)) {
-                    return [
-                        ...acc,
-                        {
-                            name: explore.name,
-                            label: explore.label,
-                            tags: explore.tags,
-                            groupLabel: explore.groupLabel,
-                            errors: explore.errors,
-                            databaseName:
-                                explore.baseTable &&
-                                explore.tables?.[explore.baseTable]?.database,
-                            schemaName:
-                                explore.baseTable &&
-                                explore.tables?.[explore.baseTable]?.schema,
-                            description:
-                                explore.baseTable &&
-                                explore.tables?.[explore.baseTable]
-                                    ?.description,
-                        },
-                    ];
+                    return includeErrors
+                        ? [
+                              ...acc,
+                              {
+                                  name: explore.name,
+                                  label: explore.label,
+                                  tags: explore.tags,
+                                  groupLabel: explore.groupLabel,
+                                  errors: explore.errors,
+                                  databaseName:
+                                      explore.baseTable &&
+                                      explore.tables?.[explore.baseTable]
+                                          ?.database,
+                                  schemaName:
+                                      explore.baseTable &&
+                                      explore.tables?.[explore.baseTable]
+                                          ?.schema,
+                                  description:
+                                      explore.baseTable &&
+                                      explore.tables?.[explore.baseTable]
+                                          ?.description,
+                              },
+                          ]
+                        : acc;
                 }
                 if (
                     doesExploreMatchRequiredAttributes(explore, userAttributes)


### PR DESCRIPTION
Closes: 

### Description:

adds "include errors" arg and specs to `getAllExploresSummary` 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
