### PR TITLE
chore: add empty states for the catalog tree

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -426,58 +426,60 @@ export const CatalogPanel: FC = () => {
                 </Group>
             </Group>
             {noResults ? (
-                <Paper
-                    p="xl"
-                    radius="lg"
-                    sx={(theme) => ({
-                        backgroundColor: theme.colors.gray[1],
-                        border: `1px solid ${theme.colors.gray[3]}`,
-                    })}
-                >
-                    <SuboptimalState
-                        icon={IconSearch}
-                        title="No search results"
-                        description={
-                            'Try using different keywords or adjusting your filters.'
-                        }
-                        action={
-                            <Button
-                                variant="default"
-                                onClick={clearSearch}
-                                mt="sm"
-                                radius="md"
-                            >
-                                Clear search
-                            </Button>
-                        }
-                    />
-                </Paper>
-            ) : noTables ? (
-                <Paper
-                    p="xl"
-                    radius="lg"
-                    sx={(theme) => ({
-                        backgroundColor: theme.colors.gray[1],
-                        border: `1px solid ${theme.colors.gray[3]}`,
-                    })}
-                >
-                    <SuboptimalState
-                        icon={IconTable}
-                        title="No tables found in this project"
-                        description={
-                            "Tables are the starting point to any data exploration in Lightdash. They come from dbt models that have been defined in your dbt project's .yml files."
-                        }
-                        action={
-                            <LinkButton
-                                color="dark"
-                                href="https://docs.lightdash.com/guides/adding-tables-to-lightdash"
-                                mt="md"
-                            >
-                                Learn more
-                            </LinkButton>
-                        }
-                    />
-                </Paper>
+                noTables ? (
+                    <Paper
+                        p="xl"
+                        radius="lg"
+                        sx={(theme) => ({
+                            backgroundColor: theme.colors.gray[1],
+                            border: `1px solid ${theme.colors.gray[3]}`,
+                        })}
+                    >
+                        <SuboptimalState
+                            icon={IconTable}
+                            title="No tables found in this project"
+                            description={
+                                "Tables are the starting point to any data exploration in Lightdash. They come from dbt models that have been defined in your dbt project's .yml files."
+                            }
+                            action={
+                                <LinkButton
+                                    color="dark"
+                                    href="https://docs.lightdash.com/guides/adding-tables-to-lightdash"
+                                    mt="md"
+                                >
+                                    Learn more
+                                </LinkButton>
+                            }
+                        />
+                    </Paper>
+                ) : (
+                    <Paper
+                        p="xl"
+                        radius="lg"
+                        sx={(theme) => ({
+                            backgroundColor: theme.colors.gray[1],
+                            border: `1px solid ${theme.colors.gray[3]}`,
+                        })}
+                    >
+                        <SuboptimalState
+                            icon={IconSearch}
+                            title="No search results"
+                            description={
+                                'Try using different keywords or adjusting your filters.'
+                            }
+                            action={
+                                <Button
+                                    variant="default"
+                                    onClick={clearSearch}
+                                    mt="sm"
+                                    radius="md"
+                                >
+                                    Clear search
+                                </Button>
+                            }
+                        />
+                    </Paper>
+                )
             ) : (
                 <CatalogTree
                     tree={catalogTree}

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -119,7 +119,11 @@ export const CatalogPanel: FC = () => {
     const [completeSearch, setCompleteSearch] = useState<string>('');
     const [debouncedSearch] = useDebouncedValue(completeSearch, 300);
 
-    const { data: catalogResults, isFetched: catalogFetched } = useCatalog({
+    const {
+        data: catalogResults,
+        isFetched: catalogFetched,
+        isFetching: catalogFetching,
+    } = useCatalog({
         projectUuid,
         type: CatalogType.Table,
         search: debouncedSearch,
@@ -325,8 +329,11 @@ export const CatalogPanel: FC = () => {
         [],
     );
 
-    const noResults = catalogFetched && Object.keys(catalogTree).length === 0;
-    const noTables = noResults && completeSearch.length === 0;
+    const noResults =
+        !catalogFetching &&
+        catalogFetched &&
+        Object.keys(catalogTree).length === 0;
+    const noTables = noResults && debouncedSearch.length === 0;
 
     return (
         <Stack>
@@ -425,16 +432,17 @@ export const CatalogPanel: FC = () => {
                     </Button>
                 </Group>
             </Group>
+
             {noResults ? (
-                noTables ? (
-                    <Paper
-                        p="xl"
-                        radius="lg"
-                        sx={(theme) => ({
-                            backgroundColor: theme.colors.gray[1],
-                            border: `1px solid ${theme.colors.gray[3]}`,
-                        })}
-                    >
+                <Paper
+                    p="xl"
+                    radius="lg"
+                    sx={(theme) => ({
+                        backgroundColor: theme.colors.gray[1],
+                        border: `1px solid ${theme.colors.gray[3]}`,
+                    })}
+                >
+                    {noTables ? (
                         <SuboptimalState
                             icon={IconTable}
                             title="No tables found in this project"
@@ -451,16 +459,7 @@ export const CatalogPanel: FC = () => {
                                 </LinkButton>
                             }
                         />
-                    </Paper>
-                ) : (
-                    <Paper
-                        p="xl"
-                        radius="lg"
-                        sx={(theme) => ({
-                            backgroundColor: theme.colors.gray[1],
-                            border: `1px solid ${theme.colors.gray[3]}`,
-                        })}
-                    >
+                    ) : (
                         <SuboptimalState
                             icon={IconSearch}
                             title="No search results"
@@ -478,8 +477,8 @@ export const CatalogPanel: FC = () => {
                                 </Button>
                             }
                         />
-                    </Paper>
-                )
+                    )}
+                </Paper>
             ) : (
                 <CatalogTree
                     tree={catalogTree}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add empty states for the catalog tree. I used the existing sub optimal state compoenet cause it had pretty much everything. The style isn't exactly like the mockup but it's close. 

Note that this doesn't include the metadata empty state. 

No search results:
<img width="1254" alt="Screenshot 2024-05-30 at 19 32 25" src="https://github.com/lightdash/lightdash/assets/1864179/9c64df39-0ec0-44ec-9fd9-c6438316e5e2">

No table in project:
<img width="1203" alt="Screenshot 2024-05-30 at 19 35 59" src="https://github.com/lightdash/lightdash/assets/1864179/1d115114-43ef-49dc-ab09-c47edd242ca7">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
