### PR TITLE
fix: focus password input in login page

### DIFF
--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -208,6 +208,7 @@ const Login: FC<{}> = () => {
                                     name="password"
                                     placeholder="Your password"
                                     required
+                                    autoFocus
                                     {...form.getInputProps('password')}
                                     disabled={disableControls}
                                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixes keyboard navigation in the login page. Now when email is entered and the PW box shows, the pw box will be focussed. 

Before:
![before](https://github.com/lightdash/lightdash/assets/1864179/746fe68d-4f52-44f9-8e06-66e1e3704ed7)

After:
![after](https://github.com/lightdash/lightdash/assets/1864179/fd57834a-483e-4cfd-9eb9-91442c723bfb)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
