### PR TITLE
feat: hide hidden catalog fields

### DIFF
--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -19,7 +19,7 @@ export const convertExploresToCatalog = (
         const dimensionsAndMetrics = [
             ...Object.values(baseTable?.dimensions || {}),
             ...Object.values(baseTable?.metrics || {}),
-        ];
+        ].filter((f) => !f.hidden); // Filter out hidden fields from catalog
         const fields = dimensionsAndMetrics.map<DbCatalogIn>((field) => ({
             project_uuid: projectUuid,
             cached_explore_uuid: explore.cachedExploreUuid,

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -34,7 +34,7 @@ export const parseFieldsFromCompiledTable = (
     const tableFields = [
         ...Object.values(table.dimensions),
         ...Object.values(table.metrics),
-    ];
+    ].filter((f) => !f.hidden); // Filter out hidden fields from catalog
     return tableFields.map((field) =>
         parseFieldFromMetricOrDimension(table, field, []),
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10309

### Description:

Hide `hidden` fields when:

- Searching ( see `...between...` field)

before

<img width="1281" alt="Screenshot 2024-06-24 at 09 30 54" src="https://github.com/lightdash/lightdash/assets/7611706/2380b382-f652-45ca-817d-f89aaac1206f">

after

<img width="1330" alt="Screenshot 2024-06-24 at 10 21 16" src="https://github.com/lightdash/lightdash/assets/7611706/325092e8-2bbb-4fd8-b644-cd200961b970">


- Viewing metadata ( see `...between...` field)


before
<img width="1347" alt="Screenshot 2024-06-24 at 10 38 35" src="https://github.com/lightdash/lightdash/assets/7611706/b338791c-c25a-4661-adaf-ce6659cbdaac">

after

<img width="1318" alt="Screenshot 2024-06-24 at 10 39 04" src="https://github.com/lightdash/lightdash/assets/7611706/9ca18333-c60d-4536-8e02-ca1252d1b565">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
