### PR TITLE
fix: allow setting offset to avoid bars overlapping/falling outside of range

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -236,6 +236,8 @@ type Axis = {
     name?: string;
     min?: string | undefined;
     max?: string | undefined;
+    minOffset?: string | undefined;
+    maxOffset?: string | undefined;
     inverse?: boolean;
     rotate?: number;
 };

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
@@ -77,7 +77,7 @@ export const useFieldsWithSuggestions = ({
                                     getResultValueArray(
                                         queryResults.rows,
                                         true,
-                                    ).reduce<string[]>((acc, row) => {
+                                    ).results.reduce<string[]>((acc, row) => {
                                         const value = row[getItemId(field)];
                                         if (typeof value === 'string') {
                                             return [...acc, value];

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -28,7 +28,6 @@ export const AxisMinMax: FC<Props> = ({
     setMaxOffset,
 }) => {
     const [isAuto, toggleAuto] = useToggle(
-        // Fix this issue; it's set as true by default because of the offsets
         !(min || max || minOffset || maxOffset),
     );
     const { track } = useTracking();

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -28,6 +28,7 @@ export const AxisMinMax: FC<Props> = ({
     setMaxOffset,
 }) => {
     const [isAuto, toggleAuto] = useToggle(
+        // Fix this issue; it's set as true by default because of the offsets
         !(min || max || minOffset || maxOffset),
     );
     const { track } = useTracking();

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -8,30 +8,18 @@ import { Config } from '../../common/Config';
 type Props = {
     label: string;
     min: string | undefined;
-    minOffset?: string | undefined;
     max: string | undefined;
-    maxOffset?: string | undefined;
     setMin: (value: string | undefined) => void;
-    setMinOffset?: (value: string | undefined) => void;
     setMax: (value: string | undefined) => void;
-    setMaxOffset?: (value: string | undefined) => void;
 };
 
-export const AxisMinMax: FC<Props> = ({
-    label,
-    min,
-    max,
-    setMin,
-
-    setMax,
-}) => {
+export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
     const [isAuto, toggleAuto] = useToggle(!(min || max));
     const { track } = useTracking();
 
     const clearRange = useCallback(() => {
         if (!isAuto) {
             setMin(undefined);
-
             setMax(undefined);
         }
         return;
@@ -43,9 +31,7 @@ export const AxisMinMax: FC<Props> = ({
                 label={isAuto && label}
                 checked={isAuto}
                 onChange={() => {
-                    toggleAuto((prev: boolean) => {
-                        return !prev;
-                    });
+                    toggleAuto((prev: boolean) => !prev);
 
                     clearRange();
                     track({
@@ -57,7 +43,7 @@ export const AxisMinMax: FC<Props> = ({
                 }}
             />
             {!isAuto && (
-                <Group spacing={'xs'} noWrap>
+                <Group noWrap spacing="xs">
                     <Config.Label>Min</Config.Label>
                     <TextInput
                         placeholder="Min"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -3,35 +3,62 @@ import { useCallback, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { useTracking } from '../../../../providers/TrackingProvider';
 import { EventName } from '../../../../types/Events';
-import { Config } from '../../common/Config';
 
 type Props = {
     label: string;
     min: string | undefined;
+    minOffset?: string | undefined;
     max: string | undefined;
+    maxOffset?: string | undefined;
     setMin: (value: string | undefined) => void;
+    setMinOffset?: (value: string | undefined) => void;
     setMax: (value: string | undefined) => void;
+    setMaxOffset?: (value: string | undefined) => void;
 };
 
-export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
-    const [isAuto, toggleAuto] = useToggle(!(min || max));
+export const AxisMinMax: FC<Props> = ({
+    label,
+    min,
+    minOffset,
+    max,
+    maxOffset,
+    setMin,
+    setMinOffset,
+    setMax,
+    setMaxOffset,
+}) => {
+    const [isAuto, toggleAuto] = useToggle(
+        !(min || max || minOffset || maxOffset),
+    );
     const { track } = useTracking();
 
     const clearRange = useCallback(() => {
         if (!isAuto) {
             setMin(undefined);
+            setMinOffset?.(undefined);
+
             setMax(undefined);
+            setMaxOffset?.(undefined);
         }
         return;
-    }, [isAuto, setMin, setMax]);
+    }, [isAuto, setMin, setMinOffset, setMax, setMaxOffset]);
 
     return (
-        <Group noWrap spacing="xs">
+        <Group noWrap spacing="xs" align="baseline">
             <Switch
                 label={isAuto && label}
                 checked={isAuto}
-                onChange={() => {
-                    toggleAuto((prev: boolean) => !prev);
+                onChange={(e) => {
+                    toggleAuto((prev: boolean) => {
+                        return !prev;
+                    });
+
+                    // When setting to manual, set the default offset to 0.5
+                    if (!e.target.checked) {
+                        setMinOffset?.('0.5');
+                        setMaxOffset?.('0.5');
+                    }
+
                     clearRange();
                     track({
                         name: EventName.CUSTOM_AXIS_RANGE_TOGGLE_CLICKED,
@@ -42,19 +69,46 @@ export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
                 }}
             />
             {!isAuto && (
-                <Group noWrap spacing="xs">
-                    <Config.Label>Min</Config.Label>
-                    <TextInput
-                        placeholder="Min"
-                        defaultValue={min || undefined}
-                        onBlur={(e) => setMin(e.currentTarget.value)}
-                    />
-                    <Config.Label>Max</Config.Label>
-                    <TextInput
-                        placeholder="Max"
-                        defaultValue={max || undefined}
-                        onBlur={(e) => setMax(e.currentTarget.value)}
-                    />
+                <Group spacing="one">
+                    <Group spacing="xs" noWrap>
+                        <TextInput
+                            label="Min"
+                            placeholder="Min"
+                            defaultValue={min || undefined}
+                            onBlur={(e) => setMin(e.currentTarget.value)}
+                        />
+
+                        {setMinOffset && (
+                            <TextInput
+                                label="Offset"
+                                placeholder="Offset"
+                                defaultValue={minOffset || undefined}
+                                onBlur={(e) =>
+                                    setMinOffset(e.currentTarget.value)
+                                }
+                            />
+                        )}
+                    </Group>
+
+                    <Group spacing="xs" noWrap>
+                        <TextInput
+                            label="Max"
+                            placeholder="Max"
+                            defaultValue={max || undefined}
+                            onBlur={(e) => setMax(e.currentTarget.value)}
+                        />
+
+                        {setMaxOffset && (
+                            <TextInput
+                                label="Offset"
+                                placeholder="Offset"
+                                defaultValue={maxOffset || undefined}
+                                onBlur={(e) =>
+                                    setMaxOffset(e.currentTarget.value)
+                                }
+                            />
+                        )}
+                    </Group>
                 </Group>
             )}
         </Group>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -1,8 +1,10 @@
-import { Group, Switch, TextInput } from '@mantine/core';
+import { Group, Switch, Text, TextInput, Tooltip } from '@mantine/core';
+import { IconHelpCircle } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { useTracking } from '../../../../providers/TrackingProvider';
 import { EventName } from '../../../../types/Events';
+import MantineIcon from '../../../common/MantineIcon';
 
 type Props = {
     label: string;
@@ -15,6 +17,8 @@ type Props = {
     setMax: (value: string | undefined) => void;
     setMaxOffset?: (value: string | undefined) => void;
 };
+
+const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE = '0.5';
 
 export const AxisMinMax: FC<Props> = ({
     label,
@@ -55,8 +59,8 @@ export const AxisMinMax: FC<Props> = ({
 
                     // When setting to manual, set the default offset to 0.5
                     if (!e.target.checked) {
-                        setMinOffset?.('0.5');
-                        setMaxOffset?.('0.5');
+                        setMinOffset?.(DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE);
+                        setMaxOffset?.(DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE);
                     }
 
                     clearRange();
@@ -80,7 +84,20 @@ export const AxisMinMax: FC<Props> = ({
 
                         {setMinOffset && (
                             <TextInput
-                                label="Offset"
+                                label={
+                                    <Group spacing="two">
+                                        <Text>Offset</Text>
+                                        <Tooltip
+                                            multiline
+                                            variant="xs"
+                                            label="Offset is a value that is added to the min value to determine the actual min value of the axis. For example, if the min value is 0 and the offset is 0.5, the actual min value will be -0.5."
+                                        >
+                                            <MantineIcon
+                                                icon={IconHelpCircle}
+                                            />
+                                        </Tooltip>
+                                    </Group>
+                                }
                                 placeholder="Offset"
                                 defaultValue={minOffset || undefined}
                                 onBlur={(e) =>
@@ -100,7 +117,20 @@ export const AxisMinMax: FC<Props> = ({
 
                         {setMaxOffset && (
                             <TextInput
-                                label="Offset"
+                                label={
+                                    <Group spacing="two">
+                                        <Text>Offset</Text>
+                                        <Tooltip
+                                            multiline
+                                            variant="xs"
+                                            label="Offset is a value that is added to the max value to determine the actual max value of the axis. For example, if the max value is 10 and the offset is 0.5, the actual max value will be 10.5."
+                                        >
+                                            <MantineIcon
+                                                icon={IconHelpCircle}
+                                            />
+                                        </Tooltip>
+                                    </Group>
+                                }
                                 placeholder="Offset"
                                 defaultValue={maxOffset || undefined}
                                 onBlur={(e) =>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -5,6 +5,7 @@ import { useToggle } from 'react-use';
 import { useTracking } from '../../../../providers/TrackingProvider';
 import { EventName } from '../../../../types/Events';
 import MantineIcon from '../../../common/MantineIcon';
+import { Config } from '../../common/Config';
 
 type Props = {
     label: string;
@@ -31,6 +32,7 @@ export const AxisMinMax: FC<Props> = ({
     setMax,
     setMaxOffset,
 }) => {
+    const isSettingOffset = !!(setMinOffset && setMaxOffset);
     const [isAuto, toggleAuto] = useToggle(
         !(min || max || minOffset || maxOffset),
     );
@@ -48,7 +50,11 @@ export const AxisMinMax: FC<Props> = ({
     }, [isAuto, setMin, setMinOffset, setMax, setMaxOffset]);
 
     return (
-        <Group noWrap spacing="xs" align="baseline">
+        <Group
+            noWrap
+            spacing="xs"
+            align={setMinOffset && setMaxOffset ? 'baseline' : 'center'}
+        >
             <Switch
                 label={isAuto && label}
                 checked={isAuto}
@@ -73,10 +79,14 @@ export const AxisMinMax: FC<Props> = ({
                 }}
             />
             {!isAuto && (
-                <Group spacing="one">
-                    <Group spacing="xs" noWrap>
+                <Group
+                    spacing={isSettingOffset ? 'one' : 'xs'}
+                    noWrap={!isSettingOffset}
+                >
+                    <Group spacing="xs" noWrap={!isSettingOffset}>
+                        {!isSettingOffset && <Config.Label>Min</Config.Label>}
                         <TextInput
-                            label="Min"
+                            label={isSettingOffset ? 'Min' : undefined}
                             placeholder="Min"
                             defaultValue={min || undefined}
                             onBlur={(e) => setMin(e.currentTarget.value)}
@@ -107,9 +117,11 @@ export const AxisMinMax: FC<Props> = ({
                         )}
                     </Group>
 
-                    <Group spacing="xs" noWrap>
+                    <Group spacing="xs" noWrap={!isSettingOffset}>
+                        {!isSettingOffset && <Config.Label>Max</Config.Label>}
+
                         <TextInput
-                            label="Max"
+                            label={isSettingOffset ? 'Max' : undefined}
                             placeholder="Max"
                             defaultValue={max || undefined}
                             onBlur={(e) => setMax(e.currentTarget.value)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -1,10 +1,8 @@
-import { Group, Switch, Text, TextInput, Tooltip } from '@mantine/core';
-import { IconHelpCircle } from '@tabler/icons-react';
+import { Group, Switch, TextInput } from '@mantine/core';
 import { useCallback, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { useTracking } from '../../../../providers/TrackingProvider';
 import { EventName } from '../../../../types/Events';
-import MantineIcon from '../../../common/MantineIcon';
 import { Config } from '../../common/Config';
 
 type Props = {
@@ -19,55 +17,35 @@ type Props = {
     setMaxOffset?: (value: string | undefined) => void;
 };
 
-const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE = '0.5';
-
 export const AxisMinMax: FC<Props> = ({
     label,
     min,
-    minOffset,
     max,
-    maxOffset,
     setMin,
-    setMinOffset,
+
     setMax,
-    setMaxOffset,
 }) => {
-    const isSettingOffset = !!(setMinOffset && setMaxOffset);
-    const [isAuto, toggleAuto] = useToggle(
-        !(min || max || minOffset || maxOffset),
-    );
+    const [isAuto, toggleAuto] = useToggle(!(min || max));
     const { track } = useTracking();
 
     const clearRange = useCallback(() => {
         if (!isAuto) {
             setMin(undefined);
-            setMinOffset?.(undefined);
 
             setMax(undefined);
-            setMaxOffset?.(undefined);
         }
         return;
-    }, [isAuto, setMin, setMinOffset, setMax, setMaxOffset]);
+    }, [isAuto, setMin, setMax]);
 
     return (
-        <Group
-            noWrap
-            spacing="xs"
-            align={setMinOffset && setMaxOffset ? 'baseline' : 'center'}
-        >
+        <Group noWrap spacing="xs">
             <Switch
                 label={isAuto && label}
                 checked={isAuto}
-                onChange={(e) => {
+                onChange={() => {
                     toggleAuto((prev: boolean) => {
                         return !prev;
                     });
-
-                    // When setting to manual, set the default offset to 0.5
-                    if (!e.target.checked) {
-                        setMinOffset?.(DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE);
-                        setMaxOffset?.(DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE);
-                    }
 
                     clearRange();
                     track({
@@ -79,78 +57,19 @@ export const AxisMinMax: FC<Props> = ({
                 }}
             />
             {!isAuto && (
-                <Group
-                    spacing={isSettingOffset ? 'one' : 'xs'}
-                    noWrap={!isSettingOffset}
-                >
-                    <Group spacing="xs" noWrap={!isSettingOffset}>
-                        {!isSettingOffset && <Config.Label>Min</Config.Label>}
-                        <TextInput
-                            label={isSettingOffset ? 'Min' : undefined}
-                            placeholder="Min"
-                            defaultValue={min || undefined}
-                            onBlur={(e) => setMin(e.currentTarget.value)}
-                        />
-
-                        {setMinOffset && (
-                            <TextInput
-                                label={
-                                    <Group spacing="two">
-                                        <Text>Offset</Text>
-                                        <Tooltip
-                                            multiline
-                                            variant="xs"
-                                            label="Offset is a value that is added to the min value to determine the actual min value of the axis. For example, if the min value is 0 and the offset is 0.5, the actual min value will be -0.5."
-                                        >
-                                            <MantineIcon
-                                                icon={IconHelpCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-                                }
-                                placeholder="Offset"
-                                defaultValue={minOffset || undefined}
-                                onBlur={(e) =>
-                                    setMinOffset(e.currentTarget.value)
-                                }
-                            />
-                        )}
-                    </Group>
-
-                    <Group spacing="xs" noWrap={!isSettingOffset}>
-                        {!isSettingOffset && <Config.Label>Max</Config.Label>}
-
-                        <TextInput
-                            label={isSettingOffset ? 'Max' : undefined}
-                            placeholder="Max"
-                            defaultValue={max || undefined}
-                            onBlur={(e) => setMax(e.currentTarget.value)}
-                        />
-
-                        {setMaxOffset && (
-                            <TextInput
-                                label={
-                                    <Group spacing="two">
-                                        <Text>Offset</Text>
-                                        <Tooltip
-                                            multiline
-                                            variant="xs"
-                                            label="Offset is a value that is added to the max value to determine the actual max value of the axis. For example, if the max value is 10 and the offset is 0.5, the actual max value will be 10.5."
-                                        >
-                                            <MantineIcon
-                                                icon={IconHelpCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-                                }
-                                placeholder="Offset"
-                                defaultValue={maxOffset || undefined}
-                                onBlur={(e) =>
-                                    setMaxOffset(e.currentTarget.value)
-                                }
-                            />
-                        )}
-                    </Group>
+                <Group spacing={'xs'} noWrap>
+                    <Config.Label>Min</Config.Label>
+                    <TextInput
+                        placeholder="Min"
+                        defaultValue={min || undefined}
+                        onBlur={(e) => setMin(e.currentTarget.value)}
+                    />
+                    <Config.Label>Max</Config.Label>
+                    <TextInput
+                        placeholder="Max"
+                        defaultValue={max || undefined}
+                        onBlur={(e) => setMax(e.currentTarget.value)}
+                    />
                 </Group>
             )}
         </Group>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -99,21 +99,19 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                 dirtyLayout?.flipAxes ? 'y' : 'x'
                             }-axis range`}
                             min={dirtyEchartsConfig?.xAxis?.[0]?.min}
-                            minOffset={
-                                dirtyEchartsConfig?.xAxis?.[0]?.minOffset
-                            }
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
-                            maxOffset={
-                                dirtyEchartsConfig?.xAxis?.[0]?.maxOffset
-                            }
                             setMin={(newValue) => setXMinValue(0, newValue)}
                             setMax={(newValue) => setXMaxValue(0, newValue)}
-                            setMinOffset={(newValue) =>
-                                setXMinOffsetValue(0, newValue)
-                            }
-                            setMaxOffset={(newValue) =>
-                                setXMaxOffsetValue(0, newValue)
-                            }
+                            {...(!dirtyLayout?.flipAxes && {
+                                minOffset:
+                                    dirtyEchartsConfig?.xAxis?.[0]?.minOffset,
+                                maxOffset:
+                                    dirtyEchartsConfig?.xAxis?.[0]?.maxOffset,
+                                setMinOffset: (newValue) =>
+                                    setXMinOffsetValue(0, newValue),
+                                setMaxOffset: (newValue) =>
+                                    setXMaxOffsetValue(0, newValue),
+                            })}
                         />
                     )}
                     <Group spacing="xs">

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -100,13 +100,11 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             }-axis range`}
                             min={dirtyEchartsConfig?.xAxis?.[0]?.min}
                             minOffset={
-                                dirtyEchartsConfig?.xAxis?.[0]?.minOffset ??
-                                '0.5'
+                                dirtyEchartsConfig?.xAxis?.[0]?.minOffset
                             }
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
                             maxOffset={
-                                dirtyEchartsConfig?.xAxis?.[0]?.maxOffset ??
-                                '0.5'
+                                dirtyEchartsConfig?.xAxis?.[0]?.maxOffset
                             }
                             setMin={(newValue) => setXMinValue(0, newValue)}
                             setMax={(newValue) => setXMaxValue(0, newValue)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -38,7 +38,9 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setYMinValue,
         setYMaxValue,
         setXMinValue,
+        setXMinOffsetValue,
         setXMaxValue,
+        setXMaxOffsetValue,
         setShowGridX,
         setShowGridY,
         setInverseX,
@@ -97,9 +99,23 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                 dirtyLayout?.flipAxes ? 'y' : 'x'
                             }-axis range`}
                             min={dirtyEchartsConfig?.xAxis?.[0]?.min}
+                            minOffset={
+                                dirtyEchartsConfig?.xAxis?.[0]?.minOffset ??
+                                '0.5'
+                            }
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
+                            maxOffset={
+                                dirtyEchartsConfig?.xAxis?.[0]?.maxOffset ??
+                                '0.5'
+                            }
                             setMin={(newValue) => setXMinValue(0, newValue)}
                             setMax={(newValue) => setXMaxValue(0, newValue)}
+                            setMinOffset={(newValue) =>
+                                setXMinOffsetValue(0, newValue)
+                            }
+                            setMaxOffset={(newValue) =>
+                                setXMaxOffsetValue(0, newValue)
+                            }
                         />
                     )}
                     <Group spacing="xs">

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -11,6 +11,7 @@ import {
     NumberInput,
     SegmentedControl,
     Stack,
+    Switch,
     TextInput,
 } from '@mantine/core';
 import { IconSortAscending, IconSortDescending } from '@tabler/icons-react';
@@ -24,6 +25,8 @@ import { AxisMinMax } from './AxisMinMax';
 type Props = {
     itemsMap: ItemsMap | undefined;
 };
+
+const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE = '5';
 
 export const Axes: FC<Props> = ({ itemsMap }) => {
     const { visualizationConfig } = useVisualizationContext();
@@ -102,17 +105,36 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
                             setMin={(newValue) => setXMinValue(0, newValue)}
                             setMax={(newValue) => setXMaxValue(0, newValue)}
-                            {...(!dirtyLayout?.flipAxes && {
-                                minOffset:
-                                    dirtyEchartsConfig?.xAxis?.[0]?.minOffset,
-                                maxOffset:
-                                    dirtyEchartsConfig?.xAxis?.[0]?.maxOffset,
-                                setMinOffset: (newValue) =>
-                                    setXMinOffsetValue(0, newValue),
-                                setMaxOffset: (newValue) =>
-                                    setXMaxOffsetValue(0, newValue),
-                            })}
                         />
+                    )}
+
+                    {isNumericItem(xAxisField) && !dirtyLayout?.flipAxes && (
+                        <>
+                            <Switch
+                                label="Truncate x-axis"
+                                checked={
+                                    dirtyEchartsConfig?.xAxis?.[0]
+                                        ?.minOffset !== undefined ||
+                                    dirtyEchartsConfig?.xAxis?.[0]
+                                        ?.maxOffset !== undefined
+                                }
+                                onChange={(e) => {
+                                    if (e.target.checked) {
+                                        setXMaxOffsetValue(
+                                            0,
+                                            DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
+                                        );
+                                        setXMinOffsetValue(
+                                            0,
+                                            DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE,
+                                        );
+                                    } else {
+                                        setXMaxOffsetValue(0, undefined);
+                                        setXMinOffsetValue(0, undefined);
+                                    }
+                                }}
+                            />
+                        </>
                     )}
                     <Group spacing="xs">
                         <Group spacing="xs">

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -239,6 +239,25 @@ const useCartesianChartConfig = ({
         [],
     );
 
+    const setXMinOffsetValue = useCallback(
+        (index: number, value: string | undefined) => {
+            setDirtyEchartsConfig((prevState) => {
+                return {
+                    ...prevState,
+                    xAxis: [
+                        prevState?.xAxis?.[0] || {},
+                        prevState?.xAxis?.[1] || {},
+                    ].map((axis, axisIndex) =>
+                        axisIndex === index
+                            ? { ...axis, minOffset: value }
+                            : axis,
+                    ),
+                };
+            });
+        },
+        [],
+    );
+
     const setXMaxValue = useCallback(
         (index: number, value: string | undefined) => {
             setDirtyEchartsConfig((prevState) => {
@@ -255,6 +274,26 @@ const useCartesianChartConfig = ({
         },
         [],
     );
+
+    const setXMaxOffsetValue = useCallback(
+        (index: number, value: string | undefined) => {
+            setDirtyEchartsConfig((prevState) => {
+                return {
+                    ...prevState,
+                    xAxis: [
+                        prevState?.xAxis?.[0] || {},
+                        prevState?.xAxis?.[1] || {},
+                    ].map((axis, axisIndex) =>
+                        axisIndex === index
+                            ? { ...axis, maxOffset: value }
+                            : axis,
+                    ),
+                };
+            });
+        },
+        [],
+    );
+
     const setXField = useCallback((xField: string | undefined) => {
         setDirtyLayout((prev) => ({
             ...prev,
@@ -867,7 +906,9 @@ const useCartesianChartConfig = ({
         setYMinValue,
         setYMaxValue,
         setXMinValue,
+        setXMinOffsetValue,
         setXMaxValue,
+        setXMaxOffsetValue,
         setLegend,
         setGrid,
         setShowGridX,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1168,12 +1168,6 @@ const getEchartAxes = ({
                 min !== undefined &&
                 max !== undefined
             ) {
-                console.log('bottom axis offset is enabled', {
-                    min,
-                    max,
-                    bottomAxisOffset,
-                });
-
                 return {
                     min: min - (bottomAxisOffset.minOffset ?? 0.5),
                     max: max + (bottomAxisOffset.maxOffset ?? 0.5),
@@ -1218,20 +1212,6 @@ const getEchartAxes = ({
             };
         }
 
-        console.log('got values', {
-            rows,
-            firstValue,
-            lastValue,
-            minValue:
-                firstValue !== undefined
-                    ? Math.min(firstValue, lastValue)
-                    : undefined,
-            maxValue:
-                lastValue !== undefined
-                    ? Math.max(firstValue, lastValue)
-                    : undefined,
-        });
-
         return {
             minValue:
                 firstValue !== undefined
@@ -1244,25 +1224,9 @@ const getEchartAxes = ({
         };
     };
 
-    const bottomAxisName = validCartesianConfig.layout.flipAxes
-        ? getAxisName({
-              isAxisTheSameForAllSeries,
-              selectedAxisIndex,
-              axisIndex: 0,
-              axisReference: 'yRef',
-              axisName: xAxisConfiguration?.[0]?.name,
-              itemsMap,
-              series: validCartesianConfig.eChartsConfig.series,
-          })
-        : xAxisConfiguration?.[0]?.name ||
-          (xAxisItem
-              ? getDateGroupLabel(xAxisItem) ||
-                getItemLabelWithoutTableName(xAxisItem)
-              : undefined);
-
     const { minValue: bottomAxisMinValue, maxValue: bottomAxisMaxValue } =
-        bottomAxisOffset.enabled && bottomAxisName
-            ? findMinMax(resultsData?.rows || [], bottomAxisName)
+        bottomAxisOffset.enabled && xAxisItemId
+            ? findMinMax(resultsData?.rows || [], xAxisItemId)
             : {
                   minValue: 0,
                   maxValue: 0,
@@ -1275,13 +1239,25 @@ const getEchartAxes = ({
         bottomAxisMaxValue,
     );
 
-    console.log({ bottomAxisName, bottomAxisBounds, bottomAxisOffset });
-
     return {
         xAxis: [
             {
                 type: bottomAxisType,
-                name: bottomAxisName,
+                name: validCartesianConfig.layout.flipAxes
+                    ? getAxisName({
+                          isAxisTheSameForAllSeries,
+                          selectedAxisIndex,
+                          axisIndex: 0,
+                          axisReference: 'yRef',
+                          axisName: xAxisConfiguration?.[0]?.name,
+                          itemsMap,
+                          series: validCartesianConfig.eChartsConfig.series,
+                      })
+                    : xAxisConfiguration?.[0]?.name ||
+                      (xAxisItem
+                          ? getDateGroupLabel(xAxisItem) ||
+                            getItemLabelWithoutTableName(xAxisItem)
+                          : undefined),
                 nameLocation: 'center',
                 nameTextStyle: {
                     fontWeight: 'bold',

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1167,9 +1167,15 @@ const getEchartAxes = ({
                 min !== undefined &&
                 max !== undefined
             ) {
+                const minX = xAxisConfiguration?.[0]?.min
+                    ? parseFloat(xAxisConfiguration?.[0]?.min)
+                    : min;
+                const maxX = xAxisConfiguration?.[0]?.max
+                    ? parseFloat(xAxisConfiguration?.[0]?.max)
+                    : max;
                 return {
-                    min: min - (bottomAxisOffset.minOffset ?? 0),
-                    max: max + (bottomAxisOffset.maxOffset ?? 0),
+                    min: minX - (bottomAxisOffset.minOffset ?? 0),
+                    max: maxX + (bottomAxisOffset.maxOffset ?? 0),
                 };
             }
             return {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -904,8 +904,6 @@ const getEchartAxes = ({
         [true, true],
     );
 
-    console.log({ series });
-
     const getAxisFormatter = ({
         axisItem,
         longestLabelWidth,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1183,11 +1183,19 @@ const getEchartAxes = ({
                         ? parseFloat(xAxisConfiguration?.[0]?.max)
                         : max;
 
-                const range = maxX - minX;
-                const minOffset =
-                    ((bottomAxisOffset.minOffset ?? 0) / 100) * range;
-                const maxOffset =
-                    ((bottomAxisOffset.maxOffset ?? 0) / 100) * range;
+                // Apply logarithmic scaling to the range to determine offsets
+                // This is helpful when the range is very large, but also accomodates small ranges
+                const logRange = Number(Math.log1p(maxX - minX).toFixed(0));
+
+                // Baseline offset to ensure minimum value
+                const baselineOffset = 0.5;
+
+                let minOffset =
+                    ((bottomAxisOffset.minOffset ?? 0) / 100) * logRange +
+                    baselineOffset;
+                let maxOffset =
+                    ((bottomAxisOffset.maxOffset ?? 0) / 100) * logRange +
+                    baselineOffset;
 
                 return {
                     min: minX - minOffset,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1184,9 +1184,16 @@ const getEchartAxes = ({
                     xAxisConfiguration?.[0]?.max !== undefined
                         ? parseFloat(xAxisConfiguration?.[0]?.max)
                         : max;
+
+                const range = maxX - minX;
+                const minOffset =
+                    ((bottomAxisOffset.minOffset ?? 0) / 100) * range;
+                const maxOffset =
+                    ((bottomAxisOffset.maxOffset ?? 0) / 100) * range;
+
                 return {
-                    min: minX - (bottomAxisOffset.minOffset ?? 0),
-                    max: maxX + (bottomAxisOffset.maxOffset ?? 0),
+                    min: minX - minOffset,
+                    max: maxX + maxOffset,
                 };
             }
             return {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1168,6 +1168,12 @@ const getEchartAxes = ({
                 min !== undefined &&
                 max !== undefined
             ) {
+                console.log('bottom axis offset is enabled', {
+                    min,
+                    max,
+                    bottomAxisOffset,
+                });
+
                 return {
                     min: min - (bottomAxisOffset.minOffset ?? 0.5),
                     max: max + (bottomAxisOffset.maxOffset ?? 0.5),
@@ -1212,6 +1218,20 @@ const getEchartAxes = ({
             };
         }
 
+        console.log('got values', {
+            rows,
+            firstValue,
+            lastValue,
+            minValue:
+                firstValue !== undefined
+                    ? Math.min(firstValue, lastValue)
+                    : undefined,
+            maxValue:
+                lastValue !== undefined
+                    ? Math.max(firstValue, lastValue)
+                    : undefined,
+        });
+
         return {
             minValue:
                 firstValue !== undefined
@@ -1254,6 +1274,8 @@ const getEchartAxes = ({
         bottomAxisMinValue,
         bottomAxisMaxValue,
     );
+
+    console.log({ bottomAxisName, bottomAxisBounds, bottomAxisOffset });
 
     return {
         xAxis: [

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1149,11 +1149,10 @@ const getEchartAxes = ({
 
     const getMinAndMaxFromBottomAxisBounds = (
         axisType: 'value' | 'category' | 'time' | string,
-        truncateAxis: boolean,
         min?: number,
         max?: number,
     ) => {
-        if (axisType === 'value' && truncateAxis) {
+        if (axisType === 'value') {
             const defaultMin =
                 xAxisConfiguration?.[0]?.min ||
                 referenceLineMinX ||
@@ -1169,8 +1168,8 @@ const getEchartAxes = ({
                 max !== undefined
             ) {
                 return {
-                    min: min - (bottomAxisOffset.minOffset ?? 0.5),
-                    max: max + (bottomAxisOffset.maxOffset ?? 0.5),
+                    min: min - (bottomAxisOffset.minOffset ?? 0),
+                    max: max + (bottomAxisOffset.maxOffset ?? 0),
                 };
             }
             return {
@@ -1234,7 +1233,6 @@ const getEchartAxes = ({
 
     const bottomAxisBounds = getMinAndMaxFromBottomAxisBounds(
         bottomAxisType,
-        true,
         bottomAxisMinValue,
         bottomAxisMaxValue,
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9814

### Description:

Screen recording: 


https://github.com/lightdash/lightdash/assets/7611706/49a88ceb-dab1-431f-b259-3076cb56afad


Requirements: 
- Only for x axis
- Only for bar charts, **not** horizontal
- Only for visualizations of type `value` on the x axis (basically, a numeric value like 0, 1, 2)

Adds `minOffset` and `maxOffset` to type `Axis`
User can set this offset when setting x-axis range to manual. 
The value set by default is `0.5` (-0.5 on the left and +0.5 on the right)
When the inputs (for max or min) are set to empty, then we apply the data min and data max from the `rows` data. If the user overrides to their own, the calculations are applied.

To replicate:

Locally:
- Go to `Tracks` table
- Select Timestamp month
- Select Event count
- Create table calculation, with this: ` (${tracks.event_count} - 4028) / 1000`
- X axis should be set to the table calculation
- Add filter for table calculation with: `is greater than` `-1`
- See overlap on Y axis
(now onto the fix)
- Open chart config
- Go to Axis tab
- Select manual x-axis range
- Overlap is no more an issue bc of the offset applied (feel free to play around with the mins and offsets)

On Render: 
- See this chart: https://lightdash-pr-10162.onrender.com/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/7bfc2abb-eb66-45cf-a161-cf89af7ba945/view
- Play around with chart config > axis > x axis > turn off `auto x-axis range`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
