### PR TITLE
fix: compile explore with join with fields and groups

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -11,6 +11,7 @@ import {
 } from '../types/field';
 import { FilterOperator } from '../types/filter';
 import { type CreateWarehouseCredentials } from '../types/projects';
+import { TimeFrames } from '../types/timeFrames';
 import { type WarehouseClient } from '../types/warehouse';
 import { type UncompiledExplore } from './exploreCompiler';
 
@@ -732,6 +733,161 @@ export const compiledSimpleJoinedExplore: Explore = {
                     tablesReferences: ['b'],
                     source: sourceMock,
                     hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+            groupLabel: undefined,
+            source: sourceMock,
+            hidden: undefined,
+        },
+    },
+};
+
+export const exploreWithJoinWithFieldsAndGroups: UncompiledExplore = {
+    ...simpleJoinedExplore,
+    joinedTables: [
+        {
+            ...simpleJoinedExplore.joinedTables[0],
+            fields: ['dim2'],
+        },
+    ],
+    tables: {
+        ...simpleJoinedExplore.tables,
+        b: {
+            ...simpleJoinedExplore.tables.b,
+            dimensions: {
+                dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'dim1',
+                    label: 'dim1',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim1',
+                    source: sourceMock,
+                    hidden: false,
+                },
+                dim2: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'dim2',
+                    label: 'dim2',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim2',
+                    source: sourceMock,
+                    hidden: false,
+                    timeInterval: TimeFrames.DAY,
+                },
+                dim2_DAY: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'dim2_DAY',
+                    label: 'dim2_DAY',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim2',
+                    source: sourceMock,
+                    hidden: false,
+                    timeInterval: TimeFrames.DAY,
+                    groups: ['test', 'dim2'],
+                },
+            },
+        },
+    },
+};
+
+export const compiledExploreWithJoinWithFieldsAndGroups: Explore = {
+    ...exploreBase,
+    joinedTables: [
+        {
+            table: 'b',
+            sqlOn: '${a.dim1} = ${b.dim1}',
+            compiledSqlOn: '("a".dim1) = ("b".dim1)',
+            type: undefined,
+            hidden: undefined,
+            always: undefined,
+        },
+    ],
+    tables: {
+        a: {
+            name: 'a',
+            label: 'Custom A label',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: 'test.table',
+            sqlWhere: undefined,
+            dimensions: {
+                dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'dim1',
+                    label: 'dim1',
+                    table: 'a',
+                    tableLabel: 'Custom A label',
+                    sql: '${TABLE}.dim1',
+                    compiledSql: '"a".dim1',
+                    tablesReferences: ['a'],
+                    source: sourceMock,
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+            groupLabel: undefined,
+            source: sourceMock,
+        },
+        b: {
+            name: 'b',
+            originalName: 'b',
+            label: 'Custom B label',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: 'test.tableb',
+            sqlWhere: undefined,
+            dimensions: {
+                dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'dim1',
+                    label: 'dim1',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim1',
+                    compiledSql: '"b".dim1',
+                    tablesReferences: ['b'],
+                    source: sourceMock,
+                    hidden: false,
+                },
+                dim2: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'dim2',
+                    label: 'dim2',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim2',
+                    compiledSql: '"b".dim2',
+                    tablesReferences: ['b'],
+                    source: sourceMock,
+                    hidden: false,
+                    timeInterval: TimeFrames.DAY,
+                },
+                dim2_DAY: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'dim2_DAY',
+                    label: 'dim2_DAY',
+                    table: 'b',
+                    tableLabel: 'Custom B label',
+                    sql: '${TABLE}.dim2',
+                    compiledSql: '"b".dim2',
+                    tablesReferences: ['b'],
+                    source: sourceMock,
+                    hidden: false,
+                    timeInterval: TimeFrames.DAY,
+                    groups: ['test', 'dim2'],
                 },
             },
             metrics: {},

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -3,6 +3,7 @@ import { friendlyName } from '../types/field';
 import { ExploreCompiler, parseAllReferences } from './exploreCompiler';
 import {
     compiledExploreWithHiddenJoin,
+    compiledExploreWithJoinWithFieldsAndGroups,
     compiledJoinedExploreOverridingAliasAndLabel,
     compiledJoinedExploreOverridingJoinAlias,
     compiledJoinedExploreOverridingJoinLabel,
@@ -34,6 +35,7 @@ import {
     exploreTableSelfReferenceCompiledSqlWhere,
     exploreTableSelfReferenceSqlWhere,
     exploreWithHiddenJoin,
+    exploreWithJoinWithFieldsAndGroups,
     exploreWithMetricNumber,
     exploreWithMetricNumberCompiled,
     exploreWithRequiredAttributes,
@@ -126,6 +128,11 @@ describe('Explores with a base table and joined table', () => {
         expect(compiler.compileExplore(simpleJoinedExplore)).toStrictEqual(
             compiledSimpleJoinedExplore,
         );
+    });
+    test('should compile explore with join with fields and a time interval dimension with groups', () => {
+        expect(
+            compiler.compileExplore(exploreWithJoinWithFieldsAndGroups),
+        ).toStrictEqual(compiledExploreWithJoinWithFieldsAndGroups);
     });
     test('should compile with a reference to a dimension in a joined table', () => {
         expect(compiler.compileExplore(exploreReferenceInJoin)).toStrictEqual(

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -178,26 +178,24 @@ export class ExploreCompiler {
                                 requiredDimensionsForJoin.includes(
                                     dimensionKey,
                                 );
-                            const tableGroups =
-                                tables[join.table].groupDetails || {};
-                            const allGroupsIncluded =
+
+                            const isTimeIntervalBaseDimensionVisible =
+                                dimension.timeInterval &&
                                 dimension.groups &&
-                                dimension.groups.every(
-                                    (group) =>
-                                        join.fields !== undefined &&
-                                        (join.fields.includes(group) ||
-                                            join.fields.includes(
-                                                tableGroups[group].label,
-                                            )),
-                                );
+                                join.fields
+                                    ? join.fields.includes(
+                                          dimension.groups[
+                                              dimension.groups.length - 1
+                                          ],
+                                      )
+                                    : true;
+
                             const isVisible =
                                 join.fields === undefined ||
                                 join.fields.includes(dimensionKey) ||
                                 (dimension.group !== undefined &&
                                     join.fields.includes(dimension.group)) ||
-                                (dimension.groups &&
-                                    dimension.groups.length > 0 &&
-                                    allGroupsIncluded);
+                                isTimeIntervalBaseDimensionVisible;
 
                             if (isRequired || isVisible) {
                                 acc[dimensionKey] = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10274 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Reproduction steps:
- Have 2 models in your YML
- Table A joins table B with a subset of fields

``` 
       - join: table_b
          sql_on: ${table_a.user_id} = ${table_b.user_id}
          fields: [user_id, date]
```
- In your table B you need a date dimension with time intervals

```
      - name: date
        description: 'Date of the forecasting.'
        meta:
          dimension:
            type: date
            time_intervals: ['DAY', 'WEEK', 'MONTH', 'QUARTER']
```



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
