### PR TITLE
fix: Revert "fix: dashboard chart from explore from here deleted all current dashboard tiles"

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -223,12 +223,7 @@ const Dashboard: FC = () => {
         try {
             const unsavedDashboardTiles = JSON.parse(unsavedDashboardTilesRaw);
             // If there are unsaved tiles, add them to the dashboard
-            setDashboardTiles((currentDashboardTiles) =>
-                appendNewTilesToBottom(
-                    currentDashboardTiles,
-                    unsavedDashboardTiles,
-                ),
-            );
+            setDashboardTiles(unsavedDashboardTiles);
 
             setHaveTilesChanged(!!unsavedDashboardTiles);
         } catch {


### PR DESCRIPTION
Reverts lightdash/lightdash#10058

Kicking off this revert so it's ready to roll out if we dont have a better answer.