### PR TITLE
chore: don't throw error for out of sync migrations

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -491,6 +491,20 @@ export default class App {
                 ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
             ],
             ignoreErrors: ['WarehouseQueryError', 'FieldReferenceError'],
+            beforeSend(event) {
+                if (
+                    event.exception?.values &&
+                    event.exception.values[0].type ===
+                        'UnexpectedDatabaseError' &&
+                    event.exception.values[0].value?.includes(
+                        'Database has not been migrated yet',
+                    )
+                ) {
+                    return null;
+                }
+
+                return event;
+            },
             tracesSampler: (context: SamplingContext): boolean | number => {
                 if (
                     context.request?.url?.endsWith('/status') ||

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -491,20 +491,6 @@ export default class App {
                 ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
             ],
             ignoreErrors: ['WarehouseQueryError', 'FieldReferenceError'],
-            beforeSend(event) {
-                if (
-                    event.exception?.values &&
-                    event.exception.values[0].type ===
-                        'UnexpectedDatabaseError' &&
-                    event.exception.values[0].value?.includes(
-                        'Database has not been migrated yet',
-                    )
-                ) {
-                    return null;
-                }
-
-                return event;
-            },
             tracesSampler: (context: SamplingContext): boolean | number => {
                 if (
                     context.request?.url?.endsWith('/status') ||

--- a/packages/backend/src/models/MigrationModel/MigrationModel.ts
+++ b/packages/backend/src/models/MigrationModel/MigrationModel.ts
@@ -16,7 +16,7 @@ export class MigrationModel {
         const migrationCurrentVersion =
             await this.database.migrate.currentVersion();
         return {
-            isComplete: migrationStatus === 0,
+            status: migrationStatus,
             currentVersion: migrationCurrentVersion,
         };
     }

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -4,7 +4,6 @@ import {
     LightdashInstallType,
     LightdashMode,
     SessionUser,
-    UnexpectedDatabaseError,
 } from '@lightdash/common';
 import { createHmac } from 'crypto';
 import { getDockerHubVersion } from '../../clients/DockerHub/DockerHub';
@@ -46,9 +45,8 @@ export class HealthService extends BaseService {
             await this.migrationModel.getMigrationStatus();
 
         if (!isComplete) {
-            throw new UnexpectedDatabaseError(
-                'Database has not been migrated yet',
-                { currentVersion },
+            console.warn(
+                `Database migrations are not up to date. Current version: ${currentVersion}`,
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10290](https://github.com/lightdash/lightdash/issues/10290)

### Description:

Triggered `Database has not been migrated yet` error. See the `after` where the event is discarded

Before 

<img width="542" alt="Screenshot 2024-06-03 at 14 19 23" src="https://github.com/lightdash/lightdash/assets/7611706/c54aff8a-d676-4991-861c-9fd44c1d7b69">

After 

<img width="540" alt="Screenshot 2024-06-03 at 14 21 06" src="https://github.com/lightdash/lightdash/assets/7611706/5e21723a-b74d-4c0c-9518-c607dec1c47a">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
