### PR TITLE
fix: wait for all chart spinners before playwright screenshot

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -551,20 +551,20 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
-                    // If we are in a dashboard, and some charts are still loading even though their API requests have finished, we wait for them to finish
+                    // If we are in a dashboard, and some charts are still loading even though their API requests have finished(or past the timeout), we wait for them to finish
                     if (lightdashPage === LightdashPage.DASHBOARD) {
                         // Reference: https://playwright.dev/docs/api/class-locator#locator-all
-
-                        // eslint-disable-next-line no-restricted-syntax
-                        for (const loadingChart of await page
+                        const loadingCharts = await page
                             .locator('.loading_chart')
-                            .all()) {
-                            // eslint-disable-next-line no-await-in-loop
-                            await loadingChart.waitFor({
-                                state: 'hidden',
-                                timeout: 60000,
-                            });
-                        }
+                            .all();
+                        await Promise.all(
+                            loadingCharts.map((loadingChart) =>
+                                loadingChart.waitFor({
+                                    state: 'hidden',
+                                    timeout: 60000,
+                                }),
+                            ),
+                        );
                     }
 
                     const path = `/tmp/${imageId}.png`;

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -551,15 +551,20 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
+                    // If we are in a dashboard, and some charts are still loading even though their API requests have finished, we wait for them to finish
                     if (lightdashPage === LightdashPage.DASHBOARD) {
-                        // wait for all components with class .loading_chart to disappear - they are the same number as the number of charts
-                        const dashboardChartsLoaders =
-                            page.locator('.loading_chart');
+                        // Reference: https://playwright.dev/docs/api/class-locator#locator-all
 
-                        await dashboardChartsLoaders.waitFor({
-                            state: 'hidden',
-                            timeout: 60000,
-                        });
+                        // eslint-disable-next-line no-restricted-syntax
+                        for (const loadingChart of await page
+                            .locator('.loading_chart')
+                            .all()) {
+                            // eslint-disable-next-line no-await-in-loop
+                            await loadingChart.waitFor({
+                                state: 'hidden',
+                                timeout: 60000,
+                            });
+                        }
                     }
 
                     const path = `/tmp/${imageId}.png`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

This solution addresses errors like this: 
```
{"error": "locator.waitFor: Error: strict mode violation: locator('.loading_chart') resolved to 3 elements:\n    1) <div class=\"mantine-Stack-root loading_chart mantine-…>…</div> aka locator('.mantine-Stack-root').first()\n    2) <div class=\"mantine-Stack-root loading_chart mantine-…>…</div> aka locator('div:nth-child(20) > .mantine-Paper-root > .sc-dJjYzT > .mantine-wsk78d > div > .mantine-Stack-root')\n    3) <div class=\"mantine-Stack-root loading_chart mantine-…>…</div> aka locator('div:nth-child(21) > .mantine-Paper-root > .sc-dJjYzT > .mantine-wsk78d > div > .mantine-Stack-root')\n\nCall log:\n  - waiting for locator('.loading_chart') to be hidden\n"}
```

When getting all remaining `.loading_chart`s, we should use the `.all()` method. This was harder to reproduce because this  happens when the `chart-and-results` endpoints have finished (or their past their timeout) **and** there are some charts loading still, as in, they haven't rendered fully yet. The current locator approach does not work with multiple locators. It can get them, but the assertion for `waitFor` can't accept a list. So this has to be done as mentioned here: https://playwright.dev/docs/api/class-locator#locator-all

Reference: https://github.com/microsoft/playwright/issues/10648#issuecomment-1509070074

#### How to replicate and assert that the `.all()` is working correctly:

1. set `SCHEDULER_SCREENSHOT_WITH_PLAYWRIGHT` to `true`
2. Change `SimpleChart` to have a delayed loading chart spinner

