### PR TITLE
fix: date dimension groups

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -17,7 +17,6 @@ import {
     DimensionType,
     FieldType,
     friendlyName,
-    intervalGroupFriendlyName,
     MetricType,
     parseMetricType,
     type Dimension,
@@ -117,7 +116,8 @@ const convertDimension = (
     }
     const isIntervalBase =
         timeInterval === undefined && isInterval(type, column);
-    let timeIntervalBaseDimensionName;
+
+    let timeIntervalBaseDimensionName: string | undefined;
     const groups: string[] = convertToGroups(
         column.meta.dimension?.groups,
         column.meta.dimension?.group_label,
@@ -135,9 +135,12 @@ const convertDimension = (
         label = `${label} ${timeFrameConfigs[timeInterval]
             .getLabel()
             .toLowerCase()}`;
+
         groups.push(
-            column.meta.dimension?.label || intervalGroupFriendlyName(name),
+            column.meta.dimension?.label ??
+                friendlyName(timeIntervalBaseDimensionName),
         );
+
         type = timeFrameConfigs[timeInterval].getDimensionType(type);
     }
     return {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -514,9 +514,3 @@ export const friendlyName = (text: string): string => {
     const result = normalizedParts.join(' ');
     return capitalize(result);
 };
-
-export const intervalGroupFriendlyName = (text: string): string => {
-    const words = friendlyName(text).split(' ');
-    words.pop();
-    return words.join(' ');
-};


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/10348

### Description:

1. without groups
![3-without-groups-and-custom-labels](https://github.com/lightdash/lightdash/assets/962095/c7eb477c-6c0c-44f5-9cd1-0f243257575a)

---

2. using groups and custom label
![4-collapsed](https://github.com/lightdash/lightdash/assets/962095/4891b9a0-0298-4a7c-89b9-ec22a71dc922)
![4-open](https://github.com/lightdash/lightdash/assets/962095/25f2ca29-3252-4954-bd07-93bd3ac71a75)
![4-zzz-d1](https://github.com/lightdash/lightdash/assets/962095/dafc2885-246d-43c3-b9ee-9d38af509fe8)

---

3. deprecated group label - 2 separate groups
![1-collapsed](https://github.com/lightdash/lightdash/assets/962095/6df5048f-71d3-4131-a421-fe0486d4efc7)
![1-open](https://github.com/lightdash/lightdash/assets/962095/f7a757ed-32cf-4f0a-949c-ba2bfcc68432)
![1-zzz-d1](https://github.com/lightdash/lightdash/assets/962095/be6833f1-beb8-4f75-a082-c5400df399a2)
![1-zzz-d2](https://github.com/lightdash/lightdash/assets/962095/75aa7a49-3aeb-4d03-bbae-0d3f15298466)



---

4. one in a group - one without a group
![2-open](https://github.com/lightdash/lightdash/assets/962095/f8a84725-fc4e-448e-908a-2b5c10a0c996)
![2-open2](https://github.com/lightdash/lightdash/assets/962095/c8a8b994-1df7-478d-890a-f810ad508065)
![2-zzz-d1](https://github.com/lightdash/lightdash/assets/962095/6ffa8be4-e34c-4a90-804a-156ddd964188)
![2-zzz-d2](https://github.com/lightdash/lightdash/assets/962095/ebbe7af8-1cea-403e-bf16-a62f2e48025c)
![2-collapsed](https://github.com/lightdash/lightdash/assets/962095/34242fa0-d8e0-4c81-af78-79b97c86987b)

---

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
