### PR TITLE
chore: use playwright to saves creenshots by default

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -225,7 +225,6 @@ export type LightdashConfig = {
         concurrency: number;
         jobTimeout: number;
         screenshotTimeout?: number;
-        screenshotWithPlaywright?: boolean;
     };
     groups: {
         enabled: boolean;
@@ -656,8 +655,6 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
             screenshotTimeout: process.env.SCHEDULER_SCREENSHOT_TIMEOUT
                 ? parseInt(process.env.SCHEDULER_SCREENSHOT_TIMEOUT, 10)
                 : undefined,
-            screenshotWithPlaywright:
-                process.env.SCHEDULER_SCREENSHOT_WITH_PLAYWRIGHT === 'true',
         },
         groups: {
             enabled: process.env.GROUPS_ENABLED === 'true',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9024

### Description:

We experimented using `playwright` to save screenshots and that has been quite reliable at getting them for scheduled deliveries and working with `browserless`. 
Besides these changes, we also:
- Added retries #10028 
- Increase `maxAttempts` of dashboard + image scheduled deliveries to 2 (#10313)
- Increased the replica count of some instances (see cloud)
- Reduced max number of concurrent jobs slightly for instances that heavily use scheduled deliveries (see cloud)
 
This PR removes: 
- usage of env var: `SCHEDULER_SCREENSHOT_WITH_PLAYWRIGHT`
- removes the puppeteer `saveScreenshot` util and replaces it with its playwright-equivalent

> [!NOTE]
> This doesn't remove `puppeteer` completely because I see some references in `headlessBrowser` and that should be handled in another PR to remove Puppeteer completely. Issue here: https://github.com/lightdash/lightdash/issues/10457

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
