### PR TITLE
feat: disable custom viz actions

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -83,6 +83,7 @@ const CustomVisualization: FC<Props> = (props) => {
                         data: { name: 'values' },
                     }}
                     data={data}
+                    actions={false}
                 />
             </Suspense>
         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10199 

### Description:

Turns off the actions menu in custom visualizations. It's possible there should be an option to turn it back on, but the main request is to turn it off and it's not clear it adds value at the moment.

This removes this button/menu:
<img width="892" alt="Screenshot 2024-05-28 at 10 44 56" src="https://github.com/lightdash/lightdash/assets/1864179/bd4c0bec-42c5-4930-ac86-2e783ce8acd8">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
