### PR TITLE
fix: convert year filter value to start of year when creating/changing filters

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -218,14 +218,20 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                             ? defaultTimeIntervalValues[field.timeInterval]
                             : moment();
 
-                    const dateValue = valueIsDate
-                        ? formatDate(
-                              // Treat the date as UTC, then remove its timezone information before formatting
-                              moment.utc(value).format('YYYY-MM-DD'),
-                              undefined,
-                              false,
-                          )
-                        : formatDate(defaultDate, undefined, false);
+                    // If the field is a year filter, we want to convert it to the start of the year. Example: 2021-03-01 -> 2021-01-01
+                    const isYearFilter =
+                        isDimension(field) &&
+                        field.timeInterval === TimeFrames.YEAR;
+
+                    const dateValue =
+                        valueIsDate && !isYearFilter
+                            ? formatDate(
+                                  // Treat the date as UTC, then remove its timezone information before formatting
+                                  moment.utc(value).format('YYYY-MM-DD'),
+                                  undefined,
+                                  false,
+                              )
+                            : formatDate(defaultDate, undefined, false);
 
                     filterRuleDefaults.values = [dateValue];
                 }

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -4,6 +4,7 @@ import {
     FilterType,
     getFilterRuleWithDefaultValue,
     getFilterTypeFromItem,
+    isDimension,
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
@@ -56,14 +57,29 @@ const FilterRuleForm: FC<Props> = ({
             );
             if (selectedField && activeField) {
                 if (selectedField.type === activeField.type) {
-                    onChange({
+                    if (
+                        isDimension(selectedField) &&
+                        isDimension(activeField) &&
+                        activeField.timeInterval !== selectedField.timeInterval
+                    ) {
+                        // If the time interval changes, we need to update the value to match the new time interval if it's converted to a YEAR timeframe
+                        // Example: If the change is from month -> year, the value of the filter `2021-03-01` should be updated to `2021-01-01`
+                        return onChange(
+                            createFilterRuleFromField(
+                                selectedField,
+                                filterRule.values?.[0],
+                            ),
+                        );
+                    }
+
+                    return onChange({
                         ...filterRule,
                         target: {
                             fieldId,
                         },
                     });
                 } else {
-                    onChange(createFilterRuleFromField(selectedField));
+                    return onChange(createFilterRuleFromField(selectedField));
                 }
             }
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/7689 https://github.com/lightdash/lightdash/issues/9985

### Description:

See tickets for description. 
Essentially, convert the date for a `Filter` of time interval `YEAR` to the start of the that year so `DATE_TRUNC` = filtering works as expected.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
