### PR TITLE
fix: invite user without org

### DIFF
--- a/packages/backend/src/services/UserService.mock.ts
+++ b/packages/backend/src/services/UserService.mock.ts
@@ -1,8 +1,11 @@
 import { Ability } from '@casl/ability';
 import {
+    CreateInviteLink,
     InviteLink,
+    LightdashUser,
     OpenIdIdentity,
     OpenIdIdentityIssuerType,
+    Organization,
     OrganizationMemberRole,
     SessionUser,
     type OpenIdUser,
@@ -38,7 +41,7 @@ export const sessionUser: SessionUser = {
     isSetupComplete: true,
     userId: 0,
     role: OrganizationMemberRole.ADMIN,
-    ability: new Ability([]),
+    ability: new Ability([{ subject: 'InviteLink', action: ['create'] }]),
     isActive: true,
     abilityRules: [],
 };
@@ -64,4 +67,44 @@ export const inviteLink: InviteLink = {
     inviteUrl: 'inviteUrl',
     organizationUuid: 'organizationUuid',
     userUuid: 'userUuid',
+};
+
+export const inviteUser: CreateInviteLink = {
+    expiresAt: new Date(),
+    email: openIdUser.openId.email,
+    role: OrganizationMemberRole.ADMIN,
+};
+
+export const newUser: SessionUser = {
+    userUuid: 'newUserUuid',
+    email: inviteUser.email,
+    firstName: 'firstName',
+    lastName: 'lastName',
+    organizationUuid: 'organizationUuid',
+    organizationName: 'organizationName',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: false,
+    userId: 0,
+    role: inviteUser.role,
+    ability: new Ability([]),
+    isActive: false,
+    abilityRules: [],
+};
+
+export const organisation: Organization = {
+    organizationUuid: 'organizationUuid',
+    name: 'organizationName',
+};
+
+export const userWithoutOrg: LightdashUser = {
+    userUuid: 'newUserUuid',
+    email: inviteUser.email,
+    firstName: 'firstName',
+    lastName: 'lastName',
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: false,
+    isActive: false,
 };

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -333,18 +333,16 @@ export class UserService extends BaseService {
         const existingUserWithEmail = await this.userModel.findUserByEmail(
             email,
         );
-        if (
-            existingUserWithEmail &&
-            existingUserWithEmail.organizationUuid !== organizationUuid
-        ) {
-            throw new ParameterError(
-                'Email is already used by a user in another organization',
-            );
-        }
-        if (existingUserWithEmail && existingUserWithEmail.isActive) {
-            throw new ParameterError(
-                'Email is already used by a user in your organization',
-            );
+        if (existingUserWithEmail && existingUserWithEmail.organizationUuid) {
+            if (existingUserWithEmail.organizationUuid !== organizationUuid) {
+                throw new ParameterError(
+                    'Email is already used by a user in another organization',
+                );
+            } else if (existingUserWithEmail.isActive) {
+                throw new ParameterError(
+                    'Email is already used by a user in your organization',
+                );
+            }
         }
 
         let userUuid: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

How to replicate: 
- set env var `ALLOW_MULTIPLE_ORGS=false` 
- register new user with email X
- see error "Cannot register user in a new organization. ..." and do **NOT** click to cancel registration
- login with demo user
- invite user with email X

Before: 
They would get the error:
<img width="612" alt="Screenshot 2024-05-21 at 19 38 42" src="https://github.com/lightdash/lightdash/assets/9117144/e8d37b23-fb27-4891-934a-34a11130a16b">

After:
user is invited


Added unit tests to cover invite logic:

- should create user and send invite when email is not found
- should send invite when email belongs to user without org
- should send invite when email belongs to inactive user in same org
- should throw error when email belongs to user in different org
- should throw error when email belongs to an active user in same org


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
