### PR TITLE
fix: get correct response pattern for explore screenshots

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -492,14 +492,20 @@ export class UnfurlService extends BaseService {
                                     timeout: 60000,
                                 }); // NOTE: No await here
                             });
-                        } else if (
-                            lightdashPage === LightdashPage.CHART ||
-                            lightdashPage === LightdashPage.EXPLORE
-                        ) {
-                            // Wait for the visualization to load if we are in an explore page
+                        } else if (lightdashPage === LightdashPage.CHART) {
+                            // Wait for the visualization to load if we are in an saved explore page
                             const responsePattern = new RegExp(
                                 `${resourceUuid}/results`,
                             );
+
+                            chartResultsPromises = [
+                                page?.waitForResponse(responsePattern, {
+                                    timeout: 60000,
+                                }), // NOTE: No await here
+                            ];
+                        } else if (lightdashPage === LightdashPage.EXPLORE) {
+                            // Wait for the visualization to load if we are in an unsaved explore page
+                            const responsePattern = /\/runQuery/;
 
                             chartResultsPromises = [
                                 page?.waitForResponse(responsePattern, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10462 

### Description:

See Sentry issue in ticket ⬆️ 

- Waits for `/runQuery` instead of `/results` when sharing an unsaved chart link so it works with Slack image unfurling.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
