### PR TITLE
fix: underlying data with null filter

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
+++ b/packages/frontend/src/components/MetricQueryData/MetricQueryDataProvider.tsx
@@ -84,7 +84,8 @@ export const getDataFromChartClick = (
         e.data,
     ).reduce((acc, entry) => {
         const [key, val] = entry;
-        return { ...acc, [key]: { raw: val, formatted: val } };
+        const raw = val === '∅' ? null : val; // convert ∅ values back to null. Echarts doesn't support null formatting https://github.com/apache/echarts/issues/15821
+        return { ...acc, [key]: { raw, formatted: val } };
     }, {});
 
     return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10221 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

For `null` values we pass the formatted value since echarts won't render them correctly otherwise. See more about bug here: https://github.com/apache/echarts/issues/15821

So when handling the echarts event we change it back to `null`.


https://github.com/lightdash/lightdash/assets/9117144/df263424-324e-4bfd-8d68-4b93b43ef176



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
