### PR TITLE
chore: check dashboardTabs before setting them in storage

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -91,10 +91,12 @@ const useDashboardStorage = () => {
                 'unsavedDashboardTiles',
                 JSON.stringify(dashboardTiles ?? []),
             );
-            sessionStorage.setItem(
-                'dashboardTabs',
-                JSON.stringify(dashboardTabs),
-            );
+            if (dashboardTabs && dashboardTabs.length > 0) {
+                sessionStorage.setItem(
+                    'dashboardTabs',
+                    JSON.stringify(dashboardTabs),
+                );
+            }
             if (
                 dashboardFilters.dimensions.length > 0 ||
                 dashboardFilters.metrics.length > 0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10305 #10301

### Description:

`dashboardTabs` was being set to string `"undefined"` - that's why it was throwing the toast error. This checks if there are tabs and their length is > 0 before storing them. 

with these changes:

https://github.com/lightdash/lightdash/assets/7611706/41bbd4c1-dae1-41f1-8fc5-9c8ce0c1e876



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
