### PR TITLE
fix: safari child src fallback

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -329,7 +329,7 @@ export default class App {
                             ...contentSecurityPolicyAllowedDomains,
                         ],
                         'child-src': [
-                            // Fallback of worker-src for older versions of safari
+                            // Fallback of worker-src for safari older than 15.5
                             "'self'",
                             'blob:',
                             ...contentSecurityPolicyAllowedDomains,

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -328,6 +328,12 @@ export default class App {
                             'blob:',
                             ...contentSecurityPolicyAllowedDomains,
                         ],
+                        'child-src': [
+                            // Fallback of worker-src for older versions of safari
+                            "'self'",
+                            'blob:',
+                            ...contentSecurityPolicyAllowedDomains,
+                        ],
                         'script-src': [
                             "'self'",
                             "'unsafe-eval'",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-internal-work/issues/1833<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Apply child-src fallback for safari older than 15.5 as worker-src wasn't supported before that version.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
