### PR TITLE
fix: add missing indexes for charts query

### DIFF
--- a/packages/backend/src/database/migrations/20240607083146_add_missing_indexes_for_charts_query.ts
+++ b/packages/backend/src/database/migrations/20240607083146_add_missing_indexes_for_charts_query.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex';
+
+const newTableSingularIndexes = {
+    saved_queries: ['dashboard_uuid'],
+    pinned_chart: ['saved_chart_uuid'],
+    saved_queries_version: ['explore_name'],
+};
+
+export async function up(knex: Knex): Promise<void> {
+    async function createIndex(table: string, columns: string[]) {
+        if (await knex.schema.hasTable(table)) {
+            await knex.schema.alterTable(table, (tableBuilder) => {
+                columns.forEach((column) => {
+                    tableBuilder.index([column]);
+                });
+            });
+        }
+    }
+
+    await Promise.all(
+        Object.entries(newTableSingularIndexes).map(([table, columns]) =>
+            createIndex(table, columns),
+        ),
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    async function dropIndex(table: string, columns: string[]) {
+        if (await knex.schema.hasTable(table)) {
+            await knex.schema.alterTable(table, (tableBuilder) => {
+                columns.forEach((column) => {
+                    tableBuilder.dropIndex([column]);
+                });
+            });
+        }
+    }
+
+    await Promise.all(
+        Object.entries(newTableSingularIndexes).map(([table, columns]) =>
+            dropIndex(table, columns),
+        ),
+    );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10327](https://github.com/lightdash/lightdash/issues/10327)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add missing indexes for the query that fetches chart summaries.

Project and Space indexes are already in another [PR](https://github.com/lightdash/lightdash/pull/10314)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved database performance by adding missing indexes for specific tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->