### PR TITLE
fix: chart and dashboard view count increase on pinning to homepage

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -18,6 +18,7 @@ import {
     SchedulerAndTargets,
     SchedulerFormat,
     SessionUser,
+    TogglePinnedItemInfo,
     UpdateDashboard,
     UpdateMultipleDashboards,
 } from '@lightdash/common';
@@ -189,8 +190,7 @@ export class DashboardService extends BaseService {
 
     async getById(
         user: SessionUser,
-        dashboardUuid: string,
-        isPinning: boolean = false
+        dashboardUuid: string
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getById(dashboardUuid);
 
@@ -213,12 +213,11 @@ export class DashboardService extends BaseService {
             );
         }
 
-        if (!isPinning) {
-            await this.analyticsModel.addDashboardViewEvent(
-                dashboard.uuid,
-                user.userUuid,
-            );
-        }
+        await this.analyticsModel.addDashboardViewEvent(
+            dashboard.uuid,
+            user.userUuid,
+        );
+
         this.analytics.track({
             event: 'dashboard.view',
             userId: user.userUuid,
@@ -567,7 +566,7 @@ export class DashboardService extends BaseService {
     async togglePinning(
         user: SessionUser,
         dashboardUuid: string,
-    ): Promise<Dashboard> {
+    ): Promise<TogglePinnedItemInfo> {
         const existingDashboardDao = await this.dashboardModel.getById(
             dashboardUuid,
         );
@@ -631,7 +630,11 @@ export class DashboardService extends BaseService {
             },
         });
 
-        return this.getById(user, dashboardUuid, true);
+        return {
+            projectUuid,
+            spaceUuid,
+            pinnedListUuid: pinnedList.pinnedListUuid
+        };
     }
 
     async updateMultiple(

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -190,7 +190,7 @@ export class DashboardService extends BaseService {
 
     async getById(
         user: SessionUser,
-        dashboardUuid: string
+        dashboardUuid: string,
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getById(dashboardUuid);
 
@@ -633,7 +633,7 @@ export class DashboardService extends BaseService {
         return {
             projectUuid,
             spaceUuid,
-            pinnedListUuid: pinnedList.pinnedListUuid
+            pinnedListUuid: pinnedList.pinnedListUuid,
         };
     }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -190,6 +190,7 @@ export class DashboardService extends BaseService {
     async getById(
         user: SessionUser,
         dashboardUuid: string,
+        isPinning: boolean = false
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getById(dashboardUuid);
 
@@ -212,10 +213,12 @@ export class DashboardService extends BaseService {
             );
         }
 
-        await this.analyticsModel.addDashboardViewEvent(
-            dashboard.uuid,
-            user.userUuid,
-        );
+        if (!isPinning) {
+            await this.analyticsModel.addDashboardViewEvent(
+                dashboard.uuid,
+                user.userUuid,
+            );
+        }
         this.analytics.track({
             event: 'dashboard.view',
             userId: user.userUuid,
@@ -628,7 +631,7 @@ export class DashboardService extends BaseService {
             },
         });
 
-        return this.getById(user, dashboardUuid);
+        return this.getById(user, dashboardUuid, true);
     }
 
     async updateMultiple(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -23,6 +23,7 @@ import {
     SchedulerFormat,
     SessionUser,
     SpaceShare,
+    TogglePinnedItemInfo,
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
@@ -432,7 +433,7 @@ export class SavedChartService extends BaseService {
     async togglePinning(
         user: SessionUser,
         savedChartUuid: string,
-    ): Promise<SavedChart> {
+    ): Promise<TogglePinnedItemInfo> {
         const { organizationUuid, projectUuid, pinnedListUuid, spaceUuid } =
             await this.savedChartModel.getSummary(savedChartUuid);
 
@@ -476,7 +477,11 @@ export class SavedChartService extends BaseService {
             },
         });
 
-        return this.get(savedChartUuid, user, true);
+        return {
+            projectUuid,
+            spaceUuid,
+            pinnedListUuid: pinnedList.pinnedListUuid
+        };
     }
 
     async updateMultiple(
@@ -605,8 +610,7 @@ export class SavedChartService extends BaseService {
 
     async get(
         savedChartUuid: string,
-        user: SessionUser,
-        isPinning: boolean = false
+        user: SessionUser
     ): Promise<SavedChart> {
         const savedChart = await this.savedChartModel.get(savedChartUuid);
         const space = await this.spaceModel.getSpaceSummary(
@@ -632,12 +636,10 @@ export class SavedChartService extends BaseService {
             );
         }
 
-        if (!isPinning) {
-            await this.analyticsModel.addChartViewEvent(
-                savedChartUuid,
-                user.userUuid,
-            );
-        }
+        await this.analyticsModel.addChartViewEvent(
+            savedChartUuid,
+            user.userUuid,
+        );
 
         this.analytics.track({
             event: 'saved_chart.view',

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -480,7 +480,7 @@ export class SavedChartService extends BaseService {
         return {
             projectUuid,
             spaceUuid,
-            pinnedListUuid: pinnedList.pinnedListUuid
+            pinnedListUuid: pinnedList.pinnedListUuid,
         };
     }
 
@@ -608,10 +608,7 @@ export class SavedChartService extends BaseService {
         return this.analyticsModel.getChartViewStats(savedChartUuid);
     }
 
-    async get(
-        savedChartUuid: string,
-        user: SessionUser
-    ): Promise<SavedChart> {
+    async get(savedChartUuid: string, user: SessionUser): Promise<SavedChart> {
         const savedChart = await this.savedChartModel.get(savedChartUuid);
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -476,7 +476,7 @@ export class SavedChartService extends BaseService {
             },
         });
 
-        return this.get(savedChartUuid, user);
+        return this.get(savedChartUuid, user, true);
     }
 
     async updateMultiple(
@@ -603,7 +603,11 @@ export class SavedChartService extends BaseService {
         return this.analyticsModel.getChartViewStats(savedChartUuid);
     }
 
-    async get(savedChartUuid: string, user: SessionUser): Promise<SavedChart> {
+    async get(
+        savedChartUuid: string,
+        user: SessionUser,
+        isPinning: boolean = false
+    ): Promise<SavedChart> {
         const savedChart = await this.savedChartModel.get(savedChartUuid);
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
@@ -628,10 +632,12 @@ export class SavedChartService extends BaseService {
             );
         }
 
-        await this.analyticsModel.addChartViewEvent(
-            savedChartUuid,
-            user.userUuid,
-        );
+        if (!isPinning) {
+            await this.analyticsModel.addChartViewEvent(
+                savedChartUuid,
+                user.userUuid,
+            );
+        }
 
         this.analytics.track({
             event: 'saved_chart.view',

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,7 +78,10 @@ import {
     type OrganizationProject,
     type UpdateAllowedEmailDomains,
 } from './types/organization';
-import { type PinnedItems } from './types/pinning';
+import {
+    type ApiTogglePinnedItem,
+    type PinnedItems
+} from './types/pinning';
 import { type ProjectGroupAccess } from './types/projectGroupAccess';
 import { type ProjectMemberRole } from './types/projectMemberRole';
 import {
@@ -638,7 +641,8 @@ type ApiResults =
     | ApiAiDashboardSummaryResponse['results']
     | ApiAiGetDashboardSummaryResponse['results']
     | ApiCatalogMetadataResults
-    | ApiCatalogAnalyticsResults;
+    | ApiCatalogAnalyticsResults
+    | ApiTogglePinnedItem['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,10 +78,7 @@ import {
     type OrganizationProject,
     type UpdateAllowedEmailDomains,
 } from './types/organization';
-import {
-    type ApiTogglePinnedItem,
-    type PinnedItems
-} from './types/pinning';
+import { type ApiTogglePinnedItem, type PinnedItems } from './types/pinning';
 import { type ProjectGroupAccess } from './types/projectGroupAccess';
 import { type ProjectMemberRole } from './types/projectMemberRole';
 import {

--- a/packages/common/src/types/pinning.ts
+++ b/packages/common/src/types/pinning.ts
@@ -5,9 +5,7 @@ import {
     type ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from './resourceViewItem';
-import { 
-    type ChartSummary
-} from './savedCharts';
+import { type ChartSummary } from './savedCharts';
 
 export type PinnedList = {
     pinnedListUuid: string;
@@ -103,6 +101,6 @@ export type TogglePinnedItemInfo = Pick<PinnedListAndItems, 'pinnedListUuid'> &
     Pick<ChartSummary, 'projectUuid' | 'spaceUuid'>;
 
 export type ApiTogglePinnedItem = {
-    status: 'ok',
-    results: TogglePinnedItemInfo
+    status: 'ok';
+    results: TogglePinnedItemInfo;
 };

--- a/packages/common/src/types/pinning.ts
+++ b/packages/common/src/types/pinning.ts
@@ -5,6 +5,9 @@ import {
     type ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from './resourceViewItem';
+import { 
+    type ChartSummary
+} from './savedCharts';
 
 export type PinnedList = {
     pinnedListUuid: string;
@@ -95,3 +98,11 @@ export type ApiPinnedItems = {
 export type PinnedItems = Array<
     ResourceViewDashboardItem | ResourceViewChartItem | ResourceViewSpaceItem
 >;
+
+export type TogglePinnedItemInfo = Pick<PinnedListAndItems, 'pinnedListUuid'> &
+    Pick<ChartSummary, 'projectUuid' | 'spaceUuid'>;
+
+export type ApiTogglePinnedItem = {
+    status: 'ok',
+    results: TogglePinnedItemInfo
+};

--- a/packages/e2e/cypress/e2e/api/pinning.cy.ts
+++ b/packages/e2e/cypress/e2e/api/pinning.cy.ts
@@ -12,24 +12,35 @@ describe('Lightdash pinning endpoints', () => {
             (projectResponse) => {
                 const savedChart = projectResponse.body.results[0];
 
-                // change once
+                expect(savedChart.pinnedListUuid).to.eq(null);
+
+                // Pin Chart
                 cy.request(
                     'PATCH',
                     `${apiUrl}/saved/${savedChart.uuid}/pinning`,
                 ).then((updatedChartResponse) => {
-                    expect(
-                        updatedChartResponse.body.results.pinnedListUuid,
-                    ).to.not.eq(savedChart.pinnedListUuid);
+                    cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
+                        (res1) => {
+                            expect(res1.body.results[0].pinnedListUuid).to.eq(
+                                updatedChartResponse.body.results
+                                    .pinnedListUuid,
+                            );
+                        },
+                    );
                 });
 
-                // change back
+                // Unpin chart
                 cy.request(
                     'PATCH',
                     `${apiUrl}/saved/${savedChart.uuid}/pinning`,
-                ).then((updatedChartResponse) => {
-                    expect(
-                        updatedChartResponse.body.results.pinnedListUuid,
-                    ).to.eq(savedChart.pinnedListUuid);
+                ).then(() => {
+                    cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
+                        (res2) => {
+                            expect(res2.body.results[0].pinnedListUuid).to.eq(
+                                null,
+                            );
+                        },
+                    );
                 });
             },
         );
@@ -40,24 +51,30 @@ describe('Lightdash pinning endpoints', () => {
             (projectResponse) => {
                 const dashboard = projectResponse.body.results[0];
 
-                // change once
+                // Pin dashboard
                 cy.request(
                     'PATCH',
                     `${apiUrl}/dashboards/${dashboard.uuid}/pinning`,
                 ).then((updatedDashboardResponse) => {
-                    expect(
-                        updatedDashboardResponse.body.results.pinnedListUuid,
-                    ).to.not.eq(dashboard.pinnedListUuid);
+                    cy.request(
+                        `${apiUrl}/projects/${projectUuid}/dashboards`,
+                    ).then((res1) => {
+                        expect(res1.body.results[0].pinnedListUuid).to.eq(
+                            updatedDashboardResponse.body.results
+                                .pinnedListUuid,
+                        );
+                    });
                 });
-                // change back
+                // Unpin dashboard
                 cy.request(
                     'PATCH',
                     `${apiUrl}/dashboards/${dashboard.uuid}/pinning`,
-                ).then((updatedDashboardResponse) => {
-                    // check value was updated back to original
-                    expect(
-                        updatedDashboardResponse.body.results.pinnedListUuid,
-                    ).to.eq(dashboard.pinnedListUuid);
+                ).then(() => {
+                    cy.request(
+                        `${apiUrl}/projects/${projectUuid}/dashboards`,
+                    ).then((res1) => {
+                        expect(res1.body.results[0].pinnedListUuid).to.eq(null);
+                    });
                 });
             },
         );

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -1,10 +1,13 @@
-import { type ApiError, type SavedChart } from '@lightdash/common';
+import {
+    type TogglePinnedItemInfo,
+    type ApiError
+} from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 
 const updateChartPinning = async (data: { uuid: string }) =>
-    lightdashApi<SavedChart>({
+    lightdashApi<TogglePinnedItemInfo>({
         url: `/saved/${data.uuid}/pinning`,
         method: 'PATCH',
         body: JSON.stringify({}),
@@ -13,7 +16,7 @@ const updateChartPinning = async (data: { uuid: string }) =>
 export const useChartPinningMutation = () => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
-    return useMutation<SavedChart, ApiError, { uuid: string }>(
+    return useMutation<TogglePinnedItemInfo, ApiError, { uuid: string }>(
         updateChartPinning,
         {
             mutationKey: ['chart_pinning_update'],

--- a/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useChartPinningMutation.ts
@@ -1,7 +1,4 @@
-import {
-    type TogglePinnedItemInfo,
-    type ApiError
-} from '@lightdash/common';
+import { type ApiError, type TogglePinnedItemInfo } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';

--- a/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
+++ b/packages/frontend/src/hooks/pinning/useDashboardPinningMutation.ts
@@ -1,10 +1,10 @@
-import { type ApiError, type Dashboard } from '@lightdash/common';
+import { type ApiError, type TogglePinnedItemInfo } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 
 const updateDashboardPinning = async (data: { uuid: string }) =>
-    lightdashApi<Dashboard>({
+    lightdashApi<TogglePinnedItemInfo>({
         url: `/dashboards/${data.uuid}/pinning`,
         method: 'PATCH',
         body: JSON.stringify({}),
@@ -13,7 +13,7 @@ const updateDashboardPinning = async (data: { uuid: string }) =>
 export const useDashboardPinningMutation = () => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
-    return useMutation<Dashboard, ApiError, { uuid: string }>(
+    return useMutation<TogglePinnedItemInfo, ApiError, { uuid: string }>(
         updateDashboardPinning,
         {
             mutationKey: ['dashboard_pinning_update'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10321

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
While pinning either a dashboard or a particular chart to the homepage, the view count increases because:
  1. `getById()` method in `DashboardService.ts` and
  2. `get()` method in `SavedChartService.ts`
call the following block of code, that is used to increase the views count:
```
await this.analyticsModel.addDashboardViewEvent(
    dashboard.uuid,
    user.userUuid,
);
```
To avoid this view count increase on `pinning/unpinning to homepage`, having a boolean value which tells whether the chart/dashboard is being pinned to homepage or not ( `isPinning` value ) helps in this case. This value will be `true` only when pinning occurs and hence will not increase the view count, the default value will be `false` if not provided otherwise.

<!-- Even better add a screenshot / gif / loom -->

https://github.com/lightdash/lightdash/assets/111004544/53591d2f-977f-41b6-ab23-b72c1b137a61

PS: Right click on the video and view in a new tab if not working over here


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
