### PR TITLE
fix: show start of the week CLI option in project settings

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/Inputs/StartOfWeekSelect.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/Inputs/StartOfWeekSelect.tsx
@@ -1,6 +1,8 @@
-import { Select } from '@mantine/core';
+import { Alert, Select } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { Controller } from 'react-hook-form';
+import MantineIcon from '../../../common/MantineIcon';
 
 const daysOfWeekOptions = [
     'Monday',
@@ -12,24 +14,49 @@ const daysOfWeekOptions = [
     'Sunday',
 ].map((x, index) => ({ value: index.toString(), label: x }));
 
-const StartOfWeekSelect: FC<{ disabled: boolean }> = ({ disabled }) => {
+const StartOfWeekSelect: FC<{
+    disabled: boolean;
+    isRedeployRequired?: boolean;
+}> = ({ disabled, isRedeployRequired = true }) => {
     return (
         <Controller
             name="warehouse.startOfWeek"
             render={({ field }) => (
-                <Select
-                    clearable
-                    placeholder="Auto"
-                    label="Start of week"
-                    description="Will be taken into account when using 'WEEK' time interval"
-                    data={daysOfWeekOptions}
-                    value={field.value?.toString()}
-                    onChange={(value) =>
-                        field.onChange(value ? parseInt(value) : null)
-                    }
-                    disabled={disabled}
-                    dropdownPosition="top"
-                />
+                <>
+                    <Select
+                        clearable
+                        placeholder="Auto"
+                        label="Start of week"
+                        description="Will be taken into account when using 'WEEK' time interval"
+                        data={daysOfWeekOptions}
+                        value={field.value?.toString()}
+                        onChange={(value) =>
+                            field.onChange(value ? parseInt(value) : null)
+                        }
+                        disabled={disabled}
+                        dropdownPosition="top"
+                    />
+                    {isRedeployRequired && parseInt(field.value) >= 0 && (
+                        <Alert
+                            icon={
+                                <MantineIcon
+                                    icon={IconInfoCircle}
+                                    size={'md'}
+                                />
+                            }
+                            title="Required CLI option"
+                            color="blue"
+                        >
+                            Going forward, if you use the CLI to deploy the
+                            project, you will need to run the deploy command
+                            with the option{' '}
+                            <b>
+                                <code>--start-of-week={field.value}</code>
+                            </b>
+                            , for the changes to take effect.
+                        </Alert>
+                    )}
+                </>
             )}
         />
     );

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -224,7 +224,10 @@ const SnowflakeForm: FC<{
                                 },
                             })}
                         />
-                        <StartOfWeekSelect disabled={disabled} />
+                        <StartOfWeekSelect
+                            disabled={disabled}
+                            isRedeployRequired={false}
+                        />
                     </Stack>
                 </FormSection>
                 <FormCollapseButton isSectionOpen={isOpen} onClick={toggleOpen}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#8465](https://github.com/lightdash/lightdash/issues/8465)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
<!-- Even better add a screenshot / gif / loom -->

Changes:
- add alert in project settings about required CLI option.
- don't show alert for snowflake as it doesn't need it

<img width="432" alt="Screenshot 2024-06-17 at 14 02 33" src="https://github.com/lightdash/lightdash/assets/9117144/9b617882-7d93-4dd5-b519-ecfea214403b">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
