### PR TITLE
fix: handle filter bys for invalid dates/empty

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -422,7 +422,7 @@ const flattenSameFilterGroupType = (filterGroup: FilterGroup): FilterGroup => {
  * @returns True if the value is an invalid date, false otherwise
  */
 export const isDimensionValueInvalidDate = (
-    item: Exclude<FilterableField, CustomSqlDimension>,
+    item: FilterableField,
     value: any,
 ) => isDateItem(item) && value.raw === 'Invalid Date'; // Message from moment.js when it can't parse a date
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -41,7 +41,7 @@ import { type MetricQuery } from '../types/metricQuery';
 import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 import { formatDate } from './formatting';
-import { getItemId } from './item';
+import { getItemId, isDateItem } from './item';
 
 export const getFilterRulesFromGroup = (
     filterGroup: FilterGroup | undefined,
@@ -422,12 +422,9 @@ const flattenSameFilterGroupType = (filterGroup: FilterGroup): FilterGroup => {
  * @returns True if the value is an invalid date, false otherwise
  */
 export const isDimensionValueInvalidDate = (
-    item: FilterableField,
+    item: Exclude<FilterableField, CustomSqlDimension>,
     value: any,
-) =>
-    isDimension(item) &&
-    Object.values(TimeFrames).includes(item.timeInterval as TimeFrames) &&
-    value.raw === 'Invalid Date'; // Message from moment.js when it can't parse a date
+) => isDateItem(item) && value.raw === 'Invalid Date'; // Message from moment.js when it can't parse a date
 
 /**
  * Takes a filter group and build a filters object from it based on the field type

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -416,6 +416,20 @@ const flattenSameFilterGroupType = (filterGroup: FilterGroup): FilterGroup => {
 };
 
 /**
+ * Checks if a dimension value is an invalid date before it is added to the filter
+ * @param item - The field to compare against the value
+ * @param value - The value to check
+ * @returns True if the value is an invalid date, false otherwise
+ */
+export const isDimensionValueInvalidDate = (
+    item: FilterableField,
+    value: any,
+) =>
+    isDimension(item) &&
+    Object.values(TimeFrames).includes(item.timeInterval as TimeFrames) &&
+    value.raw === 'Invalid Date'; // Message from moment.js when it can't parse a date
+
+/**
  * Takes a filter group and build a filters object from it based on the field type
  * @param filterGroup - The filter group to extract filters from
  * @param fields - Fields to compare against the filter group items to determine types

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -11,6 +11,7 @@ import {
     TableCalculationType,
     type CompiledDimension,
     type CustomDimension,
+    type CustomSqlDimension,
     type Dimension,
     type Field,
     type Item,
@@ -110,7 +111,12 @@ export const getItemColor = (
 };
 
 export const isDateItem = (
-    item: Field | AdditionalMetric | TableCalculation | undefined,
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomSqlDimension
+        | undefined,
 ): boolean => {
     if (!item) {
         return false;

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -3,6 +3,7 @@ import {
     hasCustomDimension,
     isCustomDimension,
     isDimension,
+    isDimensionValueInvalidDate,
     isField,
     isFilterableField,
     type Field,
@@ -91,7 +92,13 @@ const CellContextMenu: FC<
         track({
             name: EventName.ADD_FILTER_CLICKED,
         });
-        addFilter(item, value.raw === undefined ? null : value.raw, true);
+
+        const filterValue =
+            value.raw === undefined || isDimensionValueInvalidDate(item, value)
+                ? null // Set as null if value is invalid date or undefined
+                : value.raw;
+
+        addFilter(item, filterValue, true);
     }, [track, addFilter, item, value]);
 
     let parseResult: null | object = null;

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -3,6 +3,7 @@ import {
     createDashboardFilterRuleFromField,
     hasCustomDimension,
     isDimension,
+    isDimensionValueInvalidDate,
     isField,
     isFilterableField,
     type FilterDashboardToRule,
@@ -55,6 +56,12 @@ const DashboardCellContextMenu: FC<
         [cell.row.original],
     );
 
+    const filterValue =
+        value.raw === undefined ||
+        (isDimension(item) && isDimensionValueInvalidDate(item, value))
+            ? null // Set as null if value is invalid date or undefined
+            : value.raw;
+
     const filterField =
         isDimension(item) && !item.hidden
             ? [
@@ -62,7 +69,7 @@ const DashboardCellContextMenu: FC<
                       field: item,
                       availableTileFilters: {},
                       isTemporary: true,
-                      value: value.raw,
+                      value: filterValue,
                   }),
               ]
             : [];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10096

### Description:

Steps to reproduce: 
- have empty dates on a csv for the seed data
- try to filter to/by on an explore or on a dashboard
- it breaks the explore (see ticket with the Sentry replay)

Fix for a chart

https://github.com/lightdash/lightdash/assets/7611706/dd1a4a23-ab5b-48e3-b70f-76c7e132230c


Fix for a dashboard


https://github.com/lightdash/lightdash/assets/7611706/51bbbdfc-6d29-4892-8e39-681a2aa85ec3



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
