### PR TITLE
feat: increase max retries for dashboard image schedulers

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -108,7 +108,7 @@
         "pg": "^8.11.3",
         "pg-connection-string": "^2.5.0",
         "posthog-node": "^3.1.3",
-        "puppeteer": "^22.2.0",
+        "puppeteer": "^22.10.0",
         "redoc-express": "^1.0.0",
         "simple-git": "^3.16.0",
         "slackify-markdown": "^4.4.0",

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -34,6 +34,8 @@ type SchedulerClientArguments = {
     schedulerModel: SchedulerModel;
 };
 
+const SCHEDULED_JOB_MAX_ATTEMPTS = 1;
+
 export const getDailyDatesFromCron = (
     cron: string,
     when = new Date(),
@@ -132,12 +134,21 @@ export class SchedulerClient {
                   schedulerUuid,
               }
             : scheduler;
+
+        let maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS;
+        if (
+            scheduler.format === SchedulerFormat.IMAGE &&
+            !!scheduler.dashboardUuid
+        ) {
+            maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS + 1;
+        }
+
         const { id } = await graphileClient.addJob(
             'handleScheduledDelivery',
             payload,
             {
                 runAt: date,
-                maxAttempts: 1,
+                maxAttempts,
             },
         );
         await this.schedulerModel.logSchedulerJob({
@@ -175,7 +186,7 @@ export class SchedulerClient {
 
         const { id } = await graphileClient.addJob('uploadGsheets', payload, {
             runAt: date,
-            maxAttempts: 1,
+            maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
         });
         this.analytics.track({
             event: 'scheduler_notification_job.created',
@@ -255,7 +266,7 @@ export class SchedulerClient {
         const { identifier, payload, type } = getIdentifierAndPayload();
         const { id } = await graphileClient.addJob(identifier, payload, {
             runAt: date,
-            maxAttempts: 1,
+            maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
         });
         this.analytics.track({
             event: 'scheduler_notification_job.created',
@@ -364,7 +375,7 @@ export class SchedulerClient {
             payload,
             {
                 runAt: now, // now
-                maxAttempts: 1,
+                maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
             },
         );
         await this.schedulerModel.logSchedulerJob({
@@ -391,7 +402,7 @@ export class SchedulerClient {
             payload,
             {
                 runAt: now,
-                maxAttempts: 1,
+                maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
             },
         );
         await this.schedulerModel.logSchedulerJob({
@@ -418,7 +429,7 @@ export class SchedulerClient {
             payload,
             {
                 runAt: now,
-                maxAttempts: 1,
+                maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
             },
         );
         await this.schedulerModel.logSchedulerJob({
@@ -445,7 +456,7 @@ export class SchedulerClient {
             payload,
             {
                 runAt: now, // now
-                maxAttempts: 1,
+                maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
             },
         );
         await this.schedulerModel.logSchedulerJob({
@@ -474,7 +485,7 @@ export class SchedulerClient {
             payload,
             {
                 runAt: now, // now
-                maxAttempts: 1,
+                maxAttempts: SCHEDULED_JOB_MAX_ATTEMPTS,
             },
         );
         await this.schedulerModel.logSchedulerJob({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4898,10 +4898,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@puppeteer/browsers@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-2.1.0.tgz#2683d3c908ecfc9af6b63111b5037679d3cebfd8"
-  integrity sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==
+"@puppeteer/browsers@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-2.2.3.tgz#ad6b79129c50825e77ddaba082680f4dad0b674e"
+  integrity sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==
   dependencies:
     debug "4.3.4"
     extract-zip "2.0.1"
@@ -9033,13 +9033,14 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromium-bidi@0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.5.9.tgz#f068bd10e8a3007bc842ae99f5038c8689bf58a5"
-  integrity sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==
+chromium-bidi@0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.5.19.tgz#e4f4951b7d9b20d668d6b387839f7b7bf2d69ef4"
+  integrity sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==
   dependencies:
     mitt "3.0.1"
     urlpattern-polyfill "10.0.0"
+    zod "3.22.4"
 
 ci-info@^3.2.0:
   version "3.3.0"
@@ -9582,13 +9583,6 @@ cronstrue@^2.23.0:
   version "2.23.0"
   resolved "https://registry.npmjs.org/cronstrue/-/cronstrue-2.23.0.tgz"
   integrity sha512-iPoWUQbCwUmrBf1w9W+9YQs8FowWp/teC2XGz3zAmt0Aja+HWGjyjUkWASWcsdzxSuL0EIIdvlfGEVBljvTbSQ==
-
-cross-fetch@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
-  dependencies:
-    node-fetch "^2.6.12"
 
 cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
@@ -10297,10 +10291,10 @@ detective-typescript@^11.1.0:
     node-source-walk "^6.0.1"
     typescript "^5.0.4"
 
-devtools-protocol@0.0.1249869:
-  version "0.0.1249869"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz#000c3cf1afc189a18db98135a50d4a8f95a47d29"
-  integrity sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==
+devtools-protocol@0.0.1286932:
+  version "0.0.1286932"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz#2303707034426fe0b39012713d4b7339f7dbc815"
+  integrity sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==
 
 diff-match-patch@^1.0.5:
   version "1.0.5"
@@ -17647,26 +17641,26 @@ punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@22.2.0:
-  version "22.2.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-22.2.0.tgz#85bf2c492ba02e8051bb75dff3043d21d9945f21"
-  integrity sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==
+puppeteer-core@22.10.0:
+  version "22.10.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-22.10.0.tgz#eef5735f90ed29e3b10815d142b3437e05939283"
+  integrity sha512-I54J4Vy4I07UHsgB1QSmuFoF7KNQjJWcvFBPhtY+ezMdBfwgGDr8dzYrJa11aPgP9kxIUHjhktcMmmfJkOAtTw==
   dependencies:
-    "@puppeteer/browsers" "2.1.0"
-    chromium-bidi "0.5.9"
-    cross-fetch "4.0.0"
+    "@puppeteer/browsers" "2.2.3"
+    chromium-bidi "0.5.19"
     debug "4.3.4"
-    devtools-protocol "0.0.1249869"
-    ws "8.16.0"
+    devtools-protocol "0.0.1286932"
+    ws "8.17.0"
 
-puppeteer@^22.2.0:
-  version "22.2.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-22.2.0.tgz#2f4e4bff252bc6999f213288ed717940b27b0918"
-  integrity sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==
+puppeteer@^22.10.0:
+  version "22.10.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-22.10.0.tgz#10b7f8fbe5bd49933f1f3655f18573086290fefc"
+  integrity sha512-ZOkZd6a6t0BdKcWb0wAYHWQqCfdlN1PPnXOmg/XNrbo6gJhYWFX4qCNb6ahSn8TpAqBqLCoD4Q010F7GwOM7mA==
   dependencies:
-    "@puppeteer/browsers" "2.1.0"
+    "@puppeteer/browsers" "2.2.3"
     cosmiconfig "9.0.0"
-    puppeteer-core "22.2.0"
+    devtools-protocol "0.0.1286932"
+    puppeteer-core "22.10.0"
 
 pure-color@^1.2.0:
   version "1.3.0"
@@ -21568,10 +21562,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.16.0, ws@^8.16.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
-  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+ws@8.17.0:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.0.tgz#d145d18eca2ed25aaf791a183903f7be5e295fea"
+  integrity sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==
 
 ws@^5.2.3:
   version "5.2.3"
@@ -21584,6 +21578,11 @@ ws@^7.5.3:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
+ws@^8.16.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 xcase@^2.0.1:
   version "2.0.1"
@@ -21773,6 +21772,11 @@ zip-stream@^6.0.1:
     archiver-utils "^5.0.0"
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
+
+zod@3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
 
 zod@^3.23.3:
   version "3.23.3"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Increases `maxAttempts` for dashboard + image screenshot + schedulers by `1` so it's `2` now. 

Also, upgrades `puppeteer` to latest, because it includes these fixes: 

https://github.com/puppeteer/puppeteer/pull/12352
https://github.com/puppeteer/puppeteer/pull/12225

This is based on the errors we would get from logs: 
ProtocolError
`Requesting main frame too early!`


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
