### PR TITLE
chore: fix selection of tables not in results

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -211,17 +211,10 @@ export const CatalogPanel: FC = () => {
                 field: selectedItem.field,
             });
 
-            if (catalogResults) {
-                const table = catalogResults.find(
-                    (item) => item.name === selectedItem.table,
-                );
-                if (table && table.type === CatalogType.Table) {
-                    getMetadata(selectedItem.table);
-                    getAnalytics(selectedItem.table);
-                }
-            }
+            getMetadata(selectedItem.table);
+            getAnalytics(selectedItem.table);
         },
-        [setSelection, catalogResults, getMetadata, getAnalytics],
+        [setSelection, getMetadata, getAnalytics],
     );
 
     const history = useHistory();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This fixes a bug in catalog table selection where if a table wasn't returned in the results, we wouldn't fetch metadata for it. An example of this issue looks like: search 'customer', and a fields within tables get returned that match customer, but the table itself doesn't. We still build the tree showing the parent table, but if it wasn't in the results we weren't fetching it. 

This changes things to make the assumption that if the user was able to select a table, it's possible to fetch it's metadata.  

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
