### PR TITLE
feat: add right sidebar to page component

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -11,7 +11,7 @@ import { SectionName } from '../../../types/Events';
 import AboutFooter, { FOOTER_HEIGHT, FOOTER_MARGIN } from '../../AboutFooter';
 import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../../NavBar';
 import { PAGE_HEADER_HEIGHT } from './PageHeader';
-import Sidebar from './Sidebar';
+import Sidebar, { SidebarPosition } from './Sidebar';
 
 type StyleProps = {
     withCenteredContent?: boolean;
@@ -24,6 +24,7 @@ type StyleProps = {
     withPaddedContent?: boolean;
     withSidebar?: boolean;
     withSidebarFooter?: boolean;
+    withRightSidebar?: boolean;
     hasBanner?: boolean;
 };
 
@@ -56,7 +57,7 @@ const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
                       overflowY: 'auto',
                   }),
 
-            ...(params.withSidebar
+            ...(params.withSidebar || params.withRightSidebar
                 ? {
                       display: 'flex',
                       flexDirection: 'row',
@@ -71,7 +72,7 @@ const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
             width: '100%',
             minWidth: PAGE_CONTENT_WIDTH,
 
-            ...(params.withSidebar
+            ...(params.withSidebar || params.withRightSidebar
                 ? {
                       minWidth: PAGE_MIN_CONTENT_WIDTH,
                   }
@@ -135,6 +136,8 @@ type Props = {
     title?: string;
     sidebar?: React.ReactNode;
     isSidebarOpen?: boolean;
+    rightSidebar?: React.ReactNode;
+    isRightSidebarOpen?: boolean;
     header?: React.ReactNode;
 } & Omit<StyleProps, 'withSidebar' | 'withHeader'>;
 
@@ -143,6 +146,8 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     header,
     sidebar,
     isSidebarOpen = true,
+    rightSidebar,
+    isRightSidebarOpen = false,
 
     withCenteredContent = false,
     withFitContent = false,
@@ -177,6 +182,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             withPaddedContent,
             withSidebar: !!sidebar,
             withSidebarFooter,
+            withRightSidebar: !!rightSidebar,
             hasBanner: isCurrentProjectPreview,
         },
         { name: 'Page' },
@@ -210,8 +216,18 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                     </TrackSection>
                 </Box>
 
-                {withFooter && !withSidebarFooter ? <AboutFooter /> : null}
+                {rightSidebar ? (
+                    <Sidebar
+                        isOpen={isRightSidebarOpen}
+                        position={SidebarPosition.RIGHT}
+                    >
+                        <ErrorBoundary wrapper={{ mt: '4xl' }}>
+                            {rightSidebar}
+                        </ErrorBoundary>
+                    </Sidebar>
+                ) : null}
             </Box>
+            {withFooter && !withSidebarFooter ? <AboutFooter /> : null}
         </>
     );
 };

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -20,16 +20,23 @@ const SIDEBAR_MAX_WIDTH = 600;
 
 const SIDEBAR_RESIZE_HANDLE_WIDTH = 6;
 
+export enum SidebarPosition {
+    LEFT = 'left',
+    RIGHT = 'right',
+}
+
 type Props = {
     isOpen?: boolean;
     containerProps?: FlexProps;
     cardProps?: CardProps;
+    position?: SidebarPosition;
 };
 
 const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     isOpen = true,
     containerProps,
     cardProps,
+    position = SidebarPosition.LEFT,
     children,
 }) => {
     const { sidebarRef, sidebarWidth, isResizing, startResizing } =
@@ -37,20 +44,24 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             defaultWidth: SIDEBAR_DEFAULT_WIDTH,
             minWidth: SIDEBAR_MIN_WIDTH,
             maxWidth: SIDEBAR_MAX_WIDTH,
+            position,
         });
 
     const transition: MantineTransition = {
         in: {
             opacity: 1,
-            marginLeft: 0,
+            ...(position === SidebarPosition.LEFT
+                ? { marginLeft: 0 }
+                : { marginRight: 0 }),
         },
         out: {
             opacity: 0,
-            marginLeft: -sidebarWidth,
+            ...(position === SidebarPosition.LEFT
+                ? { marginLeft: -sidebarWidth }
+                : { marginRight: -sidebarWidth }),
         },
         transitionProperty: 'opacity, margin',
     };
-
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <Flex
@@ -87,7 +98,9 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                 w={SIDEBAR_RESIZE_HANDLE_WIDTH}
                                 pos="absolute"
                                 top={0}
-                                right={-SIDEBAR_RESIZE_HANDLE_WIDTH}
+                                {...(position === SidebarPosition.LEFT
+                                    ? { right: -SIDEBAR_RESIZE_HANDLE_WIDTH }
+                                    : { left: -SIDEBAR_RESIZE_HANDLE_WIDTH })}
                                 onMouseDown={startResizing}
                                 {...cardProps}
                                 sx={(theme) => ({

--- a/packages/frontend/src/hooks/useSidebarResize.ts
+++ b/packages/frontend/src/hooks/useSidebarResize.ts
@@ -1,12 +1,19 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { SidebarPosition } from '../components/common/Page/Sidebar';
 
 type Args = {
     defaultWidth: number;
     minWidth: number;
     maxWidth: number;
+    position: SidebarPosition;
 };
 
-const useSidebarResize = ({ maxWidth, minWidth, defaultWidth }: Args) => {
+const useSidebarResize = ({
+    maxWidth,
+    minWidth,
+    defaultWidth,
+    position,
+}: Args) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
     const [isResizing, setIsResizing] = useState(false);
     const [sidebarWidth, setSidebarWidth] = useState(defaultWidth);
@@ -25,12 +32,16 @@ const useSidebarResize = ({ maxWidth, minWidth, defaultWidth }: Args) => {
             if (!isResizing || !sidebarRef.current) return;
             event.preventDefault();
 
-            const newWidth =
-                event.clientX - sidebarRef.current.getBoundingClientRect().left;
-
+            const sidebarRect = sidebarRef.current.getBoundingClientRect();
+            let newWidth;
+            if (position === SidebarPosition.LEFT) {
+                newWidth = event.clientX - sidebarRect.left;
+            } else {
+                newWidth = sidebarRect.right - event.clientX;
+            }
             setSidebarWidth(Math.min(maxWidth, Math.max(minWidth, newWidth)));
         },
-        [isResizing, minWidth, maxWidth],
+        [isResizing, position, maxWidth, minWidth],
     );
 
     useLayoutEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10130 

### Description:

Adds `rightSidebar` to `Page`
Allows `Sidebar` to take a position - can be `right` or `left`
Ensures that the `useSidebarResize` hook can take a `position` arg so resizing works well. 
Adds a temporary example in `Catalog` to showcase how this works. 


Screen recording:


https://github.com/lightdash/lightdash/assets/7611706/29ec9957-e9f5-4361-9440-edc1c544c869



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
