### PR TITLE
fix: check correctly missing custom dimensions against explore's tables

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -100,7 +100,7 @@ export const CustomSqlDimensionModal: FC<{
             dimensionType: values.dimensionType,
         };
         if (isEditing && item) {
-            editCustomDimension(customDim, item.name);
+            editCustomDimension({ ...customDim, id: item.id }, item.id);
             showToastSuccess({
                 title: 'Custom dimension edited successfully',
             });

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -24,10 +24,12 @@ type Props = {
     additionalMetrics: AdditionalMetric[];
     selectedItems: Set<string>;
     onSelectedNodeChange: (itemId: string, isDimension: boolean) => void;
-    missingCustomMetrics: AdditionalMetric[];
     customDimensions?: CustomDimension[];
-    missingCustomDimensions?: CustomDimension[];
-    missingFields?: string[];
+    missingFields?: {
+        all: string[];
+        customDimensions: CustomDimension[] | undefined;
+        customMetrics: AdditionalMetric[] | undefined;
+    };
     selectedDimensions?: string[];
 };
 const TableTreeSections: FC<Props> = ({
@@ -36,8 +38,6 @@ const TableTreeSections: FC<Props> = ({
     additionalMetrics,
     customDimensions,
     selectedItems,
-    missingCustomMetrics,
-    missingCustomDimensions,
     missingFields,
     selectedDimensions,
     onSelectedNodeChange,
@@ -77,10 +77,14 @@ const TableTreeSections: FC<Props> = ({
             (metric) => metric.table === table.name,
         );
 
-        return [...customMetricsTable, ...missingCustomMetrics].reduce<
-            Record<string, AdditionalMetric>
-        >((acc, item) => ({ ...acc, [getItemId(item)]: item }), {});
-    }, [additionalMetrics, , missingCustomMetrics, table]);
+        return [
+            ...customMetricsTable,
+            ...(missingFields?.customMetrics ?? []),
+        ].reduce<Record<string, AdditionalMetric>>(
+            (acc, item) => ({ ...acc, [getItemId(item)]: item }),
+            {},
+        );
+    }, [additionalMetrics, missingFields?.customMetrics, table.name]);
 
     const customDimensionsMap = useMemo(() => {
         if (customDimensions === undefined) return undefined;
@@ -101,7 +105,7 @@ const TableTreeSections: FC<Props> = ({
 
     return (
         <>
-            {missingFields && missingFields.length > 0 && (
+            {missingFields && missingFields.all.length > 0 && (
                 <>
                     {' '}
                     <Group mt="sm" mb="xs">
@@ -109,7 +113,7 @@ const TableTreeSections: FC<Props> = ({
                             Missing fields
                         </Text>
                     </Group>
-                    {missingFields.map((missingField) => {
+                    {missingFields.all.map((missingField) => {
                         return (
                             <Tooltip
                                 key={missingField}
@@ -268,7 +272,7 @@ const TableTreeSections: FC<Props> = ({
                     searchQuery={searchQuery}
                     itemsMap={customMetrics}
                     selectedItems={selectedItems}
-                    missingCustomMetrics={missingCustomMetrics}
+                    missingCustomMetrics={missingFields?.customMetrics}
                     onItemClick={(key) => onSelectedNodeChange(key, false)}
                 >
                     <TreeRoot />
@@ -310,7 +314,7 @@ const TableTreeSections: FC<Props> = ({
                     orderFieldsBy={table.orderFieldsBy}
                     searchQuery={searchQuery}
                     itemsMap={customDimensionsMap}
-                    missingCustomDimensions={missingCustomDimensions}
+                    missingCustomDimensions={missingFields?.customDimensions}
                     selectedItems={selectedItems}
                     onItemClick={(key) => onSelectedNodeChange(key, true)}
                 >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -72,7 +72,11 @@ type Props = {
     missingCustomMetrics: AdditionalMetric[];
     customDimensions?: CustomDimension[];
     missingCustomDimensions?: CustomDimension[];
-    missingFields?: string[];
+    missingFields?: {
+        all: string[];
+        customDimensions: CustomDimension[] | undefined;
+        customMetrics: AdditionalMetric[] | undefined;
+    };
     selectedDimensions?: string[];
 };
 
@@ -126,8 +130,6 @@ const TableTree: FC<Props> = ({
                         searchQuery={searchQuery}
                         additionalMetrics={additionalMetrics}
                         customDimensions={customDimensions}
-                        missingCustomMetrics={missingCustomMetrics}
-                        missingCustomDimensions={missingCustomDimensions}
                         missingFields={missingFields}
                         selectedDimensions={selectedDimensions}
                         {...rest}

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -122,7 +122,7 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                                     ? missingFields.customDimensions
                                     : []
                             }
-                            missingFields={missingFields?.all}
+                            missingFields={missingFields}
                             selectedDimensions={selectedDimensions}
                         />
                     ))

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -1,9 +1,5 @@
 import {
-    convertFieldRefToFieldId,
-    getAllReferences,
     getItemId,
-    isCustomBinDimension,
-    isCustomSqlDimension,
     type AdditionalMetric,
     type CompiledTable,
     type CustomDimension,
@@ -25,7 +21,11 @@ type ExploreTreeProps = {
     selectedNodes: Set<string>;
     customDimensions?: CustomDimension[];
     selectedDimensions?: string[];
-    missingFields?: string[];
+    missingFields?: {
+        all: string[];
+        customDimensions: CustomDimension[] | undefined;
+        customMetrics: AdditionalMetric[] | undefined;
+    };
 };
 
 type Records = Record<string, AdditionalMetric | Dimension | Metric>;
@@ -74,39 +74,6 @@ const ExploreTree: FC<ExploreTreeProps> = ({
             );
     }, [explore, searchHasResults, isSearching]);
 
-    const missingCustomMetrics = useMemo(() => {
-        return additionalMetrics.filter((metric) => {
-            const table = explore.tables[metric.table];
-            return (
-                !table ||
-                (metric.baseDimensionName &&
-                    !table.dimensions[metric.baseDimensionName])
-            );
-        });
-    }, [explore, additionalMetrics]);
-
-    const missingCustomDimensions = useMemo(() => {
-        return customDimensions?.filter((customDimension) => {
-            const table = explore.tables[customDimension.table];
-
-            if (!table) return true;
-
-            const dimIds = Object.values(table.dimensions).map(getItemId);
-
-            const isCustomBinDimensionMissing =
-                isCustomBinDimension(customDimension) &&
-                !dimIds.includes(customDimension.dimensionId);
-
-            const isCustomSqlDimensionMissing =
-                isCustomSqlDimension(customDimension) &&
-                getAllReferences(customDimension.sql)
-                    .map((ref) => convertFieldRefToFieldId(ref))
-                    .some((refFieldId) => !dimIds.includes(refFieldId));
-
-            return isCustomBinDimensionMissing || isCustomSqlDimensionMissing;
-        });
-    }, [customDimensions, explore.tables]);
-
     return (
         <>
             <TextInput
@@ -144,16 +111,18 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                             onSelectedNodeChange={onSelectedFieldChange}
                             customDimensions={customDimensions}
                             missingCustomMetrics={
-                                table.name === explore.baseTable
-                                    ? missingCustomMetrics
+                                table.name === explore.baseTable &&
+                                missingFields?.customMetrics
+                                    ? missingFields.customMetrics
                                     : []
                             }
                             missingCustomDimensions={
-                                table.name === explore.baseTable
-                                    ? missingCustomDimensions
+                                table.name === explore.baseTable &&
+                                missingFields?.customDimensions
+                                    ? missingFields.customDimensions
                                     : []
                             }
-                            missingFields={missingFields}
+                            missingFields={missingFields?.all}
                             selectedDimensions={selectedDimensions}
                         />
                     ))

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -204,7 +204,7 @@ type Action =
           type: ActionType.EDIT_CUSTOM_DIMENSION;
           payload: {
               customDimension: CustomDimension;
-              previousCustomDimensionName: string;
+              previousCustomDimensionId: string;
           };
       }
     | {
@@ -305,7 +305,7 @@ export interface ExplorerContext {
         addCustomDimension: (customDimension: CustomDimension) => void;
         editCustomDimension: (
             customDimension: CustomDimension,
-            previousCustomDimensionName: string,
+            previousCustomDimensionId: string,
         ) => void;
         removeCustomDimension: (key: FieldId) => void;
         toggleCustomDimensionModal: (
@@ -861,8 +861,7 @@ function reducer(
             const dimensions = [
                 ...state.unsavedChartVersion.metricQuery.dimensions.filter(
                     (dimension) =>
-                        dimension !==
-                        action.payload.previousCustomDimensionName,
+                        dimension !== action.payload.previousCustomDimensionId,
                 ),
                 getItemId(action.payload.customDimension),
             ];
@@ -877,7 +876,7 @@ function reducer(
                             state.unsavedChartVersion.metricQuery.customDimensions?.map(
                                 (customDimension) =>
                                     customDimension.name ===
-                                    action.payload.previousCustomDimensionName
+                                    action.payload.previousCustomDimensionId
                                         ? action.payload.customDimension
                                         : customDimension,
                             ),
@@ -1629,11 +1628,11 @@ export const ExplorerProvider: FC<
     const editCustomDimension = useCallback(
         (
             customDimension: CustomDimension,
-            previousCustomDimensionName: string,
+            previousCustomDimensionId: string,
         ) => {
             dispatch({
                 type: ActionType.EDIT_CUSTOM_DIMENSION,
-                payload: { customDimension, previousCustomDimensionName },
+                payload: { customDimension, previousCustomDimensionId },
             });
             // TODO: add dispatch toggle
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10108](https://github.com/lightdash/lightdash/issues/10108)

### Description:

Gets `tables` in `explore` to check if there's a missing custom dimension (and also additional metric)
Followed the steps to replicate this. 
Also tried the following: 
- Create 2 custom dims (one in orders, the other one in payments)
- Edited one at a time, just the name. Edit again (you should edit it 2x!)
- Saw false missing fields in one, where there was an issue with the editing of custom sql dimensions. That is fixed now - to do with the `edit_custom_metric` action and the value received by the payload

When getting the **missing** custom dimensions, I did the calculation on the `ExplorePanel` to utilise a previous computation for `missingFields` - that way we avoid adding more loops. 
Now, the structure for `missingFiels` prop is like: 

```
{
all:...
customDimensions: ...
customMetrics:..
}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
