### PR TITLE
fix: wrap cell values in element to prevent errors from browser exten…

### DIFF
--- a/packages/frontend/src/features/metricFlow/utils/convertFieldMapToTableColumns.ts
+++ b/packages/frontend/src/features/metricFlow/utils/convertFieldMapToTableColumns.ts
@@ -3,6 +3,7 @@ import {
     columnHelper,
     type TableColumn,
 } from '../../../components/common/Table/types';
+import { getRawValueCell } from '../../../hooks/useColumns';
 
 export default function convertFieldMapToTableColumns(itemsMap: ItemsMap) {
     return Object.values(itemsMap).map<TableColumn>((item) => {
@@ -10,13 +11,7 @@ export default function convertFieldMapToTableColumns(itemsMap: ItemsMap) {
         return columnHelper.accessor((row) => row[fieldId], {
             id: fieldId,
             header: () => getItemLabel(item),
-            cell: (info) => {
-                const raw = info.getValue()?.value.raw;
-                if (raw === null) return '∅';
-                if (raw === undefined) return '-';
-                if (raw instanceof Date) return raw.toISOString();
-                return `${raw}`;
-            },
+            cell: getRawValueCell,
             meta: {
                 item,
             },

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -20,6 +20,7 @@ import {
     type TableColumn,
     type TableHeader,
 } from '../../components/common/Table/types';
+import { getFormattedValueCell } from '../useColumns';
 
 type Args = {
     itemsMap: ItemsMap;
@@ -141,8 +142,7 @@ const getDataAndColumns = ({
                             )}
                         </TableHeaderLabelContainer>
                     ),
-                    cell: (info: any) =>
-                        info.getValue()?.value.formatted || '-',
+                    cell: getFormattedValueCell,
 
                     footer: () =>
                         totals?.[itemId]

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -12,10 +12,13 @@ import {
     type CustomDimension,
     type Field,
     type ItemsMap,
+    type ResultRow,
+    type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
 import { Group, Tooltip } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
+import { type CellContext } from '@tanstack/react-table';
 import { useMemo } from 'react';
 import MantineIcon from '../components/common/MantineIcon';
 import {
@@ -40,6 +43,20 @@ export const getItemBgColor = (
     } else {
         return '#d2dfd7';
     }
+};
+
+export const getFormattedValueCell = (
+    info: CellContext<ResultRow, { value: ResultValue }>,
+) => <span>{info.getValue()?.value.formatted || '-'}</span>;
+
+export const getRawValueCell = (
+    info: CellContext<ResultRow, { value: ResultValue }>,
+) => {
+    let raw = info.getValue()?.value.raw;
+    if (raw === null) return '∅';
+    if (raw === undefined) return '-';
+    if (raw instanceof Date) return <span>{raw.toISOString()}</span>;
+    return <span>{`${raw}`}</span>;
 };
 
 export const useColumns = (): TableColumn[] => {
@@ -161,7 +178,7 @@ export const useColumns = (): TableColumn[] => {
                             )}
                         </TableHeaderLabelContainer>
                     ),
-                    cell: (info) => info.getValue()?.value.formatted || '-',
+                    cell: getFormattedValueCell,
                     footer: () =>
                         totals?.[fieldId]
                             ? formatItemValue(item, totals[fieldId])
@@ -212,7 +229,7 @@ export const useColumns = (): TableColumn[] => {
                                 </TableHeaderBoldLabel>
                             </Group>
                         ),
-                        cell: (info) => info.getValue()?.value.formatted || '-',
+                        cell: getFormattedValueCell,
                         meta: {
                             isInvalidItem: true,
                         },

--- a/packages/frontend/src/hooks/useSqlRunnerColumns.ts
+++ b/packages/frontend/src/hooks/useSqlRunnerColumns.ts
@@ -9,6 +9,7 @@ import {
     columnHelper,
     type TableColumn,
 } from '../components/common/Table/types';
+import { getRawValueCell } from './useColumns';
 import useColumnTotals from './useColumnTotals';
 
 type Args = {
@@ -34,22 +35,7 @@ const useSqlRunnerColumns = ({
                         columnHeader !== undefined
                             ? columnHeader(dimension)
                             : dimension.label,
-                    cell: (info) => {
-                        let raw;
-                        try {
-                            raw = info.getValue().value.raw;
-                        } catch {
-                            console.error(
-                                'Error getting cell data for field',
-                                fieldId,
-                            );
-                            return 'Error';
-                        }
-                        if (raw === null) return '∅';
-                        if (raw === undefined) return '-';
-                        if (raw instanceof Date) return raw.toISOString();
-                        return `${raw}`;
-                    },
+                    cell: getRawValueCell,
                     footer: () => (totals[fieldId] ? totals[fieldId] : null),
                     meta: {
                         item: dimension,

--- a/packages/frontend/src/hooks/useUnderlyingDataColumns.ts
+++ b/packages/frontend/src/hooks/useUnderlyingDataColumns.ts
@@ -10,6 +10,7 @@ import {
     columnHelper,
     type TableColumn,
 } from '../components/common/Table/types';
+import { getFormattedValueCell } from './useColumns';
 import useColumnTotals from './useColumnTotals';
 
 type Args = {
@@ -35,8 +36,7 @@ const useUnderlyingDataColumns = ({
                         columnHeader !== undefined
                             ? columnHeader(dimension)
                             : dimension.label,
-                    cell: (info: any) =>
-                        info.getValue()?.value.formatted || '-',
+                    cell: getFormattedValueCell,
                     footer: () =>
                         totals[fieldId]
                             ? formatItemValue(dimension, totals[fieldId])


### PR DESCRIPTION
…sions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10167 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fix: make sure react-table returns an element for the cell instead of text. This allows browser extensions to manipulate the value without React losing track of the cell html element. 

Before:

https://github.com/lightdash/lightdash/assets/9117144/4a0c3e02-1720-49b4-8d06-97666689a151


Afer:


https://github.com/lightdash/lightdash/assets/9117144/eb9f59e8-cac4-4f5d-b84f-5c37995af03f



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
