### PR TITLE
chore: remove custom dimension sql feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -22,9 +22,6 @@ export enum FeatureFlags {
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 
-    /** Show option to use custom SQL dimension */
-    CustomSqlDimensions = 'custom-sql-dimensions',
-
     /** Enable dashboard tabs */
     DashboardTabs = 'dashboard_tabs',
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    FeatureFlags,
     getItemId,
     type AdditionalMetric,
     type CompiledTable,
@@ -8,7 +7,6 @@ import {
 } from '@lightdash/common';
 import { Button, Center, Group, Text, Tooltip } from '@mantine/core';
 import { IconAlertTriangle, IconPlus } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { useMemo, type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApp } from '../../../../providers/AppProvider';
@@ -50,9 +48,6 @@ const TableTreeSections: FC<Props> = ({
             organizationUuid: user.data.organizationUuid,
             projectUuid,
         }),
-    );
-    const isCustomSqlDimensionFeatureFlagEnabled = useFeatureFlagEnabled(
-        FeatureFlags.CustomSqlDimensions,
     );
     const toggleCustomDimensionModal = useExplorerContext(
         (context) => context.actions.toggleCustomDimensionModal,
@@ -152,8 +147,11 @@ const TableTreeSections: FC<Props> = ({
                         Dimensions
                     </Text>
 
-                    {canManageCustomSql &&
-                        isCustomSqlDimensionFeatureFlagEnabled && (
+                    {canManageCustomSql && (
+                        <Tooltip
+                            label="Add a custom dimension with SQL"
+                            variant="xs"
+                        >
                             <Button
                                 size="xs"
                                 variant={'subtle'}
@@ -169,7 +167,8 @@ const TableTreeSections: FC<Props> = ({
                             >
                                 Add
                             </Button>
-                        )}
+                        </Tooltip>
+                    )}
                 </Group>
             )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10057](https://github.com/lightdash/lightdash/issues/10057)

### Description:

Removes feature flag `CustomSqlDimensions` `custom-sql-dimensions`
Adds small tooltip on hover of `+ Add` 

<img width="346" alt="Screenshot 2024-05-21 at 15 28 08" src="https://github.com/lightdash/lightdash/assets/7611706/67bc0395-e778-4750-9b37-4c09b2e480f0">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
