### PR TITLE
feat: add metadata to right sidebar

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -12,17 +12,20 @@ import {
     IconArrowUp,
     IconCornerDownLeft,
 } from '@tabler/icons-react';
+import { useIsFetching } from '@tanstack/react-query';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { useState, type FC } from 'react';
+import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCatalogContext } from '../context/CatalogProvider';
 import { CatalogAnalyticCharts } from './CatalogAnalyticCharts';
 
 export const CatalogMetadata: FC = () => {
-    // TODO: fix
-    const [isAnalyticsLoading] = useState(false);
     const { projectUuid, metadata, analyticsResults } = useCatalogContext();
+
+    const isFetchingAnalytics = useIsFetching({
+        queryKey: ['catalog_analytics', projectUuid],
+    });
     const history = useHistory();
 
     if (!metadata) return null;
@@ -60,7 +63,7 @@ export const CatalogMetadata: FC = () => {
                         <Tabs.Tab value={'analytics'} mx="md">
                             {/* TODO replace loading with spinner ?*/}
                             analytics (
-                            {isAnalyticsLoading
+                            {isFetchingAnalytics
                                 ? '.'
                                 : analyticsResults?.charts.length || '0'}
                             )
@@ -69,6 +72,7 @@ export const CatalogMetadata: FC = () => {
                     <Tabs.Panel value="overview">
                         <Text> Overview</Text>
                         {/* TODO make this a tab*/}
+
                         <Text>Tags</Text>
                         <Flex justify="space-between">
                             <Text>Model name </Text>
@@ -88,50 +92,7 @@ export const CatalogMetadata: FC = () => {
                             <Text>Source </Text>
                             <Text>{metadata.source}</Text>
                         </Flex>
-                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
-                        );
-                        <Text>{metadata.name}</Text>
-                        <MarkdownPreview
-                            style={{ fontSize: 'small' }}
-                            source={metadata.description}
-                        />
-                        <Text> Overview</Text>
-                        {/* TODO make this a tab*/}
-                        <Text>Tags</Text>
-                        <Flex justify="space-between">
-                            <Text>Model name </Text>
-                            <Text
-                                underline={true}
-                                weight={700}
-                                onDoubleClick={() => {
-                                    history.push(
-                                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
-                                    );
-                                }}
-                            >
-                                {metadata.modelName}
-                            </Text>
-                        </Flex>
-                        <Flex justify="space-between">
-                            <Text>Source </Text>
-                            <Text>{metadata.source}</Text>
-                        </Flex>
-                        <Table>
-                            <thead>
-                                <tr>
-                                    <th>field name</th>
-                                    <th>type</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {metadata.fields?.map((field) => (
-                                    <tr key={field.name}>
-                                        <td>{field.name}</td>
-                                        <td>{field.basicType}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+
                         <Table>
                             <thead>
                                 <tr>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -88,9 +88,7 @@ export const CatalogMetadata: FC = () => {
                                         key={field.name}
                                         style={{
                                             border:
-                                                selection &&
-                                                selection?.field &&
-                                                selection.field === field.name
+                                                selection?.field === field.name
                                                     ? `2px solid ${colors.blue[6]}`
                                                     : undefined,
                                         }}

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -1,134 +1,187 @@
 import {
-    type ApiCatalogAnalyticsResults,
-    type ApiCatalogMetadataResults,
-} from '@lightdash/common';
-import { Flex, Stack, Table, Tabs, Text } from '@mantine/core';
+    Flex,
+    Group,
+    ScrollArea,
+    Stack,
+    Table,
+    Tabs,
+    Text,
+} from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowUp,
     IconCornerDownLeft,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useCatalogContext } from '../context/CatalogProvider';
 import { CatalogAnalyticCharts } from './CatalogAnalyticCharts';
 
-type Props = {
-    projectUuid: string;
-    metadataResults: ApiCatalogMetadataResults;
-    analyticResults?: ApiCatalogAnalyticsResults;
-    isAnalyticsLoading: boolean;
-};
-
-export const CatalogMetadata: FC<React.PropsWithChildren<Props>> = ({
-    projectUuid,
-    metadataResults,
-    analyticResults,
-    isAnalyticsLoading,
-}) => {
+export const CatalogMetadata: FC = () => {
+    // TODO: fix
+    const [isAnalyticsLoading] = useState(false);
+    const { projectUuid, metadata, analyticsResults } = useCatalogContext();
     const history = useHistory();
+
+    if (!metadata) return null;
+
     return (
-        <Stack style={{ position: 'relative', minHeight: '100vh' }}>
+        <Stack h="100vh">
             <Text
                 underline={true}
                 size="l"
                 weight={700}
                 onDoubleClick={() => {
                     history.push(
-                        `/projects/${projectUuid}/tables/${metadataResults.modelName}`,
+                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
                     );
                 }}
             >
-                {metadataResults.name}
+                {metadata.name}
             </Text>
-            <MarkdownPreview
-                style={{ fontSize: 'small' }}
-                source={metadataResults.description}
-            />
-            <Tabs defaultValue="overview">
-                <Tabs.List>
-                    <Tabs.Tab value={'overview'} mx="md">
-                        Overview
-                    </Tabs.Tab>
-                    <Tabs.Tab value={'analytics'} mx="md">
-                        {/* TODO replace loading with spinner ?*/}
-                        analytics (
-                        {isAnalyticsLoading
-                            ? '.'
-                            : analyticResults?.charts.length || '0'}
-                        )
-                    </Tabs.Tab>
-                </Tabs.List>
-                <Tabs.Panel value="overview">
-                    <Text> Overview</Text>
-                    {/* TODO make this a tab*/}
+            <ScrollArea
+                variant="primary"
+                className="only-vertical"
+                offsetScrollbars
+                scrollbarSize={8}
+            >
+                <MarkdownPreview
+                    style={{ fontSize: 'small' }}
+                    source={metadata.description}
+                />
 
-                    <Text>Tags</Text>
-                    <Flex justify="space-between">
-                        <Text>Model name </Text>
-                        <Text
-                            underline={true}
-                            weight={700}
-                            onDoubleClick={() => {
-                                history.push(
-                                    `/projects/${projectUuid}/tables/${metadataResults.modelName}`,
-                                );
-                            }}
-                        >
-                            {metadataResults.modelName}
-                        </Text>
-                    </Flex>
-                    <Flex justify="space-between">
-                        <Text>Source </Text>
-                        <Text>{metadataResults.source}</Text>
-                    </Flex>
-
-                    <Table>
-                        <thead>
-                            <tr>
-                                <th>field name</th>
-                                <th>type</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {metadataResults.fields?.map((field) => (
-                                <tr key={field.name}>
-                                    <td>{field.name}</td>
-                                    <td>{field.basicType}</td>
+                <Tabs defaultValue="overview">
+                    <Tabs.List>
+                        <Tabs.Tab value={'overview'} mx="md">
+                            Overview
+                        </Tabs.Tab>
+                        <Tabs.Tab value={'analytics'} mx="md">
+                            {/* TODO replace loading with spinner ?*/}
+                            analytics (
+                            {isAnalyticsLoading
+                                ? '.'
+                                : analyticsResults?.charts.length || '0'}
+                            )
+                        </Tabs.Tab>
+                    </Tabs.List>
+                    <Tabs.Panel value="overview">
+                        <Text> Overview</Text>
+                        {/* TODO make this a tab*/}
+                        <Text>Tags</Text>
+                        <Flex justify="space-between">
+                            <Text>Model name </Text>
+                            <Text
+                                underline={true}
+                                weight={700}
+                                onDoubleClick={() => {
+                                    history.push(
+                                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
+                                    );
+                                }}
+                            >
+                                {metadata.modelName}
+                            </Text>
+                        </Flex>
+                        <Flex justify="space-between">
+                            <Text>Source </Text>
+                            <Text>{metadata.source}</Text>
+                        </Flex>
+                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
+                        );
+                        <Text>{metadata.name}</Text>
+                        <MarkdownPreview
+                            style={{ fontSize: 'small' }}
+                            source={metadata.description}
+                        />
+                        <Text> Overview</Text>
+                        {/* TODO make this a tab*/}
+                        <Text>Tags</Text>
+                        <Flex justify="space-between">
+                            <Text>Model name </Text>
+                            <Text
+                                underline={true}
+                                weight={700}
+                                onDoubleClick={() => {
+                                    history.push(
+                                        `/projects/${projectUuid}/tables/${metadata.modelName}`,
+                                    );
+                                }}
+                            >
+                                {metadata.modelName}
+                            </Text>
+                        </Flex>
+                        <Flex justify="space-between">
+                            <Text>Source </Text>
+                            <Text>{metadata.source}</Text>
+                        </Flex>
+                        <Table>
+                            <thead>
+                                <tr>
+                                    <th>field name</th>
+                                    <th>type</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </Table>
-                </Tabs.Panel>
-                <Tabs.Panel value="analytics" w={300}>
-                    <>
-                        {analyticResults && (
-                            <CatalogAnalyticCharts
-                                projectUuid={projectUuid}
-                                analyticResults={analyticResults}
-                            />
-                        )}
-                    </>
-                </Tabs.Panel>
-            </Tabs>
+                            </thead>
+                            <tbody>
+                                {metadata.fields?.map((field) => (
+                                    <tr key={field.name}>
+                                        <td>{field.name}</td>
+                                        <td>{field.basicType}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </Table>
+                        <Table>
+                            <thead>
+                                <tr>
+                                    <th>field name</th>
+                                    <th>type</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {metadata.fields?.map((field) => (
+                                    <tr key={field.name}>
+                                        <td>{field.name}</td>
+                                        <td>{field.basicType}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </Table>
+                    </Tabs.Panel>
+                    <Tabs.Panel value="analytics" w={300}>
+                        <>
+                            {analyticsResults && (
+                                <CatalogAnalyticCharts
+                                    projectUuid={projectUuid}
+                                    analyticResults={analyticsResults}
+                                />
+                            )}
+                        </>
+                    </Tabs.Panel>
+                </Tabs>
+            </ScrollArea>
             <Stack
                 p={10}
-                style={{
-                    backgroundColor: 'lightgray',
+                sx={(theme) => ({
+                    backgroundColor: theme.colors.gray[0],
+                    border: `1px solid ${theme.colors.gray[4]}`,
+                    borderLeft: 0,
                     position: 'absolute',
                     bottom: 0,
+                    left: 0,
                     width: '100%',
                     color: 'gray',
-                }}
+                })}
             >
-                <Flex>
-                    <IconArrowUp />
-                    <IconArrowDown />
+                <Group>
+                    <MantineIcon icon={IconArrowUp} />
+                    <MantineIcon icon={IconArrowDown} />
                     <Text>Navigate</Text>
 
-                    <IconCornerDownLeft />
+                    <MantineIcon icon={IconCornerDownLeft} />
                     <Text>Use</Text>
-                </Flex>
+                </Group>
             </Stack>
         </Stack>
     );

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue, useHotkeys } from '@mantine/hooks';
 import { IconFilter, IconSearch, IconX } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
@@ -96,27 +96,25 @@ export const CatalogPanel: FC = () => {
         mutate: getMetadata,
         data: metadata,
         reset: closeMetadata,
-        isSuccess,
-    } = useCatalogMetadata(projectUuid);
-    const {
-        mutate: getAnalytics,
-        data: analytics,
-        isSuccess: isAnalyticsSuccess,
-    } = useCatalogAnalytics(projectUuid);
+    } = useCatalogMetadata(projectUuid, (data) => {
+        console.log('metadata', data);
 
-    useEffect(() => {
-        if (isSuccess) {
-            setMetadata(metadata);
+        if (data) {
+            setMetadata(data);
         }
 
-        if (!isSidebarOpen && metadata) {
+        if (!isSidebarOpen && data) {
             setSidebarOpen(true);
         }
-    }, [isSidebarOpen, isSuccess, metadata, setMetadata, setSidebarOpen]);
-
-    useEffect(() => {
-        setAnalyticsResults(analytics);
-    }, [isAnalyticsSuccess, analytics, setAnalyticsResults]);
+    });
+    const { mutate: getAnalytics } = useCatalogAnalytics(
+        projectUuid,
+        (data) => {
+            if (data) {
+                setAnalyticsResults(data);
+            }
+        },
+    );
 
     const handleSearchChange = useCallback(
         (searchString: string) => {

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -97,8 +97,6 @@ export const CatalogPanel: FC = () => {
         data: metadata,
         reset: closeMetadata,
     } = useCatalogMetadata(projectUuid, (data) => {
-        console.log('metadata', data);
-
         if (data) {
             setMetadata(data);
         }

--- a/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
+++ b/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
@@ -1,0 +1,56 @@
+import { type CatalogMetadata } from '@lightdash/common';
+import {
+    createContext,
+    useContext,
+    useState,
+    type Dispatch,
+    type FC,
+    type SetStateAction,
+} from 'react';
+
+type CatalogContextValues = {
+    projectUuid: string;
+    metadata: CatalogMetadata | undefined;
+    setMetadata: Dispatch<SetStateAction<CatalogMetadata | undefined>>;
+    isSidebarOpen: boolean;
+    setSidebarOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const CatalogContext = createContext<CatalogContextValues | undefined>(
+    undefined,
+);
+
+export const CatalogProvider: FC<
+    React.PropsWithChildren<
+        Pick<
+            CatalogContextValues,
+            'isSidebarOpen' | 'setSidebarOpen' | 'projectUuid'
+        >
+    >
+> = ({ isSidebarOpen, setSidebarOpen, projectUuid, children }) => {
+    const [metadata, setMetadata] = useState<CatalogMetadata>();
+
+    return (
+        <CatalogContext.Provider
+            value={{
+                projectUuid,
+                metadata,
+                setMetadata,
+                isSidebarOpen,
+                setSidebarOpen,
+            }}
+        >
+            {children}
+        </CatalogContext.Provider>
+    );
+};
+
+export const useCatalogContext = () => {
+    const context = useContext(CatalogContext);
+    if (!context) {
+        throw new Error(
+            'useCatalogContext must be used within a CatalogProvider',
+        );
+    }
+    return context;
+};

--- a/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
+++ b/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
@@ -1,4 +1,4 @@
-import { type CatalogMetadata } from '@lightdash/common';
+import { type CatalogAnalytics, type CatalogMetadata } from '@lightdash/common';
 import {
     createContext,
     useContext,
@@ -12,6 +12,8 @@ type CatalogContextValues = {
     projectUuid: string;
     metadata: CatalogMetadata | undefined;
     setMetadata: Dispatch<SetStateAction<CatalogMetadata | undefined>>;
+    analyticsResults: CatalogAnalytics | undefined;
+    setAnalyticsResults: Dispatch<SetStateAction<CatalogAnalytics | undefined>>;
     isSidebarOpen: boolean;
     setSidebarOpen: Dispatch<SetStateAction<boolean>>;
 };
@@ -29,6 +31,8 @@ export const CatalogProvider: FC<
     >
 > = ({ isSidebarOpen, setSidebarOpen, projectUuid, children }) => {
     const [metadata, setMetadata] = useState<CatalogMetadata>();
+    const [analyticsResults, setAnalyticsResults] =
+        useState<CatalogAnalytics>();
 
     return (
         <CatalogContext.Provider
@@ -36,6 +40,8 @@ export const CatalogProvider: FC<
                 projectUuid,
                 metadata,
                 setMetadata,
+                analyticsResults,
+                setAnalyticsResults,
                 isSidebarOpen,
                 setSidebarOpen,
             }}

--- a/packages/frontend/src/features/catalog/hooks/useCatalogAnalytics.ts
+++ b/packages/frontend/src/features/catalog/hooks/useCatalogAnalytics.ts
@@ -21,13 +21,17 @@ const fetchCatalogAnalytics = async ({
         body: undefined,
     });
 
-export const useCatalogAnalytics = (projectUuid: string) => {
+export const useCatalogAnalytics = (
+    projectUuid: string,
+    onSuccess: (data: ApiCatalogAnalyticsResults) => void,
+) => {
     const setErrorResponse = useQueryError();
 
     return useMutation<ApiCatalogAnalyticsResults, ApiError, string>(
         (table) => fetchCatalogAnalytics({ projectUuid, table }),
         {
             mutationKey: ['catalog_analytics', projectUuid],
+            onSuccess: (data) => onSuccess(data),
             onError: (result) => setErrorResponse(result),
         },
     );

--- a/packages/frontend/src/features/catalog/hooks/useCatalogMetadata.ts
+++ b/packages/frontend/src/features/catalog/hooks/useCatalogMetadata.ts
@@ -21,13 +21,17 @@ const fetchCatalogMetadata = async ({
         body: undefined,
     });
 
-export const useCatalogMetadata = (projectUuid: string) => {
+export const useCatalogMetadata = (
+    projectUuid: string,
+    onSuccess: (data: ApiCatalogMetadataResults) => void,
+) => {
     const setErrorResponse = useQueryError();
 
     return useMutation<ApiCatalogMetadataResults, ApiError, string>(
         (table) => fetchCatalogMetadata({ projectUuid, table }),
         {
             mutationKey: ['catalog_metadata', projectUuid],
+            onSuccess: (data) => onSuccess(data),
             onError: (result) => setErrorResponse(result),
         },
     );

--- a/packages/frontend/src/pages/Catalog.tsx
+++ b/packages/frontend/src/pages/Catalog.tsx
@@ -1,19 +1,33 @@
 import { Stack } from '@mantine/core';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import Page from '../components/common/Page/Page';
 import { CatalogPanel } from '../features/catalog/components';
+import { CatalogMetadata } from '../features/catalog/components/CatalogMetadata';
+import { CatalogProvider } from '../features/catalog/context/CatalogProvider';
 
 const Catalog: FC = () => {
     const params = useParams<{ projectUuid: string }>();
     const selectedProjectUuid = params.projectUuid;
+    const [isSidebarOpen, setSidebarOpen] = useState(false);
 
     return (
-        <Page withFixedContent withPaddedContent withFooter>
-            <Stack>
-                <CatalogPanel projectUuid={selectedProjectUuid} />
-            </Stack>
-        </Page>
+        <CatalogProvider
+            projectUuid={selectedProjectUuid}
+            isSidebarOpen={isSidebarOpen}
+            setSidebarOpen={setSidebarOpen}
+        >
+            <Page
+                withPaddedContent
+                withRightSidebar
+                isRightSidebarOpen={isSidebarOpen}
+                rightSidebar={<CatalogMetadata />}
+            >
+                <Stack>
+                    <CatalogPanel />
+                </Stack>
+            </Page>
+        </CatalogProvider>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10130 

### Description:

Finalises the work on the right sidebar POC by adding the `CatalogMetadata` as the `rightsidebar` of `Page` component. 

This also introduces a `CatalogProvider` to help with the content display of a sidebar when interacting with the `CatalogPanel`.
When there's a table selected, it will store its value in the provider, along with its analytics

**NOTE**: I still need to check more usecases on scrolling behaviour, but that should be only assessed after the UI polish work incoming for the table.


https://github.com/lightdash/lightdash/assets/7611706/36802d1c-aa39-4eb7-b5e9-de1aaac155da




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
