### PR TITLE
feat: CSP report only configuration

### DIFF
--- a/docs/docs/self-host/customize-deployment/environment-variables.mdx
+++ b/docs/docs/self-host/customize-deployment/environment-variables.mdx
@@ -107,3 +107,10 @@ These variables enable you to control Single Sign On (SSO) functionality.
 | `LIGHTDASH_GC_DURATION_BUCKETS`             | Buckets for duration histogram in seconds.                                      |           | `0.001, 0.01, 0.1, 1, 2, 5` |
 | `LIGHTDASH_EVENT_LOOP_MONITORING_PRECISION` | Precision for event loop monitoring in milliseconds. Must be greater than zero. |           | `10`                        |
 | `LIGHTDASH_PROMETHEUS_LABELS`               | Labels to add to all metrics. Must be valid JSON                                |           |                             |
+
+# Security
+
+| Variable                        | Description                                                                                  | Required? | Default |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | --------- | ------- |
+| `LIGHTDASH_CSP_REPORT_ONLY`     | Enables Content Security Policy (CSP) reporting only mode                                    |           | `false` |
+| `LIGHTDASH_CSP_ALLOWED_DOMAINS` | List of domains that are allowed to load resources from. Values must be separated by commas. |           |         |

--- a/docs/docs/self-host/customize-deployment/environment-variables.mdx
+++ b/docs/docs/self-host/customize-deployment/environment-variables.mdx
@@ -110,7 +110,8 @@ These variables enable you to control Single Sign On (SSO) functionality.
 
 # Security
 
-| Variable                        | Description                                                                                  | Required? | Default |
-| ------------------------------- | -------------------------------------------------------------------------------------------- | --------- | ------- |
-| `LIGHTDASH_CSP_REPORT_ONLY`     | Enables Content Security Policy (CSP) reporting only mode                                    |           | `false` |
-| `LIGHTDASH_CSP_ALLOWED_DOMAINS` | List of domains that are allowed to load resources from. Values must be separated by commas. |           |         |
+| Variable                        | Description                                                                                                        | Required? | Default |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- | ------- |
+| `LIGHTDASH_CSP_REPORT_ONLY`     | Enables Content Security Policy (CSP) reporting only mode. This is recommended to be set to `false` in production. |           | `true`  |
+| `LIGHTDASH_CSP_ALLOWED_DOMAINS` | List of domains that are allowed to load resources from. Values must be separated by commas.                       |           |         |
+| `LIGHTDASH_CSP_REPORT_URI`      | URI to send CSP violation reports to.                                                                              |           |         |

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -294,7 +294,7 @@ export default class App {
             'https://apis.google.com',
             'https://accounts.google.com',
             'https://vega.github.io',
-            'https://cdn.jsdelivr.net/npm/monaco-editor',
+            'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/',
             ...this.lightdashConfig.security.contentSecurityPolicy
                 .allowedDomains,
         ];
@@ -327,7 +327,9 @@ export default class App {
                         ],
                         'report-uri': reportUri ? [reportUri.href] : [],
                     },
-                    reportOnly: true,
+                    reportOnly:
+                        this.lightdashConfig.security.contentSecurityPolicy
+                            .reportOnly,
                 },
                 strictTransportSecurity: {
                     maxAge: 31536000,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -145,6 +145,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     security: {
         contentSecurityPolicy: {
+            reportOnly: false,
             allowedDomains: [],
         },
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -198,6 +198,7 @@ export type LightdashConfig = {
         contentSecurityPolicy: {
             reportOnly: boolean;
             allowedDomains: string[];
+            reportUri?: string;
         };
     };
     cookiesMaxAgeHours?: number;
@@ -452,12 +453,13 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         mode,
         security: {
             contentSecurityPolicy: {
-                reportOnly: process.env.LIGHTDASH_CSP_REPORT_ONLY === 'true',
+                reportOnly: process.env.LIGHTDASH_CSP_REPORT_ONLY !== 'false', // defaults to true
                 allowedDomains: (
                     process.env.LIGHTDASH_CSP_ALLOWED_DOMAINS || ''
                 )
                     .split(',')
                     .map((domain) => domain.trim()),
+                reportUri: process.env.LIGHTDASH_CSP_REPORT_URI,
             },
         },
         smtp: process.env.EMAIL_SMTP_HOST

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -196,6 +196,7 @@ export type LightdashConfig = {
     secureCookies: boolean;
     security: {
         contentSecurityPolicy: {
+            reportOnly: boolean;
             allowedDomains: string[];
         };
     };
@@ -451,6 +452,7 @@ const mergeWithEnvironment = (config: LightdashConfigIn): LightdashConfig => {
         mode,
         security: {
             contentSecurityPolicy: {
+                reportOnly: process.env.LIGHTDASH_CSP_REPORT_ONLY === 'true',
                 allowedDomains: (
                     process.env.LIGHTDASH_CSP_ALLOWED_DOMAINS || ''
                 )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10356](https://github.com/lightdash/lightdash/issues/10356)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- Allow to configure "report only" via env var. Default is report only
- Allow to set report URI
- Document CSP env vars
- Amend allowed list to support all monaco editor files

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
