### PR TITLE
fix: reference lines break for tables calculations with no type

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -6,6 +6,7 @@ import {
     isDimension,
     isField,
     isNumericItem,
+    isTableCalculation,
     TimeFrames,
     type CompiledDimension,
     type CustomDimension,
@@ -169,7 +170,12 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
 
     return (
         <TextInput
-            disabled={!isNumericItem(field) || disabled}
+            disabled={
+                (!isNumericItem(field) &&
+                    // We treat untyped table calculations as numeric
+                    !(field && isTableCalculation(field) && !field.type)) ||
+                disabled
+            }
             size="xs"
             title={
                 isNumericItem(field)
@@ -287,7 +293,11 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
         ],
     );
 
-    const isNumericField = selectedField && isNumericItem(selectedField);
+    const isNumericField =
+        selectedField &&
+        (isNumericItem(selectedField) ||
+            // We treat untyped table calculations as numeric
+            (isTableCalculation(selectedField) && !selectedField.type));
 
     const averageAvailable = isNumericField && markLineKey === 'yAxis';
     const controlLabel = `Line ${index}`;

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -2,6 +2,7 @@ import {
     fieldId as getFieldId,
     isField,
     isNumericItem,
+    isTableCalculation,
     type CompiledDimension,
     type CustomDimension,
     type Field,
@@ -63,7 +64,11 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                         ? getFieldId(field)
                         : field.name;
 
-                    const isNumericField = field && isNumericItem(field);
+                    const isNumericField =
+                        field &&
+                        (isNumericItem(field) ||
+                            // Treat untyped table calculations as numeric
+                            (isTableCalculation(field) && !field.type));
                     const useAverage =
                         dynamicValue === 'average' && isNumericField;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10060 

### Description:

Treats un-typed table calculations as numeric for the purposes of reference lines. 

We could consider having the check within isNumericItem, but we have to clean filters up to handle that correctly. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
