### PR TITLE
fix: use utc time display in series config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -53,7 +53,7 @@ const getFormatterValue = (
     items: Array<Field | TableCalculation | CustomDimension>,
 ) => {
     const item = items.find((i) => getItemId(i) === key);
-    return formatItemValue(item, value);
+    return formatItemValue(item, value, true);
 };
 
 type DraggablePortalHandlerProps = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10128

### Description:

Treats time-based field values in the chart series config as UTC. There was an issue where the series config display wasn't matching the chart formatted values. 

The semantics here aren't great--the variable set to 'true' is called convertToUTC, and this it more treating them as utc, but it solves the problem. 

Before
![image](https://github.com/lightdash/lightdash/assets/1864179/3a286472-62d2-4d25-aeda-3981e8f50355)

After
<img width="1309" alt="Screenshot 2024-05-21 at 10 02 31" src="https://github.com/lightdash/lightdash/assets/1864179/df090a01-e16a-42e5-9368-d001ce001d71">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
