### PR TITLE
fix: refactor charts for validation SQL to use a cte instead of sub q…

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -980,97 +980,109 @@ export class SavedChartModel {
             sorts: string[];
         }>
     > {
-        return this.database(SavedChartsTableName)
-            .select({
-                uuid: 'saved_queries.saved_query_uuid',
-                name: 'saved_queries.name',
-                tableName: 'saved_queries_versions.explore_name',
-                filters: 'saved_queries_versions.filters',
-                dimensions: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}')",
-                ),
-                metrics: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')",
-                ),
-                tableCalculations: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')",
-                ),
-                customMetrics: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.name)) FILTER (WHERE sqvam.name IS NOT NULL), '{}')",
-                ),
-                customMetricsBaseDimensions: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.base_dimension_name)) FILTER (WHERE sqvam.base_dimension_name IS NOT NULL), '{}')",
-                ),
-                customBinDimensions: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL), '{}')",
-                ),
-                customSqlDimensions: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL), '{}')",
-                ),
-                sorts: this.database.raw(
-                    "COALESCE(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL), '{}')",
-                ),
-            })
-            .leftJoin(
-                SpaceTableName,
-                'saved_queries.space_id',
-                'spaces.space_id',
-            )
-            .leftJoin(
-                ProjectTableName,
-                'spaces.project_id',
-                'projects.project_id',
-            )
-            .leftJoin(
-                SavedChartVersionsTableName,
-                'saved_queries.saved_query_id',
-                'saved_queries_versions.saved_query_id',
-            )
-            .leftJoin(
-                'saved_queries_version_fields as svf',
-                'saved_queries_versions.saved_queries_version_id',
-                'svf.saved_queries_version_id',
-            )
-            .leftJoin(
-                'saved_queries_version_table_calculations as sqvtc',
-                'saved_queries_versions.saved_queries_version_id',
-                'sqvtc.saved_queries_version_id',
-            )
-            .leftJoin(
-                'saved_queries_version_additional_metrics as sqvam',
-                'saved_queries_versions.saved_queries_version_id',
-                'sqvam.saved_queries_version_id',
-            )
-            .leftJoin(
-                'saved_queries_version_custom_dimensions as sqvcd',
-                'saved_queries_versions.saved_queries_version_id',
-                'sqvcd.saved_queries_version_id',
-            )
-            .leftJoin(
-                'saved_queries_version_custom_sql_dimensions as sqvcsd',
-                'saved_queries_versions.saved_queries_version_id',
-                'sqvcsd.saved_queries_version_id',
-            )
-            .leftJoin(
-                'saved_queries_version_sorts as sqvs',
-                'saved_queries_versions.saved_queries_version_id',
-                'sqvs.saved_queries_version_id',
-            )
-            .where(
-                'saved_queries_versions.saved_queries_version_id',
-                this.database('saved_queries_versions')
-                    .select('saved_queries_version_id')
-                    .where(
-                        'saved_queries_versions.saved_query_id',
-                        this.database
-                            .ref('saved_query_id')
-                            .withSchema(SavedChartsTableName),
-                    )
-                    .orderBy('saved_queries_versions.created_at', 'desc')
-                    .limit(1),
-            )
-            .andWhere('projects.project_uuid', projectUuid)
-            .groupBy(1, 2, 3, 4);
+        const cteName = 'chart_last_version_cte';
+        return (
+            this.database
+                // cte to get the last version of each chart in the project
+                .with(cteName, (qb) => {
+                    void qb
+                        .select({
+                            saved_query_uuid: 'saved_queries.saved_query_uuid',
+                            name: 'saved_queries.name',
+                            saved_queries_version_id: this.database.raw(
+                                'MAX(saved_queries_versions.saved_queries_version_id)',
+                            ),
+                        })
+                        .from(SavedChartsTableName)
+                        .leftJoin(
+                            SpaceTableName,
+                            'saved_queries.space_id',
+                            'spaces.space_id',
+                        )
+                        .leftJoin(
+                            ProjectTableName,
+                            'spaces.project_id',
+                            'projects.project_id',
+                        )
+                        .leftJoin(
+                            SavedChartVersionsTableName,
+                            'saved_queries.saved_query_id',
+                            'saved_queries_versions.saved_query_id',
+                        )
+                        .where('projects.project_uuid', projectUuid)
+                        .groupBy(
+                            'saved_queries.saved_query_uuid',
+                            'saved_queries.name',
+                        );
+                })
+                .select({
+                    uuid: `${cteName}.saved_query_uuid`,
+                    name: `${cteName}.name`,
+                    tableName: 'saved_queries_versions.explore_name',
+                    filters: 'saved_queries_versions.filters',
+                    dimensions: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}')",
+                    ),
+                    metrics: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')",
+                    ),
+                    tableCalculations: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')",
+                    ),
+                    customMetrics: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.name)) FILTER (WHERE sqvam.name IS NOT NULL), '{}')",
+                    ),
+                    customMetricsBaseDimensions: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.base_dimension_name)) FILTER (WHERE sqvam.base_dimension_name IS NOT NULL), '{}')",
+                    ),
+                    customBinDimensions: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL), '{}')",
+                    ),
+                    customSqlDimensions: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL), '{}')",
+                    ),
+                    sorts: this.database.raw(
+                        "COALESCE(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL), '{}')",
+                    ),
+                })
+                .from(cteName)
+                .leftJoin(
+                    SavedChartVersionsTableName,
+                    `${cteName}.saved_queries_version_id`,
+                    'saved_queries_versions.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_fields as svf',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'svf.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_table_calculations as sqvtc',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'sqvtc.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_additional_metrics as sqvam',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'sqvam.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_custom_dimensions as sqvcd',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'sqvcd.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_custom_sql_dimensions as sqvcsd',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'sqvcsd.saved_queries_version_id',
+                )
+                .leftJoin(
+                    'saved_queries_version_sorts as sqvs',
+                    'saved_queries_versions.saved_queries_version_id',
+                    'sqvs.saved_queries_version_id',
+                )
+                .groupBy(1, 2, 3, 4)
+        );
     }
 
     async find(filters: {


### PR DESCRIPTION
…uery

### Description:

Related to comment from previous PR. https://github.com/lightdash/lightdash/pull/10226#discussion_r1618760457
> this subselect can be the new bottleneck, but needed to the the latest version. let's keep eye.

SQL optimization: moved from using subquery to use a cte

Before:

> 417 rows retrieved starting from 1 in 863 ms (execution: 565 ms, fetching: 298 ms)

```
SELECT sq.saved_query_uuid,
       sq.name,
       sv.explore_name,
       sv.filters,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}') as dimensions,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')    as metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')     as table_calculations,
       coalesce(ARRAY_AGG(DISTINCT sqvam.name) FILTER (WHERE sqvam.name IS NOT NULL), '{}')     as custom_metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL),
                '{}')                                                                           as custom_bin_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL),
                '{}')                                                                           as custom_sql_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL),
                '{}')                                                                           as sorts
FROM saved_queries as sq
         LEFT JOIN spaces as s
                   ON sq.space_id = s.space_id
         LEFT JOIN projects as p
                   ON s.project_id = p.project_id
         LEFT JOIN saved_queries_versions as sv
                   ON sq.saved_query_id = sv.saved_query_id
         LEFT JOIN saved_queries_version_fields as svf
                   ON sv.saved_queries_version_id = svf.saved_queries_version_id
         LEFT JOIN saved_queries_version_table_calculations as sqvtc
                   ON sv.saved_queries_version_id = sqvtc.saved_queries_version_id
         LEFT JOIN saved_queries_version_additional_metrics as sqvam
                   ON sv.saved_queries_version_id = sqvam.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_dimensions as sqvcd
                   ON sv.saved_queries_version_id = sqvcd.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_sql_dimensions as sqvcsd
                   ON sv.saved_queries_version_id = sqvcsd.saved_queries_version_id
         LEFT JOIN saved_queries_version_sorts as sqvs
                   ON sv.saved_queries_version_id = sqvs.saved_queries_version_id
WHERE sv.saved_queries_version_id = (SELECT saved_queries_version_id
                                     FROM saved_queries_versions
                                     WHERE saved_queries_versions.saved_query_id = sq.saved_query_id
                                     ORDER BY saved_queries_versions.created_at desc
                                     LIMIT 1)
  AND p.project_uuid = ?
GROUP BY 1, 2, 3, 4
```

After:

> 417 rows retrieved starting from 1 in 715 ms (execution: 543 ms, fetching: 172 ms)

```
with cte as
         (SELECT sq.saved_query_uuid,
                 sq.name,
                 MAX(sv.saved_queries_version_id) as saved_queries_version_id
          FROM saved_queries as sq
                   LEFT JOIN spaces as s
                             ON sq.space_id = s.space_id
                   LEFT JOIN projects as p
                             ON s.project_id = p.project_id
                   LEFT JOIN saved_queries_versions as sv
                             ON sq.saved_query_id = sv.saved_query_id
          WHERE p.project_uuid = ?
          GROUP BY 1, 2)

SELECT cte.saved_query_uuid,
       cte.name,
       sv.explore_name,
       sv.filters,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'dimension'), '{}') as dimensions,
       coalesce(ARRAY_AGG(DISTINCT svf.name) FILTER (WHERE svf.field_type = 'metric'), '{}')    as metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvtc.name) FILTER (WHERE sqvtc.name IS NOT NULL), '{}')     as table_calculations,
       coalesce(ARRAY_AGG(DISTINCT sqvam.name) FILTER (WHERE sqvam.name IS NOT NULL), '{}')     as custom_metrics,
       coalesce(ARRAY_AGG(DISTINCT sqvcd.id) FILTER (WHERE sqvcd.id IS NOT NULL),
                '{}')                                                                           as custom_bin_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvcsd.id) FILTER (WHERE sqvcsd.id IS NOT NULL),
                '{}')                                                                           as custom_sql_dimensions,
       coalesce(ARRAY_AGG(DISTINCT sqvs.field_name) FILTER (WHERE sqvs.field_name IS NOT NULL),
                '{}')                                                                           as sorts
FROM cte
         LEFT JOIN saved_queries_versions as sv
                   ON cte.saved_queries_version_id = sv.saved_queries_version_id
         LEFT JOIN saved_queries_version_fields as svf
                   ON cte.saved_queries_version_id = svf.saved_queries_version_id
         LEFT JOIN saved_queries_version_table_calculations as sqvtc
                   ON cte.saved_queries_version_id = sqvtc.saved_queries_version_id
         LEFT JOIN saved_queries_version_additional_metrics as sqvam
                   ON cte.saved_queries_version_id = sqvam.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_dimensions as sqvcd
                   ON cte.saved_queries_version_id = sqvcd.saved_queries_version_id
         LEFT JOIN saved_queries_version_custom_sql_dimensions as sqvcsd
                   ON cte.saved_queries_version_id = sqvcsd.saved_queries_version_id
         LEFT JOIN saved_queries_version_sorts as sqvs
                   ON cte.saved_queries_version_id = sqvs.saved_queries_version_id
GROUP BY 1, 2, 3, 4
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
