### PR TITLE
fix: adjust content security policy directives

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -275,11 +275,45 @@ export default class App {
             Logger.warn('Invalid security report URI', e);
         }
 
+        const contentSecurityPolicyAllowedDomains: string[] = [
+            'https://*.sentry.io',
+            'https://analytics.lightdash.com',
+            'https://*.usepylon.com',
+            'https://*.headwayapp.co',
+            'https://headway-widget.net',
+            'https://*.posthog.com',
+            'https://*.intercom.com',
+            'https://*.rudderlabs.com',
+            ...this.lightdashConfig.security.contentSecurityPolicy
+                .allowedDomains,
+        ];
+
         expressApp.use(
             helmet({
                 contentSecurityPolicy: {
                     directives: {
-                        'default-src': ["'self'", 'sentry.io'],
+                        'default-src': [
+                            "'self'",
+                            ...contentSecurityPolicyAllowedDomains,
+                        ],
+                        'img-src': ["'self'", 'data:', 'https://*'],
+                        'frame-src': ["'self'", 'https://*'],
+                        'frame-ancestors': ["'self'", 'https://*'],
+                        'worker-src': [
+                            "'self'",
+                            'blob:',
+                            ...contentSecurityPolicyAllowedDomains,
+                        ],
+                        'script-src': [
+                            "'self'",
+                            "'unsafe-eval'",
+                            ...contentSecurityPolicyAllowedDomains,
+                        ],
+                        'script-src-elem': [
+                            "'self'",
+                            "'unsafe-inline'",
+                            ...contentSecurityPolicyAllowedDomains,
+                        ],
                         'report-uri': reportUri ? [reportUri.href] : [],
                     },
                     reportOnly: true,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -160,6 +160,11 @@ export type LightdashConfig = {
     version: '1.0';
     lightdashSecret: string;
     secureCookies: boolean;
+    security: {
+        contentSecurityPolicy: {
+            allowedDomains: string[];
+        };
+    };
     cookiesMaxAgeHours?: number;
     trustProxy: boolean;
     databaseConnectionUri?: string;
@@ -402,6 +407,15 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
     return {
         ...config,
         mode,
+        security: {
+            contentSecurityPolicy: {
+                allowedDomains: (
+                    process.env.LIGHTDASH_CSP_ALLOWED_DOMAINS || ''
+                )
+                    .split(',')
+                    .map((domain) => domain.trim()),
+            },
+        },
         smtp: process.env.EMAIL_SMTP_HOST
             ? {
                   host: process.env.EMAIL_SMTP_HOST,


### PR DESCRIPTION
### Description:

Changes:
- add domain list of third party libraries/services
- support custom domains via env var
- support https iframes in markdown
- support https images in markdown
- support Lightdash to be embedded in other https websites
- support script-src eval
- support script-src-elem unsafe-inline
- support worker-src blob

<img width="750" alt="Screenshot 2024-06-11 at 14 07 01" src="https://github.com/lightdash/lightdash/assets/9117144/5e73f4e8-26a3-450f-9cda-4cbbe75610d1">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
