### PR TITLE
fix: check no_changes on promote content

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1094,7 +1094,7 @@ export class SavedChartModel {
         spaceUuids?: string[];
         slug?: string;
         exploreName?: string;
-    }): Promise<ChartSummary[]> {
+    }): Promise<(ChartSummary & { updatedAt: Date })[]> {
         return Sentry.startSpan(
             {
                 op: 'SavedChartModel.find',
@@ -1154,6 +1154,7 @@ export class SavedChartModel {
                 chartKind: 'saved_queries.last_version_chart_kind',
                 dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
                 dashboardName: `${DashboardsTableName}.name`,
+                updatedAt: `saved_queries.last_version_updated_at`,
             })
             .leftJoin(
                 DashboardsTableName,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -727,27 +727,23 @@ export class PromoteService extends BaseService {
             throw new NotFoundError(
                 'This chart does not have an upstream project',
             );
-        try {
-            const { promotedDashboard, upstreamDashboard } =
-                await this.getPromotedDashboard(
-                    user,
-                    dashboard,
-                    upstreamProjectUuid,
-                );
 
-            // We're going to be updating this structure with new UUIDs if we need to create the items (eg: spaces)
-            const [promotionChanges, promotedCharts] =
-                await this.getPromotionDashboardChanges(
-                    user,
-                    promotedDashboard,
-                    upstreamDashboard,
-                );
+        const { promotedDashboard, upstreamDashboard } =
+            await this.getPromotedDashboard(
+                user,
+                dashboard,
+                upstreamProjectUuid,
+            );
 
-            return promotionChanges;
-        } catch (e) {
-            console.error(e);
-            throw e;
-        }
+        // We're going to be updating this structure with new UUIDs if we need to create the items (eg: spaces)
+        const [promotionChanges, promotedCharts] =
+            await this.getPromotionDashboardChanges(
+                user,
+                promotedDashboard,
+                upstreamDashboard,
+            );
+
+        return promotionChanges;
     }
 
     private static getSpaceBySlug(

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1126,6 +1126,8 @@ export class PromoteService extends BaseService {
         );
 
         // TODO return charts within dashboards that are going to be deleted after the promotion
+        // For this we'll need to get all the tiles for the upstreamDashboard and compare against the promotedDashboard.tiles
+
         return [
             {
                 spaces: spaceChanges,

--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -113,9 +113,9 @@ export const PromotionConfirmDialog: FC<Props> = ({
     onConfirm,
     onClose,
 }) => {
-    const groupedChanges = useMemo(() => {
-        if (promotionChanges === undefined) return undefined;
-        return {
+    const { groupedChanges, totalChanges, withoutChanges } = useMemo(() => {
+        if (promotionChanges === undefined) return {};
+        const changes = {
             spaces: {
                 total: promotionChanges.spaces.filter(
                     (item) => item.action !== PromotionAction.NO_CHANGES,
@@ -159,6 +159,26 @@ export const PromotionConfirmDialog: FC<Props> = ({
                     (item) => item.action === PromotionAction.DELETE,
                 ),
             },
+        };
+        const totalChangesNum =
+            changes.spaces.total +
+            changes.charts.total +
+            changes.dashboards.total;
+        const withoutChangesNum =
+            promotionChanges.spaces.filter(
+                (item) => item.action === PromotionAction.NO_CHANGES,
+            ).length +
+            promotionChanges.dashboards.filter(
+                (item) => item.action === PromotionAction.NO_CHANGES,
+            ).length +
+            promotionChanges.charts.filter(
+                (item) => item.action === PromotionAction.NO_CHANGES,
+            ).length;
+
+        return {
+            groupedChanges: changes,
+            totalChanges: totalChangesNum,
+            withoutChanges: withoutChangesNum,
         };
     }, [promotionChanges]);
 
@@ -235,6 +255,18 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 />
                             </>
                         )}
+
+                        {totalChanges === 0 && (
+                            <Text color="yellow.9" fw={600}>
+                                No changes to promote
+                            </Text>
+                        )}
+                        {totalChanges !== 0 && withoutChanges > 0 && (
+                            <Text color="yellow.9" fw={600}>
+                                We only promote content that is more recent in
+                                this project.
+                            </Text>
+                        )}
                     </Stack>
                 )}
                 <Group position="right" mt="sm">
@@ -244,6 +276,7 @@ export const PromotionConfirmDialog: FC<Props> = ({
 
                     <Button
                         color="green"
+                        disabled={totalChanges === 0}
                         onClick={() => {
                             onConfirm();
                             onClose();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/10370

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Chart promote with space name change but no new chart version

![Screenshot from 2024-06-13 12-10-24](https://github.com/lightdash/lightdash/assets/1983672/7210c505-bd71-4e69-b660-7b14e9a8f5ea)

Dashboard promote without chart changes 
![Screenshot from 2024-06-13 11-06-26](https://github.com/lightdash/lightdash/assets/1983672/1a16285d-f572-4acf-81cf-9dba7591ace7)

No changes on chart promote 

![Screenshot from 2024-06-13 10-51-12](https://github.com/lightdash/lightdash/assets/1983672/a6b570cd-91e7-4174-8be8-4023d6b5da8f)

### Limitations

- Dashboard don't have updated_at so we assume they are always updated (existing behaviour) 
- We only promote for charts if promotedChart.updatedAt > upstreamChart.updatedAt or name/description changes. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
