### PR TITLE
fix: enable overflowY scroll if sidebar open

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogTree.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTree.tsx
@@ -166,10 +166,7 @@ export const CatalogTree: FC<React.PropsWithChildren<Props>> = ({
                     0 4px 16px -8px ${theme.colors.gray[2]}`,
                 })}
             >
-                <Box
-                    sx={{ maxHeight: '900px', overflowY: 'scroll' }}
-                    key={`catalog-tree-${searchString}`}
-                >
+                <Box key={`catalog-tree-${searchString}`}>
                     {isLoading || isSearching ? (
                         <Center p="lg">
                             <Loader size="sm" variant="bars" color="dark" />

--- a/packages/frontend/src/pages/Catalog.tsx
+++ b/packages/frontend/src/pages/Catalog.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import Page from '../components/common/Page/Page';
@@ -28,7 +29,18 @@ const Catalog: FC = () => {
                     maxWidth: 800,
                 }}
             >
-                <CatalogPanel />
+                <Box
+                    sx={
+                        isSidebarOpen
+                            ? {
+                                  overflowY: 'scroll',
+                                  maxHeight: 'calc(100vh - 100px)',
+                              }
+                            : {}
+                    }
+                >
+                    <CatalogPanel />
+                </Box>
             </Page>
         </CatalogProvider>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10243 

### Description:

Removed overflow-y `scroll` on `CatalogTree` wrapper
Applies it to the `Catalog`, only when the sidebar is open
Fixes first TODO in issue #10243


https://github.com/lightdash/lightdash/assets/7611706/ec180a10-1b34-414a-9054-f3759f4699ad



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
