### PR TITLE
style: address styling catalog feedback

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
@@ -98,7 +98,7 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                     ml="sm"
                     sx={(theme) => ({
                         border: `1px solid ${theme.colors.gray[2]}`,
-                        borderRadius: theme.radius.lg,
+                        borderRadius: theme.radius.md,
                         backgroundColor: 'white',
                     })}
                 >

--- a/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
@@ -34,14 +34,26 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                 onClick={toggleOpen}
                 p="sm"
                 w="100%"
+                pos="relative"
                 sx={(theme) => ({
-                    borderBottom:
-                        !isLast && !isOpen
-                            ? `1px solid ${theme.colors.gray[3]}`
-                            : undefined,
+                    paddingBottom: !isLast ? theme.spacing.xs : 0,
+                    ...(!isLast && !isOpen
+                        ? // Adds offset to the bottom border of all groups except the last one (aligns with chevron icon)
+                          {
+                              '&::after': {
+                                  content: '""',
+                                  position: `absolute`,
+                                  top: '90%',
+                                  left: '12px',
+                                  width: '100%',
+                                  height: '1px',
+                                  background: theme.colors.gray[3],
+                              },
+                          }
+                        : {}),
                 })}
             >
-                <Group spacing={'xs'}>
+                <Group spacing={'xs'} noWrap align="center">
                     <Avatar
                         radius="xl"
                         color="gray"
@@ -63,19 +75,21 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                         />
                     </Avatar>
 
