### PR TITLE
fix: undefined error when threshold doesnt have enough results

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.mock.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.mock.ts
@@ -1,0 +1,28 @@
+import { ThresholdOperator, ThresholdOptions } from '@lightdash/common';
+
+export const thresholdLessThanMock: ThresholdOptions = {
+    operator: ThresholdOperator.LESS_THAN,
+    fieldId: 'revenue',
+    value: 1000,
+};
+
+export const thresholdIncreasedByMock: ThresholdOptions = {
+    operator: ThresholdOperator.INCREASED_BY,
+    fieldId: 'revenue',
+    value: 0.01,
+};
+
+export const resultsWithOneRow = [
+    {
+        revenue: 100,
+    },
+];
+
+export const resultsWithTwoRows = [
+    {
+        revenue: 1000,
+    },
+    {
+        revenue: 100,
+    },
+];

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1,0 +1,41 @@
+import SchedulerTask from './SchedulerTask';
+import {
+    resultsWithOneRow,
+    resultsWithTwoRows,
+    thresholdIncreasedByMock,
+    thresholdLessThanMock,
+} from './SchedulerTask.mock';
+
+describe('isPositiveThresholdAlert', () => {
+    it('should return false if there are no results or no thresholds', () => {
+        expect(
+            SchedulerTask.isPositiveThresholdAlert([thresholdLessThanMock], []),
+        ).toBe(false);
+
+        expect(
+            SchedulerTask.isPositiveThresholdAlert([], resultsWithOneRow),
+        ).toBe(false);
+    });
+    it('should return false if operation requires second row but there isnt one', () => {
+        expect(
+            SchedulerTask.isPositiveThresholdAlert(
+                [thresholdIncreasedByMock],
+                resultsWithOneRow,
+            ),
+        ).toBe(false);
+    });
+    it('should return true if condition match', () => {
+        expect(
+            SchedulerTask.isPositiveThresholdAlert(
+                [thresholdLessThanMock],
+                resultsWithOneRow,
+            ),
+        ).toBe(true);
+        expect(
+            SchedulerTask.isPositiveThresholdAlert(
+                [thresholdIncreasedByMock],
+                resultsWithTwoRows,
+            ),
+        ).toBe(true);
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1177,8 +1177,10 @@ export default class SchedulerTask {
         thresholds: ThresholdOptions[],
         results: Record<string, any>[],
     ): boolean {
+        if (thresholds.length < 1 || results.length < 1) {
+            return false;
+        }
         const { fieldId, operator, value: thresholdValue } = thresholds[0];
-
         const firstResult = results[0][fieldId];
         if (firstResult === undefined) {
             throw new Error(
@@ -1193,7 +1195,7 @@ export default class SchedulerTask {
                 return firstValue < thresholdValue;
             case ThresholdOperator.INCREASED_BY:
             case ThresholdOperator.DECREASED_BY:
-                const secondValue = parseFloat(results[1][fieldId]);
+                const secondValue = parseFloat(results[1]?.[fieldId]);
                 const increase = firstValue - secondValue;
                 if (operator === ThresholdOperator.INCREASED_BY) {
                     return thresholdValue < increase / (secondValue * 100);


### PR DESCRIPTION
### Description:

Scheduler job errors when threshold condition doesn't have results.
 
Changes:
- add condition to check amount of rows and thresholds
- handle possible undefined second row
- add test

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
