### PR TITLE
chore: default catalog page to tables, add groups

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -174,6 +174,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        groupLabel: { dataType: 'string' },
                         type: { ref: 'CatalogType.Table', required: true },
                         errors: {
                             dataType: 'array',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -123,6 +123,9 @@
                     },
                     {
                         "properties": {
+                            "groupLabel": {
+                                "type": "string"
+                            },
                             "type": {
                                 "$ref": "#/components/schemas/CatalogType.Table"
                             },
@@ -7092,7 +7095,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1099.5",
+        "version": "0.1100.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -109,6 +109,7 @@ export class CatalogService extends BaseService {
                         description:
                             explore.tables[explore.baseTable].description,
                         type: CatalogType.Table,
+                        groupLabel: explore.groupLabel,
                     },
                 ];
             }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -21,6 +21,7 @@ export type CatalogTable = Pick<Explore, 'name' | 'groupLabel'> & {
     description?: string;
     errors?: InlineError[];
     type: CatalogType.Table;
+    groupLabel?: string;
 };
 
 export type CatalogItem = CatalogField | CatalogTable;

--- a/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
@@ -22,6 +22,7 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                     backgroundColor: theme.colors.gray[3],
                     borderRadius: theme.radius.sm,
                     padding: theme.spacing.xs,
+                    width: '100%',
                 })}
             >
                 <Group spacing={'sm'}>

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -33,7 +33,7 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
 
     const { data: catalogResults } = useCatalog({
         projectUuid,
-        type: CatalogType.Field,
+        type: CatalogType.Table,
         search: debouncedSearch,
     });
 
@@ -136,43 +136,45 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                     </Button>
                 </Group>
             </Group>
+            <Stack sx={{ maxHeight: '900px', overflow: 'scroll' }}>
+                {Object.keys(catalogGroupMap)
+                    .sort((a, b) => a.localeCompare(b))
+                    .map((groupLabel, idx) => (
+                        <CatalogGroup label={groupLabel} key={groupLabel}>
+                            <Table>
+                                <tbody>
+                                    {catalogGroupMap[groupLabel]
+                                        .sort((a, b) =>
+                                            a.name.localeCompare(b.name),
+                                        )
+                                        .map((item) => (
+                                            <CatalogListItem
+                                                key={`${item.name}-${idx}`}
+                                                catalogItem={item}
+                                                searchString={debouncedSearch}
+                                                tableUrl={`/projects/${projectUuid}/tables/${item.name}`}
+                                            />
+                                        ))}
+                                </tbody>
+                            </Table>
+                        </CatalogGroup>
+                    ))}
 
-            {Object.keys(catalogGroupMap)
-                .sort((a, b) => a.localeCompare(b))
-                .map((groupLabel, idx) => (
-                    <CatalogGroup label={groupLabel} key={groupLabel}>
-                        <Table>
-                            <tbody>
-                                {catalogGroupMap[groupLabel]
-                                    .sort((a, b) =>
-                                        a.name.localeCompare(b.name),
-                                    )
-                                    .map((item) => (
-                                        <CatalogListItem
-                                            key={`${item.name}-${idx}`}
-                                            catalogItem={item}
-                                            searchString={debouncedSearch}
-                                            tableUrl={`/projects/${projectUuid}/tables/${item.name}`}
-                                        />
-                                    ))}
-                            </tbody>
-                        </Table>
-                    </CatalogGroup>
-                ))}
-            <Table>
-                <tbody>
-                    {ungroupedCatalogItems
-                        .sort((a, b) => a.name.localeCompare(b.name))
-                        .map((item, idx) => (
-                            <CatalogListItem
-                                key={`${item.name}-${idx}`}
-                                catalogItem={item}
-                                searchString={debouncedSearch}
-                                tableUrl={`/projects/${projectUuid}/tables/${item.name}`}
-                            />
-                        ))}
-                </tbody>
-            </Table>
+                <Table h="100%">
+                    <tbody>
+                        {ungroupedCatalogItems
+                            .sort((a, b) => a.name.localeCompare(b.name))
+                            .map((item, idx) => (
+                                <CatalogListItem
+                                    key={`${item.name}-${idx}`}
+                                    catalogItem={item}
+                                    searchString={debouncedSearch}
+                                    tableUrl={`/projects/${projectUuid}/tables/${item.name}`}
+                                />
+                            ))}
+                    </tbody>
+                </Table>
+            </Stack>
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Makes:
- Catalog page show tables by default
- Api return table groups
- Scrolling within page height

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
