### PR TITLE
chore: make fields selectable

### DIFF
--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -15,6 +15,12 @@ export enum CatalogType {
     Field = 'field',
 }
 
+export type CatalogSelection = {
+    group: string;
+    table?: string;
+    field?: string;
+};
+
 export type ApiCatalogSearch = {
     search?: string;
     type?: CatalogType;

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -7,12 +7,15 @@ import MantineIcon from '../../../components/common/MantineIcon';
 type Props = {
     field: CatalogField;
     searchString?: string;
+    isSelected?: boolean;
+
     onClick?: () => void;
 };
 
 export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
     field,
     searchString = '',
+    isSelected = false,
     onClick,
 }) => {
     const [hovered, setHovered] = useState<boolean | undefined>(false);
@@ -28,6 +31,9 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                     backgroundColor: hovered
                         ? theme.colors.gray[1]
                         : theme.colors.gray[0],
+                    border: isSelected
+                        ? `2px solid ${theme.colors.blue[6]}`
+                        : undefined,
                 })}
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -1,5 +1,8 @@
-import { type ApiCatalogMetadataResults } from '@lightdash/common';
-import { Flex, Stack, Table, Text } from '@mantine/core';
+import {
+    type ApiCatalogMetadataResults,
+    type CatalogSelection,
+} from '@lightdash/common';
+import { Flex, Stack, Table, Text, useMantineTheme } from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowUp,
@@ -12,13 +15,16 @@ import { useHistory } from 'react-router-dom';
 type Props = {
     projectUuid: string;
     data: ApiCatalogMetadataResults;
+    selection?: CatalogSelection;
 };
 
 export const CatalogMetadata: FC<React.PropsWithChildren<Props>> = ({
     projectUuid,
     data,
+    selection,
 }) => {
     const history = useHistory();
+    const theme = useMantineTheme();
     return (
         <Stack style={{ position: 'relative', minHeight: '100vh' }}>
             <Text
@@ -70,7 +76,17 @@ export const CatalogMetadata: FC<React.PropsWithChildren<Props>> = ({
                 </thead>
                 <tbody>
                     {data.fields?.map((field) => (
-                        <tr key={field.name}>
+                        <tr
+                            key={field.name}
+                            style={{
+                                border:
+                                    selection &&
+                                    selection?.field &&
+                                    selection.field === field.name
+                                        ? `2px solid ${theme.colors.blue[6]}`
+                                        : undefined,
+                            }}
+                        >
                             <td>{field.name}</td>
                             <td>{field.basicType}</td>
                         </tr>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -16,7 +16,6 @@ import { CatalogAnalyticCharts } from './CatalogAnalyticCharts';
 
 type Props = {
     projectUuid: string;
-    data: ApiCatalogMetadataResults;
     selection?: CatalogSelection;
     metadataResults: ApiCatalogMetadataResults;
     analyticResults?: ApiCatalogAnalyticsResults;

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -1,6 +1,7 @@
 import {
     CatalogType,
     type CatalogField,
+    type CatalogSelection,
     type CatalogTable,
 } from '@lightdash/common';
 import {
@@ -61,7 +62,6 @@ function sortTree(tree: CatalogTreeType): CatalogTreeType {
             };
         });
 
-        // Assign the sorted tables to the sorted tree
         sortedTree[key] = {
             ...value,
             tables: sortedTables,
@@ -69,6 +69,29 @@ function sortTree(tree: CatalogTreeType): CatalogTreeType {
     });
 
     return sortedTree;
+}
+
+// TODO: this could become a linked list if we need the performance
+function getSelectionList(tree: CatalogTreeType): CatalogSelection[] {
+    const selectionList: CatalogSelection[] = [];
+
+    Object.keys(tree).forEach((group) => {
+        Object.keys(tree[group].tables).forEach((table) => {
+            selectionList.push({
+                table,
+                group,
+            });
+            tree[group].tables[table].fields.forEach((field) => {
+                selectionList.push({
+                    table,
+                    group,
+                    field: field.name,
+                });
+            });
+        });
+    });
+
+    return selectionList;
 }
 
 export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
@@ -85,10 +108,7 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
     });
 
     // TODO: add field
-    const [selection, setSelection] = useState<{
-        group: string;
-        table: string;
-    }>();
+    const [selection, setSelection] = useState<CatalogSelection>();
 
     const {
         mutate: getMetadata,
@@ -147,18 +167,28 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
         return {};
     }, [catalogResults]);
 
+    const selectionList = useMemo(
+        () => getSelectionList(catalogTree),
+        [catalogTree],
+    );
+
     const selectAndGetMetadata = useCallback(
-        (tableName: string, groupName: string) => {
+        (selectedItem: CatalogSelection) => {
+            if (!selectedItem.table) return;
+
             // For optimization purposes, we could only make this request if metadata panel is open
-            setSelection({ table: tableName, group: groupName });
+            setSelection({
+                table: selectedItem.table,
+                group: selectedItem.group || 'Ungrouped tables',
+                field: selectedItem.field,
+            });
 
             if (catalogResults) {
                 const table = catalogResults.find(
-                    (item) => item.name === tableName,
+                    (item) => item.name === selectedItem.table,
                 );
                 if (table && table.type === CatalogType.Table)
-                    getMetadata(tableName);
-                else console.warn('Metadata not available for fields');
+                    getMetadata(selectedItem.table);
             }
         },
         [catalogResults, getMetadata],
@@ -172,32 +202,25 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                 'ArrowDown',
                 () => {
                     if (selection) {
-                        //TODO move around grouped items
-                        const treeKeys = Object.keys(
-                            catalogTree[selection.group].tables,
+                        const selectedIndex = selectionList.findIndex(
+                            (item) =>
+                                item.table === selection.table &&
+                                item.group === selection.group &&
+                                item.field === selection.field,
                         );
-
-                        const selectedIndex = treeKeys.findIndex(
-                            (name) => name === selection.table,
-                        );
-
                         if (
                             selectedIndex !== undefined &&
-                            selectedIndex < treeKeys.length
+                            selectedIndex < selectionList.length
                         ) {
                             selectAndGetMetadata(
-                                treeKeys[(selectedIndex + 1) % treeKeys.length],
-                                selection.group,
+                                selectionList[
+                                    (selectedIndex + 1) % selectionList.length
+                                ],
                             );
                         }
                     } else {
                         // Get the first table in the first group
-                        selectAndGetMetadata(
-                            Object.entries(
-                                Object.entries(catalogTree)[0][1].tables,
-                            )[0][1].name,
-                            Object.keys(catalogTree)[0],
-                        );
+                        selectAndGetMetadata(selectionList[0]);
                     }
                 },
             ],
@@ -205,33 +228,26 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                 'ArrowUp',
                 () => {
                     if (selection) {
-                        //TODO move around grouped items
-                        const treeKeys = Object.keys(
-                            catalogTree[selection.group].tables,
-                        );
-
-                        const selectedIndex = treeKeys.findIndex(
-                            (name) => name === selection.table,
+                        const selectedIndex = selectionList.findIndex(
+                            (item) =>
+                                item.table === selection.table &&
+                                item.group === selection.group &&
+                                item.field === selection.field,
                         );
                         if (
                             selectedIndex !== undefined &&
-                            selectedIndex < treeKeys.length
+                            selectedIndex < selectionList.length
                         ) {
                             selectAndGetMetadata(
-                                treeKeys[
-                                    (selectedIndex - 1 + treeKeys.length) %
-                                        treeKeys.length
+                                selectionList[
+                                    (selectedIndex - 1 + selectionList.length) %
+                                        selectionList.length
                                 ],
-                                selection.group,
                             );
                         }
                     } else {
-                        // Get the first table in the first group
                         selectAndGetMetadata(
-                            Object.entries(
-                                Object.entries(catalogTree)[0][1].tables,
-                            )[0][1].name,
-                            Object.keys(catalogTree)[0],
+                            selectionList[selectionList.length - 1],
                         );
                     }
                 },
@@ -318,7 +334,7 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                         projectUuid={projectUuid}
                         searchString={debouncedSearch}
                         selection={selection}
-                        onTableClick={selectAndGetMetadata}
+                        onItemClick={selectAndGetMetadata}
                     />
                 </Stack>
             </Stack>
@@ -330,17 +346,8 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                                 closeMetadata();
                                 setSelection(undefined);
                             } else if (selection === undefined)
-                                selectAndGetMetadata(
-                                    catalogTree[Object.keys(catalogTree)[0]]
-                                        .tables[0].name,
-                                    catalogTree[Object.keys(catalogTree)[0]]
-                                        .name,
-                                );
-                            else
-                                selectAndGetMetadata(
-                                    selection.table,
-                                    selection.group,
-                                );
+                                selectAndGetMetadata(selectionList[0]);
+                            else selectAndGetMetadata(selection);
                         }}
                     >
                         {metadata ? 'Hide metadata' : 'Show metadata'}
@@ -350,6 +357,7 @@ export const CatalogPanel: FC<React.PropsWithChildren<Props>> = ({
                         <CatalogMetadata
                             data={metadata}
                             projectUuid={projectUuid}
+                            selection={selection}
                         />
                     )}
                 </Stack>

--- a/packages/frontend/src/features/catalog/components/CatalogTree.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTree.tsx
@@ -1,4 +1,4 @@
-import { CatalogType } from '@lightdash/common';
+import { CatalogType, type CatalogSelection } from '@lightdash/common';
 import { Stack, Tooltip } from '@mantine/core';
 import { type FC } from 'react';
 import { CatalogFieldListItem } from './CatalogFieldListItem';
@@ -8,19 +8,22 @@ import { CatalogTableListItem } from './CatalogTableListItem';
 type Props = {
     tree: any;
     projectUuid: string;
-    onTableClick: (tableName: string, groupName: string) => void;
-    selection?: { table: string; group: string };
+    onItemClick: (item: CatalogSelection) => void;
+    selection?: CatalogSelection;
     searchString?: string;
 };
 
-const renderTreeNode = (
-    node: any,
-    projectUuid: string,
-    onTableClick: (tableName: string, groupName: string) => void,
-    selection?: { table: string; group: string },
+type NodeProps = Omit<Props, 'tree'> & {
+    node: any;
+};
 
-    searchString?: string,
-) => {
+const renderTreeNode = ({
+    node,
+    projectUuid,
+    onItemClick,
+    selection,
+    searchString,
+}: NodeProps) => {
     if (!node.type) {
         return (
             <CatalogGroup
@@ -34,13 +37,13 @@ const renderTreeNode = (
                 {Object.keys(node.tables).length > 0 && (
                     <Stack spacing={3}>
                         {Object.entries(node.tables).map(([_, value]) =>
-                            renderTreeNode(
-                                value,
+                            renderTreeNode({
+                                node: value,
                                 projectUuid,
-                                onTableClick,
+                                onItemClick,
                                 selection,
                                 searchString,
-                            ),
+                            }),
                         )}
                     </Stack>
                 )}
@@ -53,20 +56,25 @@ const renderTreeNode = (
                 table={node}
                 startOpen={node.fields.length > 0}
                 searchString={searchString}
-                onClick={() => onTableClick(node.name, node.groupName)}
-                isSelected={selection?.table === node.name}
+                onClick={() =>
+                    onItemClick({
+                        table: node.name,
+                        group: node.groupName,
+                    })
+                }
+                isSelected={selection?.table === node.name && !selection?.field}
                 url={`/projects/${projectUuid}/tables/${node.name}`}
             >
                 {Object.keys(node.fields).length > 0 && (
                     <Stack spacing={0}>
                         {node.fields.map((child: any) =>
-                            renderTreeNode(
-                                child,
+                            renderTreeNode({
+                                node: child,
                                 projectUuid,
-                                onTableClick,
+                                onItemClick,
                                 selection,
                                 searchString,
-                            ),
+                            }),
                         )}
                     </Stack>
                 )}
@@ -78,6 +86,17 @@ const renderTreeNode = (
                 key={node.tableName + node.name}
                 field={node}
                 searchString={searchString}
+                isSelected={
+                    selection?.field === node.name &&
+                    selection?.table === node.tableName
+                }
+                onClick={() =>
+                    onItemClick({
+                        table: node.tableName,
+                        group: node.groupName,
+                        field: node.name,
+                    })
+                }
             />
         );
     }
@@ -89,11 +108,12 @@ export const CatalogTree: FC<React.PropsWithChildren<Props>> = ({
     searchString,
     projectUuid,
     selection,
-    onTableClick,
+    onItemClick,
 }) => {
     if (!tree) {
         return null;
     }
+
     return (
         <Tooltip.Group>
             <Stack
@@ -102,13 +122,13 @@ export const CatalogTree: FC<React.PropsWithChildren<Props>> = ({
                 key={`catalog-tree-${searchString}`}
             >
                 {Object.entries(tree).map(([_, value]) =>
-                    renderTreeNode(
-                        value,
+                    renderTreeNode({
+                        node: value,
                         projectUuid,
-                        onTableClick,
+                        onItemClick,
                         selection,
                         searchString,
-                    ),
+                    }),
                 )}
             </Stack>
         </Tooltip.Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10210

### Description:

Makes fields selectable and fixed up keyboard navigation to move across groups and tables. @rephus suggested this should make the same metadata requests as the containing table, so that's what it does. For now it doesn't display any field metadata specifically, just highlights the field in the table metadata. We can update the metadata view to show field data. 

**Note:** one main limitation here is that with keyboard navigation, selections do not scroll into view. I played with it some and I the scroll setup seems like it will sufficiently complex that we should add this once we have that finalized more. 

<img width="1122" alt="Screenshot 2024-05-28 at 18 46 43" src="https://github.com/lightdash/lightdash/assets/1864179/a6540d46-31c3-45d7-b552-d4515ad03ac9">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
