### PR TITLE
fix: filter table selection

### DIFF
--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -13,6 +13,7 @@ import { DbCatalog } from '../../../database/entities/catalog';
 const parseFieldFromMetricOrDimension = (
     table: CompiledTable,
     field: CompiledMetric | CompiledDimension,
+    tags: string[],
 ): CatalogField => ({
     name: field.name,
     description: field.description,
@@ -23,6 +24,7 @@ const parseFieldFromMetricOrDimension = (
     basicType: getBasicType(field),
     type: CatalogType.Field,
     requiredAttributes: field?.requiredAttributes || table.requiredAttributes,
+    tags,
 });
 
 export const parseFieldsFromCompiledTable = (
@@ -33,7 +35,7 @@ export const parseFieldsFromCompiledTable = (
         ...Object.values(table.metrics),
     ];
     return tableFields.map((field) =>
-        parseFieldFromMetricOrDimension(table, field),
+        parseFieldFromMetricOrDimension(table, field, []),
     );
 };
 
@@ -49,6 +51,7 @@ export const parseCatalog = (
             description: dbCatalog.description || undefined,
             type: CatalogType.Table,
             requiredAttributes: baseTable.requiredAttributes,
+            tags: dbCatalog.explore.tags,
         };
     }
 
@@ -67,5 +70,9 @@ export const parseCatalog = (
             `Field ${dbCatalog.name} not found in explore ${dbCatalog.explore.name}`,
         );
     }
-    return parseFieldFromMetricOrDimension(baseTable, findField);
+    return parseFieldFromMetricOrDimension(
+        baseTable,
+        findField,
+        dbCatalog.explore.tags,
+    );
 };

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -118,7 +118,7 @@ export class CatalogService<
         if (type === TableSelectionType.WITH_NAMES) {
             return (value || []).includes(explore.name);
         }
-        return false;
+        return true;
     }
 
     private async getCatalogTables(

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -28,6 +28,7 @@ export type CatalogField = Pick<
         basicType?: string; // string, number, timestamp... used in metadata
         tableName: string;
         tableGroupLabel?: string;
+        tags?: string[]; // Tags from table, for filtering
     };
 
 export type CatalogTable = Pick<
@@ -37,6 +38,7 @@ export type CatalogTable = Pick<
     errors?: InlineError[]; // For explore errors
     type: CatalogType.Table;
     groupLabel?: string;
+    tags?: string[];
     joinedTables?: CompiledExploreJoin[]; // Matched type in explore
 };
 

--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -21,6 +21,7 @@ describe('Lightdash catalog all tables and fields', () => {
                 description: 'users table',
                 type: 'table',
                 joinedTables: [],
+                tags: [],
             });
         });
     });
@@ -42,9 +43,12 @@ describe('Lightdash catalog all tables and fields', () => {
                 name: 'payment_method',
                 description: 'Method of payment used, for example credit card',
                 tableLabel: 'Payments',
+                tableName: 'payments',
+
                 fieldType: 'dimension',
                 basicType: 'string',
                 type: 'field',
+                tags: [],
             });
 
             const metric = resp.body.results.find(
@@ -56,9 +60,11 @@ describe('Lightdash catalog all tables and fields', () => {
                 name: 'total_revenue',
                 description: 'Sum of all payments',
                 tableLabel: 'Payments',
+                tableName: 'payments',
                 fieldType: 'metric',
                 basicType: 'number',
                 type: 'field',
+                tags: [],
             });
         });
     });
@@ -85,6 +91,7 @@ describe('Lightdash catalog search', () => {
                 description:
                     "# Customers\n\nThis table has basic information about a customer, as well as some derived\nfacts based on a customer's orders\n",
                 type: 'table',
+                tags: [],
             });
 
             const field = resp.body.results.find(
@@ -94,10 +101,12 @@ describe('Lightdash catalog search', () => {
             expect(field).to.eql({
                 name: 'customer_id',
                 tableLabel: 'Users',
+                tableName: 'users',
                 description: 'This is a unique identifier for a customer',
                 type: 'field',
                 basicType: 'number',
                 fieldType: 'dimension',
+                tags: [],
             });
         });
     });
@@ -117,9 +126,12 @@ describe('Lightdash catalog search', () => {
                 name: 'payment_method',
                 description: 'Method of payment used, for example credit card',
                 tableLabel: 'Payments',
+                tableName: 'payments',
+
                 fieldType: 'dimension',
                 basicType: 'string',
                 type: 'field',
+                tags: [],
             });
         });
     });
@@ -137,9 +149,12 @@ describe('Lightdash catalog search', () => {
                 name: 'total_revenue',
                 description: 'Sum of all payments',
                 tableLabel: 'Payments',
+                tableName: 'payments',
+
                 fieldType: 'metric',
                 basicType: 'number',
                 type: 'field',
+                tags: [],
             });
         });
     });
@@ -162,10 +177,13 @@ describe('Lightdash catalog search', () => {
             expect(matchingField).to.eql({
                 name: 'customer_id',
                 tableLabel: 'Users',
+                tableName: 'users',
+
                 description: 'This is a unique identifier for a customer',
                 type: 'field',
                 basicType: 'number',
                 fieldType: 'dimension',
+                tags: [],
             });
 
             // Check for a table
@@ -177,6 +195,7 @@ describe('Lightdash catalog search', () => {
                 description:
                     "# Customers\n\nThis table has basic information about a customer, as well as some derived\nfacts based on a customer's orders\n",
                 type: 'table',
+                tags: [],
             });
         });
     });
@@ -195,10 +214,13 @@ describe('Lightdash catalog search', () => {
             expect(matchingField).to.eql({
                 name: 'date_of_first_order',
                 tableLabel: 'Orders',
+                tableName: 'orders',
+
                 description: 'Min of Order date',
                 type: 'field',
                 basicType: 'number',
                 fieldType: 'metric',
+                tags: [],
             });
         });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10200

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
We apply the same filtering logic from explores?filtered=true

I filtered on table selection `generated_b` but not `generated_a`

Table
![Screenshot from 2024-05-28 10-55-33](https://github.com/lightdash/lightdash/assets/1983672/78f0d16a-eb6a-4889-96ff-d6df69e8778c)

Search table 
![Screenshot from 2024-05-28 11-17-40](https://github.com/lightdash/lightdash/assets/1983672/979dc8ea-ec17-46ff-a514-f734dbeabd8b)

Filter fields from generated_b on search

![Screenshot from 2024-05-28 11-27-55](https://github.com/lightdash/lightdash/assets/1983672/2d1208a1-6944-4e72-b879-390783bc263a)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
