### PR TITLE
fix: reduce amount of queries necessary to validate dashboards

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -15,6 +15,7 @@ import {
     SupportedDbtAdapter,
     TablesConfiguration,
     TableSelectionType,
+    type DashboardFilters,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import { type SavedChartModel } from '../../models/SavedChartModel';
@@ -104,45 +105,20 @@ export const chartForValidationWithJoinedField: Awaited<
     sorts: ['another_table_dimension'],
 };
 
-export const dashboard: Dashboard = {
-    organizationUuid: 'orgUuid',
-    projectUuid: 'projectUuid',
-    dashboardVersionId: 1,
-    uuid: 'dashboardUuid',
+export const dashboardForValidation: {
+    dashboardUuid: string;
+    name: string;
+    filters: DashboardFilters;
+    chartUuids: string[];
+} = {
+    dashboardUuid: 'dashboardUuid',
     name: 'test dashboard',
-    slug: 'test-dashboard',
-    updatedAt: new Date(),
-    tiles: [
-        {
-            uuid: 'tileUuid',
-            type: DashboardTileTypes.SAVED_CHART,
-            properties: {
-                title: 'test chart',
-                savedChartUuid: 'chartUuid',
-                belongsToDashboard: false,
-            },
-            x: 0,
-            y: 0,
-            w: 1,
-            h: 1,
-            // TODO: remove
-            tabUuid: 'tabUuid',
-        },
-    ],
     filters: {
         dimensions: [],
         metrics: [],
         tableCalculations: [],
     },
-    spaceUuid: '',
-    spaceName: '',
-    views: 0,
-    firstViewedAt: null,
-    pinnedListUuid: null,
-    pinnedListOrder: null,
-    isPrivate: false,
-    access: [],
-    tabs: [],
+    chartUuids: ['chartUuid'],
 };
 
 export const explore: Explore = {

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -11,7 +11,7 @@ import {
     chartForValidation,
     chartForValidationWithJoinedField,
     config,
-    dashboard,
+    dashboardForValidation,
     explore,
     exploreError,
     exploreWithJoin,
@@ -34,8 +34,7 @@ const validationModel = {
     create: jest.fn(async () => {}),
 };
 const dashboardModel = {
-    getAllByProject: jest.fn(async () => [{}]),
-    getById: jest.fn(async () => dashboard),
+    findDashboardsForValidation: jest.fn(async () => [dashboardForValidation]),
 };
 
 describe('validation', () => {


### PR DESCRIPTION
### Description:

Continuing optimizations to our validation process. First one was https://github.com/lightdash/lightdash/pull/10226

**Note** there is bug validating charts that belong to a dashboard: https://github.com/lightdash/lightdash/issues/10253

Before: 

| Step  | Queries | Real example - 426 charts and 106 dashboards |
| ------------- | ------------- |------------- |
| Get explores  | 1  | 1 |
| get tables configuration  | 1  | 1 |
| get charts  | 1  | 1 |
| get dashboard summaries  | 1  | 1 |
| get dashboard (n = number of dashboards)  | 4 * n  | 424 |
|  |  | 428 | 

Now: 

| Step  | Queries | Real example - 426 charts and 106 dashboards |
| ------------- | ------------- |------------- |
| Get explores  | 1  | 1 |
| get tables configuration  | 1  | 1 |
| get charts  | 1  | 1 |
| get dashboards  | 1  | 1 |
|  |  | 4 | 


New query:

```
with "dashboard_last_version_cte" as (select "dashboards"."dashboard_uuid"                as "dashboard_uuid",
                                             "dashboards"."name"                          as "name",
                                             MAX(dashboard_versions.dashboard_version_id) as "dashboard_version_id"
                                      from "dashboards"
                                               left join "spaces" on "dashboards"."space_id" = "spaces"."space_id"
                                               left join "projects" on "spaces"."project_id" = "projects"."project_id"
                                               left join "dashboard_versions"
                                                         on "dashboards"."dashboard_id" = "dashboard_versions"."dashboard_id"
                                      where "projects"."project_uuid" = ?
                                      group by "dashboards"."dashboard_uuid", "dashboards"."name")
select "dashboard_last_version_cte"."dashboard_uuid"                             as "dashboardUuid",
       "dashboard_last_version_cte"."name"                                       as "name",
       "dashboard_views"."filters"                                               as "filters",
       COALESCE(ARRAY_AGG(DISTINCT saved_queries.saved_query_uuid)
                FILTER (WHERE saved_queries.saved_query_uuid IS NOT NULL), '{}') as "chartUuids"
from "dashboard_last_version_cte"
         left join "dashboard_views"
                   on "dashboard_last_version_cte"."dashboard_version_id" = "dashboard_views"."dashboard_version_id"
         left join "dashboard_tile_charts" on "dashboard_last_version_cte"."dashboard_version_id" =
                                              "dashboard_tile_charts"."dashboard_version_id"
         left join "saved_queries" on "dashboard_tile_charts"."saved_chart_id" = "saved_queries"."saved_query_id"
group by 1, 2, 3
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
