### PR TITLE
fix: handle error thrown when parsing explore params

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -148,28 +148,31 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
 
     return useMemo(() => {
         if (pathParams.tableId) {
-            const unsavedChartVersion = parseExplorerSearchParams(search) || {
-                tableName: '',
-                metricQuery: {
-                    exploreName: '',
-                    dimensions: [],
-                    metrics: [],
-                    filters: {},
-                    sorts: [],
-                    limit: 500,
-                    tableCalculations: [],
-                    additionalMetrics: [],
-                },
-                pivotConfig: undefined,
-                tableConfig: {
-                    columnOrder: [],
-                },
-                chartConfig: {
-                    type: ChartType.CARTESIAN,
-                    config: { layout: {}, eChartsConfig: {} },
-                },
-            };
             try {
+                const unsavedChartVersion = parseExplorerSearchParams(
+                    search,
+                ) || {
+                    tableName: '',
+                    metricQuery: {
+                        exploreName: '',
+                        dimensions: [],
+                        metrics: [],
+                        filters: {},
+                        sorts: [],
+                        limit: 500,
+                        tableCalculations: [],
+                        additionalMetrics: [],
+                    },
+                    pivotConfig: undefined,
+                    tableConfig: {
+                        columnOrder: [],
+                    },
+                    chartConfig: {
+                        type: ChartType.CARTESIAN,
+                        config: { layout: {}, eChartsConfig: {} },
+                    },
+                };
+
                 return {
                     shouldFetchResults: true,
                     expandedSections: unsavedChartVersion
@@ -189,7 +192,11 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                     },
                 };
             } catch (e: any) {
-                showToastError({ title: 'Error parsing url', subtitle: e });
+                const errorMessage = e.message ? ` Error: "${e.message}"` : '';
+                showToastError({
+                    title: 'Error parsing url',
+                    subtitle: `URL is invalid or incomplete.${errorMessage}`,
+                });
             }
         }
     }, [pathParams, search, showToastError]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10371 

### Description:

**Steps to reproduce**
1. Click "Run a query"
2. Select a table and then some dimensions / metrics
3. Click "Run query"
4. Copy the URL from the browser
5. Paste the URL in another tab and remove the **LAST** `%7D` from the URL

**Before**
![image](https://github.com/lightdash/lightdash/assets/22939015/24e396d7-a6be-4f30-9345-e08f5a2d858a)

**After**
![image](https://github.com/lightdash/lightdash/assets/22939015/a70be016-872a-4422-9838-0d58fde122ca)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
