### PR TITLE
feat: pass organization tag to sentry events

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -451,6 +451,8 @@ export default class App {
                 passportUser: { id: string; organization: string },
                 done,
             ) => {
+                // Set the organization tag so we can filter by it in Sentry
+                Sentry.setTag('organization', passportUser.organization);
                 // Convert to a full user profile
                 try {
                     done(null, await userService.findSessionUser(passportUser));

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -36,8 +36,8 @@ const useSentry = (
                 id: user.userUuid,
                 email: user.email,
                 username: user.email,
-                segment: user.organizationUuid,
             });
+            Sentry.setTag('organization', user.organizationUuid);
         }
     }, [isSentryLoaded, setIsSentryLoaded, sentryConfig, user]);
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:[ #1764](https://github.com/lightdash/lightdash-internal-work/issues/1764)

### Description:

Sets `tag` `organization` for Sentry requests on BE and FE

On BE I triggered an exception and it includes the tags: 

```
[backend]   tags: {
[backend]     transaction: 'GET /api/v1/health',
[backend]     organization: '172a2270-000f-42be-9c68-c4752c23ae51'
[backend]   },
```

On FE I can see that being set on the network tab



```
{"conte...
....

"tags":{"organization":"172a2270-000f-42be-9c68-c4752c23ae51","effectiveConnectionType":"4g","deviceMemory":"8 GB","hardwareConcurrency":"10"},"

...

```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
