### PR TITLE
fix: remove n+1 queries when creating and updating a dashboard

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -55,7 +55,7 @@ type DbDashboardTile = Required<DbCreateDashboardTile>;
 type DbDashboardTileChart = {
     dashboard_version_id: number;
     dashboard_tile_uuid: string;
-    saved_chart_id: number;
+    saved_chart_id: number | null;
     hide_title?: boolean;
     title?: string;
 };

--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -40,7 +40,7 @@ type DbDashboardView = {
 };
 
 type DbCreateDashboardTile = {
-    dashboard_tile_uuid?: string;
+    dashboard_tile_uuid: string;
     dashboard_version_id: number;
     type: DashboardTileTypes;
     x_offset: number;

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -1,7 +1,5 @@
 import {
-    CreateDashboardLoomTile,
     CreateDashboardMarkdownTile,
-    DashboardChartTile,
     deepEqual,
     NotFoundError,
 } from '@lightdash/common';

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -1,5 +1,7 @@
 import {
+    CreateDashboardLoomTile,
     CreateDashboardMarkdownTile,
+    DashboardChartTile,
     deepEqual,
     NotFoundError,
 } from '@lightdash/common';

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1,6 +1,9 @@
 import {
     assertUnreachable,
     CreateDashboard,
+    CreateDashboardChartTile,
+    CreateDashboardLoomTile,
+    CreateDashboardMarkdownTile,
     DashboardBasicDetails,
     DashboardChartTile,
     DashboardDAO,
@@ -11,6 +14,9 @@ import {
     DashboardUnversionedFields,
     DashboardVersionedFields,
     HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    isDashboardChartTileType,
+    isDashboardLoomTileType,
+    isDashboardMarkdownTileType,
     LightdashUser,
     NotFoundError,
     sanitizeHtml,
@@ -21,6 +27,8 @@ import {
     type DashboardFilters,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { groupBy } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 import {
     DashboardsTableName,
     DashboardTable,
@@ -130,90 +138,108 @@ export class DashboardModel {
             },
         });
 
-        const tabsPromises = version.tabs.map(async (tab) => {
-            await trx(DashboardTabsTableName).insert({
-                dashboard_version_id: versionId.dashboard_version_id,
-                name: tab.name,
-                uuid: tab.uuid,
-                dashboard_id: dashboardId,
-                order: tab.order,
-            });
-        });
-
-        await Promise.all(tabsPromises);
-
-        const tilePromises = version.tiles.map(async (tile) => {
-            const { uuid: dashboardTileId, type, w, h, x, y, tabUuid } = tile;
-
-            const [insertedTile] = await trx(DashboardTilesTableName)
-                .insert({
+        if (version.tabs.length > 0) {
+            await trx(DashboardTabsTableName).insert(
+                version.tabs.map(async (tab) => ({
                     dashboard_version_id: versionId.dashboard_version_id,
-                    dashboard_tile_uuid: dashboardTileId,
+                    name: tab.name,
+                    uuid: tab.uuid,
+                    dashboard_id: dashboardId,
+                    order: tab.order,
+                })),
+            );
+        }
+
+        const tilesWithUuids: Array<
+            | (CreateDashboardChartTile & { uuid: string })
+            | (CreateDashboardMarkdownTile & { uuid: string })
+            | (CreateDashboardLoomTile & { uuid: string })
+        > = version.tiles.map((tile) => ({
+            ...tile,
+            uuid: tile.uuid || uuidv4(),
+        }));
+
+        if (tilesWithUuids.length > 0) {
+            await trx(DashboardTilesTableName).insert(
+                tilesWithUuids.map(({ uuid, type, w, h, x, y, tabUuid }) => ({
+                    dashboard_version_id: versionId.dashboard_version_id,
+                    dashboard_tile_uuid: uuid,
                     type,
                     height: h,
                     width: w,
                     x_offset: x,
                     y_offset: y,
                     tab_uuid: tabUuid,
-                })
-                .returning('*');
+                })),
+            );
+        }
 
-            switch (tile.type) {
-                case DashboardTileTypes.SAVED_CHART: {
-                    const chartUuid = tile.properties.savedChartUuid;
-                    if (chartUuid) {
-                        const [savedChart] = await trx(SavedChartsTableName)
-                            .select(['saved_query_id'])
-                            .where('saved_query_uuid', chartUuid)
-                            .limit(1);
-                        if (!savedChart) {
+        const chartTiles = tilesWithUuids.filter(isDashboardChartTileType);
+        if (chartTiles.length > 0) {
+            const chartIds = await trx(SavedChartsTableName)
+                .select(['saved_query_id', 'saved_query_uuid'])
+                .whereIn(
+                    'saved_query_uuid',
+                    chartTiles.map(
+                        ({ properties }) => properties.savedChartUuid,
+                    ),
+                );
+
+            await trx(DashboardTileChartTableName).insert(
+                tilesWithUuids
+                    .filter(isDashboardChartTileType)
+                    .map(({ uuid, properties }) => {
+                        const chartId = chartIds.find(
+                            (chart) =>
+                                chart.saved_query_uuid ===
+                                properties.savedChartUuid,
+                        )?.saved_query_id;
+                        if (!chartId) {
                             throw new NotFoundError('Saved chart not found');
                         }
-                        await trx(DashboardTileChartTableName).insert({
+                        return {
                             dashboard_version_id:
                                 versionId.dashboard_version_id,
-                            dashboard_tile_uuid:
-                                insertedTile.dashboard_tile_uuid,
-                            saved_chart_id: savedChart.saved_query_id,
-                            hide_title: tile.properties.hideTitle,
-                            title: tile.properties.title,
-                        });
-                    }
-                    break;
-                }
-                case DashboardTileTypes.MARKDOWN:
-                    await trx(DashboardTileMarkdownsTableName).insert({
-                        dashboard_version_id: versionId.dashboard_version_id,
-                        dashboard_tile_uuid: insertedTile.dashboard_tile_uuid,
-                        title: tile.properties.title,
-                        content: sanitizeHtml(
-                            tile.properties.content,
-                            HTML_SANITIZE_MARKDOWN_TILE_RULES,
-                        ),
-                    });
-                    break;
-                case DashboardTileTypes.LOOM:
-                    await trx(DashboardTileLoomsTableName).insert({
-                        dashboard_version_id: versionId.dashboard_version_id,
-                        dashboard_tile_uuid: insertedTile.dashboard_tile_uuid,
-                        title: tile.properties.title,
-                        url: tile.properties.url,
-                        hide_title: tile.properties.hideTitle,
-                    });
-                    break;
-                default: {
-                    const never: never = tile;
-                    throw new UnexpectedServerError(
-                        `Dashboard tile type "${type}" not recognised`,
-                    );
-                }
-            }
+                            dashboard_tile_uuid: uuid,
+                            saved_chart_id: chartId,
+                            hide_title: properties.hideTitle,
+                            title: properties.title,
+                        };
+                    }),
+            );
+        }
 
-            return insertedTile;
-        });
+        const loomTiles = tilesWithUuids.filter(isDashboardLoomTileType);
+        if (loomTiles.length > 0) {
+            await trx(DashboardTileLoomsTableName).insert(
+                loomTiles.map(({ uuid, properties }) => ({
+                    dashboard_version_id: versionId.dashboard_version_id,
+                    dashboard_tile_uuid: uuid,
+                    title: properties.title,
+                    url: properties.url,
+                    hide_title: properties.hideTitle,
+                })),
+            );
+        }
 
-        const tiles = await Promise.all(tilePromises);
-        const tileUuids = tiles.map((tile) => tile.dashboard_tile_uuid);
+        const markdownTiles = tilesWithUuids.filter(
+            isDashboardMarkdownTileType,
+        );
+        if (markdownTiles.length > 0) {
+            await trx(DashboardTileMarkdownsTableName).insert(
+                markdownTiles.map(({ uuid, properties }) => ({
+                    dashboard_version_id: versionId.dashboard_version_id,
+                    dashboard_tile_uuid: uuid,
+                    title: properties.title,
+                    content: sanitizeHtml(
+                        properties.content,
+                        HTML_SANITIZE_MARKDOWN_TILE_RULES,
+                    ),
+                })),
+            );
+        }
+
+        const tileUuids = tilesWithUuids.map((tile) => tile.uuid);
 
         // TODO: remove after resolving a problem with importing lodash-es in the backend
         const pick = <T>(object: Record<string, T>, keys: string[]) =>

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -189,14 +189,23 @@ export class DashboardModel {
                 tilesWithUuids
                     .filter(isDashboardChartTileType)
                     .map(({ uuid, properties }) => {
-                        const chartId = chartIds.find(
-                            (chart) =>
-                                chart.saved_query_uuid ===
-                                properties.savedChartUuid,
-                        )?.saved_query_id;
-                        if (!chartId) {
-                            throw new NotFoundError('Saved chart not found');
+                        let chartId: number | null = null;
+
+                        if (properties.savedChartUuid) {
+                            const matchingChartId = chartIds.find(
+                                (chart) =>
+                                    chart.saved_query_uuid ===
+                                    properties.savedChartUuid,
+                            )?.saved_query_id;
+                            if (matchingChartId === undefined) {
+                                throw new NotFoundError(
+                                    'Saved chart not found',
+                                );
+                            } else {
+                                chartId = matchingChartId;
+                            }
                         }
+
                         return {
                             dashboard_version_id:
                                 versionId.dashboard_version_id,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -93,6 +93,14 @@ export const isDashboardChartTileType = (
     tile: DashboardTile,
 ): tile is DashboardChartTile => tile.type === DashboardTileTypes.SAVED_CHART;
 
+export const isDashboardMarkdownTileType = (
+    tile: DashboardTile,
+): tile is DashboardMarkdownTile => tile.type === DashboardTileTypes.MARKDOWN;
+
+export const isDashboardLoomTileType = (
+    tile: DashboardTile,
+): tile is DashboardLoomTile => tile.type === DashboardTileTypes.LOOM;
+
 export type DashboardTab = {
     uuid: string;
     name: string;


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Remove 6 n+1 queries when creating/updating a dashboard.

Changes:
- moved the loops inside the insert method to insert multiple rows in the same query.
- pre generate tile uuid to simplify queries + updated typing to require uuid.
- fix saved chart id typing to allow `null` 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
