### PR TITLE
fix: get body selector for playwright chart screenshots

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -570,10 +570,7 @@ export class UnfurlService extends BaseService {
 
                     let finalSelector = selector;
 
-                    if (
-                        lightdashPage === LightdashPage.EXPLORE ||
-                        lightdashPage === LightdashPage.CHART
-                    ) {
+                    if (lightdashPage === LightdashPage.EXPLORE) {
                         finalSelector = `[data-testid="visualization"]`;
                     } else if (lightdashPage === LightdashPage.DASHBOARD) {
                         finalSelector = '.react-grid-layout';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Get the correct selector for charts' screenshots: should be `body` instead of `[data-testid="visualization"]`

Introduced here: https://github.com/lightdash/lightdash/commit/43eb5ba11d0c51390334000e2d8be6601fc4c4fd

See how these are set in: `UnfurlService` > `parseUrl`
```
 const chartUrl = new RegExp(`/projects/${uuid}/saved/${uuid}`); // will be CHART
 const exploreUrl = new RegExp(`/projects/${uuid}/tables/`); // will be EXPLORE
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
