### PR TITLE
feat: allow slack bot customization

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -105,6 +105,7 @@ import { ShareTable, ShareTableName } from '../database/entities/share';
 import {
     DbSlackAuthTokens,
     SlackAuthTokensTable,
+    SlackAuthTokensTableName,
 } from '../database/entities/slackAuthentication';
 import {
     SpaceTable,
@@ -235,7 +236,7 @@ declare module 'knex/types/tables' {
         [DbtCloudIntegrationsTableName]: DbtCloudIntegrationsTable;
         [ShareTableName]: ShareTable;
         [SpaceUserAccessTableName]: SpaceUserAccessTable;
-        [SlackAuthTokensTable]: DbSlackAuthTokens;
+        [SlackAuthTokensTableName]: SlackAuthTokensTable;
         [AnalyticsChartViewsTableName]: DbAnalyticsChartViews;
         [AnalyticsDashboardViewsTableName]: DbAnalyticsDashboardViews;
         [PinnedListTableName]: PinnedListTable;

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -173,7 +173,7 @@ export class SlackClient {
     ) {
         const { organizationUuid, ...slackMessageArgs } = message;
         const webClient = await this.getWebClient(organizationUuid);
-        const { appName } =
+        const { appName, appProfilePhotoUrl } =
             (await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                 organizationUuid,
             )) || {};
@@ -181,6 +181,7 @@ export class SlackClient {
         return webClient.chat
             .postMessage({
                 ...(appName ? { username: appName } : {}),
+                ...(appProfilePhotoUrl ? { icon_url: appProfilePhotoUrl } : {}),
                 ...slackMessageArgs,
             })
             .catch((e: any) => {
@@ -197,7 +198,11 @@ export class SlackClient {
         opts: SlackAppCustomSettings,
     ) {
         const webClient = await this.getWebClient(organizationUuid);
-        const { notificationChannel: channelId, appName } = opts;
+        const {
+            notificationChannel: channelId,
+            appName,
+            appProfilePhotoUrl,
+        } = opts;
         const currentChannelId = await this.getNotificationChannel(
             organizationUuid,
         );
@@ -215,6 +220,9 @@ export class SlackClient {
                         userFullName.trim().length ? ` by ${userFullName}` : ''
                     }. Stay informed on your job status here.`,
                     ...(appName ? { username: appName } : {}),
+                    ...(appProfilePhotoUrl
+                        ? { icon_url: appProfilePhotoUrl }
+                        : {}),
                 })
                 .catch((e: any) => {
                     Logger.error(

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -173,8 +173,14 @@ export class SlackClient {
     ) {
         const { organizationUuid, ...slackMessageArgs } = message;
         const webClient = await this.getWebClient(organizationUuid);
+        const { appName } =
+            (await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+                organizationUuid,
+            )) || {};
+
         return webClient.chat
             .postMessage({
+                ...(appName ? { username: appName } : {}),
                 ...slackMessageArgs,
             })
             .catch((e: any) => {
@@ -191,7 +197,7 @@ export class SlackClient {
         opts: SlackAppCustomSettings,
     ) {
         const webClient = await this.getWebClient(organizationUuid);
-        const { notificationChannel: channelId } = opts;
+        const { notificationChannel: channelId, appName } = opts;
         const currentChannelId = await this.getNotificationChannel(
             organizationUuid,
         );
@@ -208,6 +214,7 @@ export class SlackClient {
                     text: `This channel will now receive notifications for failed scheduled delivery jobs in Lightdash. Configuration completed${
                         userFullName.trim().length ? ` by ${userFullName}` : ''
                     }. Stay informed on your job status here.`,
+                    ...(appName ? { username: appName } : {}),
                 })
                 .catch((e: any) => {
                     Logger.error(

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -1,4 +1,8 @@
-import { SlackChannel, SlackSettings } from '@lightdash/common';
+import {
+    SlackAppCustomSettings,
+    SlackChannel,
+    SlackSettings,
+} from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Block } from '@slack/bolt';
 import {
@@ -181,19 +185,23 @@ export class SlackClient {
             });
     }
 
-    async updateNotificationChannel(
+    async updateAppCustomSettings(
         userFullName: string,
         organizationUuid: string,
-        channelId: string | null,
+        opts: SlackAppCustomSettings,
     ) {
         const webClient = await this.getWebClient(organizationUuid);
-
-        await this.slackAuthenticationModel.updateNotificationChannelFromOrganizationUuid(
+        const { notificationChannel: channelId } = opts;
+        const currentChannelId = await this.getNotificationChannel(
             organizationUuid,
-            channelId,
         );
 
-        if (channelId) {
+        await this.slackAuthenticationModel.updateAppCustomSettings(
+            organizationUuid,
+            opts,
+        );
+
+        if (channelId && channelId !== currentChannelId) {
             await webClient.chat
                 .postMessage({
                     channel: channelId,

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -173,14 +173,13 @@ export class SlackClient {
     ) {
         const { organizationUuid, ...slackMessageArgs } = message;
         const webClient = await this.getWebClient(organizationUuid);
-        const { appName, appProfilePhotoUrl } =
+        const { appProfilePhotoUrl } =
             (await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                 organizationUuid,
             )) || {};
 
         return webClient.chat
             .postMessage({
-                ...(appName ? { username: appName } : {}),
                 ...(appProfilePhotoUrl ? { icon_url: appProfilePhotoUrl } : {}),
                 ...slackMessageArgs,
             })
@@ -198,11 +197,7 @@ export class SlackClient {
         opts: SlackAppCustomSettings,
     ) {
         const webClient = await this.getWebClient(organizationUuid);
-        const {
-            notificationChannel: channelId,
-            appName,
-            appProfilePhotoUrl,
-        } = opts;
+        const { notificationChannel: channelId, appProfilePhotoUrl } = opts;
         const currentChannelId = await this.getNotificationChannel(
             organizationUuid,
         );
@@ -219,7 +214,6 @@ export class SlackClient {
                     text: `This channel will now receive notifications for failed scheduled delivery jobs in Lightdash. Configuration completed${
                         userFullName.trim().length ? ` by ${userFullName}` : ''
                     }. Stay informed on your job status here.`,
-                    ...(appName ? { username: appName } : {}),
                     ...(appProfilePhotoUrl
                         ? { icon_url: appProfilePhotoUrl }
                         : {}),

--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -19,6 +19,7 @@ const notifySlackError = async (
     url: string,
     client: any,
     event: any,
+    appName?: string,
 ): Promise<void> => {
     /** Expected slack errors:
      * - cannot_parse_attachment: Means the image on the blocks is not accessible from slack, is the URL public ?
@@ -30,6 +31,7 @@ const notifySlackError = async (
         .postMessage({
             thread_ts: event.message_ts,
             channel: event.channel,
+            ...(appName ? { username: appName } : {}),
             text: `:fire: Unable to unfurl ${url}: ${error}`,
         })
         .catch((er: any) =>
@@ -133,6 +135,7 @@ export class SlackBot {
 
     async unfurlSlackUrls(message: any) {
         const { event, client, context } = message;
+        let appName: string | undefined;
 
         if (event.channel === 'COMPOSER') return; // Do not unfurl urls when typing, only when message is sent
 
@@ -164,6 +167,12 @@ export class SlackBot {
                     const authUserUuid =
                         await this.slackAuthenticationModel.getUserUuid(teamId);
 
+                    appName = (
+                        await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+                            details?.organizationUuid,
+                        )
+                    )?.appName;
+
                     const { imageUrl } = await this.unfurlService.unfurlImage({
                         url: details.minimalUrl,
                         lightdashPage: details.pageType,
@@ -191,7 +200,7 @@ export class SlackBot {
                 }
             } catch (e) {
                 if (this.lightdashConfig.mode === LightdashMode.PR) {
-                    void notifySlackError(e, l.url, client, event);
+                    void notifySlackError(e, l.url, client, event, appName);
                 }
 
                 Sentry.captureException(e);

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -3,6 +3,7 @@ import {
     ApiSlackChannelsResponse,
     ApiSlackNotificationChannelResponse,
     ForbiddenError,
+    SlackAppCustomSettings,
 } from '@lightdash/common';
 import {
     Body,
@@ -60,11 +61,11 @@ export class SlackController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Put('/notification-channel')
+    @Put('/custom-settings')
     @OperationId('UpdateNotificationChannel')
     async updateNotificationChannel(
         @Request() req: express.Request,
-        @Body() body: { channelId: string | null },
+        @Body() body: SlackAppCustomSettings,
     ): Promise<ApiSlackNotificationChannelResponse> {
         this.setStatus(200);
         const organizationUuid = req.user?.organizationUuid;
@@ -73,10 +74,10 @@ export class SlackController extends BaseController {
             status: 'ok',
             results: await req.clients
                 .getSlackClient()
-                .updateNotificationChannel(
+                .updateAppCustomSettings(
                     `${req.user?.firstName} ${req.user?.lastName}`,
                     organizationUuid,
-                    body.channelId,
+                    body,
                 ),
         };
     }

--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -11,6 +11,7 @@ export type DbSlackAuthTokens = {
     created_at: Date;
     notification_channel: string | null;
     app_name: string | null;
+    app_profile_photo_url: string | null;
 };
 
 export type CreateDbSlackAuthTokens = Pick<
@@ -20,7 +21,7 @@ export type CreateDbSlackAuthTokens = Pick<
 
 export type UpdateDbSlackAuthTokens = Pick<
     DbSlackAuthTokens,
-    'notification_channel' | 'app_name'
+    'notification_channel' | 'app_name' | 'app_profile_photo_url'
 >;
 
 export type SlackAuthTokensTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -10,7 +10,6 @@ export type DbSlackAuthTokens = {
     created_by_user_id: number;
     created_at: Date;
     notification_channel: string | null;
-    app_name: string | null;
     app_profile_photo_url: string | null;
 };
 
@@ -21,7 +20,7 @@ export type CreateDbSlackAuthTokens = Pick<
 
 export type UpdateDbSlackAuthTokens = Pick<
     DbSlackAuthTokens,
-    'notification_channel' | 'app_name' | 'app_profile_photo_url'
+    'notification_channel' | 'app_profile_photo_url'
 >;
 
 export type SlackAuthTokensTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -1,6 +1,7 @@
 import { Installation } from '@slack/bolt';
+import { Knex } from 'knex';
 
-export const SlackAuthTokensTable = 'slack_auth_tokens';
+export const SlackAuthTokensTableName = 'slack_auth_tokens';
 
 export type DbSlackAuthTokens = {
     installation: Installation;
@@ -9,4 +10,21 @@ export type DbSlackAuthTokens = {
     created_by_user_id: number;
     created_at: Date;
     notification_channel: string | null;
+    app_name: string | null;
 };
+
+export type CreateDbSlackAuthTokens = Pick<
+    DbSlackAuthTokens,
+    'installation' | 'organization_id' | 'slack_team_id' | 'created_by_user_id'
+>;
+
+export type UpdateDbSlackAuthTokens = Pick<
+    DbSlackAuthTokens,
+    'notification_channel' | 'app_name'
+>;
+
+export type SlackAuthTokensTable = Knex.CompositeTableType<
+    DbSlackAuthTokens,
+    CreateDbSlackAuthTokens,
+    UpdateDbSlackAuthTokens
+>;

--- a/packages/backend/src/database/migrations/20240606085700_add-custom-fields-to-slack-installation.ts
+++ b/packages/backend/src/database/migrations/20240606085700_add-custom-fields-to-slack-installation.ts
@@ -5,6 +5,7 @@ const SlackAuthTokensTableName = 'slack_auth_tokens';
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
         table.string('app_name').nullable();
+        table.string('app_profile_photo_url').nullable();
     });
 }
 
@@ -12,6 +13,17 @@ export async function down(knex: Knex): Promise<void> {
     if (await knex.schema.hasColumn(SlackAuthTokensTableName, 'app_name')) {
         await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
             table.dropColumn('app_name');
+        });
+    }
+
+    if (
+        await knex.schema.hasColumn(
+            SlackAuthTokensTableName,
+            'app_profile_photo_url',
+        )
+    ) {
+        await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+            table.dropColumn('app_profile_photo_url');
         });
     }
 }

--- a/packages/backend/src/database/migrations/20240606085700_add-custom-fields-to-slack-installation.ts
+++ b/packages/backend/src/database/migrations/20240606085700_add-custom-fields-to-slack-installation.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const SlackAuthTokensTableName = 'slack_auth_tokens';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.string('app_name').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SlackAuthTokensTableName, 'app_name')) {
+        await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+            table.dropColumn('app_name');
+        });
+    }
+}

--- a/packages/backend/src/database/migrations/20240606085700_add-profile-photo-to-slack-installation.ts
+++ b/packages/backend/src/database/migrations/20240606085700_add-profile-photo-to-slack-installation.ts
@@ -4,18 +4,11 @@ const SlackAuthTokensTableName = 'slack_auth_tokens';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
-        table.string('app_name').nullable();
         table.string('app_profile_photo_url').nullable();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
-    if (await knex.schema.hasColumn(SlackAuthTokensTableName, 'app_name')) {
-        await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
-            table.dropColumn('app_name');
-        });
-    }
-
     if (
         await knex.schema.hasColumn(
             SlackAuthTokensTableName,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5836,6 +5836,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                appProfilePhotoUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 appName: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5844,14 +5844,6 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                appName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
                 notificationChannel: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5831,6 +5831,32 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SlackAppCustomSettings: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                appName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                notificationChannel: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
@@ -12381,7 +12407,7 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.put(
-        '/api/v1/slack/notification-channel',
+        '/api/v1/slack/custom-settings',
         ...fetchMiddlewares<RequestHandler>(SlackController),
         ...fetchMiddlewares<RequestHandler>(
             SlackController.prototype.updateNotificationChannel,
@@ -12403,17 +12429,7 @@ export function RegisterRoutes(app: express.Router) {
                     in: 'body',
                     name: 'body',
                     required: true,
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        channelId: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                    },
+                    ref: 'SlackAppCustomSettings',
                 },
             };
 

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7636,7 +7636,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1121.3",
+        "version": "0.1123.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6496,6 +6496,10 @@
             },
             "SlackAppCustomSettings": {
                 "properties": {
+                    "appProfilePhotoUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "appName": {
                         "type": "string",
                         "nullable": true
@@ -6505,7 +6509,11 @@
                         "nullable": true
                     }
                 },
-                "required": ["appName", "notificationChannel"],
+                "required": [
+                    "appProfilePhotoUrl",
+                    "appName",
+                    "notificationChannel"
+                ],
                 "type": "object"
             },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6500,20 +6500,12 @@
                         "type": "string",
                         "nullable": true
                     },
-                    "appName": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "notificationChannel": {
                         "type": "string",
                         "nullable": true
                     }
                 },
-                "required": [
-                    "appProfilePhotoUrl",
-                    "appName",
-                    "notificationChannel"
-                ],
+                "required": ["appProfilePhotoUrl", "notificationChannel"],
                 "type": "object"
             },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6494,6 +6494,20 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "SlackAppCustomSettings": {
+                "properties": {
+                    "appName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "notificationChannel": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["appName", "notificationChannel"],
+                "type": "object"
+            },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
                 "properties": {
                     "name": {
@@ -7614,7 +7628,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1116.1",
+        "version": "0.1121.3",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -12089,7 +12103,7 @@
                 "parameters": []
             }
         },
-        "/api/v1/slack/notification-channel": {
+        "/api/v1/slack/custom-settings": {
             "put": {
                 "operationId": "UpdateNotificationChannel",
                 "responses": {
@@ -12123,14 +12137,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "properties": {
-                                    "channelId": {
-                                        "type": "string",
-                                        "nullable": true
-                                    }
-                                },
-                                "required": ["channelId"],
-                                "type": "object"
+                                "$ref": "#/components/schemas/SlackAppCustomSettings"
                             }
                         }
                     }

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -128,6 +128,7 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appName: row.app_name ?? undefined,
+            appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
         };
     }
 
@@ -149,7 +150,11 @@ export class SlackAuthenticationModel {
 
     async updateAppCustomSettings(
         organizationUuid: string,
-        { notificationChannel, appName }: SlackAppCustomSettings,
+        {
+            notificationChannel,
+            appName,
+            appProfilePhotoUrl,
+        }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
@@ -157,6 +162,7 @@ export class SlackAuthenticationModel {
             .update({
                 notification_channel: notificationChannel,
                 app_name: appName,
+                app_profile_photo_url: appProfilePhotoUrl,
             })
             .where('organization_id', organizationId);
     }

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -127,7 +127,6 @@ export class SlackAuthenticationModel {
             token: row.installation?.bot?.token,
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
-            appName: row.app_name ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
         };
     }
@@ -150,18 +149,13 @@ export class SlackAuthenticationModel {
 
     async updateAppCustomSettings(
         organizationUuid: string,
-        {
-            notificationChannel,
-            appName,
-            appProfilePhotoUrl,
-        }: SlackAppCustomSettings,
+        { notificationChannel, appProfilePhotoUrl }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
         await this.database(SlackAuthTokensTableName)
             .update({
                 notification_channel: notificationChannel,
-                app_name: appName,
                 app_profile_photo_url: appProfilePhotoUrl,
             })
             .where('organization_id', organizationId);

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -1,10 +1,14 @@
-import { NotFoundError, SlackSettings } from '@lightdash/common';
+import {
+    NotFoundError,
+    SlackAppCustomSettings,
+    SlackSettings,
+} from '@lightdash/common';
 import { Installation, InstallationQuery } from '@slack/bolt';
 import { Knex } from 'knex';
 import { DbOrganization } from '../database/entities/organizations';
 import {
     DbSlackAuthTokens,
-    SlackAuthTokensTable,
+    SlackAuthTokensTableName,
 } from '../database/entities/slackAuthentication';
 import { DbUser } from '../database/entities/users';
 
@@ -52,7 +56,7 @@ export class SlackAuthenticationModel {
         );
 
         const teamId = getTeamId(installation);
-        await this.database(SlackAuthTokensTable)
+        await this.database(SlackAuthTokensTableName)
             .insert({
                 organization_id: organizationId,
                 created_by_user_id: metadata.userId,
@@ -65,7 +69,7 @@ export class SlackAuthenticationModel {
 
     async getInstallation(installQuery: InstallationQuery<boolean>) {
         const { teamId } = installQuery;
-        const [row] = await this.database(SlackAuthTokensTable)
+        const [row] = await this.database(SlackAuthTokensTableName)
             .select<DbSlackAuthTokens[]>('*')
             .where('slack_team_id', teamId);
         if (row === undefined) {
@@ -78,7 +82,7 @@ export class SlackAuthenticationModel {
 
     async getSlackUserId(installQuery: InstallationQuery<boolean>) {
         const { teamId } = installQuery;
-        const [row] = await this.database(SlackAuthTokensTable)
+        const [row] = await this.database(SlackAuthTokensTableName)
             .select<DbSlackAuthTokens[]>('*')
             .where('slack_team_id', teamId);
         if (row === undefined) {
@@ -88,7 +92,7 @@ export class SlackAuthenticationModel {
     }
 
     async getUserUuid(teamId: string) {
-        const [row] = await this.database(SlackAuthTokensTable)
+        const [row] = await this.database(SlackAuthTokensTableName)
             .leftJoin(
                 'users',
                 'slack_auth_tokens.created_by_user_id',
@@ -105,7 +109,7 @@ export class SlackAuthenticationModel {
     async getInstallationFromOrganizationUuid(
         organizationUuid: string,
     ): Promise<SlackSettings | undefined> {
-        const [row] = await this.database(SlackAuthTokensTable)
+        const [row] = await this.database(SlackAuthTokensTableName)
             .leftJoin(
                 'organizations',
                 'slack_auth_tokens.organization_id',
@@ -123,13 +127,14 @@ export class SlackAuthenticationModel {
             token: row.installation?.bot?.token,
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
+            appName: row.app_name ?? undefined,
         };
     }
 
     async deleteInstallation(installQuery: any) {
         const teamId = getTeamId(installQuery);
 
-        await this.database(SlackAuthTokensTable)
+        await this.database(SlackAuthTokensTableName)
             .delete()
             .where('slack_team_id', teamId);
     }
@@ -137,19 +142,22 @@ export class SlackAuthenticationModel {
     async deleteInstallationFromOrganizationUuid(organizationUuid: string) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
-        await this.database(SlackAuthTokensTable)
+        await this.database(SlackAuthTokensTableName)
             .delete()
             .where('organization_id', organizationId);
     }
 
-    async updateNotificationChannelFromOrganizationUuid(
+    async updateAppCustomSettings(
         organizationUuid: string,
-        notificationChannel: string | null,
+        { notificationChannel, appName }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
-        await this.database(SlackAuthTokensTable)
-            .update({ notification_channel: notificationChannel })
+        await this.database(SlackAuthTokensTableName)
+            .update({
+                notification_channel: notificationChannel,
+                app_name: appName,
+            })
             .where('organization_id', organizationId);
     }
 }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -43,6 +43,7 @@ export class SlackIntegrationService extends BaseService {
             scopes: slackAuth.scopes,
             notificationChannel: slackAuth.notificationChannel,
             appName: slackAuth.appName,
+            appProfilePhotoUrl: slackAuth.appProfilePhotoUrl,
         };
         return response;
     }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -42,6 +42,7 @@ export class SlackIntegrationService extends BaseService {
             createdAt: slackAuth.createdAt,
             scopes: slackAuth.scopes,
             notificationChannel: slackAuth.notificationChannel,
+            appName: slackAuth.appName,
         };
         return response;
     }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -42,7 +42,6 @@ export class SlackIntegrationService extends BaseService {
             createdAt: slackAuth.createdAt,
             scopes: slackAuth.scopes,
             notificationChannel: slackAuth.notificationChannel,
-            appName: slackAuth.appName,
             appProfilePhotoUrl: slackAuth.appProfilePhotoUrl,
         };
         return response;

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -12,3 +12,8 @@ export type ApiSlackNotificationChannelResponse = {
     status: 'ok';
     results: void;
 };
+
+export type SlackAppCustomSettings = {
+    notificationChannel: string | null;
+    appName: string | null;
+};

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -15,6 +15,5 @@ export type ApiSlackNotificationChannelResponse = {
 
 export type SlackAppCustomSettings = {
     notificationChannel: string | null;
-    appName: string | null;
     appProfilePhotoUrl: string | null;
 };

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -16,4 +16,5 @@ export type ApiSlackNotificationChannelResponse = {
 export type SlackAppCustomSettings = {
     notificationChannel: string | null;
     appName: string | null;
+    appProfilePhotoUrl: string | null;
 };

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -5,7 +5,6 @@ export type SlackSettings = {
     token?: string;
     scopes: string[];
     notificationChannel: string | undefined;
-    appName: string | undefined;
     appProfilePhotoUrl: string | undefined;
 };
 

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -5,12 +5,14 @@ export type SlackSettings = {
     token?: string;
     scopes: string[];
     notificationChannel: string | undefined;
+    appName: string | undefined;
 };
 
 export const slackRequiredScopes = [
     'links:read',
     'links:write',
     'chat:write',
+    'chat:write.customize',
     'channels:read',
     'channels:join',
     'users:read',

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -6,6 +6,7 @@ export type SlackSettings = {
     scopes: string[];
     notificationChannel: string | undefined;
     appName: string | undefined;
+    appProfilePhotoUrl: string | undefined;
 };
 
 export const slackRequiredScopes = [

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -133,9 +133,9 @@ const SlackSettingsPanel: FC = () => {
                         <form onSubmit={handleSubmit}>
                             <Stack spacing="sm">
                                 <TextInput
-                                    label="Enter the URL of an profile photo for your Slack App"
+                                    label="Enter the URL of a profile photo for your Slack App"
                                     size="xs"
-                                    placeholder="https://my-photo.com/photo.jpg"
+                                    placeholder="https://lightdash.cloud/photo.jpg"
                                     type="url"
                                     disabled={!isValidSlack}
                                     {...form.getInputProps(

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -108,15 +108,6 @@ const SlackSettingsPanel: FC = () => {
                         <Title order={4}>Slack</Title>
                     </Group>
                 </Box>
-                <Stack align="center" justify="center" h="100%">
-                    <Avatar
-                        src={form.values?.appProfilePhotoUrl}
-                        size="xl"
-                        radius="md"
-                        bg="gray.1"
-                    />
-                    <Title order={6}>Profile photo</Title>
-                </Stack>
             </Stack>
 
             <Stack>
@@ -173,6 +164,15 @@ const SlackSettingsPanel: FC = () => {
                                         undefined
                                     }
                                 />
+                                <Stack justify="center">
+                                    <Title order={6}>Profile photo</Title>
+                                    <Avatar
+                                        src={form.values?.appProfilePhotoUrl}
+                                        size="xl"
+                                        radius="md"
+                                        bg="gray.1"
+                                    />
+                                </Stack>
                                 <Select
                                     label={
                                         <Group spacing="two" mb="two">

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -70,14 +70,21 @@ const SlackSettingsPanel: FC = () => {
     const { setFieldValue, onSubmit } = form;
 
     useEffect(() => {
-        if (data?.notificationChannel) {
-            setFieldValue('notificationChannel', data.notificationChannel);
-        }
+        if (!data) return;
 
-        if (data?.appProfilePhotoUrl) {
-            setFieldValue('appProfilePhotoUrl', data.appProfilePhotoUrl);
+        const initialValues = {
+            notificationChannel: data.notificationChannel ?? null,
+            appProfilePhotoUrl: data.appProfilePhotoUrl ?? null,
+        };
+
+        if (form.initialized) {
+            form.setInitialValues(initialValues);
+            form.setValues(initialValues);
+        } else {
+            form.initialize(initialValues);
         }
-    }, [data?.appProfilePhotoUrl, data?.notificationChannel, setFieldValue]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
 
     if (isInitialLoading) {
         return <Loader />;
@@ -129,132 +136,112 @@ const SlackSettingsPanel: FC = () => {
                 </Stack>
 
                 {isValidSlack ? (
-                    <>
-                        <form onSubmit={handleSubmit}>
-                            <Stack spacing="sm">
-                                <TextInput
-                                    label="Enter the URL of a profile photo for your Slack App"
-                                    size="xs"
-                                    placeholder="https://lightdash.cloud/photo.jpg"
-                                    type="url"
-                                    disabled={!isValidSlack}
-                                    {...form.getInputProps(
-                                        'appProfilePhotoUrl',
-                                    )}
-                                    value={
-                                        form.values.appProfilePhotoUrl ??
-                                        undefined
-                                    }
-                                />
-                                <Stack justify="center">
-                                    <Title order={6}>Profile photo</Title>
-                                    <Avatar
-                                        src={form.values?.appProfilePhotoUrl}
-                                        size="xl"
-                                        radius="md"
-                                        bg="gray.1"
-                                    />
-                                </Stack>
-                                <Select
-                                    label={
-                                        <Group spacing="two" mb="two">
-                                            <Text>
-                                                Select a notification channel
-                                            </Text>
-                                            <Tooltip
-                                                multiline
-                                                maw={250}
-                                                label="Choose a channel where to send notifications to every time a scheduled delivery fails. You have to add this Slack App to this channel to enable notifications"
-                                            >
-                                                <MantineIcon
-                                                    icon={IconHelpCircle}
-                                                />
-                                            </Tooltip>
-                                        </Group>
-                                    }
-                                    disabled={isLoadingSlackChannels}
-                                    size="xs"
-                                    placeholder="Select a channel"
-                                    searchable
-                                    clearable
-                                    nothingFound="No channels found"
-                                    defaultValue={
-                                        form.values.notificationChannel
-                                    }
-                                    data={
-                                        slackChannels?.map((channel) => ({
-                                            value: channel.id,
-                                            label: channel.name,
-                                        })) ?? []
-                                    }
-                                    {...form.getInputProps(
-                                        'notificationChannel',
-                                    )}
-                                    onChange={(value) => {
-                                        setFieldValue(
-                                            'notificationChannel',
-                                            value,
-                                        );
-                                    }}
+                    <form onSubmit={handleSubmit}>
+                        <Stack spacing="sm">
+                            <TextInput
+                                label="Enter the URL of a profile photo for your Slack App"
+                                size="xs"
+                                placeholder="https://lightdash.cloud/photo.jpg"
+                                type="url"
+                                disabled={!isValidSlack}
+                                {...form.getInputProps('appProfilePhotoUrl')}
+                                value={
+                                    form.values.appProfilePhotoUrl ?? undefined
+                                }
+                            />
+                            <Stack justify="center">
+                                <Title order={6}>Profile photo</Title>
+                                <Avatar
+                                    src={form.values?.appProfilePhotoUrl}
+                                    size="xl"
+                                    radius="md"
+                                    bg="gray.1"
                                 />
                             </Stack>
-                            <Stack align="end" mt="sm">
-                                <Group>
-                                    <Button
-                                        size="xs"
-                                        component="a"
-                                        target="_blank"
-                                        variant="default"
-                                        href={SLACK_INSTALL_URL}
-                                        leftIcon={
-                                            <MantineIcon icon={IconRefresh} />
-                                        }
-                                    >
-                                        Reinstall
-                                    </Button>
-                                    <Button
-                                        size="xs"
-                                        type="submit"
-                                        leftIcon={
+                            <Select
+                                label={
+                                    <Group spacing="two" mb="two">
+                                        <Text>
+                                            Select a notification channel
+                                        </Text>
+                                        <Tooltip
+                                            multiline
+                                            maw={250}
+                                            label="Choose a channel where to send notifications to every time a scheduled delivery fails. You have to add this Slack App to this channel to enable notifications"
+                                        >
                                             <MantineIcon
-                                                icon={IconDeviceFloppy}
+                                                icon={IconHelpCircle}
                                             />
-                                        }
-                                    >
-                                        Save
-                                    </Button>
-                                    <Button
-                                        size="xs"
-                                        px="xs"
-                                        color="red"
-                                        variant="outline"
-                                        onClick={() => deleteSlack(undefined)}
-                                        leftIcon={
-                                            <MantineIcon icon={IconTrash} />
-                                        }
-                                    >
-                                        Delete
-                                    </Button>
-                                </Group>
+                                        </Tooltip>
+                                    </Group>
+                                }
+                                disabled={isLoadingSlackChannels}
+                                size="xs"
+                                placeholder="Select a channel"
+                                searchable
+                                clearable
+                                nothingFound="No channels found"
+                                data={
+                                    slackChannels?.map((channel) => ({
+                                        value: channel.id,
+                                        label: channel.name,
+                                    })) ?? []
+                                }
+                                {...form.getInputProps('notificationChannel')}
+                                onChange={(value) => {
+                                    setFieldValue('notificationChannel', value);
+                                }}
+                            />
+                        </Stack>
+                        <Stack align="end" mt="sm">
+                            <Group>
+                                <Button
+                                    size="xs"
+                                    component="a"
+                                    target="_blank"
+                                    variant="default"
+                                    href={SLACK_INSTALL_URL}
+                                    leftIcon={
+                                        <MantineIcon icon={IconRefresh} />
+                                    }
+                                >
+                                    Reinstall
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    type="submit"
+                                    leftIcon={
+                                        <MantineIcon icon={IconDeviceFloppy} />
+                                    }
+                                >
+                                    Save
+                                </Button>
+                                <Button
+                                    size="xs"
+                                    px="xs"
+                                    color="red"
+                                    variant="outline"
+                                    onClick={() => deleteSlack(undefined)}
+                                    leftIcon={<MantineIcon icon={IconTrash} />}
+                                >
+                                    Delete
+                                </Button>
+                            </Group>
 
-                                {data && !hasRequiredScopes(data) && (
-                                    <Alert
-                                        color="blue"
-                                        icon={
-                                            <MantineIcon
-                                                icon={IconAlertCircle}
-                                            />
-                                        }
-                                    >
-                                        Your Slack integration is not up to
-                                        date, you should reinstall the Slack
-                                        integration to guarantee the best user
-                                        experience.
-                                    </Alert>
-                                )}
-                            </Stack>
-                        </form>
-                    </>
+                            {data && !hasRequiredScopes(data) && (
+                                <Alert
+                                    color="blue"
+                                    icon={
+                                        <MantineIcon icon={IconAlertCircle} />
+                                    }
+                                >
+                                    Your Slack integration is not up to date,
+                                    you should reinstall the Slack integration
+                                    to guarantee the best user experience.
+                                </Alert>
+                            )}
+                        </Stack>
+                    </form>
                 ) : (
                     <Flex justify="end">
                         <Button

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -64,6 +64,7 @@ const SlackSettingsPanel: FC = () => {
         initialValues: {
             notificationChannel: null,
             appName: null,
+            appProfilePhotoUrl: null,
         },
     });
 
@@ -77,7 +78,16 @@ const SlackSettingsPanel: FC = () => {
         if (data?.appName) {
             setFieldValue('appName', data.appName);
         }
-    }, [data?.appName, data?.notificationChannel, setFieldValue]);
+
+        if (data?.appProfilePhotoUrl) {
+            setFieldValue('appProfilePhotoUrl', data.appProfilePhotoUrl);
+        }
+    }, [
+        data?.appName,
+        data?.appProfilePhotoUrl,
+        data?.notificationChannel,
+        setFieldValue,
+    ]);
 
     if (isInitialLoading) {
         return <Loader />;
@@ -91,12 +101,23 @@ const SlackSettingsPanel: FC = () => {
 
     return (
         <SettingsGridCard>
-            <Box>
-                <Group spacing="sm">
-                    <Avatar src={slackSvg} size="md" />
-                    <Title order={4}>Slack</Title>
-                </Group>
-            </Box>
+            <Stack spacing="sm">
+                <Box>
+                    <Group spacing="sm">
+                        <Avatar src={slackSvg} size="md" />
+                        <Title order={4}>Slack</Title>
+                    </Group>
+                </Box>
+                <Stack align="center" justify="center" h="100%">
+                    <Avatar
+                        src={form.values?.appProfilePhotoUrl}
+                        size="xl"
+                        radius="md"
+                        bg="gray.1"
+                    />
+                    <Title order={6}>Profile photo</Title>
+                </Stack>
+            </Stack>
 
             <Stack>
                 <Stack spacing="sm">
@@ -137,6 +158,20 @@ const SlackSettingsPanel: FC = () => {
                                     disabled={!isValidSlack}
                                     {...form.getInputProps('appName')}
                                     value={form.values.appName ?? undefined}
+                                />
+                                <TextInput
+                                    label="Enter the URL of an profile photo for your Slack App"
+                                    size="xs"
+                                    placeholder="https://my-photo.com/photo.jpg"
+                                    type="url"
+                                    disabled={!isValidSlack}
+                                    {...form.getInputProps(
+                                        'appProfilePhotoUrl',
+                                    )}
+                                    value={
+                                        form.values.appProfilePhotoUrl ??
+                                        undefined
+                                    }
                                 />
                                 <Select
                                     label={

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -63,7 +63,6 @@ const SlackSettingsPanel: FC = () => {
     const form = useForm<SlackAppCustomSettings>({
         initialValues: {
             notificationChannel: null,
-            appName: null,
             appProfilePhotoUrl: null,
         },
     });
@@ -75,19 +74,10 @@ const SlackSettingsPanel: FC = () => {
             setFieldValue('notificationChannel', data.notificationChannel);
         }
 
-        if (data?.appName) {
-            setFieldValue('appName', data.appName);
-        }
-
         if (data?.appProfilePhotoUrl) {
             setFieldValue('appProfilePhotoUrl', data.appProfilePhotoUrl);
         }
-    }, [
-        data?.appName,
-        data?.appProfilePhotoUrl,
-        data?.notificationChannel,
-        setFieldValue,
-    ]);
+    }, [data?.appProfilePhotoUrl, data?.notificationChannel, setFieldValue]);
 
     if (isInitialLoading) {
         return <Loader />;
@@ -142,14 +132,6 @@ const SlackSettingsPanel: FC = () => {
                     <>
                         <form onSubmit={handleSubmit}>
                             <Stack spacing="sm">
-                                <TextInput
-                                    label="Enter a name for your Slack App"
-                                    size="xs"
-                                    placeholder="Lightdash"
-                                    disabled={!isValidSlack}
-                                    {...form.getInputProps('appName')}
-                                    value={form.values.appName ?? undefined}
-                                />
                                 <TextInput
                                     label="Enter the URL of an profile photo for your Slack App"
                                     size="xs"

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -1,5 +1,6 @@
 import {
     type ApiError,
+    type SlackAppCustomSettings,
     type SlackChannel,
     type SlackSettings,
 } from '@lightdash/common';
@@ -69,29 +70,32 @@ export const useSlackChannels = (
         ...useQueryOptions,
     });
 
-const updateSlackNotificationChannel = async (channelId: string | null) =>
+const updateSlackCustomSettings = async (opts: SlackAppCustomSettings) =>
     lightdashApi<null>({
-        url: `/slack/notification-channel`,
+        url: `/slack/custom-settings`,
         method: 'PUT',
-        body: JSON.stringify({ channelId }),
+        body: JSON.stringify({
+            notificationChannel: opts.notificationChannel,
+            appName: opts.appName || null,
+        }),
     });
 
-export const useUpdateSlackNotificationChannelMutation = () => {
+export const useUpdateSlackAppCustomSettingsMutation = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
-    return useMutation<null, ApiError, { channelId: string | null }>(
-        ({ channelId }) => updateSlackNotificationChannel(channelId),
+    return useMutation<null, ApiError, SlackAppCustomSettings>(
+        updateSlackCustomSettings,
         {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['slack']);
 
                 showToastSuccess({
-                    title: `Success! Slack notification channel updated`,
+                    title: `Success! Slack app settings updated`,
                 });
             },
             onError: ({ error }) => {
                 showToastApiError({
-                    title: `Failed to update Slack notification channel`,
+                    title: `Failed to update Slack app settings`,
                     apiError: error,
                 });
             },

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -76,7 +76,6 @@ const updateSlackCustomSettings = async (opts: SlackAppCustomSettings) =>
         method: 'PUT',
         body: JSON.stringify({
             ...opts,
-            appName: opts.appName || null,
             appProfilePhotoUrl: opts.appProfilePhotoUrl || null,
         }),
     });

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -75,8 +75,9 @@ const updateSlackCustomSettings = async (opts: SlackAppCustomSettings) =>
         url: `/slack/custom-settings`,
         method: 'PUT',
         body: JSON.stringify({
-            notificationChannel: opts.notificationChannel,
+            ...opts,
             appName: opts.appName || null,
+            appProfilePhotoUrl: opts.appProfilePhotoUrl || null,
         }),
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [Allow customisation of bot appearance per organization](https://github.com/lightdash/lightdash-commercial/issues/229)
### Description:

- Allows to change the photo used by the bot when calling PostMessage

![image](https://github.com/lightdash/lightdash/assets/22939015/779138db-5ba4-4e7e-981e-4d568bd08358)
![image](https://github.com/lightdash/lightdash/assets/22939015/4e07099e-f603-42cb-84cc-82334cd52069)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