```tsx
import { type PivotReference } from '@lightdash/common';
import { IconChartBarOff } from '@tabler/icons-react';
import EChartsReact from 'echarts-for-react';
import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
import {
    memo,
    useCallback,
    useEffect,
    useMemo,
    useState,
    type FC,
} from 'react';
import useEchartsCartesianConfig, {
    isLineSeriesOption,
} from '../../hooks/echarts/useEchartsCartesianConfig';
import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
import { useVisualizationContext } from '../LightdashVisualization/VisualizationProvider';

type EchartBaseClickEvent = {
    // The component name clicked,
    // component type, could be 'series'、'markLine'、'markPoint'、'timeLine', etc..
    componentType: string;
    // series type, could be 'line'、'bar'、'pie', etc.. Works when componentType is 'series'.
    seriesType: string;
    // the index in option.series. Works when componentType is 'series'.
    seriesIndex: number;
    // series name, works when componentType is 'series'.
    seriesName: string;
    // name of data (categories).
    name: string;
    // the index in 'data' array.
    dataIndex: number;
    // incoming raw data item
    data: Object;
    // charts like 'sankey' and 'graph' included nodeData and edgeData as the same time.
    // dataType can be 'node' or 'edge', indicates whether the current click is on node or edge.
    // most of charts have one kind of data, the dataType is meaningless
    dataType: string;
    // incoming data value
    value: number | Array<any>;
    // color of the shape, works when componentType is 'series'.
    color: string;
    event: { event: MouseEvent };
    pivotReference?: PivotReference;
};

export type EchartSeriesClickEvent = EchartBaseClickEvent & {
    componentType: 'series';
    data: Record<string, any>;
    seriesIndex: number;
    dimensionNames: string[];
    pivotReference?: PivotReference;
};

type EchartClickEvent = EchartSeriesClickEvent | EchartBaseClickEvent;

type LegendClickEvent = {
    selected: {
        [name: string]: boolean;
    };
};

export const EmptyChart = () => (
    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
        <SuboptimalState
            title="No data available"
            description="Query metrics and dimensions with results."
            icon={IconChartBarOff}
        />
    </div>
);

export const LoadingChart = () => (
    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
        <SuboptimalState
            title="Loading chart"
            loading
            className="loading_chart"
        />
    </div>
);

const isSeriesClickEvent = (e: EchartClickEvent): e is EchartSeriesClickEvent =>
    e.componentType === 'series';

type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
    isInDashboard: boolean;
    $shouldExpand?: boolean;
    className?: string;
    'data-testid'?: string;
};

const SimpleChart: FC<SimpleChartProps> = memo((props) => {
    const { chartRef, isLoading, onSeriesContextMenu } =
        useVisualizationContext();

    const [selectedLegends, setSelectedLegends] = useState({});
    const [selectedLegendsUpdated, setSelectedLegendsUpdated] = useState({});

    const onLegendChange = useCallback((params: LegendClickEvent) => {
        setSelectedLegends(params.selected);
    }, []);

    const [isDelayed, setIsDelayed] = useState(true);

    useEffect(() => {
        const timer = setTimeout(() => {
            setIsDelayed(false);
        }, 20000); // 50 seconds delay

        return () => clearTimeout(timer);
    }, []);

    useEffect(() => {
        setSelectedLegendsUpdated(selectedLegends);
    }, [selectedLegends]);

    const eChartsOptions = useEchartsCartesianConfig(
        selectedLegendsUpdated,
        props.isInDashboard,
    );

    useEffect(() => {
        const listener = () => {
            const eCharts = chartRef.current?.getEchartsInstance();
            eCharts?.resize();
        };

        window.addEventListener('resize', listener);

        return () => window.removeEventListener('resize', listener);
    });

    const onChartContextMenu = useCallback(
        (e: EchartClickEvent) => {
            if (onSeriesContextMenu) {
                if (e.event.event.defaultPrevented) {
                    return;
                }
                e.event.event.preventDefault();
                if (isSeriesClickEvent(e)) {
                    const series = (eChartsOptions?.series || [])[
                        e.seriesIndex
                    ];
                    if (series && series.encode) {
                        onSeriesContextMenu(e, eChartsOptions?.series || []);
                    }
                }
            }
        },
        [onSeriesContextMenu, eChartsOptions],
    );

    const opts = useMemo<Opts>(() => ({ renderer: 'svg' }), []);

    const handleOnMouseOver = useCallback(
        (params: any) => {
            const eCharts = chartRef.current?.getEchartsInstance();

            if (eCharts) {
                // TODO: move to own util function
                let setTooltipItemTrigger = true;
                // Tooltip trigger 'item' does not work when symbol is not shown; reference: https://github.com/apache/echarts/issues/14563
                const series = eCharts.getOption().series;

                const isGrouped = (series as any[]).some(
                    (serie) => serie.pivotReference !== undefined,
                );
                if (Array.isArray(series) && !isGrouped) return null;

                if (
                    Array.isArray(series) &&
                    isLineSeriesOption(series[params.seriesIndex])
                ) {
                    setTooltipItemTrigger =
                        !!series[params.seriesIndex].showSymbol;
                }

                if (
                    setTooltipItemTrigger &&
                    eChartsOptions?.tooltip.formatter
                ) {
                    eCharts.setOption(
                        {
                            tooltip: {
                                trigger: 'item',
                                formatter: (param: any) => {
                                    // item param are slightly different to axis params, and they don't contain the axisValueLabel
                                    // so we need to generate it here (and wrap it in an array) and then reuse the formatter used
                                    // on `useEchartsCartesianConfig` to generate the tooltip
                                    if (eChartsOptions.tooltip.formatter) {
                                        const dim =
                                            param.encode?.x?.[0] !== undefined
                                                ? param.dimensionNames[
                                                      param.encode?.x[0]
                                                  ]
                                                : '';

                                        const axisValue = param.value[dim];
                                        return (
                                            eChartsOptions.tooltip
                                                .formatter as any
                                        )([
                                            {
                                                ...param,
                                                axisValueLabel: axisValue,
                                            },
                                        ]);
                                    }
                                },
                            },
                        },
                        false,
                        true, // lazy update
                    );
                }
                // Wait for tooltip to change from `axis` to `item` and keep hovered on item highlighted
                setTimeout(() => {
                    eCharts.dispatchAction({
                        type: 'highlight',
                        seriesIndex: params.seriesIndex,
                    });
                }, 100);
            }
        },
        [chartRef, eChartsOptions?.tooltip.formatter],
    );

    const handleOnMouseOut = useCallback(() => {
        const eCharts = chartRef.current?.getEchartsInstance();

        if (eCharts) {
            eCharts.setOption(
                {
                    tooltip: eChartsOptions?.tooltip,
                },
                false,
                true, // lazy update
            );
        }
    }, [chartRef, eChartsOptions?.tooltip]);

    if (isLoading || isDelayed) return <LoadingChart />;
    if (!eChartsOptions) return <EmptyChart />;

    return (
        <EChartsReact
            data-testid={props['data-testid']}
            className={props.className}
            style={
                props.$shouldExpand
                    ? {
                          minHeight: 'inherit',
                          height: '100%',
                          width: '100%',
                      }
                    : {
                          minHeight: 'inherit',
                          // height defaults to 300px
                          width: '100%',
                      }
            }
            ref={chartRef}
            option={eChartsOptions}
            notMerge
            opts={opts}
            onEvents={{
                contextmenu: onChartContextMenu,
                click: onChartContextMenu,
                mouseover: handleOnMouseOver,
                mouseout: handleOnMouseOut,
                legendselectchanged: onLegendChange,
            }}
            {...props}
        />
    );
});

export default SimpleChart;

```

Screenshot showing that it actually got a list: 

<img width="327" alt="Screenshot 2024-06-18 at 10 43 46" src="https://github.com/lightdash/lightdash/assets/7611706/0ec3f59f-f655-4e4b-abc0-24cd7b70c076">






### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
