### PR TITLE
chore: add eventloop utilization Prometheus metric

### DIFF
--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -24,6 +24,7 @@ export default class PrometheusMetrics {
                 const eventLoopUtilization = new prometheus.Gauge({
                     name: 'nodejs_eventloop_utilization',
                     help: 'The utilization value(%) is the calculated Event Loop Utilization (ELU).',
+                    ...rest,
                     collect() {
                         // Invoked when the registry collects its metrics' values.
                         this.set(

--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import http from 'http';
+import { performance } from 'perf_hooks';
 import prometheus from 'prom-client';
 import { LightdashConfig } from './config/parseConfig';
 import Logger from './logging/logger';
@@ -19,6 +20,16 @@ export default class PrometheusMetrics {
             try {
                 prometheus.collectDefaultMetrics({
                     ...rest,
+                });
+                const eventLoopUtilization = new prometheus.Gauge({
+                    name: 'nodejs_eventloop_utilization',
+                    help: 'The utilization value(%) is the calculated Event Loop Utilization (ELU).',
+                    collect() {
+                        // Invoked when the registry collects its metrics' values.
+                        this.set(
+                            performance.eventLoopUtilization().utilization,
+                        );
+                    },
                 });
                 const app = express();
                 this.server = http.createServer(app);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Event loop utilization [docs](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2)

<img width="869" alt="Screenshot 2024-06-20 at 11 34 36" src="https://github.com/lightdash/lightdash/assets/9117144/d674fc31-079e-4100-be16-5fe7d8f93648">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
