### PR TITLE
chore: upgrade sentry react to v8 on frontend

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,7 +39,7 @@
         "@mantine/prism": "^6.0.21",
         "@mantine/tiptap": "6.0.21",
         "@monaco-editor/react": "^4.6.0",
-        "@sentry/react": "^7.114.0",
+        "@sentry/react": "^8.8.0",
         "@shopify/react-web-worker": "^5.0.13",
         "@tabler/icons-react": "^2.32.0",
         "@tanstack/react-query": "^4.36.1",

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -5,7 +5,6 @@ import {
     type ApiResponse,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/react';
-import { spanToTraceHeader } from '@sentry/react';
 import fetch from 'isomorphic-fetch';
 
 export const BASE_API_URL =
@@ -60,7 +59,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             },
         },
         (s) => {
-            sentryTrace = spanToTraceHeader(s);
+            sentryTrace = Sentry.spanToTraceHeader(s);
         },
     );
 

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -5,6 +5,7 @@ import {
     type ApiResponse,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/react';
+import { spanToTraceHeader } from '@sentry/react';
 import fetch from 'isomorphic-fetch';
 
 export const BASE_API_URL =
@@ -44,26 +45,24 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     body,
     headers,
 }: LightdashApiProps): Promise<T> => {
+    let sentryTrace: string | undefined;
     // Manually create a span for the fetch request to be able to trace it in Sentry. This also enables Distributed Tracing.
-    const activeTransaction = Sentry.getActiveTransaction();
-
-    let sentryTrace = undefined;
-    if (activeTransaction) {
-        const span = activeTransaction.startChild({
-            data: {
+    Sentry.startSpan(
+        {
+            op: 'http.client',
+            name: `API Request: ${method} ${url}`,
+            attributes: {
+                'http.method': method,
+                'http.url': url,
                 type: 'fetch',
                 url,
                 method,
             },
-            op: 'http.client',
-            name: `API Request: ${method} ${url}`,
-        });
-        span.setAttributes({
-            'http.method': method,
-            'http.url': url,
-        });
-        sentryTrace = span.toTraceparent();
-    }
+        },
+        (s) => {
+            sentryTrace = spanToTraceHeader(s);
+        },
+    );
 
     return fetch(`${apiPrefix}${url}`, {
         method,

--- a/packages/frontend/src/features/errorBoundary/components/ErrorBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/components/ErrorBoundary.tsx
@@ -39,7 +39,11 @@ export const ErrorBoundary: FC<PropsWithChildren & { wrapper?: FlexProps }> = ({
                                     maw="400"
                                     styles={{ copy: { right: 0 } }}
                                 >
-                                    {`Error ID: ${eventId}\n${error.toString()}`}
+                                    {`Error ID: ${eventId}\n${
+                                        error instanceof Error
+                                            ? error.toString()
+                                            : ''
+                                    }`}
                                 </Prism>
                             </Box>
                         }

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -15,9 +15,7 @@ const useSentry = (
                 release: sentryConfig.release,
                 environment: sentryConfig.environment,
                 integrations: [
-                    Sentry.browserTracingIntegration({
-                        enableInp: true,
-                    }),
+                    Sentry.browserTracingIntegration(),
                     Sentry.replayIntegration(),
                 ],
                 tracesSampler(samplingContext) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5128,24 +5128,43 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@sentry-internal/feedback@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.114.0.tgz#8a1c3d8bbd014c1823d30b9b1128eb244d357c3e"
-  integrity sha512-kUiLRUDZuh10QE9JbSVVLgqxFoD9eDPOzT0MmzlPuas8JlTmJuV4FtSANNcqctd5mBuLt2ebNXH0MhRMwyae4A==
+"@sentry-internal/browser-utils@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.8.0.tgz#5378f2c19d30a051f0912944a64096210348ef98"
+  integrity sha512-yE4khknnGpAxy3TeAD9TU1eUqa0GUJ2xluIAsHKkL+RXg3AgEssMO3DBDUbpHp+QANIjzKmZIXtbdTV+1P26aQ==
   dependencies:
-    "@sentry/core" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
 
-"@sentry-internal/replay-canvas@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.114.0.tgz#b81e2c2ebec01c436ad6e687e563ba456e33b615"
-  integrity sha512-6rTiqmKi/FYtesdM2TM2U+rh6BytdPjLP65KTUodtxohJ+r/3m+termj2o4BhIYPE1YYOZNmbZfwebkuQPmWeg==
+"@sentry-internal/feedback@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.8.0.tgz#6fb81846d09d3f4dce8e3fd85a8d0f1d7ab49418"
+  integrity sha512-mybzWx99DuCJxYCVPx12NHVSVbSDF1goEo+rhDGYY8kqyn+snoVBLQtsSdDXYwZyssS1G7Gh6WhX+JVDKcQO9A==
   dependencies:
-    "@sentry/core" "7.114.0"
-    "@sentry/replay" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
+
+"@sentry-internal/replay-canvas@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.8.0.tgz#9920120d8f08b67203b0d15cc48739287448ac9c"
+  integrity sha512-LUoPi38Y8VRnxorIMmKLpfpf+jguhOsovMsZ3ZLc+FvMER62IIvSt4GKK4ARmUBX7+v3r61fdUWqxFs1j3uUTg==
+  dependencies:
+    "@sentry-internal/replay" "8.8.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
+
+"@sentry-internal/replay@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.8.0.tgz#b102c6429a55bae021bd3eb1d9ca1c3b95f9a59a"
+  integrity sha512-gMRWcjpiLJl03JB4rTMN2I4HOOJ6z611kdhUBYc+RRAue13A6uCSIPElgvlCMREkVmr/8eUKrCcIrpqj9PDJ4w==
+  dependencies:
+    "@sentry-internal/browser-utils" "8.8.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
 
 "@sentry-internal/tracing@7.114.0":
   version "7.114.0"
@@ -5156,19 +5175,18 @@
     "@sentry/types" "7.114.0"
     "@sentry/utils" "7.114.0"
 
-"@sentry/browser@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.114.0.tgz#b0741bff89189d16c8b19f0775fe6e078147ec33"
-  integrity sha512-ijJ0vOEY6U9JJADVYGkUbLrAbpGSQgA4zV+KW3tcsBLX9M1jaWq4BV1PWHdzDPPDhy4OgfOjIfaMb5BSPn1U+g==
+"@sentry/browser@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.8.0.tgz#0c3b83299ad26703e708f0534d4ac97876a010be"
+  integrity sha512-TkmbjV9pGpQ+OfUtIE8DaU467w73NqPTX/w/+241VlKpE9HbfranMG0N8Bibgt59GwoNIiC0NhmKaMTZg79elQ==
   dependencies:
-    "@sentry-internal/feedback" "7.114.0"
-    "@sentry-internal/replay-canvas" "7.114.0"
-    "@sentry-internal/tracing" "7.114.0"
-    "@sentry/core" "7.114.0"
-    "@sentry/integrations" "7.114.0"
-    "@sentry/replay" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
+    "@sentry-internal/browser-utils" "8.8.0"
+    "@sentry-internal/feedback" "8.8.0"
+    "@sentry-internal/replay" "8.8.0"
+    "@sentry-internal/replay-canvas" "8.8.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
 
 "@sentry/core@7.114.0":
   version "7.114.0"
@@ -5177,6 +5195,14 @@
   dependencies:
     "@sentry/types" "7.114.0"
     "@sentry/utils" "7.114.0"
+
+"@sentry/core@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.8.0.tgz#0071a27e366abcca8bde9afffb537ae0086434ba"
+  integrity sha512-SnQ42rOuUO03WvhS+2aogKhEzCW9cxpnpPzs2obxnS04KoAz7VL3oYyIwiACrRTlKpwdb9y6vuO89fDvgqPQbA==
+  dependencies:
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
 
 "@sentry/integrations@7.114.0":
   version "7.114.0"
@@ -5207,31 +5233,26 @@
     detect-libc "^2.0.2"
     node-abi "^3.61.0"
 
-"@sentry/react@^7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.114.0.tgz#aca57bbf943abe069c95f584184b5690bcb34733"
-  integrity sha512-zVPtvSy00Al25Z21f5GNzo3rd/TKS+iOX9wQwLrUZAxyf9RwBxKATLVJNJPkf8dQml6Qx+lfr0BHIlVcr1a1SQ==
+"@sentry/react@^8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-8.8.0.tgz#0173a28f8948da318fce65401b7298ad6e4e31da"
+  integrity sha512-7BZyYQFJCRpWz5dn5SZxrhMU8hHH7eBC7BqNMhtsbctP/ObK6BEt3YJUDjTslkXZMOCXfN9ZdBgYEAGc7EPhFQ==
   dependencies:
-    "@sentry/browser" "7.114.0"
-    "@sentry/core" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
+    "@sentry/browser" "8.8.0"
+    "@sentry/core" "8.8.0"
+    "@sentry/types" "8.8.0"
+    "@sentry/utils" "8.8.0"
     hoist-non-react-statics "^3.3.2"
-
-"@sentry/replay@7.114.0":
-  version "7.114.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.114.0.tgz#f552e4803cacb233a2f5f2a4afbf5bed9052a744"
-  integrity sha512-UvEajoLIX9n2poeW3R4Ybz7D0FgCGXoFr/x/33rdUEMIdTypknxjJWxg6fJngIduzwrlrvWpvP8QiZXczYQy2Q==
-  dependencies:
-    "@sentry-internal/tracing" "7.114.0"
-    "@sentry/core" "7.114.0"
-    "@sentry/types" "7.114.0"
-    "@sentry/utils" "7.114.0"
 
 "@sentry/types@7.114.0", "@sentry/types@^7.114.0":
   version "7.114.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.114.0.tgz#ab8009d5f6df23b7342121083bed34ee2452e856"
   integrity sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==
+
+"@sentry/types@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.8.0.tgz#dfbea2fd4cb3104b5128ccf37a45c56a411c397e"
+  integrity sha512-2EOkyHoSOJyCRCsK/O6iA3wyELkRApfY7jNxsC/Amgb5ftuGl/rGO6B4dNKjMJNLNvlkEqZIANoUKOcClBH6yw==
 
 "@sentry/utils@7.114.0":
   version "7.114.0"
@@ -5239,6 +5260,13 @@
   integrity sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==
   dependencies:
     "@sentry/types" "7.114.0"
+
+"@sentry/utils@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.8.0.tgz#f1e940ef1fe8ce44075b3eac040238900d1cccf2"
+  integrity sha512-agLqo9KlXacj7NOcdYZUYqTKlFcPXdTzCnC2u9J1LxDjru9cogbiw6yyDtxBg3kpgYZubfOPz/7F2z9wCjK1cw==
+  dependencies:
+    "@sentry/types" "8.8.0"
 
 "@shopify/react-hooks@^3.0.5":
   version "3.0.5"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10334 

### Description:

Upgrades `@sentry/react` to v8
Removes deprecated usage of `getActiveTransaction` and uses recommended version: `startSpan` https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#deprecate-scopegettransaction-and-getactivetransaction uses `spanToTraceHeader(s);` instead of `span.toTraceparent(`  https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#deprecated-fields-on-span-and-transaction

Screenshot of API and distributed tracing enabled: 

<img width="683" alt="Screenshot 2024-06-10 at 14 40 03" src="https://github.com/lightdash/lightdash/assets/7611706/6060f6b0-ce5b-4955-b82d-cb8e64c79a8a">



Relevant event: https://lightdash.sentry.io/performance/trace/32b9434735144a9d85766572b02b634e/?fov=0%2C4513.7001953125&node=txn-002ffc37fe5b47d0adeb630bddd1616a&statsPeriod=30m&timestamp=1718026417

Here ⬆️  you can verify that: 
- Distributed tracing is on (you can see references to express project)
- Version is 8.8.0 

`ErrorBoundary`'s `error` type is of type `unknown` now - https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#updated-error-types-to-be-unknown-instead-of-error, so we check if it's `instanceof` before stringifying it

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
