### PR TITLE
fix: reduce amount on queries needed to validate charts

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -964,7 +964,7 @@ export class SavedChartModel {
         }
     }
 
-    async findChartItemIds(projectUuid: string): Promise<
+    async findChartsForValidation(projectUuid: string): Promise<
         Array<{
             uuid: string;
             name: string;

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -12,6 +12,7 @@ import {
     CustomSqlDimension,
     DBFieldTypes,
     ECHARTS_DEFAULT_COLORS,
+    Filters,
     getChartKind,
     getChartType,
     getItemId,
@@ -961,6 +962,115 @@ export class SavedChartModel {
         } finally {
             span?.finish();
         }
+    }
+
+    async findChartItemIds(projectUuid: string): Promise<
+        Array<{
+            uuid: string;
+            name: string;
+            tableName: string;
+            filters: Filters;
+            dimensions: string[];
+            metrics: string[];
+            tableCalculations: string[];
+            customMetrics: string[];
+            customMetricsBaseDimensions: string[];
+            customBinDimensions: string[];
+            customSqlDimensions: string[];
+            sorts: string[];
+        }>
+    > {
+        return this.database(SavedChartsTableName)
+            .select({
+                uuid: 'saved_queries.saved_query_uuid',
+                name: 'saved_queries.name',
+                tableName: 'saved_queries_versions.explore_name',
+                filters: 'saved_queries_versions.filters',
+                dimensions: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}')",
+                ),
+                metrics: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')",
+                ),
+                tableCalculations: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')",
+                ),
+                customMetrics: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.name)) FILTER (WHERE sqvam.name IS NOT NULL), '{}')",
+                ),
+                customMetricsBaseDimensions: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.base_dimension_name)) FILTER (WHERE sqvam.base_dimension_name IS NOT NULL), '{}')",
+                ),
+                customBinDimensions: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL), '{}')",
+                ),
+                customSqlDimensions: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL), '{}')",
+                ),
+                sorts: this.database.raw(
+                    "COALESCE(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL), '{}')",
+                ),
+            })
+            .leftJoin(
+                SpaceTableName,
+                'saved_queries.space_id',
+                'spaces.space_id',
+            )
+            .leftJoin(
+                ProjectTableName,
+                'spaces.project_id',
+                'projects.project_id',
+            )
+            .leftJoin(
+                SavedChartVersionsTableName,
+                'saved_queries.saved_query_id',
+                'saved_queries_versions.saved_query_id',
+            )
+            .leftJoin(
+                'saved_queries_version_fields as svf',
+                'saved_queries_versions.saved_queries_version_id',
+                'svf.saved_queries_version_id',
+            )
+            .leftJoin(
+                'saved_queries_version_table_calculations as sqvtc',
+                'saved_queries_versions.saved_queries_version_id',
+                'sqvtc.saved_queries_version_id',
+            )
+            .leftJoin(
+                'saved_queries_version_additional_metrics as sqvam',
+                'saved_queries_versions.saved_queries_version_id',
+                'sqvam.saved_queries_version_id',
+            )
+            .leftJoin(
+                'saved_queries_version_custom_dimensions as sqvcd',
+                'saved_queries_versions.saved_queries_version_id',
+                'sqvcd.saved_queries_version_id',
+            )
+            .leftJoin(
+                'saved_queries_version_custom_sql_dimensions as sqvcsd',
+                'saved_queries_versions.saved_queries_version_id',
+                'sqvcsd.saved_queries_version_id',
+            )
+            .leftJoin(
+                'saved_queries_version_sorts as sqvs',
+                'saved_queries_versions.saved_queries_version_id',
+                'sqvs.saved_queries_version_id',
+            )
+            .where(
+                'saved_queries_versions.saved_queries_version_id',
+                this.database('saved_queries_versions')
+                    .select('saved_queries_version_id')
+                    .where(
+                        'saved_queries_versions.saved_query_id',
+                        this.database
+                            .ref('saved_query_id')
+                            .withSchema(SavedChartsTableName),
+                    )
+                    .orderBy('saved_queries_versions.created_at', 'desc')
+                    .limit(1),
+            )
+            .andWhere('projects.project_uuid', projectUuid)
+            .groupBy(1, 2, 3, 4);
     }
 
     async find(filters: {

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -1,6 +1,5 @@
 import { Ability } from '@casl/ability';
 import {
-    ChartType,
     Dashboard,
     DashboardTileTypes,
     DimensionType,
@@ -12,14 +11,13 @@ import {
     LightdashMode,
     MetricType,
     OrganizationMemberRole,
-    SavedChart,
     SessionUser,
-    ShareUrl,
     SupportedDbtAdapter,
     TablesConfiguration,
     TableSelectionType,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
+import { type SavedChartModel } from '../../models/SavedChartModel';
 
 export const config = {
     mode: LightdashMode.DEFAULT,
@@ -50,132 +48,60 @@ export const user: SessionUser = {
     abilityRules: [],
 };
 
-export const chart: SavedChart = {
+export const chartForValidation: Awaited<
+    ReturnType<SavedChartModel['findChartsForValidation']>
+>[number] = {
     uuid: 'chartUuid',
-    projectUuid: 'projectUuid',
-    dashboardUuid: null,
-    dashboardName: null,
     name: 'Test chart',
-    slug: 'test-chart',
     tableName: 'table',
-    updatedAt: new Date('2021-01-01'),
-    updatedByUser: {
-        userUuid: 'userUuid',
-        firstName: 'David',
-        lastName: 'Attenborough',
-    },
-    metricQuery: {
-        exploreName: 'table',
-        dimensions: ['table_dimension'],
-        metrics: ['table_metric'],
-        filters: {
-            dimensions: {
-                id: 'dimensionFilterUuid',
-                and: [
-                    {
-                        id: '',
-                        target: { fieldId: 'table_dimension' },
-                        values: ['2018-01-01'],
-                        operator: FilterOperator.EQUALS,
-                    },
-                ],
-            },
-            metrics: {
-                id: 'metricFilterUuid',
-                or: [
-                    {
-                        id: '',
-                        target: { fieldId: 'table_metric' },
-                        values: ['2018-01-01'],
-                        operator: FilterOperator.EQUALS,
-                    },
-                    {
-                        id: '',
-                        target: { fieldId: 'table_custom_metric' },
-                        values: [10],
-                        operator: FilterOperator.EQUALS,
-                    },
-                ],
-            },
-        },
-        sorts: [
-            {
-                fieldId: 'table_dimension',
-                descending: false,
-            },
-        ],
-        tableCalculations: [
-            {
-                name: 'table_calculation',
-                displayName: 'myTableCalculation',
-                sql: '1 + ${table_dimension} + ${table_metric}',
-            },
-        ],
-        additionalMetrics: [
-            {
-                table: 'table',
-                name: 'custom_metric',
-                type: MetricType.MAX,
-                label: 'Count of dimension',
-                description: 'Count of dimension',
-                sql: '${TABLE}.dimension',
-                baseDimensionName: 'dimension',
-            },
-        ],
-        limit: 10,
-    },
-    chartConfig: {
-        type: ChartType.CARTESIAN,
-        config: {
-            layout: {
-                xField: 'payments_payment_method',
-                yField: [
-                    'payments_total_revenue',
-                    'payments_unique_payment_count',
-                ],
-                flipAxes: true,
-            },
-            eChartsConfig: {
-                legend: {
-                    show: true,
-                    orient: 'horizontal',
+    filters: {
+        dimensions: {
+            id: 'dimensionFilterUuid',
+            and: [
+                {
+                    id: '',
+                    target: { fieldId: 'table_dimension' },
+                    values: ['2018-01-01'],
+                    operator: FilterOperator.EQUALS,
                 },
-                series: [],
-            },
+            ],
+        },
+        metrics: {
+            id: 'metricFilterUuid',
+            or: [
+                {
+                    id: '',
+                    target: { fieldId: 'table_metric' },
+                    values: ['2018-01-01'],
+                    operator: FilterOperator.EQUALS,
+                },
+                {
+                    id: '',
+                    target: { fieldId: 'table_custom_metric' },
+                    values: [10],
+                    operator: FilterOperator.EQUALS,
+                },
+            ],
         },
     },
-    tableConfig: {
-        columnOrder: [
-            'table_dimension',
-            'table_metric',
-            'table_custom_metric',
-            'table_calculation',
-        ],
-    },
-    organizationUuid: 'orgUuid',
-    spaceUuid: 'spaceUuid',
-    spaceName: 'space name',
-    pinnedListUuid: null,
-    pinnedListOrder: null,
-    colorPalette: [],
-    isPrivate: false,
-    access: [],
+    dimensions: ['table_dimension'],
+    metrics: ['table_metric'],
+    tableCalculations: ['table_calculation'],
+    customMetrics: ['table_custom_metric'],
+    customMetricsBaseDimensions: ['table_dimension'],
+    customBinDimensions: [],
+    customSqlDimensions: [],
+    sorts: ['table_dimension'],
 };
 
-export const chartWithJoinedField: SavedChart = {
-    ...chart,
+export const chartForValidationWithJoinedField: Awaited<
+    ReturnType<SavedChartModel['findChartsForValidation']>
+>[number] = {
+    ...chartForValidation,
     tableName: 'another_table',
-    metricQuery: {
-        ...chart.metricQuery,
-        dimensions: ['table_dimension', 'another_table_dimension'],
-        metrics: ['table_metric', 'another_table_metric'],
-        sorts: [
-            {
-                fieldId: 'another_table_dimension',
-                descending: false,
-            },
-        ],
-    },
+    dimensions: ['table_dimension', 'another_table_dimension'],
+    metrics: ['table_metric', 'another_table_metric'],
+    sorts: ['another_table_dimension'],
 };
 
 export const dashboard: Dashboard = {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -207,7 +207,9 @@ export class ValidationService extends BaseService {
             { dimensionIds: string[]; metricIds: string[] }
         >,
     ): Promise<CreateChartValidation[]> {
-        const charts = await this.savedChartModel.findChartItemIds(projectUuid);
+        const charts = await this.savedChartModel.findChartsForValidation(
+            projectUuid,
+        );
 
         const results = charts.flatMap(
             ({


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Before: 

| Step  | Queries | Real example - 426 charts and 106 dashboards |
| ------------- | ------------- |------------- |
| Get explores  | 1  | 1 |
| get tables configuration  | 1  | 1 |
| get chart summaries  | 1  | 1 |
| get chart (n = number of charts)  | 7 * n  | 2982 |
| get dashboard summaries  | 1  | 1 |
| get dashboard (n = number of dashboards)  | 4 * n  | 424 |
|  |  | 3411 |

Now: 

| Step  | Queries | Real example - 426 charts and 106 dashboards |
| ------------- | ------------- |------------- |
| Get explores  | 1  | 1 |
| get tables configuration  | 1  | 1 |
| get charts  | 1  | 1 |
| get dashboard summaries  | 1  | 1 |
| get dashboard (n = number of dashboards)  | 4 * n  | 424 |
|  |  | 428 |

This PR is only fixing the charts queries by stop fetching all the chart data and focus on getting all the used field ids in a single query. There will be a following PR to achieve the same for the dashboards.

```
SELECT sq.saved_query_uuid,
       sq.name,
       sv.explore_name,
       sv.filters,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}') as dimensions,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')    as metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')     as table_calculations,
       coalesce(ARRAY_AGG(DISTINCT sqvam.name) FILTER (WHERE sqvam.name IS NOT NULL), '{}')     as custom_metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL),
                '{}')                                                                           as custom_bin_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL),
                '{}')                                                                           as custom_sql_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL),
                '{}')                                                                           as sorts
FROM saved_queries as sq
         LEFT JOIN spaces as s
                   ON sq.space_id = s.space_id
         LEFT JOIN projects as p
                   ON s.project_id = p.project_id
         LEFT JOIN saved_queries_versions as sv
                   ON sq.saved_query_id = sv.saved_query_id
         LEFT JOIN saved_queries_version_fields as svf
                   ON sv.saved_queries_version_id = svf.saved_queries_version_id
         LEFT JOIN saved_queries_version_table_calculations as sqvtc
                   ON sv.saved_queries_version_id = sqvtc.saved_queries_version_id
         LEFT JOIN saved_queries_version_additional_metrics as sqvam
                   ON sv.saved_queries_version_id = sqvam.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_dimensions as sqvcd
                   ON sv.saved_queries_version_id = sqvcd.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_sql_dimensions as sqvcsd
                   ON sv.saved_queries_version_id = sqvcsd.saved_queries_version_id
         LEFT JOIN saved_queries_version_sorts as sqvs
                   ON sv.saved_queries_version_id = sqvs.saved_queries_version_id
WHERE sv.saved_queries_version_id = (SELECT saved_queries_version_id
                                     FROM saved_queries_versions
                                     WHERE saved_queries_versions.saved_query_id = sq.saved_query_id
                                     ORDER BY saved_queries_versions.created_at desc
                                     LIMIT 1)
AND p.project_uuid = '3675b69e-8324-4110-bdca-059031aa8da3'
GROUP BY 1, 2, 3, 4
```

This query took half a second to execute against a project with 427 charts:

> 427 rows retrieved starting from 1 in 579 ms (execution: 536 ms, fetching: 43 ms)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
