### PR TITLE
fix: queue monitoring sql

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -215,7 +215,7 @@ export class SchedulerClient {
         const graphileClient = await this.graphileUtils;
         const results = await graphileClient.withPgClient((pgClient) =>
             pgClient.query(
-                'select count(id) as count from graphile_worker.jobs where attempts <> max_attempts',
+                'select count(id) as count from graphile_worker.jobs where attempts <> max_attempts AND run_at < now()',
             ),
         );
         return parseInt(results.rows[0].count, 10);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-cloud/issues/433
### How I tested this

set LIGHTDASH_SCHEDULER: False

Tried downloading a CSV, the gauge increased
Scheduled some deliveries in the future, the gauge didn't increase
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

![Screenshot from 2024-06-24 09-12-47](https://github.com/lightdash/lightdash/assets/1983672/2ca226c7-2bbd-473d-bd3f-c413af241e57)

I also tried doing this: 

> add metric queue_concurrency_utilization where it filters rows by is_locked (as it is an indicator that is being processed) and divide by concurrency config to find the %.

However , when the jobs are `in progress` they are removed from the `jobs` table. so we can't track thoes jobs using SQL. We could do some manual tracking using `runner.events.on`

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
