### PR TITLE
fix: add search params when switching tab

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -10,6 +10,7 @@ import { useProfiler } from '@sentry/react';
 import { IconDots, IconPencil, IconPlus, IconTrash } from '@tabler/icons-react';
 import { memo, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
+import { useHistory, useLocation } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
 import {
     getReactGridLayoutConfig,
@@ -111,6 +112,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         }),
         [dashboardTiles, isEditMode],
     );
+
+    const { search } = useLocation();
+    const history = useHistory();
 
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const projectUuid = useDashboardContext((c) => c.projectUuid);
@@ -237,11 +241,11 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     setActiveTab(tab);
                 }
                 if (!isEditMode) {
-                    window.history.replaceState(
-                        null,
-                        '',
-                        `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
-                    ); // replace url without reloading
+                    const newParams = new URLSearchParams(search);
+                    history.replace({
+                        pathname: `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
+                        search: newParams.toString(),
+                    });
                 }
             }}
             style={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

issue:

when switching tab previously temp filter value is gone, later when sharing the link temp filter value is not copied to the link which would be miss leading.

https://github.com/lightdash/lightdash/assets/101873365/8361b367-9c98-4701-81c8-de9f37d59f9f




### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
