### PR TITLE
fix: allow safari to copy to clipboard on async values

### DIFF
--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -1,42 +1,36 @@
 import { ActionIcon } from '@mantine/core';
-import { useClipboard } from '@mantine/hooks';
 import { IconCheck, IconLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useLocation } from 'react-router-dom';
-import useToaster from '../../../hooks/toaster/useToaster';
+import { useAsyncClipboard } from '../../../hooks/useAsyncClipboard';
 import { useCreateShareMutation } from '../../../hooks/useShare';
 import MantineIcon from '../MantineIcon';
 
 const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
-    const clipboard = useClipboard({ timeout: 500 });
-    const { showToastSuccess } = useToaster();
-
     const location = useLocation();
-    const { isLoading, mutateAsync: createShareUrl } = useCreateShareMutation();
 
+    const { isLoading, mutateAsync: createShareUrl } = useCreateShareMutation();
     const isDisabled = disabled || isLoading;
 
-    const handleCopyClick = async () => {
-        const { shareUrl } = await createShareUrl({
+    const getSharedUrl = async () => {
+        const response = await createShareUrl({
             path: location.pathname,
             params: location.search,
         });
-        clipboard.copy(shareUrl || '');
-        showToastSuccess({
-            title: 'Link copied to clipboard',
-        });
+        return response.shareUrl;
     };
+    const { handleCopy, copied } = useAsyncClipboard(getSharedUrl);
 
     return (
         <ActionIcon
             variant="default"
-            onClick={handleCopyClick}
+            onClick={handleCopy}
             disabled={isDisabled}
             color="gray"
         >
             <MantineIcon
-                icon={clipboard.copied ? IconCheck : IconLink}
-                color={clipboard.copied ? 'green' : undefined}
+                icon={copied ? IconCheck : IconLink}
+                color={copied ? 'green' : undefined}
             />
         </ActionIcon>
     );

--- a/packages/frontend/src/hooks/useAsyncClipboard.tsx
+++ b/packages/frontend/src/hooks/useAsyncClipboard.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import useToaster from './toaster/useToaster';
+
+/**
+ * Custom React hook to interact with the clipboard. This hook facilitates copying text to the clipboard
+ * that is retrieved asynchronously, with special handling for different browsers.
+ *
+ * @param {() => Promise<string | undefined>} asyncOperation A function that returns a promise which resolves to the string to be copied.
+ * @returns An object containing the `copied` state indicating if the copy operation was successful, and `handleCopy` method to trigger the copy.
+ */
+export const useAsyncClipboard = (
+    asyncOperation: () => Promise<string | undefined>,
+) => {
+    const { showToastSuccess } = useToaster();
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = useCallback(async () => {
+        if ('clipboard' in navigator) {
+            if (typeof ClipboardItem !== 'undefined' && navigator.clipboard) {
+                // Safari-specific handling: Safari restricts clipboard API to direct user interactions.
+                // The workaround involves using ClipboardItem with a Blob wrapping the promise.
+                // Source: https://developer.apple.com/forums/thread/691873
+                const shareUrl = new ClipboardItem({
+                    'text/plain': asyncOperation().then(
+                        (s) => new Blob([s ?? ''], { type: 'text/plain' }),
+                    ),
+                });
+                await navigator.clipboard.write([shareUrl]);
+            } else {
+                // Firefox also support for ClipboardItem and navigator.clipboard.write,
+                // but that is behind `dom.events.asyncClipboard.clipboardItem` preference.
+                // Unlike Safari, Firefox does not restrict the Clipboard API to direct user interactions, so we can do the default async operation without any special handling.
+                const response = await asyncOperation();
+                await navigator.clipboard.writeText(response ?? '');
+            }
+
+            setCopied(true);
+            showToastSuccess({ title: 'Link copied to clipboard' });
+            setTimeout(() => setCopied(false), 1000);
+        }
+    }, [asyncOperation, showToastSuccess]);
+
+    return {
+        copied,
+        handleCopy,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10148](https://github.com/lightdash/lightdash/issues/10148)

### Description:

When dealing with async operations to retrieve text to then copy to clipboard, Safari blocks this operation because it doesn't consider it a direct user action: on click -> API call -> copy to clipboard. Since there's an API in the middle of the process, that is then blocked by Safari. 

Found this blog post that explained it nicely: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
And also it mentions this safari thread with the solution: https://developer.apple.com/forums/thread/691873

Also added a custom hook `useAsyncClipboard` which covers both major browsers: Chrome Firefox and Safari. 

> [!NOTE]  
> I checked other places in the code where we use `useClipboard` - and these are only used for non-async values. So all good! I also tested this in Safari: clicking `copy value` on a table cell. And it copied correctly!


Demo on Safari (I also tested in Chrome, all good): 


https://github.com/lightdash/lightdash/assets/7611706/e940a9d4-c33f-40c3-a8b6-e65c2bbd81a2



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
