### PR TITLE
fix: get all explores in one query for dashboard available filters

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -636,7 +636,7 @@ export class ProjectModel {
     async findExploresFromCache(
         projectUuid: string,
         exploreNames?: string[],
-    ): Promise<Array<Explore | ExploreError>> {
+    ): Promise<Record<string, Explore | ExploreError>> {
         return wrapOtelSpan(
             'ProjectModel.findExploresFromCache',
             {
@@ -652,10 +652,15 @@ export class ProjectModel {
                 }
                 const explores = await query;
                 span.setAttribute('foundExplores', !!explores.length);
-                return explores.map(({ explore }) =>
-                    ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
-                        explore,
-                    ),
+                return explores.reduce<Record<string, Explore | ExploreError>>(
+                    (acc, { explore }) => {
+                        acc[explore.name] =
+                            ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
+                                explore,
+                            );
+                        return acc;
+                    },
+                    {},
                 );
             },
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -56,6 +56,9 @@ const projectModel = {
     updateTablesConfiguration: jest.fn(),
     getExploresFromCache: jest.fn(async () => allExplores),
     getExploreFromCache: jest.fn(async () => validExplore),
+    findExploresFromCache: jest.fn(async () => ({
+        [validExplore.name]: validExplore,
+    })),
     lockProcess: jest.fn((projectUuid, fun) => fun()),
     getWarehouseCredentialsForProject: jest.fn(
         async () => warehouseClientMock.credentials,
@@ -157,7 +160,7 @@ describe('ProjectService', () => {
                 user,
                 metricQueryMock,
                 projectUuid,
-                'table1',
+                'valid_explore',
                 null,
             );
             expect(result).toEqual(expectedApiQueryResultsWith1Row);
@@ -176,7 +179,7 @@ describe('ProjectService', () => {
                 user,
                 metricQueryMock,
                 projectUuid,
-                'table1',
+                'valid_explore',
                 null,
             );
             expect(result).toEqual(expectedApiQueryResultsWith501Rows);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2456,54 +2456,103 @@ export class ProjectService extends BaseService {
             },
             async () =>
                 wrapOtelSpan('ProjectService.getExplore', {}, async () => {
-                    const project = organizationUuid
-                        ? { organizationUuid }
-                        : await this.projectModel.getSummary(projectUuid);
-                    if (
-                        user.ability.cannot(
-                            'view',
-                            subject('Project', {
-                                organizationUuid: project.organizationUuid,
-                                projectUuid,
-                            }),
-                        )
-                    ) {
-                        throw new ForbiddenError();
-                    }
-                    const explore = await this.projectModel.getExploreFromCache(
+                    const exploresMap = await this.findExplores({
+                        user,
                         projectUuid,
-                        exploreName,
-                    );
+                        exploreNames: [exploreName],
+                        organizationUuid,
+                    });
+                    const explore = exploresMap[exploreName];
 
-                    if (isExploreError(explore)) {
+                    if (!explore) {
                         throw new NotExistsError(
                             `Explore "${exploreName}" does not exist.`,
                         );
                     }
-
-                    const shouldFilterExplore = await wrapOtelSpan(
-                        'ProjectService.getExplore.shouldFilterExplore',
-                        {},
-                        async () => exploreHasFilteredAttribute(explore),
-                    );
-
-                    if (!shouldFilterExplore) {
-                        return explore;
+                    if (isExploreError(explore)) {
+                        throw new NotExistsError(
+                            `Explore "${exploreName}" has an error.`,
+                        );
                     }
-                    const userAttributes =
-                        await this.userAttributesModel.getAttributeValuesForOrgMember(
-                            {
-                                organizationUuid: project.organizationUuid,
-                                userUuid: user.userUuid,
-                            },
+                    return explore;
+                }),
+        );
+    }
+
+    private async findExplores({
+                                   user,
+                                   projectUuid,
+                                   exploreNames,
+                                   organizationUuid,
+                               }: {
+        user: SessionUser;
+        projectUuid: string;
+        exploreNames: string[];
+        organizationUuid?: string;
+    }): Promise<Record<string, Explore | ExploreError>> {
+        return Sentry.startSpan(
+            {
+                op: 'ProjectService.getExplore',
+                name: 'ProjectService.getExplore',
+            },
+            async () =>
+                wrapOtelSpan(
+                    'ProjectService.findExplores',
+                    {
+                        projectUuid,
+                        exploreNames,
+                        organizationUuid,
+                    },
+                    async () => {
+                        const project = organizationUuid
+                            ? {organizationUuid}
+                            : await this.projectModel.getSummary(projectUuid);
+                        if (
+                            user.ability.cannot(
+                                'view',
+                                subject('Project', {
+                                    organizationUuid: project.organizationUuid,
+                                    projectUuid,
+                                }),
+                            )
+                        ) {
+                            throw new ForbiddenError();
+                        }
+                        const explores = await this.projectModel.findExploresFromCache(
+                            projectUuid,
+                            exploreNames,
                         );
 
-                    return wrapOtelSpan(
-                        'ProjectService.getExplore.getFilteredExplore',
-                        {},
-                        async () => getFilteredExplore(explore, userAttributes),
-                    );
-                }),
+                        const userAttributes =
+                            await this.userAttributesModel.getAttributeValuesForOrgMember(
+                                {
+                                    organizationUuid: project.organizationUuid,
+                                    userUuid: user.userUuid,
+                                },
+                            );
+
+                        return explores.reduce<Record<string, Explore | ExploreError>>(
+                            (acc, explore) => {
+                                if (isExploreError(explore)) {
+                                    acc[explore.name] = explore;
+                                } else {
+                                    const shouldFilterExplore =
+                                        exploreHasFilteredAttribute(explore);
+                                    if (!shouldFilterExplore) {
+                                        acc[explore.name] = explore;
+                                    } else {
+                                        acc[explore.name] = getFilteredExplore(
+                                            explore,
+                                            userAttributes,
+                                        );
+                                    }
+                                }
+                                return acc;
+                            },
+                            {},
+                        );
+                    },
+                )
         );
     }
 
@@ -2669,42 +2718,29 @@ export class ProjectService extends BaseService {
                 const uniqueSpaceUuids = [
                     ...new Set(savedCharts.map((chart) => chart.spaceUuid)),
                 ];
-                const exploreCacheKeys: Record<string, boolean> = {};
-                const exploreCache: Record<string, Explore> = {};
 
-                const explorePromises = savedCharts.reduce<
-                    Promise<{ key: string; explore: Explore }>[]
-                >((acc, chart) => {
-                    const key = chart.tableName;
-                    if (!exploreCacheKeys[key]) {
-                        acc.push(
-                            this.getExplore(user, chart.projectUuid, key).then(
-                                (explore) => ({ key, explore }),
+                if (savedCharts.length === 0) {
+                    return [];
+                }
+
+                const [spaceAccessMap, exploresMap, userSpacesAccess] =
+                    await Promise.all([
+                        this.spaceModel.getSpacesForAccessCheck(uniqueSpaceUuids),
+                        this.findExplores({
+                            user,
+                            projectUuid: savedCharts[0].projectUuid, // TODO: route should be updated to be project/dashboard specific. For now we pick it from first chart as they all should be from the same project
+                            exploreNames: savedCharts.map(
+                                (chart) => chart.tableName,
                             ),
-                        );
-                        exploreCacheKeys[key] = true;
-                    }
-                    return acc;
-                }, []);
+                        }),
+                        this.spaceModel.getUserSpacesAccess(
+                            user.userUuid,
+                            uniqueSpaceUuids,
+                        ),
+                    ]);
 
-                const [spaceAccessMap, resolvedExplores] = await Promise.all([
-                    this.spaceModel.getSpacesForAccessCheck(uniqueSpaceUuids),
-                    Promise.all(explorePromises),
-                ]);
-                const userSpacesAccess =
-                    await this.spaceModel.getUserSpacesAccess(
-                        user.userUuid,
-                        uniqueSpaceUuids,
-                    );
-
-                resolvedExplores.forEach(({ key, explore }) => {
-                    exploreCache[key] = explore;
-                });
-
-                const filterPromises = savedCharts.map(async (savedChart) => {
-                    const spaceAccess = spaceAccessMap.get(
-                        savedChart.spaceUuid,
-                    );
+                return savedCharts.map((savedChart) => {
+                    const spaceAccess = spaceAccessMap.get(savedChart.spaceUuid);
 
                     if (
                         user.ability.cannot(
@@ -2718,20 +2754,21 @@ export class ProjectService extends BaseService {
                             }),
                         )
                     ) {
-                        return { uuid: savedChart.uuid, filters: [] };
+                        return {uuid: savedChart.uuid, filters: []};
                     }
 
-                    const explore = exploreCache[savedChart.tableName];
+                    const explore = exploresMap[savedChart.tableName];
 
-                    const filters = getDimensions(explore).filter(
-                        (field) =>
-                            isFilterableDimension(field) && !field.hidden,
-                    );
+                    let filters: CompiledDimension[] = [];
+                    if (explore && !isExploreError(explore)) {
+                        filters = getDimensions(explore).filter(
+                            (field) =>
+                                isFilterableDimension(field) && !field.hidden,
+                        );
+                    }
 
-                    return { uuid: savedChart.uuid, filters };
+                    return {uuid: savedChart.uuid, filters};
                 });
-
-                return Promise.all(filterPromises);
             },
         );
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2505,7 +2505,7 @@ export class ProjectService extends BaseService {
                     },
                     async () => {
                         const project = organizationUuid
-                            ? {organizationUuid}
+                            ? { organizationUuid }
                             : await this.projectModel.getSummary(projectUuid);
                         if (
                             user.ability.cannot(
@@ -2531,26 +2531,25 @@ export class ProjectService extends BaseService {
                                 },
                             );
 
-                        return explores.reduce<Record<string, Explore | ExploreError>>(
-                            (acc, explore) => {
-                                if (isExploreError(explore)) {
+                        return Object.values(explores).reduce<
+                            Record<string, Explore | ExploreError>
+                        >((acc, explore) => {
+                            if (isExploreError(explore)) {
+                                acc[explore.name] = explore;
+                            } else {
+                                const shouldFilterExplore =
+                                    exploreHasFilteredAttribute(explore);
+                                if (!shouldFilterExplore) {
                                     acc[explore.name] = explore;
                                 } else {
-                                    const shouldFilterExplore =
-                                        exploreHasFilteredAttribute(explore);
-                                    if (!shouldFilterExplore) {
-                                        acc[explore.name] = explore;
-                                    } else {
-                                        acc[explore.name] = getFilteredExplore(
-                                            explore,
-                                            userAttributes,
-                                        );
-                                    }
+                                    acc[explore.name] = getFilteredExplore(
+                                        explore,
+                                        userAttributes,
+                                    );
                                 }
-                                return acc;
-                            },
-                            {},
-                        );
+                            }
+                            return acc;
+                        }, {});
                     },
                 )
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2734,6 +2734,7 @@ export class ProjectService extends BaseService {
                             exploreNames: savedCharts.map(
                                 (chart) => chart.tableName,
                             ),
+                            organizationUuid: user.organizationUuid,
                         }),
                         this.spaceModel.getUserSpacesAccess(
                             user.userUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2480,11 +2480,11 @@ export class ProjectService extends BaseService {
     }
 
     private async findExplores({
-                                   user,
-                                   projectUuid,
-                                   exploreNames,
-                                   organizationUuid,
-                               }: {
+        user,
+        projectUuid,
+        exploreNames,
+        organizationUuid,
+    }: {
         user: SessionUser;
         projectUuid: string;
         exploreNames: string[];
@@ -2492,8 +2492,8 @@ export class ProjectService extends BaseService {
     }): Promise<Record<string, Explore | ExploreError>> {
         return Sentry.startSpan(
             {
-                op: 'ProjectService.getExplore',
-                name: 'ProjectService.getExplore',
+                op: 'ProjectService.findExplores',
+                name: 'ProjectService.findExplores',
             },
             async () =>
                 wrapOtelSpan(
@@ -2518,10 +2518,11 @@ export class ProjectService extends BaseService {
                         ) {
                             throw new ForbiddenError();
                         }
-                        const explores = await this.projectModel.findExploresFromCache(
-                            projectUuid,
-                            exploreNames,
-                        );
+                        const explores =
+                            await this.projectModel.findExploresFromCache(
+                                projectUuid,
+                                exploreNames,
+                            );
 
                         const userAttributes =
                             await this.userAttributesModel.getAttributeValuesForOrgMember(
@@ -2551,7 +2552,7 @@ export class ProjectService extends BaseService {
                             return acc;
                         }, {});
                     },
-                )
+                ),
         );
     }
 
@@ -2724,7 +2725,9 @@ export class ProjectService extends BaseService {
 
                 const [spaceAccessMap, exploresMap, userSpacesAccess] =
                     await Promise.all([
-                        this.spaceModel.getSpacesForAccessCheck(uniqueSpaceUuids),
+                        this.spaceModel.getSpacesForAccessCheck(
+                            uniqueSpaceUuids,
+                        ),
                         this.findExplores({
                             user,
                             projectUuid: savedCharts[0].projectUuid, // TODO: route should be updated to be project/dashboard specific. For now we pick it from first chart as they all should be from the same project
@@ -2739,7 +2742,9 @@ export class ProjectService extends BaseService {
                     ]);
 
                 return savedCharts.map((savedChart) => {
-                    const spaceAccess = spaceAccessMap.get(savedChart.spaceUuid);
+                    const spaceAccess = spaceAccessMap.get(
+                        savedChart.spaceUuid,
+                    );
 
                     if (
                         user.ability.cannot(
@@ -2753,7 +2758,7 @@ export class ProjectService extends BaseService {
                             }),
                         )
                     ) {
-                        return {uuid: savedChart.uuid, filters: []};
+                        return { uuid: savedChart.uuid, filters: [] };
                     }
 
                     const explore = exploresMap[savedChart.tableName];
@@ -2766,7 +2771,7 @@ export class ProjectService extends BaseService {
                         );
                     }
 
-                    return {uuid: savedChart.uuid, filters};
+                    return { uuid: savedChart.uuid, filters };
                 });
             },
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Query all explores in 1 query (removes n+1 query)

There is a separate [tech debt ticket](https://github.com/lightdash/lightdash/issues/10384) to replace all the old model methods with the new one.


test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
