### PR TITLE
fix: custom metric date max format

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -778,6 +778,7 @@ const models: TsoaRoute.Models = {
             target: { ref: 'DashboardFieldTarget', required: true },
             settings: { dataType: 'any' },
             disabled: { dataType: 'boolean' },
+            required: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -800,7 +801,6 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        required: { dataType: 'boolean' },
                         label: {
                             dataType: 'union',
                             subSchemas: [
@@ -1058,6 +1058,7 @@ const models: TsoaRoute.Models = {
             target: { ref: 'FieldTarget', required: true },
             settings: { dataType: 'any' },
             disabled: { dataType: 'boolean' },
+            required: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -1130,7 +1131,15 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CustomFormatType: {
         dataType: 'refEnum',
-        enums: ['default', 'percent', 'currency', 'number', 'id'],
+        enums: [
+            'default',
+            'percent',
+            'currency',
+            'number',
+            'id',
+            'date',
+            'timestamp',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     NumberSeparator: {
@@ -1173,6 +1182,34 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TimeFrames: {
+        dataType: 'refEnum',
+        enums: [
+            'RAW',
+            'YEAR',
+            'QUARTER',
+            'MONTH',
+            'WEEK',
+            'DAY',
+            'HOUR',
+            'MINUTE',
+            'SECOND',
+            'MILLISECOND',
+            'DAY_OF_WEEK_INDEX',
+            'DAY_OF_MONTH_NUM',
+            'DAY_OF_YEAR_NUM',
+            'WEEK_NUM',
+            'MONTH_NUM',
+            'QUARTER_NUM',
+            'YEAR_NUM',
+            'DAY_OF_WEEK_NAME',
+            'MONTH_NAME',
+            'QUARTER_NAME',
+            'HOUR_OF_DAY_NUM',
+            'MINUTE_OF_HOUR_NUM',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CustomFormat: {
         dataType: 'refObject',
         properties: {
@@ -1201,6 +1238,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'union',
                 subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
             },
+            timeInterval: { ref: 'TimeFrames' },
         },
         additionalProperties: true,
     },
@@ -1265,6 +1303,7 @@ const models: TsoaRoute.Models = {
             },
             settings: { dataType: 'any' },
             disabled: { dataType: 'boolean' },
+            required: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -2507,6 +2546,10 @@ const models: TsoaRoute.Models = {
                     ref: 'Record_string.string-or-string-Array_',
                 },
                 hidden: { dataType: 'boolean' },
+                requiredFilters: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'MetricFilterRule' },
+                },
                 sqlWhere: { dataType: 'string' },
                 groupLabel: { dataType: 'string' },
                 orderFieldsBy: { ref: 'OrderFieldsByStrategy' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -736,6 +736,9 @@
                     "settings": {},
                     "disabled": {
                         "type": "boolean"
+                    },
+                    "required": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -754,9 +757,6 @@
                     },
                     {
                         "properties": {
-                            "required": {
-                                "type": "boolean"
-                            },
                             "label": {
                                 "type": "string"
                             },
@@ -1071,6 +1071,9 @@
                     "settings": {},
                     "disabled": {
                         "type": "boolean"
+                    },
+                    "required": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -1144,7 +1147,15 @@
                 "type": "object"
             },
             "CustomFormatType": {
-                "enum": ["default", "percent", "currency", "number", "id"],
+                "enum": [
+                    "default",
+                    "percent",
+                    "currency",
+                    "number",
+                    "id",
+                    "date",
+                    "timestamp"
+                ],
                 "type": "string"
             },
             "NumberSeparator": {
@@ -1181,6 +1192,33 @@
                     }
                 ]
             },
+            "TimeFrames": {
+                "enum": [
+                    "RAW",
+                    "YEAR",
+                    "QUARTER",
+                    "MONTH",
+                    "WEEK",
+                    "DAY",
+                    "HOUR",
+                    "MINUTE",
+                    "SECOND",
+                    "MILLISECOND",
+                    "DAY_OF_WEEK_INDEX",
+                    "DAY_OF_MONTH_NUM",
+                    "DAY_OF_YEAR_NUM",
+                    "WEEK_NUM",
+                    "MONTH_NUM",
+                    "QUARTER_NUM",
+                    "YEAR_NUM",
+                    "DAY_OF_WEEK_NAME",
+                    "MONTH_NAME",
+                    "QUARTER_NAME",
+                    "HOUR_OF_DAY_NUM",
+                    "MINUTE_OF_HOUR_NUM"
+                ],
+                "type": "string"
+            },
             "CustomFormat": {
                 "properties": {
                     "type": {
@@ -1204,6 +1242,9 @@
                     },
                     "suffix": {
                         "type": "string"
+                    },
+                    "timeInterval": {
+                        "$ref": "#/components/schemas/TimeFrames"
                     }
                 },
                 "required": ["type"],
@@ -1284,6 +1325,9 @@
                     },
                     "settings": {},
                     "disabled": {
+                        "type": "boolean"
+                    },
+                    "required": {
                         "type": "boolean"
                     }
                 },
@@ -2699,6 +2743,12 @@
                     },
                     "hidden": {
                         "type": "boolean"
+                    },
+                    "requiredFilters": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricFilterRule"
+                        },
+                        "type": "array"
                     },
                     "sqlWhere": {
                         "type": "string"
@@ -7817,7 +7867,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1129.1",
+        "version": "0.1133.10",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -160,6 +160,7 @@ export interface CustomFormat {
     compact?: CompactOrAlias | undefined;
     prefix?: string | undefined;
     suffix?: string | undefined;
+    timeInterval?: TimeFrames;
 }
 
 export enum CustomFormatType {
@@ -168,6 +169,8 @@ export enum CustomFormatType {
     CURRENCY = 'currency',
     NUMBER = 'number',
     ID = 'id',
+    DATE = 'date',
+    TIMESTAMP = 'timestamp',
 }
 
 export enum TableCalculationType {

--- a/packages/common/src/utils/formatting.mock.ts
+++ b/packages/common/src/utils/formatting.mock.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     FieldType,
     MetricType,
+    type AdditionalMetric,
     type Dimension,
     type Metric,
     type TableCalculation,
@@ -31,4 +32,9 @@ export const tableCalculation: TableCalculation = {
     name: 'name',
     displayName: 'displayName',
     sql: 'sql',
+};
+
+export const additionalMetric: AdditionalMetric = {
+    ...metric,
+    type: MetricType.COUNT,
 };

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -18,7 +18,12 @@ import {
     getCustomFormatFromLegacy,
     isMomentInput,
 } from './formatting';
-import { dimension, metric, tableCalculation } from './formatting.mock';
+import {
+    additionalMetric,
+    dimension,
+    metric,
+    tableCalculation,
+} from './formatting.mock';
 
 describe('Formatting', () => {
     describe('convert legacy Format type', () => {
@@ -811,6 +816,112 @@ describe('Formatting', () => {
                     1000,
                 ),
             ).toEqual('1K');
+        });
+    });
+    describe('additional metric formatting', () => {
+        test('format additional metric with custom format DATE', () => {
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MIN,
+                        formatOptions: { type: CustomFormatType.DATE },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10');
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MAX,
+                        formatOptions: {
+                            type: CustomFormatType.DATE,
+                            timeInterval: TimeFrames.DAY,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10');
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MIN,
+                        formatOptions: {
+                            type: CustomFormatType.DATE,
+                            timeInterval: TimeFrames.YEAR,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021');
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MAX,
+                        formatOptions: {
+                            type: CustomFormatType.DATE,
+                            timeInterval: TimeFrames.MONTH,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03');
+        });
+
+        test('format additional metric with custom format TIMESTAMP', () => {
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MIN,
+                        formatOptions: { type: CustomFormatType.TIMESTAMP },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10, 00:00:00:000 (+00:00)');
+
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MAX,
+                        formatOptions: {
+                            type: CustomFormatType.TIMESTAMP,
+                            timeInterval: TimeFrames.HOUR,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10, 00 (+00:00)');
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MIN,
+                        formatOptions: {
+                            type: CustomFormatType.TIMESTAMP,
+                            timeInterval: TimeFrames.MINUTE,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10, 00:00 (+00:00)');
+            expect(
+                formatItemValue(
+                    {
+                        ...additionalMetric,
+                        type: MetricType.MAX,
+                        formatOptions: {
+                            type: CustomFormatType.TIMESTAMP,
+                            timeInterval: TimeFrames.SECOND,
+                        },
+                    },
+                    new Date('2021-03-10T00:00:00.000Z'),
+                ),
+            ).toEqual('2021-03-10, 00:00:00 (+00:00)');
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -336,10 +336,6 @@ export function applyCustomFormat(
 
     if (value === '') return '';
 
-    if (value instanceof Date) {
-        return formatTimestamp(value, undefined, false);
-    }
-
     if (valueIsNaN(value) || value === null) {
         return applyDefaultFormat(value);
     }
@@ -362,6 +358,10 @@ export function applyCustomFormat(
             ).replace(/\u00A0/, ' ');
 
             return `${currencyFormatted}${compactSuffix}`;
+        case CustomFormatType.DATE:
+            return formatDate(value, format?.timeInterval, false);
+        case CustomFormatType.TIMESTAMP:
+            return formatTimestamp(value, format?.timeInterval, false);
         case CustomFormatType.NUMBER:
             const prefix = format.prefix || '';
             const suffix = format.suffix || '';
@@ -396,6 +396,8 @@ export function formatItemValue(
     if (value === undefined) return '-';
 
     if (item) {
+        const customFormat = getCustomFormat(item);
+
         if (isCustomSqlDimension(item) || 'type' in item) {
             const type = getItemType(item);
             switch (type) {
@@ -429,7 +431,7 @@ export function formatItemValue(
                         : 'NaT';
                 case MetricType.MAX:
                 case MetricType.MIN:
-                    if (value instanceof Date) {
+                    if (value instanceof Date && customFormat === undefined) {
                         return formatTimestamp(
                             value,
                             isDimension(item) ? item.timeInterval : undefined,
@@ -450,7 +452,6 @@ export function formatItemValue(
             }
         }
 
-        const customFormat = getCustomFormat(item);
         return applyCustomFormat(value, customFormat);
     }
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -336,6 +336,15 @@ export function applyCustomFormat(
 
     if (value === '') return '';
 
+    if (
+        value instanceof Date &&
+        ![CustomFormatType.DATE, CustomFormatType.TIMESTAMP].includes(
+            format.type,
+        )
+    ) {
+        return formatTimestamp(value, undefined, false);
+    }
+
     if (valueIsNaN(value) || value === null) {
         return applyDefaultFormat(value);
     }

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -1,4 +1,5 @@
 import {
+    CustomFormatType,
     DimensionType,
     friendlyName,
     isAdditionalMetric,
@@ -84,31 +85,21 @@ const getTypeOverridesForAdditionalMetric = (
 
     switch (type) {
         case MetricType.MIN:
-            switch (item.type) {
-                case DimensionType.DATE:
-                    return {
-                        type: MetricType.DATE,
-                        sql: `MIN(${item.sql})`,
-                    };
-                case DimensionType.TIMESTAMP:
-                    return {
-                        type: MetricType.TIMESTAMP,
-                        sql: `MIN(${item.sql})`,
-                    };
-                default:
-                    return;
-            }
         case MetricType.MAX:
             switch (item.type) {
                 case DimensionType.DATE:
                     return {
-                        type: MetricType.DATE,
-                        sql: `MAX(${item.sql})`,
+                        formatOptions: {
+                            type: CustomFormatType.DATE,
+                            timeInterval: item.timeInterval,
+                        },
                     };
                 case DimensionType.TIMESTAMP:
                     return {
-                        type: MetricType.TIMESTAMP,
-                        sql: `MAX(${item.sql})`,
+                        formatOptions: {
+                            type: CustomFormatType.TIMESTAMP,
+                            timeInterval: item.timeInterval,
+                        },
                     };
                 default:
                     return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10358

### Description:

> ideally - it should keep the min/max format of the metric but still use the value formatting of date.
<!-- Add a description of the changes proposed in the pull request. -->
Keep `max` type on the custom metric, and add a new `date/timestamp` custom format .

- [x]  Keep in mind that the new solution should also include the fix linked below without breaking the above-described behavior



![Screenshot from 2024-06-17 16-18-35](https://github.com/lightdash/lightdash/assets/1983672/169bee1e-27ba-4c4c-a020-099a6ba60c3f)

<!-- Even better add a screenshot / gif / loom -->

### New side effects

There are a couple of unexpected side effects when keeping this a `max` . We could create separate issues for these. 

- [ ] Max Date should not show totals 
![Screenshot from 2024-06-17 16-21-29](https://github.com/lightdash/lightdash/assets/1983672/5adf0686-33c0-4ffd-951f-a9601adc6476)
- [ ] Max date tooltips should be formatted correctly 
![image](https://github.com/lightdash/lightdash/assets/1983672/5e46d5ae-0ffe-4f0b-b111-63fbe9138738)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
