### PR TITLE
style: initial catalog field styling

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -35,7 +35,7 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}
                 onClick={onClick}
-                py="xs"
+                py="two"
             >
                 <Box miw={150}>
                     <Group

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -1,6 +1,6 @@
-import { type CatalogField } from '@lightdash/common';
-import { Box, Group, Highlight } from '@mantine/core';
-import { IconAbc } from '@tabler/icons-react';
+import { FieldType, type CatalogField } from '@lightdash/common';
+import { Box, Group, Highlight, UnstyledButton } from '@mantine/core';
+import { IconAbc, IconNumber } from '@tabler/icons-react';
 import React, { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 
@@ -22,40 +22,58 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
 
     return (
         <>
-            <Group
-                noWrap
-                py="xs"
+            <UnstyledButton
                 sx={(theme) => ({
                     borderRadius: theme.radius.sm,
-                    padding: theme.spacing.md,
                     backgroundColor: hovered
                         ? theme.colors.gray[1]
-                        : theme.colors.gray[0],
-                    border: isSelected
-                        ? `2px solid ${theme.colors.blue[6]}`
-                        : undefined,
+                        : 'transparent',
+                    border: `2px solid ${
+                        isSelected ? theme.colors.blue[6] : 'transparent'
+                    }`,
                 })}
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}
                 onClick={onClick}
+                py="xs"
             >
-                <Group noWrap spacing="xs">
-                    <MantineIcon
-                        icon={IconAbc}
-                        color="gray"
-                        size="lg"
-                    ></MantineIcon>
-                </Group>
                 <Box miw={150}>
-                    <Highlight
-                        highlight={searchString}
-                        highlightColor="violet"
-                        fw={600}
+                    <Group
+                        spacing="xs"
+                        noWrap
+                        w="fit-content"
+                        px="xs"
+                        sx={(theme) => ({
+                            border: `1px solid ${theme.colors.gray[2]}`,
+                            borderRadius: theme.radius.md,
+                        })}
                     >
-                        {field.name || ''}
-                    </Highlight>
+                        <MantineIcon
+                            icon={
+                                // TODO: Add icon for field type and for subtype
+                                field.fieldType === FieldType.DIMENSION
+                                    ? IconAbc
+                                    : IconNumber
+                            }
+                            // TODO: update when new icons are added
+                            color={
+                                field.fieldType === FieldType.DIMENSION
+                                    ? 'blue'
+                                    : 'orange'
+                            }
+                        />
+
+                        <Highlight
+                            highlight={searchString}
+                            highlightColor="violet"
+                            fw={500}
+                            fz="sm"
+                        >
+                            {field.name || ''}
+                        </Highlight>
+                    </Group>
                 </Box>
-            </Group>
+            </UnstyledButton>
         </>
     );
 };

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -1,5 +1,5 @@
 import { FieldType, type CatalogField } from '@lightdash/common';
-import { Box, Group, Highlight, UnstyledButton } from '@mantine/core';
+import { Box, Group, Highlight } from '@mantine/core';
 import { IconAbc, IconNumber } from '@tabler/icons-react';
 import React, { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -22,8 +22,10 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
 
     return (
         <>
-            <UnstyledButton
+            <Group
+                noWrap
                 sx={(theme) => ({
+                    cursor: 'pointer',
                     borderRadius: theme.radius.sm,
                     backgroundColor: hovered
                         ? theme.colors.gray[1]
@@ -36,6 +38,7 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                 onMouseLeave={() => setHovered(false)}
                 onClick={onClick}
                 py="two"
+                mr="xs"
             >
                 <Box miw={150}>
                     <Group
@@ -73,7 +76,7 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                         </Highlight>
                     </Group>
                 </Box>
-            </UnstyledButton>
+            </Group>
         </>
     );
 };

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -54,9 +54,10 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                 px="xs"
                 sx={(theme) => ({
                     minHeight: 48,
-                    borderBottom: isLast
-                        ? 'none'
-                        : `1px solid ${theme.colors.gray[2]}`,
+                    borderBottom:
+                        isLast || isOpen
+                            ? 'none'
+                            : `1px solid ${theme.colors.gray[2]}`,
                     backgroundColor: hovered
                         ? theme.colors.gray[1]
                         : 'transparent',

--- a/packages/frontend/src/features/catalog/components/CatalogTree.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTree.tsx
@@ -77,7 +77,14 @@ const renderTreeNode = ({
                 isLast={index === length - 1}
             >
                 {Object.keys(node.fields).length > 0 && (
-                    <Stack spacing={0}>
+                    <Stack
+                        spacing={0}
+                        my="xs"
+                        pl="xs"
+                        sx={(theme) => ({
+                            borderLeft: `1px solid ${theme.colors.gray[2]}`,
+                        })}
+                    >
                         {node.fields.map((child: any, fieldIndex: number) =>
                             renderTreeNode({
                                 node: child,

--- a/packages/frontend/src/features/catalog/components/CatalogTree.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTree.tsx
@@ -79,7 +79,7 @@ const renderTreeNode = ({
                 {Object.keys(node.fields).length > 0 && (
                     <Stack
                         spacing={0}
-                        my="xs"
+                        mb="xs"
                         pl="xs"
                         sx={(theme) => ({
                             borderLeft: `1px solid ${theme.colors.gray[2]}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/10193

### Description:

Made the `CatalogFieldListItem` an  `unstyled` button
Added a transparent border to it regardless of it being selected or not - helps with content jumping when selecting/de-selecting
Added some spacings necessary for making it look nicer
Added temporary styles/icons to fields that are dimensions or metrics. This will change soon once I get @PriPatel 's new assets. 

Before

<img width="1237" alt="Screenshot 2024-05-30 at 14 56 58" src="https://github.com/lightdash/lightdash/assets/7611706/5407e514-bd4e-40e6-abed-e434d07d1d17">


After

<img width="1225" alt="Screenshot 2024-05-30 at 14 55 20" src="https://github.com/lightdash/lightdash/assets/7611706/388ffca3-f4eb-4e93-9b59-046f595682db">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
