### PR TITLE
fix: remove n+1 query by fetching user access from multiple spaces

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -55,6 +55,7 @@ const spaceModel = {
     getSpaceSummary: jest.fn(async () => publicSpace),
     getFirstAccessibleSpace: jest.fn(async () => space),
     getUserSpaceAccess: jest.fn(async () => []),
+    getUserSpacesAccess: jest.fn(async () => ({})),
 };
 const analyticsModel = {
     addDashboardViewEvent: jest.fn(async () => null),

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -160,24 +160,13 @@ export class DashboardService extends BaseService {
                 this.spaceModel.getSpaceSummary(spaceUuid),
             ),
         );
-        const dashboardAccesses = await Promise.all(
-            dashboards.map(async (dashboard) => {
-                const spaceAccess = await this.spaceModel.getUserSpaceAccess(
-                    user.userUuid,
-                    dashboard.spaceUuid,
-                );
-                return {
-                    uuid: dashboard.uuid,
-                    access: spaceAccess,
-                };
-            }),
+        const spacesAccess = await this.spaceModel.getUserSpacesAccess(
+            user.userUuid,
+            spaces.map((s) => s.uuid),
         );
         return dashboards.filter((dashboard) => {
             const dashboardSpace = spaces.find(
                 (space) => space.uuid === dashboard.spaceUuid,
-            );
-            const spaceAccess = dashboardAccesses.find(
-                (access) => access.uuid === dashboard.uuid,
             );
             const hasAbility = user.ability.can(
                 'view',
@@ -185,7 +174,7 @@ export class DashboardService extends BaseService {
                     organizationUuid: dashboardSpace?.organizationUuid,
                     projectUuid: dashboardSpace?.projectUuid,
                     isPrivate: dashboardSpace?.isPrivate,
-                    access: spaceAccess?.access,
+                    access: spacesAccess[dashboard.spaceUuid] ?? [],
                 }),
             );
             return (

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -91,6 +91,11 @@ export class SearchService extends BaseService {
                 this.spaceModel.getSpaceSummary(spaceUuid),
             ),
         );
+        const spacesAccess = await this.spaceModel.getUserSpacesAccess(
+            user.userUuid,
+            spaces.map((s) => s.uuid),
+        );
+
         const filterItem = async (
             item:
                 | DashboardSearchResult
@@ -100,11 +105,14 @@ export class SearchService extends BaseService {
             const spaceUuid: string =
                 'spaceUuid' in item ? item.spaceUuid : item.uuid;
             const itemSpace = spaces.find((s) => s.uuid === spaceUuid);
-            const access = await this.spaceModel.getUserSpaceAccess(
-                user.userUuid,
-                spaceUuid,
+            return (
+                itemSpace &&
+                hasViewAccessToSpace(
+                    user,
+                    itemSpace,
+                    spacesAccess[spaceUuid] ?? [],
+                )
             );
-            return itemSpace && hasViewAccessToSpace(user, itemSpace, access);
         };
 
         const hasExploreAccess = user.ability.can(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10347](https://github.com/lightdash/lightdash/issues/10347)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:

- update query to fetch multiple spaces
- fix services to use new method

Routes fixed:

- POST /api/v1/dashboards/availableFilters
- GET /api/v1/projects/{project}/spaces
- GET /api/v1/projects/{project}/chart-summaries
- GET /api/v1/projects/{project}/charts
- GET /api/v1/projects/{project}/dashboards
- GET /api/v1/projects/{project}/pinned-lists/{list}/items
- GET /api/v1/projects/{project}/search/:query
- GET /api/v1/projects/{project}/dataCatalog/{table}/analytics
- GET /api/v1/projects/{project}/dataCatalog/{table}/analytics/{field}
- GET /api/v1/projects/{project}/validate



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
