### PR TITLE
style: improve right sidebar resize and fit page

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -3,6 +3,7 @@ import { type FC } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { ProjectType } from '@lightdash/common';
+import { useElementSize } from '@mantine/hooks';
 import { ErrorBoundary } from '../../../features/errorBoundary';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useProjects } from '../../../hooks/useProjects';
@@ -29,7 +30,8 @@ type StyleProps = {
 };
 
 export const PAGE_CONTENT_WIDTH = 900;
-const PAGE_MIN_CONTENT_WIDTH = 600;
+const PAGE_CONTENT_WIDTH_LARGE = 1200;
+export const PAGE_MIN_CONTENT_WIDTH = 600;
 
 const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
     let containerHeight = '100vh';
@@ -114,6 +116,12 @@ const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
                   }
                 : {}),
 
+            ...(params.withRightSidebar
+                ? {
+                      width: PAGE_CONTENT_WIDTH_LARGE,
+                  }
+                : {}),
+
             ...(params.withPaddedContent
                 ? {
                       paddingLeft: theme.spacing.lg,
@@ -162,6 +170,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
 
     children,
 }) => {
+    const { ref: mainRef, width: mainWidth } = useElementSize();
     const { activeProjectUuid } = useActiveProjectUuid({
         refetchOnMount: true,
     });
@@ -210,7 +219,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                     </Sidebar>
                 ) : null}
 
-                <Box component="main" className={classes.content}>
+                <Box component="main" className={classes.content} ref={mainRef}>
                     <TrackSection name={SectionName.PAGE_CONTENT}>
                         <ErrorBoundary wrapper={{ mt: '4xl' }}>
                             {children}
@@ -223,6 +232,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                         isOpen={isRightSidebarOpen}
                         position={SidebarPosition.RIGHT}
                         widthProps={rightSidebarWidthProps}
+                        mainWidth={mainWidth}
                     >
                         <ErrorBoundary wrapper={{ mt: '4xl' }}>
                             {rightSidebar}

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -37,6 +37,7 @@ type Props = {
     cardProps?: CardProps;
     position?: SidebarPosition;
     widthProps?: SidebarWidthProps;
+    mainWidth?: number;
 };
 
 const Sidebar: FC<React.PropsWithChildren<Props>> = ({
@@ -45,6 +46,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     cardProps,
     position = SidebarPosition.LEFT,
     widthProps = {},
+    mainWidth,
     children,
 }) => {
     const {
@@ -58,6 +60,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             minWidth,
             maxWidth,
             position,
+            mainWidth,
         });
 
     const transition: MantineTransition = {

--- a/packages/frontend/src/hooks/useSidebarResize.ts
+++ b/packages/frontend/src/hooks/useSidebarResize.ts
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { PAGE_MIN_CONTENT_WIDTH } from '../components/common/Page/Page';
 import { SidebarPosition } from '../components/common/Page/Sidebar';
 
 type Args = {
@@ -6,6 +7,7 @@ type Args = {
     minWidth: number;
     maxWidth: number;
     position: SidebarPosition;
+    mainWidth?: number;
 };
 
 const useSidebarResize = ({
@@ -13,6 +15,7 @@ const useSidebarResize = ({
     minWidth,
     defaultWidth,
     position,
+    mainWidth,
 }: Args) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
     const [isResizing, setIsResizing] = useState(false);
@@ -34,14 +37,22 @@ const useSidebarResize = ({
 
             const sidebarRect = sidebarRef.current.getBoundingClientRect();
             let newWidth;
+
             if (position === SidebarPosition.LEFT) {
                 newWidth = event.clientX - sidebarRect.left;
             } else {
                 newWidth = sidebarRect.right - event.clientX;
+                if (mainWidth && mainWidth < PAGE_MIN_CONTENT_WIDTH) {
+                    // Allow shrinking but prevent growing when mainWidth < PAGE_MIN_CONTENT_WIDTH
+                    if (newWidth > sidebarRect.width) {
+                        return;
+                    }
+                }
             }
+
             setSidebarWidth(Math.min(maxWidth, Math.max(minWidth, newWidth)));
         },
-        [isResizing, position, maxWidth, minWidth],
+        [isResizing, position, maxWidth, minWidth, mainWidth],
     );
 
     useLayoutEffect(() => {

--- a/packages/frontend/src/pages/Catalog.tsx
+++ b/packages/frontend/src/pages/Catalog.tsx
@@ -18,6 +18,7 @@ const Catalog: FC = () => {
             setSidebarOpen={setSidebarOpen}
         >
             <Page
+                withFitContent
                 withPaddedContent
                 withRightSidebar
                 isRightSidebarOpen={isSidebarOpen}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/10193

### Description:

adds `withFitContent` to `Catalog` Page
Ensures the siderbar resize respects `mainWidth` and stops it from increasing if we've reached the min width of `main` (600 atm)
Applies a wider page width on the panel when there's a `withRightSidebar`


Demo:

https://github.com/lightdash/lightdash/assets/7611706/913d5adc-a857-4a37-aebc-165b341681e1



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
