### PR TITLE
fix: get correct table label and label on metadata

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -346,7 +346,8 @@ export class CatalogService<
         );
 
         const metadata: CatalogMetadata = {
-            name: explore.label,
+            name: explore.name,
+            label: explore.label,
             description: baseTable.description,
             modelName: explore.name,
             source: explore.ymlPath,

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -55,11 +55,13 @@ export type ApiCatalogResults = CatalogItem[];
 export type CatalogMetadata = {
     name: string;
     description: string | undefined;
+    label: string;
     // TODO Tags
     modelName: string;
     source: string | undefined;
     fields: CatalogField[];
     joinedTables: string[];
+    tableLabel?: string;
 };
 export type ApiCatalogMetadataResults = CatalogMetadata;
 

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -85,6 +85,8 @@ export const CatalogMetadata: FC = () => {
             const catalogMetadata: CatalogMetadataType = {
                 ...metadataResults,
                 name: field.name,
+                label: field.label,
+                tableLabel: field.tableLabel,
                 description: field.description,
                 fields: [],
             };
@@ -153,12 +155,12 @@ export const CatalogMetadata: FC = () => {
                             }}
                         >
                             {' '}
-                            {selection?.table}
+                            {metadata?.tableLabel}
                         </Text>
                         {' / '}
                     </>
                 )}
-                <Tooltip variant="xs" label={metadata?.modelName}>
+                <Tooltip variant="xs" label={metadata?.name}>
                     <Text
                         fz="lg"
                         fw={600}
@@ -168,7 +170,7 @@ export const CatalogMetadata: FC = () => {
                             );
                         }}
                     >
-                        {metadata?.name}
+                        {metadata?.label}
                     </Text>
                 </Tooltip>
             </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Missed one bit in: https://github.com/lightdash/lightdash/pull/10485

Before

<img width="607" alt="Screenshot 2024-06-25 at 14 12 27" src="https://github.com/lightdash/lightdash/assets/7611706/ff3bde65-928b-436d-bdea-08855123f9e5">

After

<img width="656" alt="Screenshot 2024-06-25 at 14 09 46" src="https://github.com/lightdash/lightdash/assets/7611706/5f3f9c5b-77ec-45e9-8ffb-4fbf842b9eaf">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
