### PR TITLE
fix: remove and under from first custom dim range

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModel.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModel.tsx
@@ -303,9 +303,6 @@ export const CustomBinDimensionModal: FC<{
                                                     type="number"
                                                     {...toProps}
                                                 />
-                                                <Text color="gray.6" fw="400">
-                                                    and under{' '}
-                                                </Text>
                                             </Flex>
                                         );
                                     } else if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10124 

### Description:

Removed `and under` from first line range since it will be `< x`, not `<= x`

<img width="631" alt="Screenshot 2024-05-20 at 17 46 28" src="https://github.com/lightdash/lightdash/assets/7611706/358f3cbb-7564-4191-bcb4-91cf661e4c82">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
