### PR TITLE
feat: make sentry anr configurable

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -491,6 +491,19 @@ export default class App {
                 new Sentry.Integrations.Postgres({ usePgNative: true }),
                 nodeProfilingIntegration(),
                 ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+                ...(this.lightdashConfig.sentry.anr.enabled
+                    ? [
+                          Sentry.anrIntegration({
+                              pollInterval: 50, // ms
+                              anrThreshold:
+                                  this.lightdashConfig.sentry.anr.timeout ||
+                                  5000, // ms
+                              captureStackTrace:
+                                  this.lightdashConfig.sentry.anr
+                                      .captureStacktrace,
+                          }),
+                      ]
+                    : []),
             ],
             ignoreErrors: ['WarehouseQueryError', 'FieldReferenceError'],
             tracesSampler: (context: SamplingContext): boolean | number => {

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -107,6 +107,10 @@ export const lightdashConfigMock: LightdashConfig = {
         },
         release: '',
         environment: '',
+        anr: {
+            enabled: false,
+            captureStacktrace: false,
+        },
     },
     staticIp: '',
     trustProxy: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -55,6 +55,11 @@ test('Should use default sentry configuration if no environment vars', () => {
         },
         release: VERSION,
         environment: BASIC_CONFIG.mode,
+        anr: {
+            enabled: false,
+            captureStacktrace: false,
+            timeout: undefined,
+        },
     };
     expect(parseConfig(BASIC_CONFIG).sentry).toStrictEqual(expected);
 });
@@ -69,10 +74,18 @@ test('Should parse sentry config from env', () => {
         },
         release: VERSION,
         environment: 'development',
+        anr: {
+            enabled: true,
+            captureStacktrace: true,
+            timeout: 1000,
+        },
     };
     process.env.SENTRY_BE_DSN = 'mydsnbackend.sentry.io';
     process.env.SENTRY_FE_DSN = 'mydsnfrontend.sentry.io';
     process.env.NODE_ENV = 'development';
+    process.env.SENTRY_ANR_ENABLED = 'true';
+    process.env.SENTRY_ANR_CAPTURE_STACKTRACE = 'true';
+    process.env.SENTRY_ANR_TIMEOUT = '1000';
     expect(parseConfig(BASIC_CONFIG).sentry).toStrictEqual(expected);
 });
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -419,6 +419,13 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             release: VERSION,
             environment:
                 process.env.NODE_ENV === 'development' ? 'development' : mode,
+            anr: {
+                enabled: process.env.SENTRY_ANR_ENABLED === 'true',
+                captureStacktrace:
+                    process.env.SENTRY_ANR_CAPTURE_STACKTRACE === 'true',
+                timeout:
+                    getIntegerFromEnvironmentVariable('SENTRY_ANR_TIMEOUT'),
+            },
         },
         lightdashSecret,
         secureCookies: process.env.SECURE_COOKIES === 'true',

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -684,6 +684,11 @@ export type SentryConfig = {
     };
     release: string;
     environment: string;
+    anr: {
+        enabled: boolean;
+        timeout?: number;
+        captureStacktrace: boolean;
+    };
 };
 
 export type HealthState = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#1784](https://github.com/lightdash/lightdash-internal-work/issues/1784)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Sentry ANR (Application Not Responding) integration with configurable settings such as `enabled`, `timeout`, and `captureStackTrace`.

- **Configuration**
  - Added new ANR settings to the configuration, allowing users to enable or disable ANR monitoring and set specific parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->