### PR TITLE
chore: remove lazy loading from dashboard tiles

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -30,9 +30,6 @@ export enum FeatureFlags {
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 
-    /** */
-    LazyLoadDashboardTiles = 'lazy-load-dashboard-tiles',
-
     /** Show option to use custom SQL dimension */
     CustomSqlDimensions = 'custom-sql-dimensions',
 

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -8,9 +8,8 @@ import {
 import { ActionIcon, Box, Button, Group, Menu, Tabs } from '@mantine/core';
 import { useProfiler } from '@sentry/react';
 import { IconDots, IconPencil, IconPlus, IconTrash } from '@tabler/icons-react';
-import { memo, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { memo, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
-import { useIntersection } from 'react-use';
 import { v4 as uuid4 } from 'uuid';
 import {
     getReactGridLayoutConfig,
@@ -37,42 +36,18 @@ const GridTile: FC<
         React.ComponentProps<typeof TileBase>,
         'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
     > & {
-        isLazyLoadEnabled: boolean;
         index: number;
         tabs?: DashboardTab[];
         onAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
         locked: boolean;
     }
 > = memo((props) => {
-    const { tile, isLazyLoadEnabled, index } = props;
+    const { tile } = props;
     useProfiler(`Dashboard-${tile.type}`);
-    const [isTiledViewed, setIsTiledViewed] = useState(false);
-    const ref = useRef(null);
-    const intersection = useIntersection(ref, {
-        root: null,
-        threshold: 0.3,
-    });
-    useEffect(() => {
-        if (intersection?.isIntersecting) {
-            setIsTiledViewed(true);
-        }
-    }, [intersection]);
-
-    if (isLazyLoadEnabled && !isTiledViewed) {
-        setTimeout(() => {
-            setIsTiledViewed(true);
-            // Prefetch tile sequentially, even if it's not in view
-        }, index * 1000);
-        return (
-            <Box ref={ref} h="100%">
-                <TileBase isLoading {...props} title={''} />
-            </Box>
-        );
-    }
 
     if (props.locked) {
         return (
-            <Box ref={ref} h="100%">
+            <Box h="100%">
                 <TileBase isLoading={false} title={''} {...props} />
             </Box>
         );
@@ -98,7 +73,6 @@ type DashboardTabsProps = {
     isEditMode: boolean;
     hasRequiredDashboardFiltersToSet: boolean;
     addingTab: boolean;
-    isLazyLoadEnabled: boolean;
     dashboardTiles: DashboardTile[] | undefined;
     activeTab: DashboardTab | undefined;
     handleAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
@@ -116,7 +90,6 @@ type DashboardTabsProps = {
 const DashboardTabs: FC<DashboardTabsProps> = ({
     isEditMode,
     hasRequiredDashboardFiltersToSet,
-    isLazyLoadEnabled,
     addingTab,
     dashboardTiles,
     activeTab,
@@ -425,9 +398,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     <GridTile
                                         locked={
                                             hasRequiredDashboardFiltersToSet
-                                        }
-                                        isLazyLoadEnabled={
-                                            isLazyLoadEnabled ?? true
                                         }
                                         index={idx}
                                         isEditMode={isEditMode}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import {
     DashboardTileTypes,
-    FeatureFlags,
     isDashboardChartTileType,
     ResourceViewItemType,
     type Dashboard as IDashboard,
@@ -11,7 +10,6 @@ import { Box, Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { captureException, useProfiler } from '@sentry/react';
 import { IconAlertCircle } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type Layout } from 'react-grid-layout';
 import { useHistory, useParams } from 'react-router-dom';
@@ -83,11 +81,6 @@ export const getResponsiveGridLayoutProps = ({
 });
 
 const Dashboard: FC = () => {
-    const isLazyLoadFeatureFlagEnabled = useFeatureFlagEnabled(
-        FeatureFlags.LazyLoadDashboardTiles,
-    );
-    const isLazyLoadEnabled =
-        !!isLazyLoadFeatureFlagEnabled && !(window as any).Cypress; // disable lazy load for e2e test
     const history = useHistory();
     const { projectUuid, dashboardUuid, mode, tabUuid } = useParams<{
         projectUuid: string;
@@ -659,7 +652,6 @@ const Dashboard: FC = () => {
                     hasRequiredDashboardFiltersToSet={
                         hasRequiredDashboardFiltersToSet
                     }
-                    isLazyLoadEnabled={isLazyLoadEnabled}
                     addingTab={addingTab}
                     dashboardTiles={dashboardTiles}
                     handleAddTiles={handleAddTiles}

--- a/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
+++ b/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
@@ -89,11 +89,6 @@ const ThirdPartyServicesEnabledProvider: FC<React.PropsWithChildren<{}>> = ({
                     api_host: health.data?.posthog.apiHost,
                     autocapture: false,
                     capture_pageview: false,
-                    bootstrap: {
-                        featureFlags: {
-                            'lazy-load-dashboard-tiles': true,
-                        },
-                    },
                 }}
             >
                 <PosthogIdentified>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Reverts changes added in: https://github.com/lightdash/lightdash/pull/7876

### Description:

Removes feature flag check for `lazy-load-dashboard-tiles`.
Removes lazy loading from dashboard tiles

Re-ran a dashboard and all is OK

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
