### PR TITLE
chore: make sentry traces and profiles sample rate configurable

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -509,9 +509,9 @@ export default class App {
                 if (context.parentSampled !== undefined) {
                     return context.parentSampled;
                 }
-                return 0.2;
+                return this.lightdashConfig.sentry.tracesSampleRate;
             },
-            profilesSampleRate: 0.2, // 20% of samples will be profiled
+            profilesSampleRate: this.lightdashConfig.sentry.profilesSampleRate, // x% of samples will be profiled
             beforeBreadcrumb(breadcrumb) {
                 if (
                     breadcrumb.category === 'http' &&

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -107,6 +107,8 @@ export const lightdashConfigMock: LightdashConfig = {
         },
         release: '',
         environment: '',
+        tracesSampleRate: 0,
+        profilesSampleRate: 0,
     },
     staticIp: '',
     trustProxy: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -55,6 +55,8 @@ test('Should use default sentry configuration if no environment vars', () => {
         },
         release: VERSION,
         environment: BASIC_CONFIG.mode,
+        tracesSampleRate: 0.1,
+        profilesSampleRate: 0.2,
     };
     expect(parseConfig(BASIC_CONFIG).sentry).toStrictEqual(expected);
 });
@@ -69,10 +71,14 @@ test('Should parse sentry config from env', () => {
         },
         release: VERSION,
         environment: 'development',
+        tracesSampleRate: 0.8,
+        profilesSampleRate: 1.0,
     };
     process.env.SENTRY_BE_DSN = 'mydsnbackend.sentry.io';
     process.env.SENTRY_FE_DSN = 'mydsnfrontend.sentry.io';
     process.env.NODE_ENV = 'development';
