### PR TITLE
fix: create new group with opposite operator

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -216,10 +216,19 @@ const FilterGroupForm: FC<Props> = ({
                                 onConvertToGroup={
                                     allowConvertToGroup
                                         ? () =>
-                                              onChangeItem(index, {
-                                                  id: uuidv4(),
-                                                  or: [item],
-                                              })
+                                              onChangeItem(
+                                                  index,
+                                                  // create new group with opposite operator
+                                                  isAndFilterGroup(filterGroup)
+                                                      ? {
+                                                            id: uuidv4(),
+                                                            or: [item],
+                                                        }
+                                                      : {
+                                                            id: uuidv4(),
+                                                            and: [item],
+                                                        },
+                                              )
                                         : undefined
                                 }
                             />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10132 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We now create a group with the opposite operation of the parent group. This avoid the group from being flatten automatically.


https://github.com/lightdash/lightdash/assets/9117144/bfbd91ae-74e2-4cc9-b10d-ac2e5c120867



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
