### PR TITLE
fix: do not add daily jobs for disabled schedulers

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -401,6 +401,7 @@ export class SchedulerClient {
     async generateDailyJobsForScheduler(
         scheduler: SchedulerAndTargets,
     ): Promise<void> {
+        if (scheduler.enabled === false) return; // Do not add jobs for disabled schedulers
         const dates = getDailyDatesFromCron(scheduler.cron);
         try {
             const promises = dates.map((date: Date) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #10429

### Description:

Now we automatically disable some schedulers that are throwing non retriable , so we're throwing more errors of this type.
<!-- Add a description of the changes proposed in the pull request. -->
![image](https://github.com/lightdash/lightdash/assets/1983672/3457fd85-bc8c-4128-9a55-53a161c74957)

Before:
![image](https://github.com/lightdash/lightdash/assets/1983672/1083ec30-9d26-447d-a53b-70811d53293c)

![Screenshot from 2024-06-17 09-38-40](https://github.com/lightdash/lightdash/assets/1983672/8885b556-02a4-4770-8138-05d2bc81972e)

Now:

``
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