+    process.env.SENTRY_TRACES_SAMPLE_RATE = '0.8';
+    process.env.SENTRY_PROFILES_SAMPLE_RATE = '1.0';
     expect(parseConfig(BASIC_CONFIG).sentry).toStrictEqual(expected);
 });
 

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1,6 +1,7 @@
 import { ParseError, SentryConfig } from '@lightdash/common';
 import { VERSION } from '../version';
 import {
+    getFloatFromEnvironmentVariable,
     getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
     parseConfig,
@@ -120,7 +121,16 @@ test('Should throw ParseError if not a valid integer', () => {
 });
 test('Should parse valid float', () => {
     process.env.MY_NUMBER = '0.5';
-    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(0.5);
+    expect(getFloatFromEnvironmentVariable('MY_NUMBER')).toEqual(0.5);
+});
+test('Should parse non existent float as undefined', () => {
+    expect(getFloatFromEnvironmentVariable('MY_NUMBER')).toEqual(undefined);
+});
+test('Should throw ParseError if not a valid float', () => {
+    process.env.MY_NUMBER = 'hello';
+    expect(() => getFloatFromEnvironmentVariable('MY_NUMBER')).toThrowError(
+        ParseError,
+    );
 });
 
 describe('getMaybeBase64EncodedFromEnvironmentVariable', () => {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1,8 +1,8 @@
 import { ParseError, SentryConfig } from '@lightdash/common';
 import { VERSION } from '../version';
 import {
+    getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
-    getNumberFromEnvironmentVariable,
     parseConfig,
 } from './parseConfig';
 import {
@@ -107,20 +107,20 @@ test('Should include secret in output', () => {
 
 test('Should parse valid integer', () => {
     process.env.MY_NUMBER = '100';
-    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(100);
+    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(100);
 });
 test('Should parse non existent integer as undefined', () => {
-    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(undefined);
+    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(undefined);
 });
 test('Should throw ParseError if not a valid integer', () => {
     process.env.MY_NUMBER = 'hello';
-    expect(() => getNumberFromEnvironmentVariable('MY_NUMBER')).toThrowError(
+    expect(() => getIntegerFromEnvironmentVariable('MY_NUMBER')).toThrowError(
         ParseError,
     );
 });
 test('Should parse valid float', () => {
     process.env.MY_NUMBER = '0.5';
-    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(0.5);
+    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(0.5);
 });
 
 describe('getMaybeBase64EncodedFromEnvironmentVariable', () => {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1,8 +1,8 @@
 import { ParseError, SentryConfig } from '@lightdash/common';
 import { VERSION } from '../version';
 import {
-    getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
+    getNumberFromEnvironmentVariable,
     parseConfig,
 } from './parseConfig';
 import {
@@ -94,16 +94,20 @@ test('Should include secret in output', () => {
 
 test('Should parse valid integer', () => {
     process.env.MY_NUMBER = '100';
-    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(100);
+    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(100);
 });
 test('Should parse non existent integer as undefined', () => {
-    expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(undefined);
+    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(undefined);
 });
 test('Should throw ParseError if not a valid integer', () => {
     process.env.MY_NUMBER = 'hello';
-    expect(() => getIntegerFromEnvironmentVariable('MY_NUMBER')).toThrowError(
+    expect(() => getNumberFromEnvironmentVariable('MY_NUMBER')).toThrowError(
         ParseError,
     );
+});
+test('Should parse valid float', () => {
+    process.env.MY_NUMBER = '0.5';
+    expect(getNumberFromEnvironmentVariable('MY_NUMBER')).toEqual(0.5);
 });
 
 describe('getMaybeBase64EncodedFromEnvironmentVariable', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -419,6 +419,12 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             release: VERSION,
             environment:
                 process.env.NODE_ENV === 'development' ? 'development' : mode,
+            tracesSampleRate: parseFloat(
+                process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1',
+            ),
+            profilesSampleRate: parseFloat(
+                process.env.SENTRY_PROFILES_SAMPLE_RATE || '0.2',
+            ),
         },
         lightdashSecret,
         secureCookies: process.env.SECURE_COOKIES === 'true',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -26,6 +26,22 @@ export const getIntegerFromEnvironmentVariable = (
     return parsed;
 };
 
+export const getFloatFromEnvironmentVariable = (
+    name: string,
+): number | undefined => {
+    const raw = process.env[name];
+    if (raw === undefined) {
+        return undefined;
+    }
+    const parsed = Number.parseFloat(raw);
+    if (Number.isNaN(parsed)) {
+        throw new ParseError(
+            `Cannot parse environment variable "${name}". Value must be a float but ${name}=${raw}`,
+        );
+    }
+    return parsed;
+};
+
 /**
  * Given a value, uses the arguments provided to figure out if that value
  * should be decoded as a base64 string.
@@ -425,12 +441,13 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             release: VERSION,
             environment:
                 process.env.NODE_ENV === 'development' ? 'development' : mode,
-            tracesSampleRate: parseFloat(
-                process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1',
-            ),
-            profilesSampleRate: parseFloat(
-                process.env.SENTRY_PROFILES_SAMPLE_RATE || '0.2',
-            ),
+            tracesSampleRate:
+                getFloatFromEnvironmentVariable('SENTRY_TRACES_SAMPLE_RATE') ||
+                0.1,
+            profilesSampleRate:
+                getFloatFromEnvironmentVariable(
+                    'SENTRY_PROFILES_SAMPLE_RATE',
+                ) || 0.2,
             anr: {
                 enabled: process.env.SENTRY_ANR_ENABLED === 'true',
                 captureStacktrace:

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -10,17 +10,17 @@ import { type ClientAuthMethod } from 'openid-client';
 import lightdashV1JsonSchema from '../jsonSchemas/lightdashConfig/v1.json';
 import { VERSION } from '../version';
 
-export const getNumberFromEnvironmentVariable = (
+export const getIntegerFromEnvironmentVariable = (
     name: string,
 ): number | undefined => {
     const raw = process.env[name];
     if (raw === undefined) {
         return undefined;
     }
-    const parsed = Number.parseFloat(raw);
+    const parsed = Number.parseInt(raw, 10);
     if (Number.isNaN(parsed)) {
         throw new ParseError(
-            `Cannot parse environment variable "${name}". Value must be a number but ${name}=${raw}`,
+            `Cannot parse environment variable "${name}". Value must be an integer but ${name}=${raw}`,
         );
     }
     return parsed;
@@ -441,16 +441,16 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         },
         lightdashSecret,
         secureCookies: process.env.SECURE_COOKIES === 'true',
-        cookiesMaxAgeHours: getNumberFromEnvironmentVariable(
+        cookiesMaxAgeHours: getIntegerFromEnvironmentVariable(
             'COOKIES_MAX_AGE_HOURS',
         ),
         trustProxy: process.env.TRUST_PROXY === 'true',
         database: {
             connectionUri: process.env.PGCONNECTIONURI,
             maxConnections:
-                getNumberFromEnvironmentVariable('PGMAXCONNECTIONS'),
+                getIntegerFromEnvironmentVariable('PGMAXCONNECTIONS'),
             minConnections:
-                getNumberFromEnvironmentVariable('PGMINCONNECTIONS'),
+                getIntegerFromEnvironmentVariable('PGMINCONNECTIONS'),
         },
         auth: {
             disablePat: process.env.DISABLE_PAT === 'true',
@@ -552,17 +552,19 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',
         query: {
             maxLimit:
-                getNumberFromEnvironmentVariable('LIGHTDASH_QUERY_MAX_LIMIT') ||
-                5000,
+                getIntegerFromEnvironmentVariable(
+                    'LIGHTDASH_QUERY_MAX_LIMIT',
+                ) || 5000,
             csvCellsLimit:
-                getNumberFromEnvironmentVariable('LIGHTDASH_CSV_CELLS_LIMIT') ||
-                100000,
+                getIntegerFromEnvironmentVariable(
+                    'LIGHTDASH_CSV_CELLS_LIMIT',
+                ) || 100000,
             timezone: process.env.LIGHTDASH_QUERY_TIMEZONE,
         },
         chart: {
             versionHistory: {
                 daysLimit:
-                    getNumberFromEnvironmentVariable(
+                    getIntegerFromEnvironmentVariable(
                         'LIGHTDASH_CHART_VERSION_HISTORY_DAYS_LIMIT',
                     ) || 3,
             },
@@ -573,7 +575,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         },
         pivotTable: {
             maxColumnLimit:
-                getNumberFromEnvironmentVariable(
+                getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT',
                 ) || 60,
         },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -10,17 +10,17 @@ import { type ClientAuthMethod } from 'openid-client';
 import lightdashV1JsonSchema from '../jsonSchemas/lightdashConfig/v1.json';
 import { VERSION } from '../version';
 
-export const getIntegerFromEnvironmentVariable = (
+export const getNumberFromEnvironmentVariable = (
     name: string,
 ): number | undefined => {
     const raw = process.env[name];
     if (raw === undefined) {
         return undefined;
     }
-    const parsed = Number.parseInt(raw, 10);
+    const parsed = Number.parseFloat(raw);
     if (Number.isNaN(parsed)) {
         throw new ParseError(
-            `Cannot parse environment variable "${name}". Value must be an integer but ${name}=${raw}`,
+            `Cannot parse environment variable "${name}". Value must be a number but ${name}=${raw}`,
         );
     }
     return parsed;
@@ -428,16 +428,16 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         },
         lightdashSecret,
         secureCookies: process.env.SECURE_COOKIES === 'true',
-        cookiesMaxAgeHours: getIntegerFromEnvironmentVariable(
+        cookiesMaxAgeHours: getNumberFromEnvironmentVariable(
             'COOKIES_MAX_AGE_HOURS',
         ),
         trustProxy: process.env.TRUST_PROXY === 'true',
         database: {
             connectionUri: process.env.PGCONNECTIONURI,
             maxConnections:
-                getIntegerFromEnvironmentVariable('PGMAXCONNECTIONS'),
+                getNumberFromEnvironmentVariable('PGMAXCONNECTIONS'),
             minConnections:
-                getIntegerFromEnvironmentVariable('PGMINCONNECTIONS'),
+                getNumberFromEnvironmentVariable('PGMINCONNECTIONS'),
         },
         auth: {
             disablePat: process.env.DISABLE_PAT === 'true',
@@ -533,19 +533,17 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',
         query: {
             maxLimit:
-                getIntegerFromEnvironmentVariable(
-                    'LIGHTDASH_QUERY_MAX_LIMIT',
-                ) || 5000,
+                getNumberFromEnvironmentVariable('LIGHTDASH_QUERY_MAX_LIMIT') ||
+                5000,
             csvCellsLimit:
-                getIntegerFromEnvironmentVariable(
-                    'LIGHTDASH_CSV_CELLS_LIMIT',
-                ) || 100000,
+                getNumberFromEnvironmentVariable('LIGHTDASH_CSV_CELLS_LIMIT') ||
+                100000,
             timezone: process.env.LIGHTDASH_QUERY_TIMEZONE,
         },
         chart: {
             versionHistory: {
                 daysLimit:
-                    getIntegerFromEnvironmentVariable(
+                    getNumberFromEnvironmentVariable(
                         'LIGHTDASH_CHART_VERSION_HISTORY_DAYS_LIMIT',
                     ) || 3,
             },
@@ -556,7 +554,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         },
         pivotTable: {
             maxColumnLimit:
-                getIntegerFromEnvironmentVariable(
+                getNumberFromEnvironmentVariable(
                     'LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT',
                 ) || 60,
         },

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -73,6 +73,8 @@ export const BaseResponse: HealthState = {
             dsn: '',
         },
         release: '',
+        tracesSampleRate: 0,
+        profilesSampleRate: 0,
     },
 };
 

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -73,6 +73,9 @@ export class HealthService extends BaseService {
                 frontend: this.lightdashConfig.sentry.frontend,
                 environment: this.lightdashConfig.sentry.environment,
                 release: this.lightdashConfig.sentry.release,
+                tracesSampleRate: this.lightdashConfig.sentry.tracesSampleRate,
+                profilesSampleRate:
+                    this.lightdashConfig.sentry.profilesSampleRate,
             },
             intercom: this.lightdashConfig.intercom,
             pylon: {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -684,6 +684,8 @@ export type SentryConfig = {
     };
     release: string;
     environment: string;
+    tracesSampleRate: number;
+    profilesSampleRate: number;
 };
 
 export type HealthState = {
@@ -702,7 +704,14 @@ export type HealthState = {
         writeKey: string;
         dataPlaneUrl: string;
     };
-    sentry: Pick<SentryConfig, 'frontend' | 'release' | 'environment'>;
+    sentry: Pick<
+        SentryConfig,
+        | 'frontend'
+        | 'release'
+        | 'environment'
+        | 'tracesSampleRate'
+        | 'profilesSampleRate'
+    >;
     auth: {
         disablePasswordAuthentication: boolean;
         google: {

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -25,7 +25,7 @@ const useSentry = (
                         return samplingContext.parentSampled;
                     }
 
-                    return 0.2;
+                    return sentryConfig.tracesSampleRate;
                 },
                 replaysOnErrorSampleRate: 1.0,
             });

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -21,6 +21,8 @@ export default function mockHealthResponse(
             frontend: {
                 dsn: '',
             },
+            tracesSampleRate: 0,
+            profilesSampleRate: 0,
             release: '',
             environment: '',
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#10296](https://github.com/lightdash/lightdash/issues/10296)

Closes: [#10296](https://github.com/lightdash/lightdash/issues/10296)


### Description:

initially, the ticket mentioned to only allow traces sampling rate to be configurable, but I figured we would want the same for profiling in the backend.

Reads: 

```
SENTRY_TRACES_SAMPLE_RATE
SENTRY_PROFILES_SAMPLE_RATE
```

and parses them into: 

```
tracesSampleRate
profilesSampleRate
```



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
