### PR TITLE
fix: support dbt_project flags

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -2,14 +2,10 @@ import {
     assertUnreachable,
     DbtError,
     DbtLog,
-    DbtManifestVersion,
     DbtPackages,
-    DbtRpcDocsGenerateResults,
     DbtRpcGetManifestResults,
-    DefaultSupportedDbtVersion,
     isDbtLog,
     isDbtPackages,
-    isDbtRpcDocsGenerateResults,
     isDbtRpcManifestResults,
     ParseError,
     SupportedDbtVersions,
@@ -188,6 +184,8 @@ export class DbtCliClient implements DbtClient {
                 all: true,
                 stdio: ['pipe', 'pipe', process.stderr],
                 env: {
+                    DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
+                    DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
                     ...this.environment,
                 },
             });

--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -194,10 +194,6 @@ export const profileFromCredentials = (
     );
 
     const profile = yaml.dump({
-        config: {
-            partial_parse: false,
-            send_anonymous_usage_stats: false,
-        },
         [LIGHTDASH_PROFILE_NAME]: {
             target: targetName,
             outputs: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10359](https://github.com/lightdash/lightdash/issues/10359)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem:
> Runtime Error Do not specify both 'config' in profiles.yml and 'flags' in dbt_project.yml. Using 'config' in profiles.yml is deprecated."

Lightdash generates temporary profile files which had `config`. 
I have moved that config from the profile file to the dbt command env vars.

Note: `flags` was only supported from dbt >= 1.6
Note 2:
1.4 / 1.5 - should work without `flags`. Adding it would throw an error.
1.6 / 1.7 - should work with `flags`
1.8 - should work with flags but we don't support postgres atm so you need to test with BigQuery/Snowflake/Trino

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
