### PR TITLE
fix: wait for `.loading_chart` regardless of scheduled delivery

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -523,21 +523,19 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
-                    // If we are in a dashboard, and some charts are still loading even though their API requests have finished(or past the timeout), we wait for them to finish
-                    if (lightdashPage === LightdashPage.DASHBOARD) {
-                        // Reference: https://playwright.dev/docs/api/class-locator#locator-all
-                        const loadingCharts = await page
-                            .locator('.loading_chart')
-                            .all();
-                        await Promise.all(
-                            loadingCharts.map((loadingChart) =>
-                                loadingChart.waitFor({
-                                    state: 'hidden',
-                                    timeout: 60000,
-                                }),
-                            ),
-                        );
-                    }
+                    // If some charts are still loading even though their API requests have finished(or past the timeout), we wait for them to finish
+                    // Reference: https://playwright.dev/docs/api/class-locator#locator-all
+                    const loadingCharts = await page
+                        .locator('.loading_chart')
+                        .all();
+                    await Promise.all(
+                        loadingCharts.map((loadingChart) =>
+                            loadingChart.waitFor({
+                                state: 'hidden',
+                                timeout: 60000,
+                            }),
+                        ),
+                    );
 
                     const path = `/tmp/${imageId}.png`;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10479

### Description:

In here: https://github.com/lightdash/lightdash/pull/10451 we waited for all charts to load on dashboard scheduled deliveries. We should actually wait for `CHART` and `EXPLORE` scheduled deliveries as well. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
