### PR TITLE
fix: add missing index in cached explore table

### DIFF
--- a/packages/backend/src/database/migrations/20240604135815_add_missing_key_in_cached_explore_table.ts
+++ b/packages/backend/src/database/migrations/20240604135815_add_missing_key_in_cached_explore_table.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+const table = 'cached_explore';
+const columnToIndex = 'project_uuid';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(table)) {
+        await knex.schema.alterTable(table, (tableBuilder) => {
+            tableBuilder.index([columnToIndex]);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(table)) {
+        await knex.schema.alterTable(table, (tableBuilder) => {
+            tableBuilder.dropIndex([columnToIndex]);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#1782](https://github.com/lightdash/lightdash-internal-work/issues/1782)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Used in the query that deletes all explores for a project:
https://github.com/lightdash/lightdash/blob/3c573d385251cb8e6e94252d66cf18535d8673cf/packages/backend/src/models/ProjectModel/ProjectModel.ts#L830

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved database performance by adding an index to the `project_uuid` column in the `cached_explore` table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->