### PR TITLE
fix: clear dashboard storage before explore from here

### DIFF
--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mantine/core';
 import { IconTelescope } from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
+import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import { useApp } from '../../providers/AppProvider';
@@ -25,6 +26,7 @@ const ExploreFromHereButton = () => {
     const { user } = useApp();
     const history = useHistory();
     const { mutateAsync: createShareUrl } = useCreateShareMutation();
+    const { clearDashboardStorage } = useDashboardStorage();
 
     const handleCreateShareUrl = useCallback(async () => {
         if (!exploreFromHereUrl) return;
@@ -34,8 +36,11 @@ const ExploreFromHereButton = () => {
             params: `?` + exploreFromHereUrl.search,
         });
 
+        // Clear dashboard storage to prevent banner from showing when `exploring from here` on a chart from a dashboard
+        clearDashboardStorage();
+
         history.push(`/share/${shareUrl.nanoid}`);
-    }, [createShareUrl, exploreFromHereUrl, history]);
+    }, [clearDashboardStorage, createShareUrl, exploreFromHereUrl, history]);
 
     const cannotManageExplore = user.data?.ability.cannot(
         'manage',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10039

### Description:

Steps:
- Click on chart from dashboard in dashboard
- Click explore from here
- Should not see banner (you are creating/editing/viewing chart from dashboard)

Before this change, users were seeing that banner when exploring from here on chart within a dashboard.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
