### PR TITLE
fix: minimum knex connections

### DIFF
--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -14,7 +14,7 @@ const development: Knex.Config<Knex.PgConnectionConfig> = {
     client: 'pg',
     connection: CONNECTION,
     pool: {
-        min: lightdashConfig.database.minConnections || 1,
+        min: lightdashConfig.database.minConnections || 0,
         max: lightdashConfig.database.maxConnections || 10,
     },
     migrations: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9952 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Knex sporadically errors when getting a connection.

> Connection terminated unexpectedly

Found this related thread https://github.com/knex/knex/issues/3523

Knex [docs](https://knexjs.org/guide/#pool) recommend setting min pool connection to 0.

> Note that the default value of min is 2 only for historical reasons. It can result in problems with stale connections, despite tarn's default idle connection timeout of 30 seconds, which is only applied when there are more than min active connections. It is recommended to set min: 0 so all idle connections can be terminated.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
