### PR TITLE
fix: list private channels that the app has joined

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -83,7 +83,7 @@ export class SlackClient {
                 const conversations: ConversationsListResponse =
                     // eslint-disable-next-line no-await-in-loop
                     await webClient.conversations.list({
-                        types: 'public_channel',
+                        types: 'public_channel,private_channel',
                         limit: 900,
                         cursor: nextCursor,
                     });

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -18,6 +18,7 @@ export const slackRequiredScopes = [
     'chat:write.customize',
     'channels:read',
     'channels:join',
+    'groups:read',
     'users:read',
     'files:write',
     'files:read',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#257](https://github.com/lightdash/lightdash-commercial/issues/257)

Information about the new scope: https://api.slack.com/scopes/groups:read

### Description:

- Allows slack app to notify and list private channels that it has been added to


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
