### PR TITLE
feat: display field labels in catalog metadata

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -95,12 +95,13 @@ const models: TsoaRoute.Models = {
         enums: ['metric', 'dimension'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Field.name-or-fieldType-or-tableLabel-or-description_': {
+    'Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 name: { dataType: 'string', required: true },
+                label: { dataType: 'string', required: true },
                 fieldType: { ref: 'FieldType', required: true },
                 tableLabel: { dataType: 'string', required: true },
                 description: { dataType: 'string' },
@@ -142,7 +143,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Field.name-or-fieldType-or-tableLabel-or-description_',
+                    ref: 'Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_',
                 },
                 { ref: 'Pick_Dimension.requiredAttributes_' },
                 {
@@ -170,11 +171,11 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     name: { dataType: 'string', required: true },
+                    label: { dataType: 'string', required: true },
                     description: { dataType: 'string' },
                     requiredAttributes: {
                         ref: 'Record_string.string-or-string-Array_',
                     },
-                    label: { dataType: 'string', required: true },
                     groupLabel: { dataType: 'string' },
                 },
                 validators: {},
@@ -364,6 +365,7 @@ const models: TsoaRoute.Models = {
             'pie',
             'table',
             'big_number',
+            'funnel',
             'custom',
         ],
     },
@@ -2017,6 +2019,41 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartType.FUNNEL': {
+        dataType: 'refEnum',
+        enums: ['funnel'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FunnelChartDataInput: {
+        dataType: 'refEnum',
+        enums: ['row', 'column'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FunnelChart: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metadata: { ref: 'Record_string.SeriesMetadata_' },
+                fieldId: { dataType: 'string' },
+                dataInput: { ref: 'FunnelChartDataInput' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FunnelChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: { ref: 'FunnelChart' },
+                type: { ref: 'ChartType.FUNNEL', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ChartType.TABLE': {
         dataType: 'refEnum',
         enums: ['table'],
@@ -2190,6 +2227,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'CartesianChartConfig' },
                 { ref: 'CustomVisConfig' },
                 { ref: 'PieChartConfig' },
+                { ref: 'FunnelChartConfig' },
                 { ref: 'TableChartConfig' },
             ],
             validators: {},
@@ -3758,7 +3796,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ChartType: {
         dataType: 'refEnum',
-        enums: ['cartesian', 'table', 'big_number', 'pie', 'custom'],
+        enums: ['cartesian', 'table', 'big_number', 'pie', 'funnel', 'custom'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SpaceQuery.uuid-or-name-or-chartType-or-chartKind-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_':

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -44,9 +44,12 @@
                 "enum": ["metric", "dimension"],
                 "type": "string"
             },
-            "Pick_Field.name-or-fieldType-or-tableLabel-or-description_": {
+            "Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_": {
                 "properties": {
                     "name": {
+                        "type": "string"
+                    },
+                    "label": {
                         "type": "string"
                     },
                     "fieldType": {
@@ -59,7 +62,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "fieldType", "tableLabel"],
+                "required": ["name", "label", "fieldType", "tableLabel"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -84,7 +87,7 @@
             "CatalogField": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Field.name-or-fieldType-or-tableLabel-or-description_"
+                        "$ref": "#/components/schemas/Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_"
                     },
                     {
                         "$ref": "#/components/schemas/Pick_Dimension.requiredAttributes_"
@@ -120,14 +123,14 @@
                     "name": {
                         "type": "string"
                     },
+                    "label": {
+                        "type": "string"
+                    },
                     "description": {
                         "type": "string"
                     },
                     "requiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
-                    },
-                    "label": {
-                        "type": "string"
                     },
                     "groupLabel": {
                         "type": "string"
@@ -300,6 +303,7 @@
                     "pie",
                     "table",
                     "big_number",
+                    "funnel",
                     "custom"
                 ],
                 "type": "string"
@@ -2167,6 +2171,40 @@
                 "required": ["type"],
                 "type": "object"
             },
+            "ChartType.FUNNEL": {
+                "enum": ["funnel"],
+                "type": "string"
+            },
+            "FunnelChartDataInput": {
+                "enum": ["row", "column"],
+                "type": "string"
+            },
+            "FunnelChart": {
+                "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/Record_string.SeriesMetadata_"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    },
+                    "dataInput": {
+                        "$ref": "#/components/schemas/FunnelChartDataInput"
+                    }
+                },
+                "type": "object"
+            },
+            "FunnelChartConfig": {
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/FunnelChart"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ChartType.FUNNEL"
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
             "ChartType.TABLE": {
                 "enum": ["table"],
                 "type": "string"
@@ -2356,6 +2394,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/PieChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/FunnelChartConfig"
                     },
                     {
                         "$ref": "#/components/schemas/TableChartConfig"
@@ -4076,7 +4117,14 @@
                 "type": "string"
             },
             "ChartType": {
-                "enum": ["cartesian", "table", "big_number", "pie", "custom"],
+                "enum": [
+                    "cartesian",
+                    "table",
+                    "big_number",
+                    "pie",
+                    "funnel",
+                    "custom"
+                ],
                 "type": "string"
             },
             "Pick_SpaceQuery.uuid-or-name-or-chartType-or-chartKind-or-firstViewedAt-or-views-or-pinnedListUuid-or-pinnedListOrder-or-spaceUuid-or-description-or-updatedAt-or-updatedByUser-or-validationErrors_": {
@@ -7871,7 +7919,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1135.2",
+        "version": "0.1138.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -1,17 +1,14 @@
 import {
-    CatalogAnalytics,
     CatalogField,
     CatalogTable,
     CatalogType,
     Explore,
-    getBasicType,
     NotFoundError,
     UnexpectedServerError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { CatalogTableName, DbCatalog } from '../../database/entities/catalog';
 import { CachedExploreTableName } from '../../database/entities/projects';
-import { SavedChartVersionsTableName } from '../../database/entities/savedCharts';
 import { wrapSentryTransaction } from '../../utils';
 import {
     getFullTextSearchQuery,

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -16,6 +16,7 @@ const parseFieldFromMetricOrDimension = (
     tags: string[],
 ): CatalogField => ({
     name: field.name,
+    label: field.label,
     description: field.description,
     tableLabel: field.tableLabel,
     tableName: table.name,

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -28,7 +28,7 @@ export type ApiCatalogSearch = {
 };
 export type CatalogField = Pick<
     Field,
-    'name' | 'fieldType' | 'tableLabel' | 'description'
+    'name' | 'label' | 'fieldType' | 'tableLabel' | 'description'
 > &
     Pick<Dimension, 'requiredAttributes'> & {
         type: CatalogType.Field;

--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -50,7 +50,7 @@ describe('Lightdash catalog all tables and fields', () => {
                 description: 'Method of payment used, for example credit card',
                 tableLabel: 'Payments',
                 tableName: 'payments',
-
+                label: 'Payment method',
                 fieldType: 'dimension',
                 basicType: 'string',
                 type: 'field',
@@ -69,6 +69,7 @@ describe('Lightdash catalog all tables and fields', () => {
                 tableName: 'payments',
                 fieldType: 'metric',
                 basicType: 'number',
+                label: 'Total revenue',
                 type: 'field',
                 tags: [],
             });
@@ -107,6 +108,7 @@ describe('Lightdash catalog search', () => {
 
             expect(field).to.eql({
                 name: 'customer_id',
+                label: 'Customer id',
                 tableLabel: 'Users',
                 tableName: 'users',
                 description: 'This is a unique identifier for a customer',
@@ -134,7 +136,7 @@ describe('Lightdash catalog search', () => {
                 description: 'Method of payment used, for example credit card',
                 tableLabel: 'Payments',
                 tableName: 'payments',
-
+                label: 'Payment method',
                 fieldType: 'dimension',
                 basicType: 'string',
                 type: 'field',
@@ -157,7 +159,7 @@ describe('Lightdash catalog search', () => {
                 description: 'Sum of all payments',
                 tableLabel: 'Payments',
                 tableName: 'payments',
-
+                label: 'Total revenue',
                 fieldType: 'metric',
                 basicType: 'number',
                 type: 'field',
@@ -185,7 +187,7 @@ describe('Lightdash catalog search', () => {
                 name: 'customer_id',
                 tableLabel: 'Users',
                 tableName: 'users',
-
+                label: 'Customer id',
                 description: 'This is a unique identifier for a customer',
                 type: 'field',
                 basicType: 'number',
@@ -223,7 +225,7 @@ describe('Lightdash catalog search', () => {
                 name: 'date_of_first_order',
                 tableLabel: 'Orders',
                 tableName: 'orders',
-
+                label: 'Date of first order',
                 description: 'Min of Order date',
                 type: 'field',
                 basicType: 'number',

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -72,7 +72,7 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                             fw={500}
                             fz="sm"
                         >
-                            {field.name || ''}
+                            {field.label ?? ''}
                         </Highlight>
                     </Group>
                 </Box>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -1,7 +1,6 @@
 import { type CatalogMetadata as CatalogMetadataType } from '@lightdash/common';
 import {
     Avatar,
-    Badge,
     Box,
     Button,
     Divider,
@@ -10,7 +9,6 @@ import {
     LoadingOverlay,
     Paper,
     Stack,
-    Table,
     Tabs,
     Text,
     Tooltip,
@@ -30,17 +28,16 @@ import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useCatalogContext } from '../context/CatalogProvider';
 import { useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
 import { useCatalogMetadata } from '../hooks/useCatalogMetadata';
 import { CatalogAnalyticCharts } from './CatalogAnalyticCharts';
+import { CatalogMetadataFieldsTable } from './CatalogMetadataFieldsTable';
 
 export const CatalogMetadata: FC = () => {
     const history = useHistory();
 
-    const { classes, cx } = useTableStyles();
     const { colors } = useMantineTheme();
     const { ref, isTruncated } = useIsTruncated<HTMLDivElement>();
 
@@ -371,79 +368,14 @@ export const CatalogMetadata: FC = () => {
 
                                 {selection?.field === undefined &&
                                     !selectedFieldInTable && (
-                                        <Paper withBorder>
-                                            <Table
-                                                className={cx(
-                                                    classes.root,
-                                                    classes.smallPadding,
-                                                )}
-                                            >
-                                                <thead>
-                                                    <tr>
-                                                        <th>Field</th>
-                                                        <th>Type</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {metadata?.fields?.map(
-                                                        (field) => (
-                                                            <tr
-                                                                key={field.name}
-                                                                style={{
-                                                                    border:
-                                                                        selection?.field ===
-                                                                        field.name
-                                                                            ? `2px solid ${colors.blue[6]}`
-                                                                            : undefined,
-                                                                }}
-                                                            >
-                                                                <td
-                                                                    style={{
-                                                                        color: `${colors.blue[6]}`,
-                                                                        cursor: 'pointer',
-                                                                    }}
-                                                                    onClick={() => {
-                                                                        setSelectedFieldInTable(
-                                                                            field.name,
-                                                                        );
-                                                                        if (
-                                                                            selection?.table
-                                                                        )
-                                                                            getAnalytics(
-                                                                                {
-                                                                                    table: selection.table,
-                                                                                    field: field.name,
-                                                                                },
-                                                                            );
-                                                                    }}
-                                                                >
-                                                                    {field.name}
-                                                                </td>
-                                                                <td>
-                                                                    <Badge
-                                                                        color="gray.4"
-                                                                        radius="lg"
-                                                                        size="xs"
-                                                                        fz="xs"
-                                                                        fw={500}
-                                                                        style={{
-                                                                            textTransform:
-                                                                                'none',
-                                                                            color: colors
-                                                                                .gray[6],
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            field.basicType
-                                                                        }
-                                                                    </Badge>
-                                                                </td>
-                                                            </tr>
-                                                        ),
-                                                    )}
-                                                </tbody>
-                                            </Table>
-                                        </Paper>
+                                        <CatalogMetadataFieldsTable
+                                            selection={selection}
+                                            metadata={metadata}
+                                            getAnalytics={getAnalytics}
+                                            setSelectedFieldInTable={
+                                                setSelectedFieldInTable
+                                            }
+                                        />
                                     )}
                             </Stack>
                         </Tabs.Panel>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadataFieldsTable.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadataFieldsTable.tsx
@@ -1,0 +1,81 @@
+import { Badge, Paper, Table, useMantineTheme } from '@mantine/core';
+import { type FC, type SetStateAction } from 'react';
+import { useTableStyles } from '../../../hooks/styles/useTableStyles';
+import { type useCatalogContext } from '../context/CatalogProvider';
+import { type useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
+
+type Props = {
+    metadata: ReturnType<typeof useCatalogContext>['metadata'];
+    selection: ReturnType<typeof useCatalogContext>['selection'];
+    getAnalytics: ReturnType<typeof useCatalogAnalytics>['mutate'];
+    setSelectedFieldInTable: (
+        value: SetStateAction<string | undefined>,
+    ) => void;
+};
+
+export const CatalogMetadataFieldsTable: FC<Props> = ({
+    metadata,
+    selection,
+    getAnalytics,
+    setSelectedFieldInTable,
+}) => {
+    const { colors } = useMantineTheme();
+    const { classes, cx } = useTableStyles();
+    return (
+        <Paper withBorder>
+            <Table className={cx(classes.root, classes.smallPadding)}>
+                <thead>
+                    <tr>
+                        <th>Field</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {metadata?.fields?.map((field) => (
+                        <tr
+                            key={field.name}
+                            style={{
+                                border:
+                                    selection?.field === field.name
+                                        ? `2px solid ${colors.blue[6]}`
+                                        : undefined,
+                            }}
+                        >
+                            <td
+                                style={{
+                                    color: `${colors.blue[6]}`,
+                                    cursor: 'pointer',
+                                }}
+                                onClick={() => {
+                                    setSelectedFieldInTable(field.name);
+                                    if (selection?.table)
+                                        getAnalytics({
+                                            table: selection.table,
+                                            field: field.name,
+                                        });
+                                }}
+                            >
+                                {field.label}
+                            </td>
+                            <td>
+                                <Badge
+                                    color="gray.4"
+                                    radius="lg"
+                                    size="xs"
+                                    fz="xs"
+                                    fw={500}
+                                    style={{
+                                        textTransform: 'none',
+                                        color: colors.gray[6],
+                                    }}
+                                >
+                                    {field.basicType}
+                                </Badge>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -276,9 +276,7 @@ export const CatalogPanel: FC = () => {
                         groupName !== 'Ungrouped tables' &&
                         filters.hideGroupedTables
                     ) {
-                        {
-                            return acc;
-                        }
+                        return acc;
                     }
                     // Add to the tree if not filtered out
                     if (!acc[groupName]) {
@@ -289,6 +287,7 @@ export const CatalogPanel: FC = () => {
                             name: item.tableName,
                             type: CatalogType.Table,
                             fields: [],
+                            label: item.tableLabel,
                         };
                     }
                     acc[groupName].tables[item.tableName].fields.push(item);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10328](https://github.com/lightdash/lightdash/issues/10328)

### Description:

- Display field labels on the panel **and** on the metadata sidebar table
- Created a separate component for the fields table as a lil refactor
- Added `tableLabel` to the CatalogTree so when we're searching we don't get _empty_ table labels 

<img width="1881" alt="Screenshot 2024-06-21 at 17 11 48" src="https://github.com/lightdash/lightdash/assets/7611706/d0fa1bed-44c2-4f4a-b640-0fd2ec493cfb">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
