### PR TITLE
fix: add missing indexes for dashboards query

### DIFF
--- a/packages/backend/src/database/migrations/20240604140542_add_missing_indexes_for_dashboards_query.ts
+++ b/packages/backend/src/database/migrations/20240604140542_add_missing_indexes_for_dashboards_query.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+const newTableSingularIndexes = {
+    dashboard_versions: ['dashboard_id', 'updated_by_user_uuid'],
+    spaces: ['project_id'],
+    projects: ['organization_id'],
+    pinned_dashboard: ['pinned_list_uuid', 'dashboard_uuid'],
+    dashboard_tiles: ['dashboard_tile_uuid', 'dashboard_version_id'],
+    dashboard_tile_charts: ['dashboard_tile_uuid', 'saved_chart_id'],
+};
+
+export async function up(knex: Knex): Promise<void> {
+    async function createIndex(table: string, columns: string[]) {
+        if (await knex.schema.hasTable(table)) {
+            await knex.schema.alterTable(table, (tableBuilder) => {
+                columns.forEach((column) => {
+                    tableBuilder.index([column]);
+                });
+            });
+        }
+    }
+
+    await Promise.all(
+        Object.entries(newTableSingularIndexes).map(([table, columns]) =>
+            createIndex(table, columns),
+        ),
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    async function dropIndex(table: string, columns: string[]) {
+        if (await knex.schema.hasTable(table)) {
+            await knex.schema.alterTable(table, (tableBuilder) => {
+                columns.forEach((column) => {
+                    tableBuilder.dropIndex([column]);
+                });
+            });
+        }
+    }
+
+    await Promise.all(
+        Object.entries(newTableSingularIndexes).map(([table, columns]) =>
+            dropIndex(table, columns),
+        ),
+    );
+}

--- a/packages/backend/src/database/migrations/20240604140542_add_missing_indexes_for_dashboards_query.ts
+++ b/packages/backend/src/database/migrations/20240604140542_add_missing_indexes_for_dashboards_query.ts
@@ -5,8 +5,7 @@ const newTableSingularIndexes = {
     spaces: ['project_id'],
     projects: ['organization_id'],
     pinned_dashboard: ['pinned_list_uuid', 'dashboard_uuid'],
-    dashboard_tiles: ['dashboard_tile_uuid', 'dashboard_version_id'],
-    dashboard_tile_charts: ['dashboard_tile_uuid', 'saved_chart_id'],
+    dashboard_tile_charts: ['saved_chart_id'],
 };
 
 export async function up(knex: Knex): Promise<void> {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -346,8 +346,18 @@ export class DashboardModel {
                 )
                 .leftJoin(
                     DashboardTileChartTableName,
-                    `${DashboardTileChartTableName}.dashboard_tile_uuid`,
-                    `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                    function joinDashboardTileChartTableName() {
+                        this.on(
+                            `${DashboardTileChartTableName}.dashboard_version_id`,
+                            '=',
+                            `${DashboardTilesTableName}.dashboard_version_id`,
+                        );
+                        this.andOn(
+                            `${DashboardTileChartTableName}.dashboard_tile_uuid`,
+                            '=',
+                            `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                        );
+                    },
                 )
                 .leftJoin(
                     SavedChartsTableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to https://github.com/lightdash/lightdash-internal-work/issues/1782

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Adds indexes for tables used in the query that fetches dashboards.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved database performance by adding indexes for dashboards queries.
  
- **Refactor**
  - Updated the `DashboardModel` to optimize how tables are joined, enhancing query efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->