### PR TITLE
fix: disable chart link while editing dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -100,6 +100,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     const isMarkdownTileTitleEmpty =
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
+    console.log('it', titleHref);
+
     return (
         <Card
             component={Flex}
@@ -162,16 +164,22 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                     withinPortal
                                     maw={400}
                                 >
-                                    <TileTitleLink
-                                        ref={titleRef}
-                                        href={titleHref}
-                                        $hovered={titleHovered}
-                                        target="_blank"
-                                        className="non-draggable"
-                                        hidden={hideTitle}
-                                    >
-                                        {title}
-                                    </TileTitleLink>
+                                    {isEditMode ? (
+                                        <Text fw={600} fz="md">
+                                            {title}
+                                        </Text>
+                                    ) : (
+                                        <TileTitleLink
+                                            ref={titleRef}
+                                            href={titleHref}
+                                            $hovered={titleHovered}
+                                            target="_blank"
+                                            className="non-draggable"
+                                            hidden={hideTitle}
+                                        >
+                                            {title}
+                                        </TileTitleLink>
+                                    )}
                                 </Tooltip>
                             </Group>
                         </TitleWrapper>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -163,7 +163,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                     maw={400}
                                 >
                                     {isEditMode ? (
-                                        <Text fw={600} fz="md">
+                                        <Text fw={600} fz="md" hidden={hideTitle}>
                                             {title}
                                         </Text>
                                     ) : (

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -163,7 +163,11 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                     maw={400}
                                 >
                                     {isEditMode ? (
-                                        <Text fw={600} fz="md" hidden={hideTitle}>
+                                        <Text
+                                            fw={600}
+                                            fz="md"
+                                            hidden={hideTitle}
+                                        >
                                             {title}
                                         </Text>
                                     ) : (

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -100,8 +100,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     const isMarkdownTileTitleEmpty =
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
-    console.log('it', titleHref);
-
     return (
         <Card
             component={Flex}


### PR DESCRIPTION
### Description:

Disables the explore link in dashboard tile titles when editing a dashboard. When linking out we can't keep dashboard state and it's easy to lose dashboard changes. This makes it so users have to finish editing to explore. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