-                    <Text fw={600} fz={14}>
-                        {label}
-                    </Text>
-                    <Badge
-                        color="gray"
-                        size="xs"
-                        radius="xl"
-                        sx={(theme) => ({
-                            backgroundColor: theme.colors.gray[2],
-                        })}
-                    >
-                        {tableCount}
-                    </Badge>
+                    <Group w="100%">
+                        <Text fw={600} fz={14}>
+                            {label}
+                        </Text>
+                        <Badge
+                            color="gray"
+                            size="xs"
+                            radius="xl"
+                            sx={(theme) => ({
+                                backgroundColor: theme.colors.gray[2],
+                            })}
+                        >
+                            {tableCount}
+                        </Badge>
+                    </Group>
                 </Group>
             </UnstyledButton>
             <Collapse in={isOpen}>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -173,7 +173,7 @@ export const CatalogMetadata: FC = () => {
                     },
                     panel: {
                         paddingTop: theme.spacing.xl,
-                        height: `calc(100vh - 230px)`,
+                        height: `calc(100vh - 240px)`,
                         overflowY: 'scroll',
                     },
                     tab: {

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -19,6 +19,7 @@ import {
     IconArrowUp,
     IconCornerDownLeft,
     IconDatabase,
+    IconLayoutSidebarRightCollapse,
     IconLink,
     IconTable,
 } from '@tabler/icons-react';
@@ -30,6 +31,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { useCatalogContext } from '../context/CatalogProvider';
 import { useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
+import { useCatalogMetadata } from '../hooks/useCatalogMetadata';
 import { CatalogAnalyticCharts } from './CatalogAnalyticCharts';
 
 export const CatalogMetadata: FC = () => {
@@ -38,10 +40,14 @@ export const CatalogMetadata: FC = () => {
     const {
         projectUuid,
         metadata: metadataResults,
+        setSidebarOpen,
         analyticsResults,
         selection,
         setAnalyticsResults,
+        setSelection,
     } = useCatalogContext();
+
+    const { reset: resetMetadata } = useCatalogMetadata(projectUuid);
 
     const isFetchingAnalytics = useIsFetching({
         queryKey: ['catalog_analytics', projectUuid],
@@ -87,7 +93,31 @@ export const CatalogMetadata: FC = () => {
     if (!metadata) return null;
 
     return (
-        <Stack h="100vh" spacing="xl">
+        <Stack h="100vh" spacing="xl" pos="relative">
+            <Button
+                variant="default"
+                size="xs"
+                pos="absolute"
+                right={0}
+                top={0}
+                compact
+                rightIcon={
+                    <MantineIcon
+                        color="gray.6"
+                        icon={IconLayoutSidebarRightCollapse}
+                    />
+                }
+                onClick={() => {
+                    setSidebarOpen(false);
+
+                    if (metadata) {
+                        resetMetadata();
+                        setSelection(undefined);
+                    }
+                }}
+            >
+                Close
+            </Button>
             <Group spacing="xs">
                 <Avatar
                     size="sm"

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -95,18 +95,13 @@ export const CatalogMetadata: FC = () => {
     return (
         <Stack h="100vh" spacing="xl">
             <Button
-                variant="default"
+                variant="light"
                 size="xs"
                 pos="absolute"
-                right={10}
+                left={0}
                 top={10}
                 compact
-                rightIcon={
-                    <MantineIcon
-                        color="gray.6"
-                        icon={IconLayoutSidebarRightCollapse}
-                    />
-                }
+                leftIcon={<MantineIcon icon={IconLayoutSidebarRightCollapse} />}
                 onClick={() => {
                     setSidebarOpen(false);
 
@@ -115,10 +110,15 @@ export const CatalogMetadata: FC = () => {
                         setSelection(undefined);
                     }
                 }}
+                sx={{
+                    borderLeft: 'none',
+                    borderTopLeftRadius: 0,
+                    borderBottomLeftRadius: 0,
+                }}
             >
                 Close
             </Button>
-            <Group spacing="xs">
+            <Group spacing="xs" mt="lg">
                 <Avatar
                     size="md"
                     radius="xl"
@@ -173,7 +173,7 @@ export const CatalogMetadata: FC = () => {
                     },
                     panel: {
                         paddingTop: theme.spacing.xl,
-                        height: `calc(100vh - 240px)`,
+                        height: `calc(100vh - 260px)`,
                         overflowY: 'scroll',
                     },
                     tab: {

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -98,8 +98,8 @@ export const CatalogMetadata: FC = () => {
                 variant="default"
                 size="xs"
                 pos="absolute"
-                right={0}
-                top={0}
+                right={10}
+                top={10}
                 compact
                 rightIcon={
                     <MantineIcon

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -137,7 +137,8 @@ export const CatalogMetadata: FC = () => {
                 {selectedFieldInTable && (
                     <>
                         <Text
-                            color={colors.blue[6]}
+                            color={colors.blue[4]}
+                            fz="md"
                             sx={{ cursor: 'pointer' }}
                             onClick={() => {
                                 setSelectedFieldInTable(undefined);
@@ -148,7 +149,7 @@ export const CatalogMetadata: FC = () => {
                             {' '}
                             {selection?.table}
                         </Text>
-                        {' > '}
+                        {' / '}
                     </>
                 )}
                 <Text

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -93,7 +93,7 @@ export const CatalogMetadata: FC = () => {
     if (!metadata) return null;
 
     return (
-        <Stack h="100vh" spacing="xl" pos="relative">
+        <Stack h="100vh" spacing="xl">
             <Button
                 variant="default"
                 size="xs"
@@ -173,7 +173,7 @@ export const CatalogMetadata: FC = () => {
                     },
                     panel: {
                         paddingTop: theme.spacing.xl,
-                        height: `calc(100vh - 220px)`,
+                        height: `calc(100vh - 230px)`,
                         overflowY: 'scroll',
                     },
                     tab: {
@@ -366,17 +366,19 @@ export const CatalogMetadata: FC = () => {
             </Tabs>
 
             <Stack
+                h={72}
+                justify="center"
                 p="sm"
+                c="gray"
+                w="100%"
+                pos="absolute"
+                bottom={0}
+                left={0}
                 sx={(theme) => ({
                     backgroundColor: theme.colors.gray[0],
                     border: `1px solid ${theme.colors.gray[4]}`,
                     borderLeft: 0,
                     borderRight: 0,
-                    position: 'absolute',
-                    bottom: 0,
-                    left: 0,
-                    width: '100%',
-                    color: 'gray',
                 })}
             >
                 <Group position="apart">
@@ -428,7 +430,7 @@ export const CatalogMetadata: FC = () => {
                         </Group>
                     </Group>
                     <Button
-                        size="xs"
+                        size="sm"
                         sx={(theme) => ({
                             backgroundColor: theme.colors.gray[8],
                             '&:hover': {

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -120,7 +120,7 @@ export const CatalogMetadata: FC = () => {
             </Button>
             <Group spacing="xs">
                 <Avatar
-                    size="sm"
+                    size="md"
                     radius="xl"
                     styles={(theme) => ({
                         root: {
@@ -152,7 +152,7 @@ export const CatalogMetadata: FC = () => {
                     </>
                 )}
                 <Text
-                    fs="lg"
+                    fz="lg"
                     fw={600}
                     onDoubleClick={() => {
                         history.push(

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -121,11 +121,7 @@ export const CatalogPanel: FC = () => {
         search: debouncedSearch,
     });
 
-    const {
-        mutate: getMetadata,
-        data: metadata,
-        reset: closeMetadata,
-    } = useCatalogMetadata(projectUuid, (data) => {
+    const { mutate: getMetadata } = useCatalogMetadata(projectUuid, (data) => {
         if (data) {
             setMetadata(data);
         }
@@ -344,23 +340,6 @@ export const CatalogPanel: FC = () => {
                             </Box>
                         </Group>
                     </Box>
-                    {selection && (
-                        <Button
-                            variant="default"
-                            size="xs"
-                            onClick={() => {
-                                setSidebarOpen((prev) => !prev);
-                                if (metadata) {
-                                    closeMetadata();
-                                    setSelection(undefined);
-                                } else if (selection === undefined)
-                                    selectAndGetMetadata(selectionList[0]);
-                                else selectAndGetMetadata(selection);
-                            }}
-                        >
-                            {isSidebarOpen ? 'Hide metadata' : 'Show metadata'}
-                        </Button>
-                    )}
                 </Group>
 
                 <Group spacing="xs">

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue, useHotkeys } from '@mantine/hooks';
 import {
-    IconFilter,
+    IconAdjustmentsHorizontal,
     IconReportSearch,
     IconSearch,
     IconX,
@@ -392,7 +392,9 @@ export const CatalogPanel: FC = () => {
                         <Button
                             variant="default"
                             disabled // TODO: remove when implemented
-                            leftIcon={<MantineIcon icon={IconFilter} />}
+                            leftIcon={
+                                <MantineIcon icon={IconAdjustmentsHorizontal} />
+                            }
                         >
                             Filters
                         </Button>

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -369,6 +369,12 @@ export const CatalogPanel: FC = () => {
                             'error',
                         ]}
                         onChange={(e) => handleSearchChange(e.target.value)}
+                        styles={(theme) => ({
+                            input: {
+                                borderRadius: theme.radius.md,
+                                border: `1px solid ${theme.colors.gray[3]}`,
+                            },
+                        })}
                     />
                     <Group>
                         <SegmentedControl

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -317,102 +317,109 @@ export const CatalogPanel: FC = () => {
     );
 
     return (
-        <Stack>
-            <Group position="apart" align="flex-start">
-                <Box>
-                    <Group>
-                        <Paper
-                            p="sm"
-                            withBorder
-                            radius="md"
-                            sx={(theme) => ({
-                                boxShadow: theme.shadows.xs,
-                            })}
+        <Stack spacing="xxl">
+            <Stack>
+                <Group position="apart" align="flex-start">
+                    <Box mt="xl">
+                        <Group>
+                            <Paper
+                                p="sm"
+                                withBorder
+                                radius="md"
+                                sx={(theme) => ({
+                                    boxShadow: theme.shadows.xs,
+                                })}
+                            >
+                                <MantineIcon
+                                    size={24}
+                                    icon={IconReportSearch}
+                                />
+                            </Paper>
+
+                            <Box>
+                                <Title order={4}>Start exploring</Title>
+                                <Text color="gray.6" fw={500}>
+                                    Select a table or field to start exploring.
+                                </Text>
+                            </Box>
+                        </Group>
+                    </Box>
+                    {selection && (
+                        <Button
+                            variant="default"
+                            size="xs"
+                            onClick={() => {
+                                setSidebarOpen((prev) => !prev);
+                                if (metadata) {
+                                    closeMetadata();
+                                    setSelection(undefined);
+                                } else if (selection === undefined)
+                                    selectAndGetMetadata(selectionList[0]);
+                                else selectAndGetMetadata(selection);
+                            }}
                         >
-                            <MantineIcon size={24} icon={IconReportSearch} />
-                        </Paper>
-
-                        <Box>
-                            <Title order={4}>Start exploring</Title>
-                            <Text color="gray.6" fw={500}>
-                                Select a table or field to start exploring.
-                            </Text>
-                        </Box>
-                    </Group>
-                </Box>
-                {selection && (
-                    <Button
-                        variant="default"
-                        size="xs"
-                        onClick={() => {
-                            setSidebarOpen((prev) => !prev);
-                            if (metadata) {
-                                closeMetadata();
-                                setSelection(undefined);
-                            } else if (selection === undefined)
-                                selectAndGetMetadata(selectionList[0]);
-                            else selectAndGetMetadata(selection);
-                        }}
-                    >
-                        {isSidebarOpen ? 'Hide metadata' : 'Show metadata'}
-                    </Button>
-                )}
-            </Group>
-
-            <Group spacing="xs">
-                <TextInput
-                    w={'50%'}
-                    icon={<MantineIcon icon={IconSearch} />}
-                    rightSection={
-                        search ? (
-                            <ActionIcon onClick={() => handleSearchChange('')}>
-                                <MantineIcon icon={IconX} />
-                            </ActionIcon>
-                        ) : null
-                    }
-                    placeholder="Search"
-                    description={
-                        search && search.length < 3
-                            ? 'Enter at least 3 characters to search'
-                            : undefined
-                    }
-                    value={search}
-                    inputWrapperOrder={[
-                        'label',
-                        'input',
-                        'description',
-                        'error',
-                    ]}
-                    onChange={(e) => handleSearchChange(e.target.value)}
-                />
-                <Group>
-                    <SegmentedControl
-                        w={200}
-                        disabled // TODO: remove when implemented
-                        defaultValue={'tables'}
-                        data={[
-                            {
-                                value: 'tables',
-                                label: 'Tables',
-                            },
-                            {
-                                value: 'fields',
-                                label: 'Fields',
-                            },
-                        ]}
-                        onChange={() => {
-                            // NYI
-                        }}
-                    />
-                    <Button
-                        variant="default"
-                        disabled // TODO: remove when implemented
-                        leftIcon={<MantineIcon icon={IconFilter} />}
-                    >
-                        Filters
-                    </Button>
+                            {isSidebarOpen ? 'Hide metadata' : 'Show metadata'}
+                        </Button>
+                    )}
                 </Group>
-            </Group>
+
+                <Group spacing="xs">
+                    <TextInput
+                        w={'50%'}
+                        icon={<MantineIcon icon={IconSearch} />}
+                        rightSection={
+                            search ? (
+                                <ActionIcon
+                                    onClick={() => handleSearchChange('')}
+                                >
+                                    <MantineIcon icon={IconX} />
+                                </ActionIcon>
+                            ) : null
+                        }
+                        placeholder="Search"
+                        description={
+                            search && search.length < 3
+                                ? 'Enter at least 3 characters to search'
+                                : undefined
+                        }
+                        value={search}
+                        inputWrapperOrder={[
+                            'label',
+                            'input',
+                            'description',
+                            'error',
+                        ]}
+                        onChange={(e) => handleSearchChange(e.target.value)}
+                    />
+                    <Group>
+                        <SegmentedControl
+                            w={200}
+                            disabled // TODO: remove when implemented
+                            defaultValue={'tables'}
+                            data={[
+                                {
+                                    value: 'tables',
+                                    label: 'Tables',
+                                },
+                                {
+                                    value: 'fields',
+                                    label: 'Fields',
+                                },
+                            ]}
+                            onChange={() => {
+                                // NYI
+                            }}
+                        />
+                        <Button
+                            variant="default"
+                            disabled // TODO: remove when implemented
+                            leftIcon={<MantineIcon icon={IconFilter} />}
+                        >
+                            Filters
+                        </Button>
+                    </Group>
+                </Group>
+            </Stack>
 
             <CatalogTree
                 tree={catalogTree}

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -7,11 +7,7 @@ import {
     Tooltip,
     UnstyledButton,
 } from '@mantine/core';
-import {
-    IconExternalLink,
-    IconLayersIntersect,
-    IconTable,
-} from '@tabler/icons-react';
+import { IconLayersIntersect, IconTable } from '@tabler/icons-react';
 import React, { useState, type FC } from 'react';
 import { useToggle } from 'react-use';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -126,16 +122,10 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                         }}
                     >
                         <MantineLinkButton
-                            size="xs"
+                            size="sm"
                             href={url}
                             target="_blank"
                             compact
-                            rightIcon={
-                                <MantineIcon
-                                    size="sm"
-                                    icon={IconExternalLink}
-                                />
-                            }
                             sx={(theme) => ({
                                 backgroundColor: theme.colors.gray[8],
                                 '&:hover': {

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -78,7 +78,11 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
             >
                 <UnstyledButton onClick={() => toggleOpen()} miw={150}>
                     <Group noWrap spacing="xs">
-                        <MantineIcon icon={IconTable} color="gray" size="sm" />
+                        <MantineIcon
+                            icon={IconTable}
+                            color="gray.6"
+                            size="md"
+                        />
 
                         <Highlight
                             highlight={searchString}

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -51,7 +51,8 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                 noWrap
                 position="apart"
                 spacing="xs"
-                px="xs"
+                p="xs"
+                px="sm"
                 sx={(theme) => ({
                     minHeight: 48,
                     borderBottom: isLast

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -65,12 +65,12 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                         ? `2px solid ${theme.colors.blue[6]}`
                         : undefined,
                     cursor: 'pointer',
-                    borderTopLeftRadius: isFirst ? theme.radius.lg : 0,
-                    borderTopRightRadius: isFirst ? theme.radius.lg : 0,
+                    borderTopLeftRadius: isFirst ? theme.radius.md : 0,
+                    borderTopRightRadius: isFirst ? theme.radius.md : 0,
                     borderBottomLeftRadius:
-                        isLast && !isOpen ? theme.radius.lg : 0,
+                        isLast && !isOpen ? theme.radius.md : 0,
                     borderBottomRightRadius:
-                        isLast && !isOpen ? theme.radius.lg : 0,
+                        isLast && !isOpen ? theme.radius.md : 0,
                 })}
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -98,7 +98,7 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                         >
                             <Group noWrap spacing="one">
                                 <MantineIcon
-                                    color="gray"
+                                    color="gray.5"
                                     icon={IconLayersIntersect}
                                 />
                             </Group>

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -1,5 +1,6 @@
 import { type CatalogField, type CatalogTable } from '@lightdash/common';
 import {
+    Badge,
     Box,
     Collapse,
     Group,
@@ -45,7 +46,6 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
         <>
             <Group
                 noWrap
-                position="apart"
                 spacing="xs"
                 p="xs"
                 px="sm"
@@ -54,12 +54,14 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                     borderBottom: isLast
                         ? 'none'
                         : `1px solid ${theme.colors.gray[2]}`,
-                    backgroundColor: hovered
+                    backgroundColor: isSelected
                         ? theme.colors.gray[1]
+                        : hovered
+                        ? theme.colors.gray[2]
                         : 'transparent',
-                    border: isSelected
-                        ? `2px solid ${theme.colors.blue[6]}`
-                        : undefined,
+                    border: `2px solid ${
+                        isSelected ? theme.colors.blue[6] : 'transparent'
+                    }`,
                     cursor: 'pointer',
                     borderTopLeftRadius: isFirst ? theme.radius.md : 0,
                     borderTopRightRadius: isFirst ? theme.radius.md : 0,
@@ -103,17 +105,24 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                         </Tooltip>
                     )}
                 </Box>
-                <Highlight
-                    fz="13px"
-                    w="100%"
-                    c="gray.7"
-                    lineClamp={2}
-                    highlight={searchString}
-                    highlightColor="violet"
-                >
-                    {table.description || ''}
-                </Highlight>
-                {hovered && (
+                {!isSelected ? (
+                    <Highlight
+                        fz="13px"
+                        w="100%"
+                        c="gray.7"
+                        lineClamp={2}
+                        highlight={searchString}
+                        highlightColor="violet"
+                        sx={{
+                            lineHeight: '1.2',
+                        }}
+                    >
+                        {table.description || ''}
+                    </Highlight>
+                ) : (
+                    <Badge color="violet">previewing</Badge>
+                )}
+                {(hovered || isSelected) && (
                     <Box
                         pos={'absolute'}
                         right={10}

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -108,8 +108,9 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                     )}
                 </Box>
                 <Highlight
-                    fz="xs"
+                    fz="13px"
                     w="100%"
+                    c="gray.7"
                     lineClamp={2}
                     highlight={searchString}
                     highlightColor="violet"

--- a/packages/frontend/src/features/catalog/hooks/useCatalogMetadata.ts
+++ b/packages/frontend/src/features/catalog/hooks/useCatalogMetadata.ts
@@ -23,7 +23,7 @@ const fetchCatalogMetadata = async ({
 
 export const useCatalogMetadata = (
     projectUuid: string,
-    onSuccess: (data: ApiCatalogMetadataResults) => void,
+    onSuccess?: (data: ApiCatalogMetadataResults) => void,
 ) => {
     const setErrorResponse = useQueryError();
 
@@ -31,7 +31,7 @@ export const useCatalogMetadata = (
         (table) => fetchCatalogMetadata({ projectUuid, table }),
         {
             mutationKey: ['catalog_metadata', projectUuid],
-            onSuccess: (data) => onSuccess(data),
+            onSuccess: (data) => onSuccess?.(data),
             onError: (result) => setErrorResponse(result),
         },
     );

--- a/packages/frontend/src/pages/Catalog.tsx
+++ b/packages/frontend/src/pages/Catalog.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import Page from '../components/common/Page/Page';
@@ -29,9 +28,7 @@ const Catalog: FC = () => {
                     maxWidth: 800,
                 }}
             >
-                <Stack>
-                    <CatalogPanel />
-                </Stack>
+                <CatalogPanel />
             </Page>
         </CatalogProvider>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Instructions to review this PR: 

- Go to: https://www.notion.so/lightdash/To-do-batch-1-8e64d5610dc9408ea02aecd32d8f7b30
- Follow each step and there's a commit attached to each comment (except for the last [chore: re-style close button](https://github.com/lightdash/lightdash/commit/bd21f8fab6d0301f726c878ebe8c6589ca7b294b)) which is fix after the changes applied

If the commits aren't sufficient I'm happy to go through each step together/split into smaller PRs

One **NOTE**

- [style: add close button to CatalogMetadata](https://github.com/lightdash/lightdash/commit/47b07c42f1119634851c4b0e3b9a354c9237bf11)
See changes here ^ I'm positive we should only handle the **close event** which will set the `selection` to `undefined`, close the sidebar, and reset the `metadata`. LMK what you think about this change!

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
