### PR TITLE
fix: save temp dashboard tabs to session storage when creating new chart

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -428,6 +428,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     isEditMode={isEditMode}
                     setAddingTab={setAddingTab}
                     activeTabUuid={activeTab?.uuid}
+                    dashboardTabs={dashboardTabs}
                 />
             )}
             <TabAddModal

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -32,6 +32,7 @@ type Props = {
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     activeTabUuid?: string;
+    dashboardTabs?: Dashboard['tabs'];
 } & Pick<ButtonProps, 'disabled'>;
 
 const AddTileButton: FC<Props> = ({
@@ -39,6 +40,7 @@ const AddTileButton: FC<Props> = ({
     setAddingTab,
     disabled,
     activeTabUuid,
+    dashboardTabs,
 }) => {
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
@@ -102,6 +104,7 @@ const AddTileButton: FC<Props> = ({
                                 dashboard?.uuid,
                                 dashboard?.name,
                                 activeTabUuid,
+                                dashboardTabs,
                             );
                             history.push(`/projects/${projectUuid}/tables`);
                         }}

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -24,6 +24,7 @@ interface SavedChartsAvailableProps {
     isEditMode: boolean;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     activeTabUuid?: string;
+    dashboardTabs?: Dashboard['tabs'];
 }
 
 const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
@@ -32,6 +33,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     isEditMode,
     setAddingTab,
     activeTabUuid,
+    dashboardTabs,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
@@ -73,6 +75,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
                                     onAddTiles={onAddTiles}
                                     setAddingTab={setAddingTab}
                                     activeTabUuid={activeTabUuid}
+                                    dashboardTabs={dashboardTabs}
                                 />
                             ) : undefined
                         }

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -68,6 +68,7 @@ type DashboardHeaderProps = {
     isPinned: boolean;
     oldestCacheTime?: Date;
     activeTabUuid?: string;
+    dashboardTabs?: Dashboard['tabs'];
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     onCancel: () => void;
     onSaveDashboard: () => void;
@@ -91,6 +92,7 @@ const DashboardHeader = ({
     isPinned,
     oldestCacheTime,
     activeTabUuid,
+    dashboardTabs,
     onAddTiles,
     onCancel,
     onSaveDashboard,
@@ -251,6 +253,7 @@ const DashboardHeader = ({
                         disabled={isSaving}
                         setAddingTab={setAddingTab}
                         activeTabUuid={activeTabUuid}
+                        dashboardTabs={dashboardTabs}
                     />
                     <Tooltip
                         fz="xs"

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -1,6 +1,7 @@
 import {
     type CreateDashboardChartTile,
     type DashboardFilters,
+    type DashboardTab,
     type DashboardTile,
 } from '@lightdash/common';
 import { useCallback, useEffect, useState } from 'react';
@@ -63,6 +64,10 @@ const useDashboardStorage = () => {
         return sessionStorage.getItem('activeTabUuid');
     }, []);
 
+    const getDashboardTabs = useCallback(() => {
+        return sessionStorage.getItem('dashboardTabs');
+    }, []);
+
     const clearDashboardStorage = useCallback(() => {
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
@@ -82,12 +87,17 @@ const useDashboardStorage = () => {
             dashboardUuid?: string,
             dashboardName?: string,
             activeTabUuid?: string,
+            dashboardTabs?: DashboardTab[],
         ) => {
             sessionStorage.setItem('fromDashboard', dashboardName ?? '');
             sessionStorage.setItem('dashboardUuid', dashboardUuid ?? '');
             sessionStorage.setItem(
                 'unsavedDashboardTiles',
                 JSON.stringify(dashboardTiles ?? []),
+            );
+            sessionStorage.setItem(
+                'dashboardTabs',
+                JSON.stringify(dashboardTabs),
             );
             if (
                 dashboardFilters.dimensions.length > 0 ||
@@ -141,6 +151,7 @@ const useDashboardStorage = () => {
         getUnsavedDashboardTiles,
         setUnsavedDashboardTiles,
         getDashboardActiveTabUuid,
+        getDashboardTabs,
     };
 };
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -64,10 +64,6 @@ const useDashboardStorage = () => {
         return sessionStorage.getItem('activeTabUuid');
     }, []);
 
-    const getDashboardTabs = useCallback(() => {
-        return sessionStorage.getItem('dashboardTabs');
-    }, []);
-
     const clearDashboardStorage = useCallback(() => {
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
@@ -151,7 +147,6 @@ const useDashboardStorage = () => {
         getUnsavedDashboardTiles,
         setUnsavedDashboardTiles,
         getDashboardActiveTabUuid,
-        getDashboardTabs,
     };
 };
 

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -231,8 +231,6 @@ const Dashboard: FC = () => {
 
         const unsavedDashboardTabsRaw = sessionStorage.getItem('dashboardTabs');
 
-        console.log('unsavedDashboardTabsRaw', unsavedDashboardTabsRaw);
-
         sessionStorage.removeItem('dashboardTabs');
 
         if (!unsavedDashboardTabsRaw) return;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -228,11 +228,35 @@ const Dashboard: FC = () => {
                 `Error parsing chart in dashboard. Attempted to parse: ${unsavedDashboardTilesRaw} `,
             );
         }
+
+        const unsavedDashboardTabsRaw = sessionStorage.getItem('dashboardTabs');
+
+        console.log('unsavedDashboardTabsRaw', unsavedDashboardTabsRaw);
+
+        sessionStorage.removeItem('dashboardTabs');
+
+        if (!unsavedDashboardTabsRaw) return;
+
+        try {
+            const unsavedDashboardTabs = JSON.parse(unsavedDashboardTabsRaw);
+            setDashboardTabs(unsavedDashboardTabs);
+            setHaveTabsChanged(!!unsavedDashboardTabs);
+        } catch {
+            showToastError({
+                title: 'Error parsing tabs',
+                subtitle: 'Unable to save tabs in dashboard',
+            });
+            captureException(
+                `Error parsing tabs in dashboard. Attempted to parse: ${unsavedDashboardTabsRaw} `,
+            );
+        }
     }, [
         isDashboardLoading,
         dashboardTiles,
         setHaveTilesChanged,
         setDashboardTiles,
+        setDashboardTabs,
+        setHaveTabsChanged,
         clearIsEditingDashboardChart,
         showToastError,
     ]);
@@ -599,6 +623,7 @@ const Dashboard: FC = () => {
                         isFullscreen={isFullscreen}
                         isPinned={isPinned}
                         activeTabUuid={activeTab?.uuid}
+                        dashboardTabs={dashboardTabs}
                         onToggleFullscreen={handleToggleFullscreen}
                         hasDashboardChanged={
                             haveTilesChanged ||

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -209,48 +209,63 @@ const Dashboard: FC = () => {
         const unsavedDashboardTilesRaw = sessionStorage.getItem(
             'unsavedDashboardTiles',
         );
-        if (!unsavedDashboardTilesRaw) return;
+        if (unsavedDashboardTilesRaw) {
+            sessionStorage.removeItem('unsavedDashboardTiles');
 
-        sessionStorage.removeItem('unsavedDashboardTiles');
+            try {
+                const unsavedDashboardTiles = JSON.parse(
+                    unsavedDashboardTilesRaw,
+                );
+                // If there are unsaved tiles, add them to the dashboard
+                setDashboardTiles(unsavedDashboardTiles);
 
-        try {
-            const unsavedDashboardTiles = JSON.parse(unsavedDashboardTilesRaw);
-            // If there are unsaved tiles, add them to the dashboard
-            setDashboardTiles(unsavedDashboardTiles);
-
-            setHaveTilesChanged(!!unsavedDashboardTiles);
-        } catch {
-            showToastError({
-                title: 'Error parsing chart',
-                subtitle: 'Unable to save chart in dashboard',
-            });
-            captureException(
-                `Error parsing chart in dashboard. Attempted to parse: ${unsavedDashboardTilesRaw} `,
-            );
+                setHaveTilesChanged(!!unsavedDashboardTiles);
+            } catch {
+                showToastError({
+                    title: 'Error parsing chart',
+                    subtitle: 'Unable to save chart in dashboard',
+                });
+                captureException(
+                    `Error parsing chart in dashboard. Attempted to parse: ${unsavedDashboardTilesRaw} `,
+                );
+            }
         }
 
         const unsavedDashboardTabsRaw = sessionStorage.getItem('dashboardTabs');
 
         sessionStorage.removeItem('dashboardTabs');
 
-        if (!unsavedDashboardTabsRaw) return;
-
-        try {
-            const unsavedDashboardTabs = JSON.parse(unsavedDashboardTabsRaw);
-            setDashboardTabs(unsavedDashboardTabs);
-            setHaveTabsChanged(!!unsavedDashboardTabs);
-        } catch {
-            showToastError({
-                title: 'Error parsing tabs',
-                subtitle: 'Unable to save tabs in dashboard',
-            });
-            captureException(
-                `Error parsing tabs in dashboard. Attempted to parse: ${unsavedDashboardTabsRaw} `,
-            );
+        if (unsavedDashboardTabsRaw) {
+            try {
+                const unsavedDashboardTabs = JSON.parse(
+                    unsavedDashboardTabsRaw,
+                );
+                setDashboardTabs(unsavedDashboardTabs);
+                setHaveTabsChanged(!!unsavedDashboardTabs);
+                if (activeTab === undefined) {
+                    // set up the active tab to previously selected tab
+                    const activeTabUuid =
+                        sessionStorage.getItem('activeTabUuid');
+                    setActiveTab(
+                        unsavedDashboardTabs.find(
+                            (tab: DashboardTab) => tab.uuid === activeTabUuid,
+                        ) ?? unsavedDashboardTabs[0],
+                    );
+                }
+            } catch {
+                showToastError({
+                    title: 'Error parsing tabs',
+                    subtitle: 'Unable to save tabs in dashboard',
+                });
+                captureException(
+                    `Error parsing tabs in dashboard. Attempted to parse: ${unsavedDashboardTabsRaw} `,
+                );
+            }
         }
     }, [
         isDashboardLoading,
         dashboardTiles,
+        activeTab,
         setHaveTilesChanged,
         setDashboardTiles,
         setDashboardTabs,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

issue:

when creating a tab without save it and then create a "dashboard chart" for this tab, it will be redirected to chart creation page and when the process finished and navigate back to the dashboard page, previously created tab would gone.

https://github.com/lightdash/lightdash/assets/101873365/2e034dca-6b58-419b-9bb0-7a9b0637cc0e


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
