### PR TITLE
fix: defer state when opening metadata sidebar

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -24,7 +24,7 @@ import {
     IconLink,
     IconTable,
 } from '@tabler/icons-react';
-import { useIsFetching } from '@tanstack/react-query';
+import { useIsMutating } from '@tanstack/react-query';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -41,6 +41,7 @@ export const CatalogMetadata: FC = () => {
     const {
         projectUuid,
         metadata: metadataResults,
+        setMetadata,
         setSidebarOpen,
         analyticsResults,
         selection,
@@ -50,9 +51,11 @@ export const CatalogMetadata: FC = () => {
 
     const { reset: resetMetadata } = useCatalogMetadata(projectUuid);
 
-    const isFetchingAnalytics = useIsFetching({
-        queryKey: ['catalog_analytics', projectUuid],
-    });
+    const isMutatingAnalytics = useIsMutating([
+        'catalog_analytics',
+        projectUuid,
+    ]);
+    const isMutatingMetadata = useIsMutating(['catalog_metadata', projectUuid]);
 
     const history = useHistory();
 
@@ -91,8 +94,6 @@ export const CatalogMetadata: FC = () => {
         }
     }, [metadataResults, selection, selectedFieldInTable]);
 
-    if (!metadata) return <LoadingOverlay visible />;
-
     return (
         <Stack h="100vh" spacing="xl">
             <Button
@@ -108,6 +109,7 @@ export const CatalogMetadata: FC = () => {
 
                     if (metadata) {
                         resetMetadata();
+                        setMetadata(undefined);
                         setSelection(undefined);
                     }
                 }}
@@ -158,13 +160,24 @@ export const CatalogMetadata: FC = () => {
                     fw={600}
                     onDoubleClick={() => {
                         history.push(
-                            `/projects/${projectUuid}/tables/${metadata.modelName}`,
+                            `/projects/${projectUuid}/tables/${metadata?.modelName}`,
                         );
                     }}
                 >
-                    {metadata.name}
+                    {metadata?.name}
                 </Text>
             </Group>
+
+            <LoadingOverlay
+                loaderProps={{
+                    size: 'sm',
+                    color: 'gray.7',
+                    pos: 'absolute',
+                    variant: 'dots',
+                }}
+                visible={!metadata || !!isMutatingMetadata}
+                transitionDuration={1000}
+            />
 
             <Tabs
                 color="dark"
@@ -197,58 +210,59 @@ export const CatalogMetadata: FC = () => {
                     <Tabs.Tab value={'overview'}>Overview</Tabs.Tab>
                     <Tabs.Tab value={'analytics'}>
                         <Group spacing="xs">
-                            {/* TODO replace loading with spinner ?*/}
                             Usage Analytics
-                            {isFetchingAnalytics ? (
-                                <Loader
-                                    color="gray"
-                                    size="xs"
-                                    speed={1}
-                                    radius="xl"
-                                    ml="xs"
-                                />
-                            ) : (
-                                <Avatar
-                                    radius="xl"
-                                    size="xs"
-                                    fz="md"
-                                    styles={(theme) => ({
-                                        placeholder: {
-                                            fontSize: theme.fontSizes.xs,
-                                            color: theme.colors.gray[7],
-                                            backgroundColor:
-                                                theme.colors.gray[1],
-                                        },
-                                    })}
-                                >
-                                    {analyticsResults?.charts.length || '0'}
-                                </Avatar>
-                            )}
+                            <Avatar
+                                radius="xl"
+                                size="xs"
+                                fz="md"
+                                styles={(theme) => ({
+                                    placeholder: {
+                                        fontSize: theme.fontSizes.xs,
+                                        color: theme.colors.gray[7],
+                                        backgroundColor: theme.colors.gray[1],
+                                    },
+                                })}
+                            >
+                                {isMutatingAnalytics ? (
+                                    <Loader
+                                        color="gray"
+                                        size={8}
+                                        speed={1}
+                                        radius="xl"
+                                    />
+                                ) : (
+                                    analyticsResults?.charts.length || '0'
+                                )}
+                            </Avatar>
                         </Group>
                     </Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="overview">
                     <Stack>
-                        <Box
-                            sx={(theme) => ({
-                                padding: theme.spacing.sm,
-                                border: `1px solid ${theme.colors.gray[3]}`,
-                                borderRadius: theme.radius.sm,
-                                backgroundColor: theme.colors.gray[0],
-                                fontSize: theme.fontSizes.sm,
-                            })}
-                        >
-                            <MarkdownPreview
-                                style={{
-                                    backgroundColor: colors.gray[0],
-                                    fontSize: 'small',
-                                }}
-                                source={metadata.description}
-                            />
-                        </Box>
+                        {metadata?.description && (
+                            <>
+                                <Box
+                                    sx={(theme) => ({
+                                        padding: theme.spacing.sm,
+                                        border: `1px solid ${theme.colors.gray[3]}`,
+                                        borderRadius: theme.radius.sm,
+                                        backgroundColor: theme.colors.gray[0],
+                                        fontSize: theme.fontSizes.sm,
+                                    })}
+                                >
+                                    <MarkdownPreview
+                                        style={{
+                                            backgroundColor: colors.gray[0],
+                                            fontSize: 'small',
+                                        }}
+                                        source={metadata?.description}
+                                    />
+                                </Box>
 
-                        <Divider />
+                                <Divider />
+                            </>
+                        )}
 
                         <Group position="apart">
                             <Group spacing="xs">
@@ -261,12 +275,12 @@ export const CatalogMetadata: FC = () => {
                                 </Text>
                             </Group>
                             <Text fw={500} fz={13} c="gray.7">
-                                {metadata.source}
+                                {metadata?.source}
                             </Text>
                         </Group>
 
                         <Group position="apart" noWrap>
-                            <Group spacing="xs">
+                            <Group spacing="xs" noWrap>
                                 <MantineIcon
                                     color={colors.gray[5]}
                                     icon={IconLink}
@@ -275,10 +289,20 @@ export const CatalogMetadata: FC = () => {
                                     Joins
                                 </Text>
                             </Group>
-                            <Text fw={500} fz={13} c="blue" truncate w="50%">
-                                {metadata.joinedTables &&
-                                metadata.joinedTables.length > 0
-                                    ? metadata.joinedTables.join(', ')
+                            <Text
+                                fw={500}
+                                fz={13}
+                                c={
+                                    metadata?.joinedTables &&
+                                    metadata.joinedTables.length > 0
+                                        ? 'blue'
+                                        : 'gray.7'
+                                }
+                                truncate
+                            >
+                                {metadata?.joinedTables &&
+                                metadata?.joinedTables.length > 0
+                                    ? metadata?.joinedTables.join(', ')
                                     : 'None'}
                             </Text>
                         </Group>
@@ -301,7 +325,7 @@ export const CatalogMetadata: FC = () => {
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            {metadata.fields?.map((field) => (
+                                            {metadata?.fields?.map((field) => (
                                                 <tr
                                                     key={field.name}
                                                     style={{
@@ -443,7 +467,7 @@ export const CatalogMetadata: FC = () => {
                         })}
                         onClick={() => {
                             history.push(
-                                `/projects/${projectUuid}/tables/${metadata.modelName}`,
+                                `/projects/${projectUuid}/tables/${metadata?.modelName}`,
                             );
                         }}
                     >

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -7,6 +7,7 @@ import {
     Divider,
     Group,
     Loader,
+    LoadingOverlay,
     Paper,
     Stack,
     Table,
@@ -90,7 +91,7 @@ export const CatalogMetadata: FC = () => {
         }
     }, [metadataResults, selection, selectedFieldInTable]);
 
-    if (!metadata) return null;
+    if (!metadata) return <LoadingOverlay visible />;
 
     return (
         <Stack h="100vh" spacing="xl">

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -23,7 +23,7 @@ import {
     IconSearch,
     IconX,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, useTransition, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCatalogContext } from '../context/CatalogProvider';
@@ -97,6 +97,7 @@ function getSelectionList(tree: CatalogTreeType): CatalogSelection[] {
 }
 
 export const CatalogPanel: FC = () => {
+    const [, startTransition] = useTransition();
     const {
         setMetadata,
         isSidebarOpen,
@@ -123,18 +124,18 @@ export const CatalogPanel: FC = () => {
 
     const { mutate: getMetadata } = useCatalogMetadata(projectUuid, (data) => {
         if (data) {
-            setMetadata(data);
-        }
-
-        if (!isSidebarOpen && data) {
-            setSidebarOpen(true);
+            startTransition(() => {
+                setMetadata(data);
+            });
         }
     });
     const { mutate: getAnalytics } = useCatalogAnalytics(
         projectUuid,
         (data) => {
             if (data) {
-                setAnalyticsResults(data);
+                startTransition(() => {
+                    setAnalyticsResults(data);
+                });
             }
         },
     );
@@ -204,6 +205,12 @@ export const CatalogPanel: FC = () => {
         (selectedItem: CatalogSelection) => {
             if (!selectedItem.table) return;
 
+            startTransition(() => {
+                if (!isSidebarOpen) {
+                    setSidebarOpen(true);
+                }
+            });
+
             // For optimization purposes, we could only make this request if metadata panel is open
             setSelection({
                 table: selectedItem.table,
@@ -229,7 +236,14 @@ export const CatalogPanel: FC = () => {
                 }
             }
         },
-        [setSelection, catalogResults, getMetadata, getAnalytics],
+        [
+            setSelection,
+            catalogResults,
+            isSidebarOpen,
+            setSidebarOpen,
+            getMetadata,
+            getAnalytics,
+        ],
     );
 
     const history = useHistory();

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -133,9 +133,7 @@ export const CatalogPanel: FC = () => {
         projectUuid,
         (data) => {
             if (data) {
-                startTransition(() => {
-                    setAnalyticsResults(data);
-                });
+                setAnalyticsResults(data);
             }
         },
     );
@@ -205,11 +203,9 @@ export const CatalogPanel: FC = () => {
         (selectedItem: CatalogSelection) => {
             if (!selectedItem.table) return;
 
-            startTransition(() => {
-                if (!isSidebarOpen) {
-                    setSidebarOpen(true);
-                }
-            });
+            if (!isSidebarOpen) {
+                setSidebarOpen(true);
+            }
 
             // For optimization purposes, we could only make this request if metadata panel is open
             setSelection({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

We could start opening the sidebar before waiting for the data to be returned. 
Added a temporary loading overlay (I'm sure this is being worked on a separate ticket)

This uses `useTransition` and we apply it to: 
- when we store the metadata

This unblocks the UI thread while the processing is happening 
Displays a loading indicator on the usage analytics + on the whole metadata sidebar

Demo: 


https://github.com/lightdash/lightdash/assets/7611706/46010d77-2c53-43d0-94a4-fea078aa595b




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
