### PR TITLE
feat: allow select field to explore in catalog

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -315,6 +315,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                fieldType: { ref: 'FieldType' },
+                tableLabel: { dataType: 'string' },
                 joinedTables: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -334,6 +336,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 modelName: { dataType: 'string', required: true },
+                label: { dataType: 'string', required: true },
                 description: {
                     dataType: 'union',
                     subSchemas: [
@@ -2029,11 +2032,24 @@ const models: TsoaRoute.Models = {
         enums: ['row', 'column'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FunnelChartLabelPosition: {
+        dataType: 'refEnum',
+        enums: ['inside', 'left', 'right'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FunnelChart: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                label: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        showPercentage: { dataType: 'boolean' },
+                        showValue: { dataType: 'boolean' },
+                        position: { ref: 'FunnelChartLabelPosition' },
+                    },
+                },
                 metadata: { ref: 'Record_string.SeriesMetadata_' },
                 fieldId: { dataType: 'string' },
                 dataInput: { ref: 'FunnelChartDataInput' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -261,6 +261,12 @@
             },
             "CatalogMetadata": {
                 "properties": {
+                    "fieldType": {
+                        "$ref": "#/components/schemas/FieldType"
+                    },
+                    "tableLabel": {
+                        "type": "string"
+                    },
                     "joinedTables": {
                         "items": {
                             "type": "string"
@@ -279,6 +285,9 @@
                     "modelName": {
                         "type": "string"
                     },
+                    "label": {
+                        "type": "string"
+                    },
                     "description": {
                         "type": "string"
                     },
@@ -286,7 +295,13 @@
                         "type": "string"
                     }
                 },
-                "required": ["joinedTables", "fields", "modelName", "name"],
+                "required": [
+                    "joinedTables",
+                    "fields",
+                    "modelName",
+                    "label",
+                    "name"
+                ],
                 "type": "object"
             },
             "ApiCatalogMetadataResults": {
@@ -2179,8 +2194,26 @@
                 "enum": ["row", "column"],
                 "type": "string"
             },
+            "FunnelChartLabelPosition": {
+                "enum": ["inside", "left", "right"],
+                "type": "string"
+            },
             "FunnelChart": {
                 "properties": {
+                    "label": {
+                        "properties": {
+                            "showPercentage": {
+                                "type": "boolean"
+                            },
+                            "showValue": {
+                                "type": "boolean"
+                            },
+                            "position": {
+                                "$ref": "#/components/schemas/FunnelChartLabelPosition"
+                            }
+                        },
+                        "type": "object"
+                    },
                     "metadata": {
                         "$ref": "#/components/schemas/Record_string.SeriesMetadata_"
                     },
@@ -7919,7 +7952,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1138.0",
+        "version": "0.1143.2",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -7,7 +7,7 @@ import {
     UnexpectedServerError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import { CatalogTableName, DbCatalog } from '../../database/entities/catalog';
+import { CatalogTableName } from '../../database/entities/catalog';
 import { CachedExploreTableName } from '../../database/entities/projects';
 import { wrapSentryTransaction } from '../../utils';
 import {

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -17,7 +17,9 @@ export const convertExploresToCatalog = (
             type: CatalogType.Table,
         };
         const dimensionsAndMetrics = [
-            ...Object.values(baseTable?.dimensions || {}),
+            ...Object.values(baseTable?.dimensions || {}).filter(
+                (d) => !d.isIntervalBase,
+            ),
             ...Object.values(baseTable?.metrics || {}),
         ].filter((f) => !f.hidden); // Filter out hidden fields from catalog
         const fields = dimensionsAndMetrics.map<DbCatalogIn>((field) => ({

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -32,7 +32,7 @@ export const parseFieldsFromCompiledTable = (
     table: CompiledTable,
 ): CatalogField[] => {
     const tableFields = [
-        ...Object.values(table.dimensions),
+        ...Object.values(table.dimensions).filter((d) => !d.isIntervalBase),
         ...Object.values(table.metrics),
     ].filter((f) => !f.hidden); // Filter out hidden fields from catalog
     return tableFields.map((field) =>

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -7,6 +7,7 @@ import {
     type CompiledMetric,
     type Dimension,
     type Field,
+    type FieldType,
 } from './field';
 import { type ChartSummary } from './savedCharts';
 import { type TableBase } from './table';
@@ -62,6 +63,7 @@ export type CatalogMetadata = {
     fields: CatalogField[];
     joinedTables: string[];
     tableLabel?: string;
+    fieldType?: FieldType;
 };
 export type ApiCatalogMetadataResults = CatalogMetadata;
 

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -4,7 +4,10 @@ import { Icon123, IconAbc } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineLinkButton from '../../../components/common/MantineLinkButton';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
+import {
+    DEFAULT_EMPTY_EXPLORE_CONFIG,
+    getExplorerUrlFromCreateSavedChartVersion,
+} from '../../../hooks/useExplorerRoute';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useCatalogContext } from '../context/CatalogProvider';
 
@@ -27,44 +30,27 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
     const { projectUuid } = useCatalogContext();
 
     const exploreWithFieldUrl = useMemo(() => {
+        const fieldToExplore = getItemId({
+            name: field.name,
+            table: field.tableName,
+        });
         const draftChartUrl = getExplorerUrlFromCreateSavedChartVersion(
             projectUuid,
             {
+                ...DEFAULT_EMPTY_EXPLORE_CONFIG,
                 tableName: field.tableName,
                 metricQuery: {
+                    ...DEFAULT_EMPTY_EXPLORE_CONFIG.metricQuery,
                     exploreName: field.tableName,
-                    dimensions:
-                        field.fieldType === FieldType.DIMENSION
-                            ? [
-                                  getItemId({
-                                      name: field.name,
-                                      table: field.tableName,
-                                  }),
-                              ]
-                            : [],
-                    metrics:
-                        field.fieldType === FieldType.METRIC
-                            ? [
-                                  getItemId({
-                                      name: field.name,
-                                      table: field.tableName,
-                                  }),
-                              ]
-                            : [],
-                    tableCalculations: [],
-                    filters: {},
-                    sorts: [],
-                    limit: 500,
-                },
-                chartConfig: {
-                    type: ChartType.CARTESIAN,
-                    config: {
-                        layout: {},
-                        eChartsConfig: {},
-                    },
-                },
-                tableConfig: {
-                    columnOrder: [],
+                    ...(field.fieldType === FieldType.DIMENSION
+                        ? {
+                              dimensions: [fieldToExplore],
+                          }
+                        : field.fieldType === FieldType.METRIC
+                        ? {
+                              metrics: [fieldToExplore],
+                          }
+                        : []),
                 },
             },
         );

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -8,7 +8,6 @@ import {
     DEFAULT_EMPTY_EXPLORE_CONFIG,
     getExplorerUrlFromCreateSavedChartVersion,
 } from '../../../hooks/useExplorerRoute';
-import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useCatalogContext } from '../context/CatalogProvider';
 
 type Props = {
@@ -25,7 +24,6 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
     isSelected = false,
     onClick,
 }) => {
-    const { ref: descriptionRef } = useIsTruncated<HTMLDivElement>();
     const [hovered, setHovered] = useState<boolean | undefined>(false);
     const { projectUuid } = useCatalogContext();
 
@@ -111,7 +109,6 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
             <Grid.Col span={'auto'}>
                 {!isSelected ? (
                     <Highlight
-                        ref={descriptionRef}
                         fz="13px"
                         w="auto"
                         c="gray.7"

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -33,6 +33,7 @@ import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useCatalogContext } from '../context/CatalogProvider';
 import { useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
@@ -435,12 +436,60 @@ export const CatalogMetadata: FC = () => {
                             },
                         })}
                         onClick={() => {
-                            history.push(
+                            if (metadata && isViewingField) {
+                                return history.push(
+                                    getExplorerUrlFromCreateSavedChartVersion(
+                                        projectUuid,
+                                        {
+                                            tableName: metadata.modelName,
+                                            metricQuery: {
+                                                exploreName: metadata.modelName,
+                                                dimensions:
+                                                    metadata?.fieldType ===
+                                                    FieldType.DIMENSION
+                                                        ? [
+                                                              getItemId({
+                                                                  name: metadata.name,
+                                                                  table: metadata.modelName,
+                                                              }),
+                                                          ]
+                                                        : [],
+                                                metrics:
+                                                    metadata.fieldType ===
+                                                    FieldType.METRIC
+                                                        ? [
+                                                              getItemId({
+                                                                  name: metadata.name,
+                                                                  table: metadata.modelName,
+                                                              }),
+                                                          ]
+                                                        : [],
+                                                tableCalculations: [],
+                                                filters: {},
+                                                sorts: [],
+                                                limit: 500,
+                                            },
+                                            chartConfig: {
+                                                type: ChartType.CARTESIAN,
+                                                config: {
+                                                    layout: {},
+                                                    eChartsConfig: {},
+                                                },
+                                            },
+                                            tableConfig: {
+                                                columnOrder: [],
+                                            },
+                                        },
+                                    ),
+                                );
+                            }
+
+                            return history.push(
                                 `/projects/${projectUuid}/tables/${metadata?.modelName}`,
                             );
                         }}
                     >
-                        Select table
+                        Select {isViewingField ? 'field' : 'table'}
                     </Button>
                 </Group>
             </Stack>

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -1,5 +1,4 @@
 import {
-    ChartType,
     FieldType,
     getItemId,
     type CatalogMetadata as CatalogMetadataType,
@@ -33,7 +32,10 @@ import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
+import {
+    DEFAULT_EMPTY_EXPLORE_CONFIG,
+    getExplorerUrlFromCreateSavedChartVersion,
+} from '../../../hooks/useExplorerRoute';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useCatalogContext } from '../context/CatalogProvider';
 import { useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
@@ -437,47 +439,34 @@ export const CatalogMetadata: FC = () => {
                         })}
                         onClick={() => {
                             if (metadata && isViewingField) {
+                                const fieldToExplore = getItemId({
+                                    name: metadata.name,
+                                    table: metadata.modelName,
+                                });
                                 return history.push(
                                     getExplorerUrlFromCreateSavedChartVersion(
                                         projectUuid,
                                         {
+                                            ...DEFAULT_EMPTY_EXPLORE_CONFIG,
                                             tableName: metadata.modelName,
                                             metricQuery: {
+                                                ...DEFAULT_EMPTY_EXPLORE_CONFIG.metricQuery,
                                                 exploreName: metadata.modelName,
-                                                dimensions:
-                                                    metadata?.fieldType ===
-                                                    FieldType.DIMENSION
-                                                        ? [
-                                                              getItemId({
-                                                                  name: metadata.name,
-                                                                  table: metadata.modelName,
-                                                              }),
-                                                          ]
-                                                        : [],
-                                                metrics:
-                                                    metadata.fieldType ===
-                                                    FieldType.METRIC
-                                                        ? [
-                                                              getItemId({
-                                                                  name: metadata.name,
-                                                                  table: metadata.modelName,
-                                                              }),
-                                                          ]
-                                                        : [],
-                                                tableCalculations: [],
-                                                filters: {},
-                                                sorts: [],
-                                                limit: 500,
-                                            },
-                                            chartConfig: {
-                                                type: ChartType.CARTESIAN,
-                                                config: {
-                                                    layout: {},
-                                                    eChartsConfig: {},
-                                                },
-                                            },
-                                            tableConfig: {
-                                                columnOrder: [],
+                                                ...(metadata.fieldType ===
+                                                FieldType.DIMENSION
+                                                    ? {
+                                                          dimensions: [
+                                                              fieldToExplore,
+                                                          ],
+                                                      }
+                                                    : metadata.fieldType ===
+                                                      FieldType.METRIC
+                                                    ? {
+                                                          metrics: [
+                                                              fieldToExplore,
+                                                          ],
+                                                      }
+                                                    : {}),
                                             },
                                         },
                                     ),

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -1,4 +1,9 @@
-import { type CatalogMetadata as CatalogMetadataType } from '@lightdash/common';
+import {
+    ChartType,
+    FieldType,
+    getItemId,
+    type CatalogMetadata as CatalogMetadataType,
+} from '@lightdash/common';
 import {
     Avatar,
     Box,
@@ -62,6 +67,8 @@ export const CatalogMetadata: FC = () => {
         string | undefined
     >();
 
+    const isViewingField = selectedFieldInTable || selection?.field;
+
     useEffect(() => {
         setSelectedFieldInTable(undefined);
     }, [selection]);
@@ -76,10 +83,9 @@ export const CatalogMetadata: FC = () => {
     );
 
     const metadata = useMemo(() => {
-        const fieldSelected = selection?.field || selectedFieldInTable;
-        if (fieldSelected && metadataResults) {
+        if (metadataResults && (selectedFieldInTable || selection?.field)) {
             const field = metadataResults?.fields?.find(
-                (f) => f.name === fieldSelected,
+                (f) => f.name === (selectedFieldInTable || selection?.field),
             );
             if (!field) return undefined;
             const catalogMetadata: CatalogMetadataType = {
@@ -89,12 +95,13 @@ export const CatalogMetadata: FC = () => {
                 tableLabel: field.tableLabel,
                 description: field.description,
                 fields: [],
+                fieldType: field.fieldType,
             };
             return catalogMetadata;
         } else {
             return metadataResults;
         }
-    }, [metadataResults, selection, selectedFieldInTable]);
+    }, [metadataResults, selectedFieldInTable, selection?.field]);
 
     return (
         <Stack h="100vh" spacing="xl">

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -16,6 +16,29 @@ import {
 } from '../providers/ExplorerProvider';
 import useToaster from './toaster/useToaster';
 
+export const DEFAULT_EMPTY_EXPLORE_CONFIG: CreateSavedChartVersion = {
+    tableName: '',
+    metricQuery: {
+        exploreName: '',
+        dimensions: [],
+        metrics: [],
+        tableCalculations: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {},
+            eChartsConfig: {},
+        },
+    },
+    tableConfig: {
+        columnOrder: [],
+    },
+};
+
 export const getExplorerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
     createSavedChart: CreateSavedChartVersion,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10150](https://github.com/lightdash/lightdash/issues/10150)

### Description:

- Allows field selection when searching it (on hover) and also when viewing its metadata


Demo:


https://github.com/lightdash/lightdash/assets/7611706/4a653f98-8434-4784-8b55-d0b5c1203265



**NOTE**: this also filters out dimensions that have `isIntervalBase`: `true` - for example, we have a `Timestamp` dimension that has many granularities. Currently, we display its base dimension, but that isn't explorable. Instead, we should just filter them out from the catalog fields that we can search. If we want to bring back this functionality in the future, we should remove this filtering but handle these fields differently on the Catalog - we should have a tree basically.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
