### PR TITLE
fix: increase timeout to wait for charts to 60s (playwright)

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -547,7 +547,9 @@ export class UnfurlService extends BaseService {
                             );
 
                             chartResultsPromises = [
-                                page?.waitForResponse(responsePattern),
+                                page?.waitForResponse(responsePattern, {
+                                    timeout: 40000,
+                                }),
                             ];
                         }
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -536,7 +536,7 @@ export class UnfurlService extends BaseService {
                                 );
 
                                 return page?.waitForResponse(responsePattern, {
-                                    timeout: 40000,
+                                    timeout: 60000,
                                 }); // NOTE: No await here
                             });
                         } else if (
@@ -550,7 +550,7 @@ export class UnfurlService extends BaseService {
 
                             chartResultsPromises = [
                                 page?.waitForResponse(responsePattern, {
-                                    timeout: 40000,
+                                    timeout: 60000,
                                 }), // NOTE: No await here
                             ];
                         }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -535,7 +535,9 @@ export class UnfurlService extends BaseService {
                                     `${id}/chart-and-results`,
                                 );
 
-                                return page?.waitForResponse(responsePattern); // NOTE: No await here
+                                return page?.waitForResponse(responsePattern, {
+                                    timeout: 40000,
+                                }); // NOTE: No await here
                             });
                         } else if (
                             lightdashPage === LightdashPage.CHART ||
@@ -549,7 +551,7 @@ export class UnfurlService extends BaseService {
                             chartResultsPromises = [
                                 page?.waitForResponse(responsePattern, {
                                     timeout: 40000,
-                                }),
+                                }), // NOTE: No await here
                             ];
                         }
 
@@ -566,6 +568,16 @@ export class UnfurlService extends BaseService {
                         this.logger.warn(
                             `Got a timeout when waiting for the page to load, returning current content`,
                         );
+                    }
+
+                    if (lightdashPage === LightdashPage.DASHBOARD) {
+                        // wait for all components with class .loading_chart to disappear - they are the same number as the number of charts
+                        const dashboardChartsLoaders =
+                            page.locator('.loading_chart');
+
+                        await dashboardChartsLoaders.waitFor({
+                            state: 'hidden',
+                        });
                     }
 
                     const path = `/tmp/${imageId}.png`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Playwright's default timeout for `waitForResponse` is 30s - https://playwright.dev/docs/api/class-page#page-wait-for-response
Increased to 60s - some charts might take longer

Re-added the `.loading_chart` `wait`s that we already have in puppeteer - thought I didn't need this, but it increases reliability.

How to test:
1. add this to the browser connection
```ts
browser = await playwright.chromium.connectOverCDP(
    browserWSEndpoint,
    {
        logger: {
            isEnabled: (name, severity) => true,
            log: (name, severity, message, args) =>
                console.log(
                    `PLAYWRIGHT: ${name} ${message}`,
                ),
        },
    },
);
```
2. Add a delay to the `getChartsAndResults` in `ProjectService` before the return:
```ts

        const delay = (ms: number | undefined) =>
            new Promise((resolve) => setTimeout(resolve, ms));
        if (
            chartUuid === 'ONE CHART UUID IN YOUR DASHBOARD' ||
            chartUuid === 'ANOTHER CHART UUID IN YOUR DASHBOARD' 
        ) {
            await delay(30000);
        }
```

Tested this mostly with generating a dashboard preview: 

<img width="783" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/61a0cb97-8203-444b-86fa-6977ee614e23">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
