### PR TITLE
fix: allow new charts to be moved around tabs

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -236,6 +236,25 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                         Edit tile content
                                                     </Menu.Item>
                                                 </Box>
+                                                {tabs && tabs.length > 1 && (
+                                                    <Menu.Item
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconArrowAutofitContent
+                                                                }
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setIsMovingTabs(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Move to another tab
+                                                    </Menu.Item>
+                                                )}
+                                                <Menu.Divider />
                                                 {belongsToDashboard ? (
                                                     <Menu.Item
                                                         color="red"
@@ -248,44 +267,19 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                                         Delete chart
                                                     </Menu.Item>
                                                 ) : (
-                                                    <>
-                                                        {tabs &&
-                                                            tabs.length > 1 && (
-                                                                <Menu.Item
-                                                                    icon={
-                                                                        <MantineIcon
-                                                                            icon={
-                                                                                IconArrowAutofitContent
-                                                                            }
-                                                                        />
-                                                                    }
-                                                                    onClick={() =>
-                                                                        setIsMovingTabs(
-                                                                            true,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    Move to
-                                                                    another tab
-                                                                </Menu.Item>
-                                                            )}
-                                                        <Menu.Divider />
-                                                        <Menu.Item
-                                                            color="red"
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconTrash
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                onDelete(tile)
-                                                            }
-                                                        >
-                                                            Remove tile
-                                                        </Menu.Item>
-                                                    </>
+                                                    <Menu.Item
+                                                        color="red"
+                                                        icon={
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            onDelete(tile)
+                                                        }
+                                                    >
+                                                        Remove tile
+                                                    </Menu.Item>
                                                 )}
                                             </>
                                         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

issue:
"move to another tab" option is not available for the chart that only belongs to dashboard

fix:

https://github.com/lightdash/lightdash/assets/101873365/9d40af28-e572-4851-a711-422e9610fe42



### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
