### PR TITLE
feat: hide explore errors in catalog

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -11,6 +11,7 @@ import {
     ExploreError,
     ForbiddenError,
     hasIntersection,
+    InlineErrorType,
     isExploreError,
     SessionUser,
     SummaryExplore,
@@ -127,6 +128,15 @@ export class CatalogService<
             await this.projectModel.getTablesConfiguration(projectUuid);
         return explores.reduce<CatalogTable[]>((acc, explore) => {
             if (isExploreError(explore)) {
+                // If no dimensions found, we don't show the explore error
+                if (
+                    explore.errors.every(
+                        (error) =>
+                            error.type === InlineErrorType.NO_DIMENSIONS_FOUND,
+                    )
+                )
+                    return acc;
+
                 return [
                     ...acc,
                     {
@@ -256,6 +266,16 @@ export class CatalogService<
         const filteredExplores = explores.reduce<(Explore | ExploreError)[]>(
             (acc, explore) => {
                 if (isExploreError(explore)) {
+                    // If no dimensions found, we don't show the explore error
+                    if (
+                        explore.errors.every(
+                            (error) =>
+                                error.type ===
+                                InlineErrorType.NO_DIMENSIONS_FOUND,
+                        )
+                    )
+                        return acc;
+
                     return [...acc, explore];
                 }
                 if (

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -50,8 +50,6 @@ export const CatalogMetadata: FC = () => {
         selection,
         setAnalyticsResults,
         setSelection,
-        metadataErrors,
-        setMetadataErrors,
     } = useCatalogContext();
     const { reset: resetMetadata } = useCatalogMetadata(projectUuid);
     const isMutatingAnalytics = useIsMutating([
@@ -109,7 +107,6 @@ export const CatalogMetadata: FC = () => {
                 onClick={() => {
                     setSidebarOpen(false);
                     setSelection(undefined);
-                    setMetadataErrors(undefined);
 
                     if (metadata) {
                         resetMetadata();
@@ -161,322 +158,283 @@ export const CatalogMetadata: FC = () => {
                         {' / '}
                     </>
                 )}
-                <Tooltip
-                    variant="xs"
-                    label={metadata?.modelName}
-                    disabled={!!metadataErrors}
-                >
+                <Tooltip variant="xs" label={metadata?.modelName}>
                     <Text
                         fz="lg"
                         fw={600}
                         onDoubleClick={() => {
-                            if (metadataErrors) return;
                             history.push(
                                 `/projects/${projectUuid}/tables/${metadata?.modelName}`,
                             );
                         }}
                     >
-                        {metadataErrors ? selection?.table : metadata?.name}
+                        {metadata?.name}
                     </Text>
                 </Tooltip>
             </Group>
 
-            {metadataErrors && metadataErrors.length > 0 ? (
-                <Stack>
-                    <Text fw={500} c="gray.7">
-                        There was an error loading the metadata for this table:
-                    </Text>
-                    <Box
-                        p="sm"
-                        sx={{
-                            border: `1px solid ${colors.red[5]}`,
-                            borderRadius: 4,
-                            backgroundColor: colors.red[0],
-                        }}
-                    >
-                        {metadataErrors.map((error) => (
-                            <Text key={error.message} color="red">
-                                {error.message}
-                            </Text>
-                        ))}
-                    </Box>
-                </Stack>
-            ) : (
-                <>
-                    <LoadingOverlay
-                        loaderProps={{
-                            size: 'sm',
-                            color: 'gray.7',
-                            pos: 'absolute',
-                            variant: 'dots',
-                        }}
-                        visible={!metadata || !!isMutatingMetadata}
-                        transitionDuration={1000}
-                    />
+            <LoadingOverlay
+                loaderProps={{
+                    size: 'sm',
+                    color: 'gray.7',
+                    pos: 'absolute',
+                    variant: 'dots',
+                }}
+                visible={!metadata || !!isMutatingMetadata}
+                transitionDuration={1000}
+            />
 
-                    <Tabs
-                        color="dark"
-                        defaultValue="overview"
-                        styles={(theme) => ({
-                            tabsList: {
-                                borderBottom: `1px solid ${theme.colors.gray[3]}`,
-                            },
-                            panel: {
-                                paddingTop: theme.spacing.xl,
-                                height: `calc(100vh - 260px)`,
-                                overflowY: 'scroll',
-                            },
-                            tab: {
-                                paddingRight: theme.spacing.sm,
-                                paddingLeft: 0,
-                                fontSize: theme.fontSizes.sm,
-                                fontWeight: 500,
-                                '&[data-active="true"]': {
-                                    color: theme.colors.gray[9],
-                                },
+            <Tabs
+                color="dark"
+                defaultValue="overview"
+                styles={(theme) => ({
+                    tabsList: {
+                        borderBottom: `1px solid ${theme.colors.gray[3]}`,
+                    },
+                    panel: {
+                        paddingTop: theme.spacing.xl,
+                        height: `calc(100vh - 260px)`,
+                        overflowY: 'scroll',
+                    },
+                    tab: {
+                        paddingRight: theme.spacing.sm,
+                        paddingLeft: 0,
+                        fontSize: theme.fontSizes.sm,
+                        fontWeight: 500,
+                        '&[data-active="true"]': {
+                            color: theme.colors.gray[9],
+                        },
 
-                                '&:not([data-active])': {
-                                    color: theme.colors.gray[6],
-                                },
-                            },
-                        })}
-                    >
-                        <Tabs.List>
-                            <Tabs.Tab value={'overview'}>Overview</Tabs.Tab>
-                            <Tabs.Tab value={'analytics'}>
-                                <Group spacing="xs">
-                                    Usage Analytics
-                                    <Avatar
-                                        radius="xl"
-                                        size="xs"
-                                        fz="md"
-                                        styles={(theme) => ({
-                                            placeholder: {
-                                                fontSize: theme.fontSizes.xs,
-                                                color: theme.colors.gray[7],
-                                                backgroundColor:
-                                                    theme.colors.gray[1],
-                                            },
-                                        })}
-                                    >
-                                        {isMutatingAnalytics ? (
-                                            <Loader
-                                                color="gray"
-                                                size={8}
-                                                speed={1}
-                                                radius="xl"
-                                            />
-                                        ) : (
-                                            analyticsResults?.charts.length ||
-                                            '0'
-                                        )}
-                                    </Avatar>
-                                </Group>
-                            </Tabs.Tab>
-                        </Tabs.List>
-
-                        <Tabs.Panel value="overview">
-                            <Stack>
-                                {metadata?.description && (
-                                    <>
-                                        <Box
-                                            sx={(theme) => ({
-                                                padding: theme.spacing.sm,
-                                                border: `1px solid ${theme.colors.gray[3]}`,
-                                                borderRadius: theme.radius.sm,
-                                                backgroundColor:
-                                                    theme.colors.gray[0],
-                                                fontSize: theme.fontSizes.sm,
-                                            })}
-                                        >
-                                            <MarkdownPreview
-                                                style={{
-                                                    backgroundColor:
-                                                        colors.gray[0],
-                                                    fontSize: 'small',
-                                                }}
-                                                source={metadata?.description}
-                                            />
-                                        </Box>
-
-                                        <Divider />
-                                    </>
-                                )}
-
-                                <Group position="apart">
-                                    <Group spacing="xs">
-                                        <MantineIcon
-                                            color={colors.gray[5]}
-                                            icon={IconDatabase}
-                                        />
-                                        <Text fw={500} fz={13} c="gray.7">
-                                            Source
-                                        </Text>
-                                    </Group>
-                                    <Text fw={500} fz={13} c="gray.7">
-                                        {metadata?.source}
-                                    </Text>
-                                </Group>
-
-                                <Group position="apart" noWrap>
-                                    <Group spacing="xs" noWrap>
-                                        <MantineIcon
-                                            color={colors.gray[5]}
-                                            icon={IconLink}
-                                        />
-                                        <Text fw={500} fz={13} c="gray.7">
-                                            Joins
-                                        </Text>
-                                    </Group>
-
-                                    <Tooltip
-                                        multiline
-                                        maw={300}
-                                        variant="xs"
-                                        label={metadata?.joinedTables.join(
-                                            ', ',
-                                        )}
-                                        disabled={
-                                            !isTruncated ||
-                                            !metadata?.joinedTables ||
-                                            metadata.joinedTables.length === 0
-                                        }
-                                    >
-                                        <Text
-                                            ref={ref}
-                                            fw={500}
-                                            fz={13}
-                                            c={
-                                                metadata?.joinedTables &&
-                                                metadata.joinedTables.length > 0
-                                                    ? 'blue'
-                                                    : 'gray.7'
-                                            }
-                                            truncate
-                                        >
-                                            {metadata?.joinedTables &&
-                                            metadata?.joinedTables.length > 0
-                                                ? metadata?.joinedTables.join(
-                                                      ', ',
-                                                  )
-                                                : 'None'}
-                                        </Text>
-                                    </Tooltip>
-                                </Group>
-
-                                <Divider />
-
-                                {selection?.field === undefined &&
-                                    !selectedFieldInTable && (
-                                        <CatalogMetadataFieldsTable
-                                            selection={selection}
-                                            metadata={metadata}
-                                            getAnalytics={getAnalytics}
-                                            setSelectedFieldInTable={
-                                                setSelectedFieldInTable
-                                            }
-                                        />
-                                    )}
-                            </Stack>
-                        </Tabs.Panel>
-                        <Tabs.Panel value="analytics">
-                            <>
-                                {analyticsResults && (
-                                    <CatalogAnalyticCharts
-                                        projectUuid={projectUuid}
-                                        analyticResults={analyticsResults}
-                                    />
-                                )}
-                            </>
-                        </Tabs.Panel>
-                    </Tabs>
-
-                    <Stack
-                        h={72}
-                        justify="center"
-                        p="sm"
-                        c="gray"
-                        w="100%"
-                        pos="absolute"
-                        bottom={0}
-                        left={0}
-                        sx={(theme) => ({
-                            backgroundColor: theme.colors.gray[0],
-                            border: `1px solid ${theme.colors.gray[4]}`,
-                            borderLeft: 0,
-                            borderRight: 0,
-                        })}
-                    >
-                        <Group position="apart">
-                            <Group>
-                                <Group spacing="xs">
-                                    <Paper
-                                        withBorder
-                                        sx={(theme) => ({
-                                            backgroundColor: 'white',
-                                            border: `1px solid ${theme.colors.gray[9]}`,
-                                            borderRadius: theme.radius.sm,
-                                            padding: 4,
-                                        })}
-                                    >
-                                        <MantineIcon
-                                            icon={IconCornerDownLeft}
-                                        />
-                                    </Paper>
-                                    <Text fz="xs" fw={500} c="gray.6">
-                                        Select Table
-                                    </Text>
-                                </Group>
-
-                                <Group spacing="xs">
-                                    <Paper
-                                        withBorder
-                                        sx={(theme) => ({
-                                            backgroundColor: 'white',
-                                            border: `1px solid ${theme.colors.gray[9]}`,
-                                            borderRadius: theme.radius.sm,
-                                            padding: 4,
-                                        })}
-                                    >
-                                        <MantineIcon icon={IconArrowDown} />
-                                    </Paper>
-
-                                    <Paper
-                                        withBorder
-                                        sx={(theme) => ({
-                                            backgroundColor: 'white',
-                                            border: `1px solid ${theme.colors.gray[9]}`,
-                                            borderRadius: theme.radius.sm,
-                                            padding: 4,
-                                        })}
-                                    >
-                                        <MantineIcon icon={IconArrowUp} />
-                                    </Paper>
-                                    <Text fz="xs" fw={500} c="gray.6">
-                                        Navigate
-                                    </Text>
-                                </Group>
-                            </Group>
-                            <Button
-                                size="sm"
-                                sx={(theme) => ({
-                                    backgroundColor: theme.colors.gray[8],
-                                    '&:hover': {
-                                        backgroundColor: theme.colors.gray[9],
+                        '&:not([data-active])': {
+                            color: theme.colors.gray[6],
+                        },
+                    },
+                })}
+            >
+                <Tabs.List>
+                    <Tabs.Tab value={'overview'}>Overview</Tabs.Tab>
+                    <Tabs.Tab value={'analytics'}>
+                        <Group spacing="xs">
+                            Usage Analytics
+                            <Avatar
+                                radius="xl"
+                                size="xs"
+                                fz="md"
+                                styles={(theme) => ({
+                                    placeholder: {
+                                        fontSize: theme.fontSizes.xs,
+                                        color: theme.colors.gray[7],
+                                        backgroundColor: theme.colors.gray[1],
                                     },
                                 })}
-                                onClick={() => {
-                                    history.push(
-                                        `/projects/${projectUuid}/tables/${metadata?.modelName}`,
-                                    );
-                                }}
                             >
-                                Select table
-                            </Button>
+                                {isMutatingAnalytics ? (
+                                    <Loader
+                                        color="gray"
+                                        size={8}
+                                        speed={1}
+                                        radius="xl"
+                                    />
+                                ) : (
+                                    analyticsResults?.charts.length || '0'
+                                )}
+                            </Avatar>
                         </Group>
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value="overview">
+                    <Stack>
+                        {metadata?.description && (
+                            <>
+                                <Box
+                                    sx={(theme) => ({
+                                        padding: theme.spacing.sm,
+                                        border: `1px solid ${theme.colors.gray[3]}`,
+                                        borderRadius: theme.radius.sm,
+                                        backgroundColor: theme.colors.gray[0],
+                                        fontSize: theme.fontSizes.sm,
+                                    })}
+                                >
+                                    <MarkdownPreview
+                                        style={{
+                                            backgroundColor: colors.gray[0],
+                                            fontSize: 'small',
+                                        }}
+                                        source={metadata?.description}
+                                    />
+                                </Box>
+
+                                <Divider />
+                            </>
+                        )}
+
+                        <Group position="apart">
+                            <Group spacing="xs">
+                                <MantineIcon
+                                    color={colors.gray[5]}
+                                    icon={IconDatabase}
+                                />
+                                <Text fw={500} fz={13} c="gray.7">
+                                    Source
+                                </Text>
+                            </Group>
+                            <Text fw={500} fz={13} c="gray.7">
+                                {metadata?.source}
+                            </Text>
+                        </Group>
+
+                        <Group position="apart" noWrap>
+                            <Group spacing="xs" noWrap>
+                                <MantineIcon
+                                    color={colors.gray[5]}
+                                    icon={IconLink}
+                                />
+                                <Text fw={500} fz={13} c="gray.7">
+                                    Joins
+                                </Text>
+                            </Group>
+
+                            <Tooltip
+                                multiline
+                                maw={300}
+                                variant="xs"
+                                label={metadata?.joinedTables.join(', ')}
+                                disabled={
+                                    !isTruncated ||
+                                    !metadata?.joinedTables ||
+                                    metadata.joinedTables.length === 0
+                                }
+                            >
+                                <Text
+                                    ref={ref}
+                                    fw={500}
+                                    fz={13}
+                                    c={
+                                        metadata?.joinedTables &&
+                                        metadata.joinedTables.length > 0
+                                            ? 'blue'
+                                            : 'gray.7'
+                                    }
+                                    truncate
+                                >
+                                    {metadata?.joinedTables &&
+                                    metadata?.joinedTables.length > 0
+                                        ? metadata?.joinedTables.join(', ')
+                                        : 'None'}
+                                </Text>
+                            </Tooltip>
+                        </Group>
+
+                        <Divider />
+
+                        {selection?.field === undefined &&
+                            !selectedFieldInTable && (
+                                <CatalogMetadataFieldsTable
+                                    selection={selection}
+                                    metadata={metadata}
+                                    getAnalytics={getAnalytics}
+                                    setSelectedFieldInTable={
+                                        setSelectedFieldInTable
+                                    }
+                                />
+                            )}
                     </Stack>
-                </>
-            )}
+                </Tabs.Panel>
+                <Tabs.Panel value="analytics">
+                    <>
+                        {analyticsResults && (
+                            <CatalogAnalyticCharts
+                                projectUuid={projectUuid}
+                                analyticResults={analyticsResults}
+                            />
+                        )}
+                    </>
+                </Tabs.Panel>
+            </Tabs>
+
+            <Stack
+                h={72}
+                justify="center"
+                p="sm"
+                c="gray"
+                w="100%"
+                pos="absolute"
+                bottom={0}
+                left={0}
+                sx={(theme) => ({
+                    backgroundColor: theme.colors.gray[0],
+                    border: `1px solid ${theme.colors.gray[4]}`,
+                    borderLeft: 0,
+                    borderRight: 0,
+                })}
+            >
+                <Group position="apart">
+                    <Group>
+                        <Group spacing="xs">
+                            <Paper
+                                withBorder
+                                sx={(theme) => ({
+                                    backgroundColor: 'white',
+                                    border: `1px solid ${theme.colors.gray[9]}`,
+                                    borderRadius: theme.radius.sm,
+                                    padding: 4,
+                                })}
+                            >
+                                <MantineIcon icon={IconCornerDownLeft} />
+                            </Paper>
+                            <Text fz="xs" fw={500} c="gray.6">
+                                Select Table
+                            </Text>
+                        </Group>
+
+                        <Group spacing="xs">
+                            <Paper
+                                withBorder
+                                sx={(theme) => ({
+                                    backgroundColor: 'white',
+                                    border: `1px solid ${theme.colors.gray[9]}`,
+                                    borderRadius: theme.radius.sm,
+                                    padding: 4,
+                                })}
+                            >
+                                <MantineIcon icon={IconArrowDown} />
+                            </Paper>
+
+                            <Paper
+                                withBorder
+                                sx={(theme) => ({
+                                    backgroundColor: 'white',
+                                    border: `1px solid ${theme.colors.gray[9]}`,
+                                    borderRadius: theme.radius.sm,
+                                    padding: 4,
+                                })}
+                            >
+                                <MantineIcon icon={IconArrowUp} />
+                            </Paper>
+                            <Text fz="xs" fw={500} c="gray.6">
+                                Navigate
+                            </Text>
+                        </Group>
+                    </Group>
+                    <Button
+                        size="sm"
+                        sx={(theme) => ({
+                            backgroundColor: theme.colors.gray[8],
+                            '&:hover': {
+                                backgroundColor: theme.colors.gray[9],
+                            },
+                        })}
+                        onClick={() => {
+                            history.push(
+                                `/projects/${projectUuid}/tables/${metadata?.modelName}`,
+                            );
+                        }}
+                    >
+                        Select table
+                    </Button>
+                </Group>
+            </Stack>
         </Stack>
     );
 };

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -121,7 +121,6 @@ export const CatalogPanel: FC = () => {
     const [, startTransition] = useTransition();
     const {
         setMetadata,
-        setMetadataErrors,
         isSidebarOpen,
         setAnalyticsResults,
         setSidebarOpen,
@@ -313,28 +312,15 @@ export const CatalogPanel: FC = () => {
         (selectedItem: CatalogSelection) => {
             if (!selectedItem.table) return;
 
-            // Reset metadata errors when selecting a new item
-            setMetadataErrors(undefined);
-
             if (selectedItem.group === TABLES_WITH_ERRORS_GROUP_NAME) {
                 if (!isSidebarOpen) {
                     setSidebarOpen(true);
                 }
 
-                const errors =
-                    catalogTree &&
-                    catalogTree[TABLES_WITH_ERRORS_GROUP_NAME].tables[
-                        selectedItem.table
-                    ].errors;
-
                 setSelection({
                     table: selectedItem.table,
                     group: selectedItem.group,
                 });
-
-                if (errors) {
-                    setMetadataErrors(errors);
-                }
 
                 return; // no metadata for tables with errors
             }
@@ -371,8 +357,6 @@ export const CatalogPanel: FC = () => {
             isSidebarOpen,
             setSelection,
             catalogResults,
-            catalogTree,
-            setMetadataErrors,
             setSidebarOpen,
             getMetadata,
             getAnalytics,

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -137,7 +137,7 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                     {table.errors && table.errors.length > 0 ? (
                         <Tooltip
                             variant="xs"
-                            disabled={isErrorDescriptionTruncated}
+                            disabled={!isErrorDescriptionTruncated}
                             label={table.errors[0].message}
                             withinPortal
                             multiline

--- a/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogTableListItem.tsx
@@ -43,6 +43,10 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
     const [hovered, setHovered] = useState<boolean | undefined>(false);
     const { ref, isTruncated: isNameTruncated } =
         useIsTruncated<HTMLDivElement>();
+    const {
+        ref: errorDescriptionRef,
+        isTruncated: isErrorDescriptionTruncated,
+    } = useIsTruncated<HTMLDivElement>();
 
     const countJoinedTables =
         'joinedTables' in table ? table.joinedTables?.length || 0 : 0;
@@ -77,10 +81,11 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
                         isLast && !isOpen ? theme.radius.md : 0,
                     borderBottomRightRadius:
                         isLast && !isOpen ? theme.radius.md : 0,
+                    opacity: table.errors ? 0.5 : 1,
                 })}
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}
-                onClick={onClick}
+                onClick={() => (!table.errors ? onClick?.() : undefined)}
                 pos="relative"
             >
                 <Grid.Col span={'content'}>
@@ -130,9 +135,24 @@ export const CatalogTableListItem: FC<React.PropsWithChildren<Props>> = ({
 
                 <Grid.Col span={'auto'}>
                     {table.errors && table.errors.length > 0 ? (
-                        <Text fz="13px" c="gray.7" w="100%" lineClamp={2}>
-                            {table.errors[0].message}
-                        </Text>
+                        <Tooltip
+                            variant="xs"
+                            disabled={isErrorDescriptionTruncated}
+                            label={table.errors[0].message}
+                            withinPortal
+                            multiline
+                            maw={300}
+                        >
+                            <Text
+                                ref={errorDescriptionRef}
+                                fz="13px"
+                                c="gray.7"
+                                w="100%"
+                                lineClamp={2}
+                            >
+                                {table.errors[0].message}
+                            </Text>
+                        </Tooltip>
                     ) : !isSelected ? (
                         <Highlight
                             fz="13px"

--- a/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
+++ b/packages/frontend/src/features/catalog/context/CatalogProvider.tsx
@@ -2,7 +2,6 @@ import {
     type CatalogAnalytics,
     type CatalogMetadata,
     type CatalogSelection,
-    type InlineError,
 } from '@lightdash/common';
 import {
     createContext,
@@ -17,8 +16,6 @@ type CatalogContextValues = {
     projectUuid: string;
     metadata: CatalogMetadata | undefined;
     setMetadata: Dispatch<SetStateAction<CatalogMetadata | undefined>>;
-    metadataErrors: InlineError[] | undefined;
-    setMetadataErrors: Dispatch<SetStateAction<InlineError[] | undefined>>;
     selection: CatalogSelection | undefined;
     setSelection: Dispatch<SetStateAction<CatalogSelection | undefined>>;
     analyticsResults: CatalogAnalytics | undefined;
@@ -40,7 +37,6 @@ export const CatalogProvider: FC<
     >
 > = ({ isSidebarOpen, setSidebarOpen, projectUuid, children }) => {
     const [metadata, setMetadata] = useState<CatalogMetadata>();
-    const [metadataErrors, setMetadataErrors] = useState<InlineError[]>();
     const [analyticsResults, setAnalyticsResults] =
         useState<CatalogAnalytics>();
     const [selection, setSelection] = useState<CatalogSelection>();
@@ -51,8 +47,6 @@ export const CatalogProvider: FC<
                 projectUuid,
                 metadata,
                 setMetadata,
-                metadataErrors,
-                setMetadataErrors,
                 selection,
                 setSelection,
                 analyticsResults,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10489

### Description:

Hide explore errors in Catalog if they have `NO_DIMENSIONS_FOUND` error - we do the same in the validator.
Reduce opacity of errors table list item (this will be revisited a bit more when we deal with the removal of this grouping)
Display tooltip if the error is truncated, but don't open the sidebar with the full error anymore

**note**: I see that the keyboard navigation could be handled differently. I believe this can be done on a separate PR, but lmk if pressing

To test, I changed this locally in `schema.yml`

<img width="1243" alt="image" src="https://github.com/lightdash/lightdash/assets/7611706/b0c407b0-e39f-4307-acac-5e97ea2ba25f">


before
<img width="1332" alt="Screenshot 2024-06-24 at 11 02 29" src="https://github.com/lightdash/lightdash/assets/7611706/7d4c9fb0-368c-49eb-b34e-25093f98a8fd">

after

https://github.com/lightdash/lightdash/assets/7611706/2393cd12-1f54-4b62-9246-6daaea421eae



And now we don't see the errors group and we don't handle if there are errors in the explore because they don't get added to the payload

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
