### PR TITLE
feat: enable searching catalog with filters (including search index)

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -42,11 +42,13 @@ export class CatalogController extends BaseController {
         @Request() req: express.Request,
         @Query() search?: ApiCatalogSearch['search'],
         @Query() type?: ApiCatalogSearch['type'],
+        @Query() filter?: ApiCatalogSearch['filter'],
     ): Promise<{ status: 'ok'; results: ApiCatalogResults }> {
         this.setStatus(200);
         const query: ApiCatalogSearch = {
             search,
             type,
+            filter,
         };
 
         const results = await this.services

--- a/packages/backend/src/database/migrations/20240625163709_add_field_type_to_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20240625163709_add_field_type_to_catalog_search.ts
@@ -1,13 +1,15 @@
 import { Knex } from 'knex';
 
+const CatalogTableName = 'catalog_search';
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable('catalog_search', (table) => {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
         table.text('field_type').nullable().index();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.schema.alterTable('catalog_search', (table) => {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
         table.dropColumn('field_type');
     });
 }

--- a/packages/backend/src/database/migrations/20240625163709_add_field_type_to_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20240625163709_add_field_type_to_catalog_search.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.text('field_type').nullable().index();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.dropColumn('field_type');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -310,6 +310,11 @@ const models: TsoaRoute.Models = {
         enums: ['table', 'field'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CatalogFilter: {
+        dataType: 'refEnum',
+        enums: ['tables', 'dimensions', 'metrics'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CatalogMetadata: {
         dataType: 'refAlias',
         type: {
@@ -7141,6 +7146,7 @@ export function RegisterRoutes(app: express.Router) {
                 },
                 search: { in: 'query', name: 'search', dataType: 'string' },
                 type: { in: 'query', name: 'type', ref: 'CatalogType' },
+                filter: { in: 'query', name: 'filter', ref: 'CatalogFilter' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -27,32 +27,21 @@
                                 "description": "HTTP status code"
                             }
                         },
-                        "required": [
-                            "name",
-                            "statusCode"
-                        ],
+                        "required": ["name", "statusCode"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "error"
-                        ],
+                        "enum": ["error"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "error",
-                    "status"
-                ],
+                "required": ["error", "status"],
                 "type": "object",
                 "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
             },
             "FieldType": {
-                "enum": [
-                    "metric",
-                    "dimension"
-                ],
+                "enum": ["metric", "dimension"],
                 "type": "string"
             },
             "Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_": {
@@ -73,12 +62,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "name",
-                    "label",
-                    "fieldType",
-                    "tableLabel"
-                ],
+                "required": ["name", "label", "fieldType", "tableLabel"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -97,9 +81,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "CatalogType.Field": {
-                "enum": [
-                    "field"
-                ],
+                "enum": ["field"],
                 "type": "string"
             },
             "CatalogField": {
@@ -131,10 +113,7 @@
                                 "$ref": "#/components/schemas/CatalogType.Field"
                             }
                         },
-                        "required": [
-                            "tableName",
-                            "type"
-                        ],
+                        "required": ["tableName", "type"],
                         "type": "object"
                     }
                 ]
@@ -157,18 +136,12 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "name",
-                    "label"
-                ],
+                "required": ["name", "label"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "InlineErrorType": {
-                "enum": [
-                    "METADATA_PARSE_ERROR",
-                    "NO_DIMENSIONS_FOUND"
-                ],
+                "enum": ["METADATA_PARSE_ERROR", "NO_DIMENSIONS_FOUND"],
                 "type": "string"
             },
             "InlineError": {
@@ -180,26 +153,16 @@
                         "$ref": "#/components/schemas/InlineErrorType"
                     }
                 },
-                "required": [
-                    "message",
-                    "type"
-                ],
+                "required": ["message", "type"],
                 "type": "object"
             },
             "CatalogType.Table": {
-                "enum": [
-                    "table"
-                ],
+                "enum": ["table"],
                 "type": "string"
             },
             "DbtModelJoinType": {
                 "type": "string",
-                "enum": [
-                    "inner",
-                    "full",
-                    "left",
-                    "right"
-                ]
+                "enum": ["inner", "full", "left", "right"]
             },
             "Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_": {
                 "properties": {
@@ -219,10 +182,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "table",
-                    "sqlOn"
-                ],
+                "required": ["table", "sqlOn"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -237,9 +197,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "compiledSqlOn"
-                        ],
+                        "required": ["compiledSqlOn"],
                         "type": "object"
                     }
                 ]
@@ -276,9 +234,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "type"
-                        ],
+                        "required": ["type"],
                         "type": "object"
                     }
                 ]
@@ -300,18 +256,11 @@
                 "type": "array"
             },
             "CatalogType": {
-                "enum": [
-                    "table",
-                    "field"
-                ],
+                "enum": ["table", "field"],
                 "type": "string"
             },
             "CatalogFilter": {
-                "enum": [
-                    "tables",
-                    "dimensions",
-                    "metrics"
-                ],
+                "enum": ["tables", "dimensions", "metrics"],
                 "type": "string"
             },
             "CatalogMetadata": {
@@ -424,9 +373,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "charts"
-                ],
+                "required": ["charts"],
                 "type": "object"
             },
             "ApiCatalogAnalyticsResults": {
@@ -439,16 +386,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_Comment.text-or-replyTo-or-mentions-or-textHtml_": {
@@ -469,11 +411,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "text",
-                    "mentions",
-                    "textHtml"
-                ],
+                "required": ["text", "mentions", "textHtml"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -506,9 +444,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "name"
-                        ],
+                        "required": ["name"],
                         "type": "object"
                     },
                     "createdAt": {
@@ -551,31 +487,22 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiResolveComment": {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object"
             },
             "ApiCsvUrlResponse": {
@@ -592,33 +519,20 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "truncated",
-                            "status",
-                            "url"
-                        ],
+                        "required": ["truncated", "status", "url"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "DashboardTileTypes": {
-                "enum": [
-                    "saved_chart",
-                    "markdown",
-                    "loom"
-                ],
+                "enum": ["saved_chart", "markdown", "loom"],
                 "type": "string"
             },
             "Required_CreateDashboardTileBase_": {
@@ -649,14 +563,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "uuid",
-                    "type",
-                    "x",
-                    "y",
-                    "h",
-                    "w"
-                ],
+                "required": ["uuid", "type", "x", "y", "h", "w"],
                 "type": "object",
                 "description": "Make all properties in T required"
             },
@@ -664,9 +571,7 @@
                 "$ref": "#/components/schemas/Required_CreateDashboardTileBase_"
             },
             "DashboardTileTypes.SAVED_CHART": {
-                "enum": [
-                    "saved_chart"
-                ],
+                "enum": ["saved_chart"],
                 "type": "string"
             },
             "DashboardChartTileProperties": {
@@ -699,19 +604,14 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "savedChartUuid"
-                        ],
+                        "required": ["savedChartUuid"],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.SAVED_CHART"
                     }
                 },
-                "required": [
-                    "properties",
-                    "type"
-                ],
+                "required": ["properties", "type"],
                 "type": "object"
             },
             "DashboardChartTile": {
@@ -725,9 +625,7 @@
                 ]
             },
             "DashboardTileTypes.MARKDOWN": {
-                "enum": [
-                    "markdown"
-                ],
+                "enum": ["markdown"],
                 "type": "string"
             },
             "DashboardMarkdownTileProperties": {
@@ -741,20 +639,14 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "content",
-                            "title"
-                        ],
+                        "required": ["content", "title"],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.MARKDOWN"
                     }
                 },
-                "required": [
-                    "properties",
-                    "type"
-                ],
+                "required": ["properties", "type"],
                 "type": "object"
             },
             "DashboardMarkdownTile": {
@@ -768,9 +660,7 @@
                 ]
             },
             "DashboardTileTypes.LOOM": {
-                "enum": [
-                    "loom"
-                ],
+                "enum": ["loom"],
                 "type": "string"
             },
             "DashboardLoomTileProperties": {
@@ -787,20 +677,14 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "url",
-                            "title"
-                        ],
+                        "required": ["url", "title"],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.LOOM"
                     }
                 },
-                "required": [
-                    "properties",
-                    "type"
-                ],
+                "required": ["properties", "type"],
                 "type": "object"
             },
             "DashboardLoomTile": {
@@ -835,10 +719,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "tableName",
-                    "fieldId"
-                ],
+                "required": ["tableName", "fieldId"],
                 "type": "object"
             },
             "ConditionalOperator": {
@@ -887,11 +768,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "operator",
-                    "id",
-                    "target"
-                ],
+                "required": ["operator", "id", "target"],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -939,11 +816,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "tableCalculations",
-                    "metrics",
-                    "dimensions"
-                ],
+                "required": ["tableCalculations", "metrics", "dimensions"],
                 "type": "object"
             },
             "UpdatedByUser": {
@@ -958,11 +831,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "userUuid",
-                    "firstName",
-                    "lastName"
-                ],
+                "required": ["userUuid", "firstName", "lastName"],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -979,11 +848,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "order",
-                    "name",
-                    "uuid"
-                ],
+                "required": ["order", "name", "uuid"],
                 "type": "object"
             },
             "Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__": {
@@ -1099,25 +964,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "PromotionAction": {
-                "enum": [
-                    "no changes",
-                    "create",
-                    "update",
-                    "delete"
-                ],
+                "enum": ["no changes", "create", "update", "delete"],
                 "type": "string"
             },
             "Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__": {
@@ -1198,9 +1053,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "spaceSlug"
-                        ],
+                        "required": ["spaceSlug"],
                         "type": "object"
                     }
                 ]
@@ -1224,9 +1077,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "fieldId"
-                ],
+                "required": ["fieldId"],
                 "type": "object"
             },
             "FilterRule": {
@@ -1252,11 +1103,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "operator",
-                    "id",
-                    "target"
-                ],
+                "required": ["operator", "id", "target"],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -1282,10 +1129,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "or",
-                    "id"
-                ],
+                "required": ["or", "id"],
                 "type": "object"
             },
             "AndFilterGroup": {
@@ -1300,10 +1144,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "and",
-                    "id"
-                ],
+                "required": ["and", "id"],
                 "type": "object"
             },
             "Filters": {
@@ -1329,10 +1170,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "descending",
-                    "fieldId"
-                ],
+                "required": ["descending", "fieldId"],
                 "type": "object"
             },
             "CustomFormatType": {
@@ -1358,12 +1196,7 @@
                 "type": "string"
             },
             "Compact": {
-                "enum": [
-                    "thousands",
-                    "millions",
-                    "billions",
-                    "trillions"
-                ],
+                "enum": ["thousands", "millions", "billions", "trillions"],
                 "type": "string"
             },
             "CompactOrAlias": {
@@ -1441,20 +1274,12 @@
                         "$ref": "#/components/schemas/TimeFrames"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "additionalProperties": true
             },
             "TableCalculationType": {
-                "enum": [
-                    "number",
-                    "string",
-                    "date",
-                    "timestamp",
-                    "boolean"
-                ],
+                "enum": ["number", "string", "date", "timestamp", "boolean"],
                 "type": "string"
             },
             "TableCalculation": {
@@ -1479,11 +1304,7 @@
                         "format": "double"
                     }
                 },
-                "required": [
-                    "sql",
-                    "displayName",
-                    "name"
-                ],
+                "required": ["sql", "displayName", "name"],
                 "type": "object"
             },
             "MetricType": {
@@ -1505,15 +1326,7 @@
                 "type": "string"
             },
             "Format": {
-                "enum": [
-                    "km",
-                    "mi",
-                    "usd",
-                    "gbp",
-                    "eur",
-                    "id",
-                    "percent"
-                ],
+                "enum": ["km", "mi", "usd", "gbp", "eur", "id", "percent"],
                 "type": "string"
             },
             "MetricFilterRule": {
@@ -1534,9 +1347,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "fieldRef"
-                        ],
+                        "required": ["fieldRef"],
                         "type": "object"
                     },
                     "settings": {},
@@ -1547,11 +1358,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "operator",
-                    "id",
-                    "target"
-                ],
+                "required": ["operator", "id", "target"],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -1613,27 +1420,16 @@
                         "$ref": "#/components/schemas/CustomFormat"
                     }
                 },
-                "required": [
-                    "type",
-                    "sql",
-                    "table",
-                    "name"
-                ],
+                "required": ["type", "sql", "table", "name"],
                 "type": "object",
                 "additionalProperties": true
             },
             "CustomDimensionType.BIN": {
-                "enum": [
-                    "bin"
-                ],
+                "enum": ["bin"],
                 "type": "string"
             },
             "BinType": {
-                "enum": [
-                    "fixed_number",
-                    "fixed_width",
-                    "custom_range"
-                ],
+                "enum": ["fixed_number", "fixed_width", "custom_range"],
                 "type": "string"
             },
             "BinRange": {
@@ -1650,10 +1446,7 @@
                 "type": "object"
             },
             "CustomDimensionType": {
-                "enum": [
-                    "bin",
-                    "sql"
-                ],
+                "enum": ["bin", "sql"],
                 "type": "string"
             },
             "CustomBinDimension": {
@@ -1703,19 +1496,11 @@
                 "additionalProperties": true
             },
             "CustomDimensionType.SQL": {
-                "enum": [
-                    "sql"
-                ],
+                "enum": ["sql"],
                 "type": "string"
             },
             "DimensionType": {
-                "enum": [
-                    "string",
-                    "number",
-                    "timestamp",
-                    "date",
-                    "boolean"
-                ],
+                "enum": ["string", "number", "timestamp", "date", "boolean"],
                 "type": "string"
             },
             "CustomSqlDimension": {
@@ -1769,10 +1554,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "name",
-                    "label"
-                ],
+                "required": ["name", "label"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -1784,9 +1566,7 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": [
-                            "hasADateDimension"
-                        ],
+                        "required": ["hasADateDimension"],
                         "type": "object"
                     },
                     "timezone": {
@@ -1851,16 +1631,11 @@
                 "type": "object"
             },
             "ChartType.BIG_NUMBER": {
-                "enum": [
-                    "big_number"
-                ],
+                "enum": ["big_number"],
                 "type": "string"
             },
             "ComparisonFormatTypes": {
-                "enum": [
-                    "raw",
-                    "percentage"
-                ],
+                "enum": ["raw", "percentage"],
                 "type": "string"
             },
             "BigNumber": {
@@ -1901,15 +1676,11 @@
                         "$ref": "#/components/schemas/ChartType.BIG_NUMBER"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartType.CARTESIAN": {
-                "enum": [
-                    "cartesian"
-                ],
+                "enum": ["cartesian"],
                 "type": "string"
             },
             "Partial_CompleteCartesianChartLayout_": {
@@ -1956,11 +1727,7 @@
                     },
                     "align": {
                         "type": "string",
-                        "enum": [
-                            "auto",
-                            "left",
-                            "right"
-                        ]
+                        "enum": ["auto", "left", "right"]
                     },
                     "height": {
                         "type": "string"
@@ -1982,17 +1749,11 @@
                     },
                     "orient": {
                         "type": "string",
-                        "enum": [
-                            "horizontal",
-                            "vertical"
-                        ]
+                        "enum": ["horizontal", "vertical"]
                     },
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "plain",
-                            "scroll"
-                        ]
+                        "enum": ["plain", "scroll"]
                     },
                     "show": {
                         "type": "boolean"
@@ -2033,10 +1794,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "value",
-                    "field"
-                ],
+                "required": ["value", "field"],
                 "type": "object"
             },
             "PivotReference": {
@@ -2051,38 +1809,25 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "field"
-                ],
+                "required": ["field"],
                 "type": "object"
             },
             "CartesianSeriesType": {
-                "enum": [
-                    "line",
-                    "bar",
-                    "scatter",
-                    "area"
-                ],
+                "enum": ["line", "bar", "scatter", "area"],
                 "type": "string"
             },
             "MarkLineData": {
                 "properties": {
                     "dynamicValue": {
                         "type": "string",
-                        "enum": [
-                            "average"
-                        ],
+                        "enum": ["average"],
                         "nullable": false
                     },
                     "label": {
                         "properties": {
                             "position": {
                                 "type": "string",
-                                "enum": [
-                                    "start",
-                                    "middle",
-                                    "end"
-                                ]
+                                "enum": ["start", "middle", "end"]
                             },
                             "formatter": {
                                 "type": "string"
@@ -2096,9 +1841,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "color"
-                        ],
+                        "required": ["color"],
                         "type": "object"
                     },
                     "uuid": {
@@ -2120,9 +1863,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "uuid"
-                ],
+                "required": ["uuid"],
                 "type": "object"
             },
             "MarkLine": {
@@ -2148,11 +1889,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "type",
-                            "width",
-                            "color"
-                        ],
+                        "required": ["type", "width", "color"],
                         "type": "object"
                     },
                     "symbol": {
@@ -2165,9 +1902,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "data"
-                ],
+                "required": ["data"],
                 "type": "object"
             },
             "Series": {
@@ -2245,17 +1980,11 @@
                                 "$ref": "#/components/schemas/PivotReference"
                             }
                         },
-                        "required": [
-                            "yRef",
-                            "xRef"
-                        ],
+                        "required": ["yRef", "xRef"],
                         "type": "object"
                     }
                 },
-                "required": [
-                    "type",
-                    "encode"
-                ],
+                "required": ["type", "encode"],
                 "type": "object"
             },
             "Axis": {
@@ -2335,10 +2064,7 @@
                         "$ref": "#/components/schemas/CartesianChartLayout"
                     }
                 },
-                "required": [
-                    "eChartsConfig",
-                    "layout"
-                ],
+                "required": ["eChartsConfig", "layout"],
                 "type": "object"
             },
             "CartesianChartConfig": {
@@ -2350,15 +2076,11 @@
                         "$ref": "#/components/schemas/ChartType.CARTESIAN"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartType.CUSTOM": {
-                "enum": [
-                    "custom"
-                ],
+                "enum": ["custom"],
                 "type": "string"
             },
             "CustomVis": {
@@ -2379,24 +2101,16 @@
                         "$ref": "#/components/schemas/ChartType.CUSTOM"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartType.PIE": {
-                "enum": [
-                    "pie"
-                ],
+                "enum": ["pie"],
                 "type": "string"
             },
             "PieChartValueLabel": {
                 "type": "string",
-                "enum": [
-                    "hidden",
-                    "inside",
-                    "outside"
-                ],
+                "enum": ["hidden", "inside", "outside"],
                 "nullable": false
             },
             "Record_string.string_": {
@@ -2411,10 +2125,7 @@
             },
             "PieChartLegendPosition": {
                 "type": "string",
-                "enum": [
-                    "horizontal",
-                    "vertical"
-                ],
+                "enum": ["horizontal", "vertical"],
                 "nullable": false
             },
             "PieChart": {
@@ -2476,30 +2187,19 @@
                         "$ref": "#/components/schemas/ChartType.PIE"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartType.FUNNEL": {
-                "enum": [
-                    "funnel"
-                ],
+                "enum": ["funnel"],
                 "type": "string"
             },
             "FunnelChartDataInput": {
-                "enum": [
-                    "row",
-                    "column"
-                ],
+                "enum": ["row", "column"],
                 "type": "string"
             },
             "FunnelChartLabelPosition": {
-                "enum": [
-                    "inside",
-                    "left",
-                    "right"
-                ],
+                "enum": ["inside", "left", "right"],
                 "type": "string"
             },
             "FunnelChart": {
@@ -2539,15 +2239,11 @@
                         "$ref": "#/components/schemas/ChartType.FUNNEL"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartType.TABLE": {
-                "enum": [
-                    "table"
-                ],
+                "enum": ["table"],
                 "type": "string"
             },
             "Record_string.ColumnProperties_": {
@@ -2571,10 +2267,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "operator",
-                    "id"
-                ],
+                "required": ["operator", "id"],
                 "type": "object"
             },
             "ConditionalFormattingWithConditionalOperator": {
@@ -2592,9 +2285,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "values"
-                        ],
+                        "required": ["values"],
                         "type": "object"
                     }
                 ]
@@ -2619,11 +2310,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "rules",
-                    "color",
-                    "target"
-                ],
+                "required": ["rules", "color", "target"],
                 "type": "object"
             },
             "ConditionalFormattingWithRange": {
@@ -2637,10 +2324,7 @@
                         "format": "double"
                     }
                 },
-                "required": [
-                    "max",
-                    "min"
-                ],
+                "required": ["max", "min"],
                 "type": "object"
             },
             "ConditionalFormattingConfigWithColorRange": {
@@ -2652,9 +2336,7 @@
                         "properties": {
                             "steps": {
                                 "type": "number",
-                                "enum": [
-                                    5
-                                ],
+                                "enum": [5],
                                 "nullable": false
                             },
                             "end": {
@@ -2664,11 +2346,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "steps",
-                            "end",
-                            "start"
-                        ],
+                        "required": ["steps", "end", "start"],
                         "type": "object"
                     },
                     "target": {
@@ -2680,11 +2358,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "rule",
-                    "color",
-                    "target"
-                ],
+                "required": ["rule", "color", "target"],
                 "type": "object"
             },
             "ConditionalFormattingConfig": {
@@ -2741,9 +2415,7 @@
                         "$ref": "#/components/schemas/ChartType.TABLE"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object"
             },
             "ChartConfig": {
@@ -2833,9 +2505,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "columns"
-                        ],
+                        "required": ["columns"],
                         "type": "object"
                     },
                     "chartConfig": {
@@ -2850,9 +2520,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "columnOrder"
-                        ],
+                        "required": ["columnOrder"],
                         "type": "object"
                     },
                     "colorPalette": {
@@ -2905,10 +2573,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "oldUuid",
-                            "spaceSlug"
-                        ],
+                        "required": ["oldUuid", "spaceSlug"],
                         "type": "object"
                     }
                 ]
@@ -2925,10 +2590,7 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": [
-                                "data",
-                                "action"
-                            ],
+                            "required": ["data", "action"],
                             "type": "object"
                         },
                         "type": "array"
@@ -2943,10 +2605,7 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": [
-                                "data",
-                                "action"
-                            ],
+                            "required": ["data", "action"],
                             "type": "object"
                         },
                         "type": "array"
@@ -2961,20 +2620,13 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": [
-                                "data",
-                                "action"
-                            ],
+                            "required": ["data", "action"],
                             "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": [
-                    "charts",
-                    "dashboards",
-                    "spaces"
-                ],
+                "required": ["charts", "dashboards", "spaces"],
                 "type": "object"
             },
             "ApiPromotionChangesResponse": {
@@ -2984,16 +2636,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_CreateDbtCloudIntegration.metricsJobId_": {
@@ -3003,9 +2650,7 @@
                         "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
                     }
                 },
-                "required": [
-                    "metricsJobId"
-                ],
+                "required": ["metricsJobId"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3020,15 +2665,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object"
             },
             "ApiDbtCloudSettingsDeleteSuccess": {
@@ -3036,15 +2677,11 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object"
             },
             "ApiSuccessEmpty": {
@@ -3052,15 +2689,11 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object"
             },
             "Pick_Explore.SummaryExploreFields_": {
@@ -3081,11 +2714,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "name",
-                    "label",
-                    "tags"
-                ],
+                "required": ["name", "label", "tags"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3101,10 +2730,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "databaseName",
-                    "schemaName"
-                ],
+                "required": ["databaseName", "schemaName"],
                 "type": "object"
             },
             "Pick_ExploreError.SummaryExploreErrorFields_": {
@@ -3131,12 +2757,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "name",
-                    "label",
-                    "tags",
-                    "errors"
-                ],
+                "required": ["name", "label", "tags", "errors"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3186,10 +2807,7 @@
                 "type": "array"
             },
             "OrderFieldsByStrategy": {
-                "enum": [
-                    "LABEL",
-                    "INDEX"
-                ],
+                "enum": ["LABEL", "INDEX"],
                 "type": "string"
             },
             "Record_string.GroupType_": {
@@ -3245,13 +2863,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "sqlTable",
-                    "schema",
-                    "database",
-                    "label",
-                    "name"
-                ],
+                "required": ["sqlTable", "schema", "database", "label", "name"],
                 "type": "object"
             },
             "Record_string.CompiledDimension_": {
@@ -3283,10 +2895,7 @@
                         "format": "double"
                     }
                 },
-                "required": [
-                    "character",
-                    "line"
-                ],
+                "required": ["character", "line"],
                 "type": "object"
             },
             "Source": {
@@ -3303,10 +2912,7 @@
                                 "$ref": "#/components/schemas/SourcePosition"
                             }
                         },
-                        "required": [
-                            "end",
-                            "start"
-                        ],
+                        "required": ["end", "start"],
                         "type": "object"
                     },
                     "range": {
@@ -3318,21 +2924,14 @@
                                 "$ref": "#/components/schemas/SourcePosition"
                             }
                         },
-                        "required": [
-                            "end",
-                            "start"
-                        ],
+                        "required": ["end", "start"],
                         "type": "object"
                     },
                     "path": {
                         "type": "string"
                     }
                 },
-                "required": [
-                    "content",
-                    "range",
-                    "path"
-                ],
+                "required": ["content", "range", "path"],
                 "type": "object"
             },
             "CompiledTable": {
@@ -3355,11 +2954,7 @@
                                 "$ref": "#/components/schemas/Record_string.CompiledDimension_"
                             }
                         },
-                        "required": [
-                            "lineageGraph",
-                            "metrics",
-                            "dimensions"
-                        ],
+                        "required": ["lineageGraph", "metrics", "dimensions"],
                         "type": "object"
                     }
                 ]
@@ -3450,11 +3045,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "ownerLogin",
-                    "fullName",
-                    "name"
-                ],
+                "required": ["ownerLogin", "fullName", "name"],
                 "type": "object"
             },
             "GitIntegrationConfiguration": {
@@ -3463,9 +3054,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "enabled"
-                ],
+                "required": ["enabled"],
                 "type": "object"
             },
             "PullRequestCreated": {
@@ -3477,10 +3066,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "prUrl",
-                    "prTitle"
-                ],
+                "required": ["prUrl", "prTitle"],
                 "type": "object"
             },
             "ApiGdriveAccessTokenResponse": {
@@ -3490,16 +3076,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiJobScheduledResponse": {
@@ -3510,23 +3091,16 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "jobId"
-                        ],
+                        "required": ["jobId"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "FilterGroupResponse": {
@@ -3541,10 +3115,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "or",
-                            "id"
-                        ],
+                        "required": ["or", "id"],
                         "type": "object"
                     },
                     {
@@ -3557,10 +3128,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "and",
-                            "id"
-                        ],
+                        "required": ["and", "id"],
                         "type": "object"
                     }
                 ]
@@ -3587,9 +3155,7 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": [
-                            "hasADateDimension"
-                        ],
+                        "required": ["hasADateDimension"],
                         "type": "object"
                     },
                     "customDimensions": {
@@ -3716,12 +3282,7 @@
                         "description": "The group's UUID"
                     }
                 },
-                "required": [
-                    "organizationUuid",
-                    "createdAt",
-                    "name",
-                    "uuid"
-                ],
+                "required": ["organizationUuid", "createdAt", "name", "uuid"],
                 "type": "object"
             },
             "GroupMember": {
@@ -3744,12 +3305,7 @@
                         "format": "uuid"
                     }
                 },
-                "required": [
-                    "lastName",
-                    "firstName",
-                    "email",
-                    "userUuid"
-                ],
+                "required": ["lastName", "firstName", "email", "userUuid"],
                 "type": "object",
                 "description": "A summary for a Lightdash user within a group"
             },
@@ -3774,10 +3330,7 @@
                                 "description": "A list of the group's members."
                             }
                         },
-                        "required": [
-                            "memberUuids",
-                            "members"
-                        ],
+                        "required": ["memberUuids", "members"],
                         "type": "object"
                     }
                 ],
@@ -3797,16 +3350,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiGroupMembersResponse": {
@@ -3819,16 +3367,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_GroupMember.userUuid_": {
@@ -3839,9 +3382,7 @@
                         "format": "uuid"
                     }
                 },
-                "required": [
-                    "userUuid"
-                ],
+                "required": ["userUuid"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3881,11 +3422,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "role",
-                    "groupUuid",
-                    "projectUuid"
-                ],
+                "required": ["role", "groupUuid", "projectUuid"],
                 "type": "object"
             },
             "ApiCreateProjectGroupAccess": {
@@ -3895,16 +3432,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_CreateDBProjectGroupAccess.role_": {
@@ -3913,9 +3445,7 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": [
-                    "role"
-                ],
+                "required": ["role"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3926,16 +3456,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_DBProjectGroupAccess.role_": {
@@ -3944,9 +3469,7 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": [
-                    "role"
-                ],
+                "required": ["role"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3975,17 +3498,11 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "viewed",
-                    "createdAt",
-                    "notificationId"
-                ],
+                "required": ["viewed", "createdAt", "notificationId"],
                 "type": "object"
             },
             "ApiNotificationResourceType.DashboardComments": {
-                "enum": [
-                    "dashboardComments"
-                ],
+                "enum": ["dashboardComments"],
                 "type": "string"
             },
             "NotificationDashboardTileCommentMetadata": {
@@ -4026,9 +3543,7 @@
                                 "$ref": "#/components/schemas/ApiNotificationResourceType.DashboardComments"
                             }
                         },
-                        "required": [
-                            "resourceType"
-                        ],
+                        "required": ["resourceType"],
                         "type": "object"
                     }
                 ]
@@ -4049,22 +3564,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiNotificationResourceType": {
-                "enum": [
-                    "dashboardComments"
-                ],
+                "enum": ["dashboardComments"],
                 "type": "string"
             },
             "Pick_Notification.viewed_": {
@@ -4073,9 +3581,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "viewed"
-                ],
+                "required": ["viewed"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4109,10 +3615,7 @@
                         "format": "uuid"
                     }
                 },
-                "required": [
-                    "name",
-                    "organizationUuid"
-                ],
+                "required": ["name", "organizationUuid"],
                 "type": "object",
                 "description": "Details of a user's Organization"
             },
@@ -4123,16 +3626,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_Organization.name_": {
@@ -4142,9 +3640,7 @@
                         "description": "The name of the organization"
                     }
                 },
-                "required": [
-                    "name"
-                ],
+                "required": ["name"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4176,10 +3672,7 @@
                 "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
             },
             "ProjectType": {
-                "enum": [
-                    "DEFAULT",
-                    "PREVIEW"
-                ],
+                "enum": ["DEFAULT", "PREVIEW"],
                 "type": "string"
             },
             "WarehouseTypes": {
@@ -4233,16 +3726,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object",
                 "description": "List of projects in the current organization"
             },
@@ -4312,16 +3800,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiOrganizationMemberProfile": {
@@ -4331,16 +3814,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "UUID": {
@@ -4355,33 +3833,23 @@
                         "$ref": "#/components/schemas/OrganizationMemberRole"
                     }
                 },
-                "required": [
-                    "role"
-                ],
+                "required": ["role"],
                 "type": "object"
             },
             "OrganizationMemberRole.EDITOR": {
-                "enum": [
-                    "editor"
-                ],
+                "enum": ["editor"],
                 "type": "string"
             },
             "OrganizationMemberRole.INTERACTIVE_VIEWER": {
-                "enum": [
-                    "interactive_viewer"
-                ],
+                "enum": ["interactive_viewer"],
                 "type": "string"
             },
             "OrganizationMemberRole.VIEWER": {
-                "enum": [
-                    "viewer"
-                ],
+                "enum": ["viewer"],
                 "type": "string"
             },
             "OrganizationMemberRole.MEMBER": {
-                "enum": [
-                    "member"
-                ],
+                "enum": ["member"],
                 "type": "string"
             },
             "AllowedEmailDomainsRole": {
@@ -4401,21 +3869,15 @@
                 ]
             },
             "ProjectMemberRole.EDITOR": {
-                "enum": [
-                    "editor"
-                ],
+                "enum": ["editor"],
                 "type": "string"
             },
             "ProjectMemberRole.INTERACTIVE_VIEWER": {
-                "enum": [
-                    "interactive_viewer"
-                ],
+                "enum": ["interactive_viewer"],
                 "type": "string"
             },
             "ProjectMemberRole.VIEWER": {
-                "enum": [
-                    "viewer"
-                ],
+                "enum": ["viewer"],
                 "type": "string"
             },
             "AllowedEmailDomainProjectsRole": {
@@ -4443,10 +3905,7 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "role",
-                                "projectUuid"
-                            ],
+                            "required": ["role", "projectUuid"],
                             "type": "object"
                         },
                         "type": "array"
@@ -4479,16 +3938,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
@@ -4512,20 +3966,13 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "role",
-                                "projectUuid"
-                            ],
+                            "required": ["role", "projectUuid"],
                             "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": [
-                    "role",
-                    "emailDomains",
-                    "projects"
-                ],
+                "required": ["role", "emailDomains", "projects"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4543,9 +3990,7 @@
                         "description": "A friendly name for the group"
                     }
                 },
-                "required": [
-                    "name"
-                ],
+                "required": ["name"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4587,22 +4032,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ResourceViewItemType.DASHBOARD": {
-                "enum": [
-                    "dashboard"
-                ],
+                "enum": ["dashboard"],
                 "type": "string"
             },
             "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
@@ -4619,11 +4057,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "validationId",
-                    "createdAt",
-                    "error"
-                ],
+                "required": ["validationId", "createdAt", "error"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4697,11 +4131,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ResourceItemCategory": {
-                "enum": [
-                    "mostPopular",
-                    "recentlyUpdated",
-                    "pinned"
-                ],
+                "enum": ["mostPopular", "recentlyUpdated", "pinned"],
                 "type": "string"
             },
             "ResourceViewDashboardItem": {
@@ -4716,16 +4146,11 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
                     }
                 },
-                "required": [
-                    "data",
-                    "type"
-                ],
+                "required": ["data", "type"],
                 "type": "object"
             },
             "ResourceViewItemType.CHART": {
-                "enum": [
-                    "chart"
-                ],
+                "enum": ["chart"],
                 "type": "string"
             },
             "ChartType": {
@@ -4823,16 +4248,11 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.CHART"
                     }
                 },
-                "required": [
-                    "data",
-                    "type"
-                ],
+                "required": ["data", "type"],
                 "type": "object"
             },
             "ResourceViewItemType.SPACE": {
-                "enum": [
-                    "space"
-                ],
+                "enum": ["space"],
                 "type": "string"
             },
             "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
@@ -4916,10 +4336,7 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
                     }
                 },
-                "required": [
-                    "data",
-                    "type"
-                ],
+                "required": ["data", "type"],
                 "type": "object"
             },
             "PinnedItems": {
@@ -4945,24 +4362,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ResourceViewItemType": {
-                "enum": [
-                    "chart",
-                    "dashboard",
-                    "space"
-                ],
+                "enum": ["chart", "dashboard", "space"],
                 "type": "string"
             },
             "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
@@ -4976,10 +4384,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "uuid",
-                    "pinnedListOrder"
-                ],
+                "required": ["uuid", "pinnedListOrder"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4992,16 +4397,11 @@
                         "$ref": "#/components/schemas/ResourceViewItemType"
                     }
                 },
-                "required": [
-                    "data",
-                    "type"
-                ],
+                "required": ["data", "type"],
                 "type": "object"
             },
             "DbtProjectType.DBT": {
-                "enum": [
-                    "dbt"
-                ],
+                "enum": ["dbt"],
                 "type": "string"
             },
             "DbtProjectEnvironmentVariable": {
@@ -5013,10 +4413,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "value",
-                    "key"
-                ],
+                "required": ["value", "key"],
                 "type": "object"
             },
             "DbtProjectType": {
@@ -5052,16 +4449,12 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "additionalProperties": true
             },
             "DbtProjectType.DBT_CLOUD_IDE": {
-                "enum": [
-                    "dbt_cloud_ide"
-                ],
+                "enum": ["dbt_cloud_ide"],
                 "type": "string"
             },
             "DbtCloudIDEProjectConfig": {
@@ -5076,18 +4469,12 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "api_key",
-                    "environment_id"
-                ],
+                "required": ["type", "api_key", "environment_id"],
                 "type": "object",
                 "additionalProperties": true
             },
             "DbtProjectType.GITHUB": {
-                "enum": [
-                    "github"
-                ],
+                "enum": ["github"],
                 "type": "string"
             },
             "DbtGithubProjectConfig": {
@@ -5131,9 +4518,7 @@
                 "additionalProperties": true
             },
             "DbtProjectType.BITBUCKET": {
-                "enum": [
-                    "bitbucket"
-                ],
+                "enum": ["bitbucket"],
                 "type": "string"
             },
             "DbtBitBucketProjectConfig": {
@@ -5181,9 +4566,7 @@
                 "additionalProperties": true
             },
             "DbtProjectType.GITLAB": {
-                "enum": [
-                    "gitlab"
-                ],
+                "enum": ["gitlab"],
                 "type": "string"
             },
             "DbtGitlabProjectConfig": {
@@ -5227,9 +4610,7 @@
                 "additionalProperties": true
             },
             "DbtProjectType.AZURE_DEVOPS": {
-                "enum": [
-                    "azure_devops"
-                ],
+                "enum": ["azure_devops"],
                 "type": "string"
             },
             "DbtAzureDevOpsProjectConfig": {
@@ -5278,9 +4659,7 @@
                 "additionalProperties": true
             },
             "DbtProjectType.NONE": {
-                "enum": [
-                    "none"
-                ],
+                "enum": ["none"],
                 "type": "string"
             },
             "DbtNoneProjectConfig": {
@@ -5301,9 +4680,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -5333,21 +4710,11 @@
                 ]
             },
             "WarehouseTypes.SNOWFLAKE": {
-                "enum": [
-                    "snowflake"
-                ],
+                "enum": ["snowflake"],
                 "type": "string"
             },
             "WeekDay": {
-                "enum": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6
-                ],
+                "enum": [0, 1, 2, 3, 4, 5, 6],
                 "type": "number"
             },
             "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
@@ -5416,9 +4783,7 @@
                 "$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.REDSHIFT": {
-                "enum": [
-                    "redshift"
-                ],
+                "enum": ["redshift"],
                 "type": "string"
             },
             "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
@@ -5481,13 +4846,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "type",
-                    "schema",
-                    "host",
-                    "port",
-                    "dbname"
-                ],
+                "required": ["type", "schema", "host", "port", "dbname"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5499,9 +4858,7 @@
                 "$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.POSTGRES": {
-                "enum": [
-                    "postgres"
-                ],
+                "enum": ["postgres"],
                 "type": "string"
             },
             "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
@@ -5567,13 +4924,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "schema",
-                    "host",
-                    "port",
-                    "dbname"
-                ],
+                "required": ["type", "schema", "host", "port", "dbname"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5585,9 +4936,7 @@
                 "$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.BIGQUERY": {
-                "enum": [
-                    "bigquery"
-                ],
+                "enum": ["bigquery"],
                 "type": "string"
             },
             "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
@@ -5622,10 +4971,7 @@
                     },
                     "priority": {
                         "type": "string",
-                        "enum": [
-                            "interactive",
-                            "batch"
-                        ]
+                        "enum": ["interactive", "batch"]
                     },
                     "retries": {
                         "type": "number",
@@ -5639,11 +4985,7 @@
                         "format": "double"
                     }
                 },
-                "required": [
-                    "type",
-                    "project",
-                    "dataset"
-                ],
+                "required": ["type", "project", "dataset"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5655,9 +4997,7 @@
                 "$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.DATABRICKS": {
-                "enum": [
-                    "databricks"
-                ],
+                "enum": ["databricks"],
                 "type": "string"
             },
             "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
@@ -5689,12 +5029,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "database",
-                    "serverHostName",
-                    "httpPath"
-                ],
+                "required": ["type", "database", "serverHostName", "httpPath"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5706,9 +5041,7 @@
                 "$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.TRINO": {
-                "enum": [
-                    "trino"
-                ],
+                "enum": ["trino"],
                 "type": "string"
             },
             "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
@@ -5785,13 +5118,7 @@
                 ]
             },
             "SupportedDbtVersions": {
-                "enum": [
-                    "v1.4",
-                    "v1.5",
-                    "v1.6",
-                    "v1.7",
-                    "v1.8"
-                ],
+                "enum": ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8"],
                 "type": "string"
             },
             "Project": {
@@ -5841,16 +5168,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_": {
@@ -5936,10 +5258,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "updatedAt",
-                    "pinnedListOrder"
-                ],
+                "required": ["updatedAt", "pinnedListOrder"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5962,10 +5281,7 @@
                         "format": "double"
                     }
                 },
-                "required": [
-                    "firstViewedAt",
-                    "views"
-                ],
+                "required": ["firstViewedAt", "views"],
                 "type": "object"
             },
             "SpaceQuery": {
@@ -6002,16 +5318,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiChartSummaryListResponse": {
@@ -6024,16 +5335,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-slug_": {
@@ -6080,11 +5386,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "SpaceMemberRole": {
-                "enum": [
-                    "viewer",
-                    "editor",
-                    "admin"
-                ],
+                "enum": ["viewer", "editor", "admin"],
                 "type": "string"
             },
             "SpaceShare": {
@@ -6162,11 +5464,7 @@
                                 "$ref": "#/components/schemas/SpaceShare"
                             }
                         },
-                        "required": [
-                            "dashboardCount",
-                            "chartCount",
-                            "access"
-                        ],
+                        "required": ["dashboardCount", "chartCount", "access"],
                         "type": "object"
                     }
                 ]
@@ -6181,16 +5479,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ProjectMemberProfile": {
@@ -6234,16 +5527,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiGetProjectMemberResponse": {
@@ -6253,16 +5541,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "CreateProjectMember": {
@@ -6277,11 +5560,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "sendEmail",
-                    "role",
-                    "email"
-                ],
+                "required": ["sendEmail", "role", "email"],
                 "type": "object"
             },
             "UpdateProjectMember": {
@@ -6290,9 +5569,7 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": [
-                    "role"
-                ],
+                "required": ["role"],
                 "type": "object"
             },
             "ApiGetProjectGroupAccesses": {
@@ -6305,16 +5582,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Record_string._type-DimensionType--__": {
@@ -6339,10 +5611,7 @@
                         "$ref": "#/components/schemas/Record_string._type-DimensionType--__"
                     }
                 },
-                "required": [
-                    "rows",
-                    "fields"
-                ],
+                "required": ["rows", "fields"],
                 "type": "object"
             },
             "Record_string.number_": {
@@ -6357,26 +5626,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "DateGranularity": {
-                "enum": [
-                    "Day",
-                    "Week",
-                    "Month",
-                    "Quarter",
-                    "Year"
-                ],
+                "enum": ["Day", "Week", "Month", "Quarter", "Year"],
                 "type": "string"
             },
             "MetricQueryRequest": {
@@ -6390,9 +5648,7 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": [
-                            "hasADateDimension"
-                        ],
+                        "required": ["hasADateDimension"],
                         "type": "object"
                     },
                     "granularity": {
@@ -6474,10 +5730,7 @@
                         "$ref": "#/components/schemas/MetricQueryRequest"
                     }
                 },
-                "required": [
-                    "explore",
-                    "metricQuery"
-                ],
+                "required": ["explore", "metricQuery"],
                 "type": "object"
             },
             "Record_string.DbtExposure_": {
@@ -6494,10 +5747,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "user"
-                ],
+                "required": ["type", "user"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -6507,9 +5757,7 @@
                         "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -6519,9 +5767,7 @@
                         "$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
                     }
                 },
-                "required": [
-                    "type"
-                ],
+                "required": ["type"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -6587,9 +5833,7 @@
                         "format": "date-time"
                     }
                 },
-                "required": [
-                    "cacheHit"
-                ],
+                "required": ["cacheHit"],
                 "type": "object"
             },
             "Record_string.Item-or-AdditionalMetric_": {
@@ -6615,25 +5859,16 @@
                                 "$ref": "#/components/schemas/MetricQueryResponse"
                             }
                         },
-                        "required": [
-                            "rows",
-                            "cacheMetadata",
-                            "metricQuery"
-                        ],
+                        "required": ["rows", "cacheMetadata", "metricQuery"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_LightdashUser.userUuid-or-firstName-or-lastName_": {
@@ -6648,11 +5883,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "userUuid",
-                    "firstName",
-                    "lastName"
-                ],
+                "required": ["userUuid", "firstName", "lastName"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -6698,9 +5929,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "history"
-                ],
+                "required": ["history"],
                 "type": "object"
             },
             "ApiGetChartHistoryResponse": {
@@ -6710,16 +5939,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "SavedChart": {
@@ -6784,9 +6008,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "columnOrder"
-                        ],
+                        "required": ["columnOrder"],
                         "type": "object"
                     },
                     "chartConfig": {
@@ -6801,9 +6023,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "columns"
-                        ],
+                        "required": ["columns"],
                         "type": "object"
                     },
                     "metricQuery": {
@@ -6888,16 +6108,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiPromoteChartResponse": {
@@ -6907,24 +6122,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "SchedulerFormat": {
-                "enum": [
-                    "csv",
-                    "image",
-                    "gsheets"
-                ],
+                "enum": ["csv", "image", "gsheets"],
                 "type": "string"
             },
             "SchedulerCsvOptions": {
@@ -6937,10 +6143,7 @@
                             },
                             {
                                 "type": "string",
-                                "enum": [
-                                    "table",
-                                    "all"
-                                ]
+                                "enum": ["table", "all"]
                             }
                         ]
                     },
@@ -6948,10 +6151,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "limit",
-                    "formatted"
-                ],
+                "required": ["limit", "formatted"],
                 "type": "object"
             },
             "SchedulerImageOptions": {
@@ -7020,18 +6220,11 @@
                         "$ref": "#/components/schemas/ThresholdOperator"
                     }
                 },
-                "required": [
-                    "value",
-                    "fieldId",
-                    "operator"
-                ],
+                "required": ["value", "fieldId", "operator"],
                 "type": "object"
             },
             "NotificationFrequency": {
-                "enum": [
-                    "always",
-                    "once"
-                ],
+                "enum": ["always", "once"],
                 "type": "string"
             },
             "SchedulerBase": {
@@ -7110,19 +6303,14 @@
                         "properties": {
                             "dashboardUuid": {
                                 "type": "number",
-                                "enum": [
-                                    null
-                                ],
+                                "enum": [null],
                                 "nullable": true
                             },
                             "savedChartUuid": {
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
+                        "required": ["dashboardUuid", "savedChartUuid"],
                         "type": "object"
                     }
                 ]
@@ -7162,16 +6350,11 @@
                             },
                             "savedChartUuid": {
                                 "type": "number",
-                                "enum": [
-                                    null
-                                ],
+                                "enum": [null],
                                 "nullable": true
                             }
                         },
-                        "required": [
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
+                        "required": ["dashboardUuid", "savedChartUuid"],
                         "type": "object"
                     }
                 ]
@@ -7265,20 +6448,13 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "targets"
-                        ],
+                        "required": ["targets"],
                         "type": "object"
                     }
                 ]
             },
             "SchedulerJobStatus": {
-                "enum": [
-                    "scheduled",
-                    "started",
-                    "completed",
-                    "error"
-                ],
+                "enum": ["scheduled", "started", "completed", "error"],
                 "type": "string"
             },
             "Record_string.any_": {
@@ -7293,11 +6469,7 @@
                     },
                     "targetType": {
                         "type": "string",
-                        "enum": [
-                            "email",
-                            "slack",
-                            "gsheets"
-                        ]
+                        "enum": ["email", "slack", "gsheets"]
                     },
                     "target": {
                         "type": "string"
@@ -7364,10 +6536,7 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "dashboardUuid",
-                                "name"
-                            ],
+                            "required": ["dashboardUuid", "name"],
                             "type": "object"
                         },
                         "type": "array"
@@ -7382,10 +6551,7 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "savedChartUuid",
-                                "name"
-                            ],
+                            "required": ["savedChartUuid", "name"],
                             "type": "object"
                         },
                         "type": "array"
@@ -7403,11 +6569,7 @@
                                     "type": "string"
                                 }
                             },
-                            "required": [
-                                "userUuid",
-                                "lastName",
-                                "firstName"
-                            ],
+                            "required": ["userUuid", "lastName", "firstName"],
                             "type": "object"
                         },
                         "type": "array"
@@ -7435,16 +6597,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiSchedulerAndTargetsResponse": {
@@ -7454,16 +6611,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ScheduledJobs": {
@@ -7476,10 +6628,7 @@
                         "format": "date-time"
                     }
                 },
-                "required": [
-                    "id",
-                    "date"
-                ],
+                "required": ["id", "date"],
                 "type": "object"
             },
             "ApiScheduledJobsResponse": {
@@ -7492,16 +6641,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiJobStatusResponse": {
@@ -7520,24 +6664,16 @@
                                 "$ref": "#/components/schemas/SchedulerJobStatus"
                             }
                         },
-                        "required": [
-                            "details",
-                            "status"
-                        ],
+                        "required": ["details", "status"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiTestSchedulerResponse": {
@@ -7548,23 +6684,16 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "jobId"
-                        ],
+                        "required": ["jobId"],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ShareUrl": {
@@ -7598,11 +6727,7 @@
                         "description": "Unique shareable id"
                     }
                 },
-                "required": [
-                    "params",
-                    "path",
-                    "nanoid"
-                ],
+                "required": ["params", "path", "nanoid"],
                 "type": "object",
                 "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
             },
@@ -7613,16 +6738,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_ShareUrl.path-or-params_": {
@@ -7635,10 +6755,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "path",
-                    "params"
-                ],
+                "required": ["path", "params"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7655,10 +6772,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "name",
-                    "id"
-                ],
+                "required": ["name", "id"],
                 "type": "object"
             },
             "ApiSlackChannelsResponse": {
@@ -7671,16 +6785,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiSlackCustomSettingsResponse": {
@@ -7688,16 +6797,11 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "SlackChannelProjectMapping": {
@@ -7709,10 +6813,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "slackChannelId",
-                    "projectUuid"
-                ],
+                "required": ["slackChannelId", "projectUuid"],
                 "type": "object"
             },
             "SlackAppCustomSettings": {
@@ -7732,10 +6833,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "appProfilePhotoUrl",
-                    "notificationChannel"
-                ],
+                "required": ["appProfilePhotoUrl", "notificationChannel"],
                 "type": "object"
             },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
@@ -7839,11 +6937,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "spaceRole",
-                    "groupName",
-                    "groupUuid"
-                ],
+                "required": ["spaceRole", "groupName", "groupUuid"],
                 "type": "object"
             },
             "Space": {
@@ -7923,16 +7017,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_SpaceShare.userUuid-or-role_": {
@@ -7944,10 +7033,7 @@
                         "$ref": "#/components/schemas/SpaceMemberRole"
                     }
                 },
-                "required": [
-                    "userUuid",
-                    "role"
-                ],
+                "required": ["userUuid", "role"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7966,9 +7052,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "name"
-                ],
+                "required": ["name"],
                 "type": "object"
             },
             "UpdateSpace": {
@@ -7980,10 +7064,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "isPrivate",
-                    "name"
-                ],
+                "required": ["isPrivate", "name"],
                 "type": "object"
             },
             "AddSpaceUserAccess": {
@@ -7995,10 +7076,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "spaceRole",
-                    "userUuid"
-                ],
+                "required": ["spaceRole", "userUuid"],
                 "type": "object"
             },
             "AddSpaceGroupAccess": {
@@ -8010,10 +7088,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "spaceRole",
-                    "groupUuid"
-                ],
+                "required": ["spaceRole", "groupUuid"],
                 "type": "object"
             },
             "Pick_SshKeyPair.publicKey_": {
@@ -8022,9 +7097,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "publicKey"
-                ],
+                "required": ["publicKey"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8035,16 +7108,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "UserAttributeValue": {
@@ -8059,11 +7127,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "value",
-                    "email",
-                    "userUuid"
-                ],
+                "required": ["value", "email", "userUuid"],
                 "type": "object"
             },
             "GroupAttributeValue": {
@@ -8075,10 +7139,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "value",
-                    "groupUuid"
-                ],
+                "required": ["value", "groupUuid"],
                 "type": "object"
             },
             "UserAttribute": {
@@ -8137,16 +7198,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiCreateUserAttributeResponse": {
@@ -8156,16 +7212,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_UserAttribute.name-or-description-or-attributeDefault_": {
@@ -8181,10 +7232,7 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "name",
-                    "attributeDefault"
-                ],
+                "required": ["name", "attributeDefault"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8197,10 +7245,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "userUuid",
-                    "value"
-                ],
+                "required": ["userUuid", "value"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8234,10 +7279,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": [
-                            "groups",
-                            "users"
-                        ],
+                        "required": ["groups", "users"],
                         "type": "object"
                     }
                 ]
@@ -8301,16 +7343,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object",
                 "description": "Shows the authenticated user"
             },
@@ -8321,16 +7358,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ActivateUser": {
@@ -8345,11 +7377,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "password",
-                    "lastName",
-                    "firstName"
-                ],
+                "required": ["password", "lastName", "firstName"],
                 "type": "object"
             },
             "ActivateUserWithInviteCode": {
@@ -8363,9 +7391,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "inviteCode"
-                        ],
+                        "required": ["inviteCode"],
                         "type": "object"
                     }
                 ]
@@ -8390,12 +7416,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "password",
-                    "email",
-                    "lastName",
-                    "firstName"
-                ],
+                "required": ["password", "email", "lastName", "firstName"],
                 "type": "object"
             },
             "RegisterOrActivateUser": {
@@ -8421,10 +7442,7 @@
                         "description": "Time that the passcode was created"
                     }
                 },
-                "required": [
-                    "numberOfAttempts",
-                    "createdAt"
-                ],
+                "required": ["numberOfAttempts", "createdAt"],
                 "type": "object"
             },
             "EmailStatus": {
@@ -8439,10 +7457,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "isVerified",
-                    "email"
-                ],
+                "required": ["isVerified", "email"],
                 "type": "object"
             },
             "EmailOneTimePasswordExpiring": {
@@ -8463,11 +7478,7 @@
                                 "format": "date-time"
                             }
                         },
-                        "required": [
-                            "isMaxAttempts",
-                            "isExpired",
-                            "expiresAt"
-                        ],
+                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
                         "type": "object"
                     }
                 ]
@@ -8496,16 +7507,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object",
                 "description": "Shows the current verification status of an email address"
             },
@@ -8522,11 +7528,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "membersCount",
-                    "name",
-                    "organizationUuid"
-                ],
+                "required": ["membersCount", "name", "organizationUuid"],
                 "type": "object"
             },
             "ApiUserAllowedOrganizationsResponse": {
@@ -8539,16 +7541,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_CreateRedshiftCredentials.type-or-user-or-password_": {
@@ -8563,11 +7560,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "user",
-                    "password"
-                ],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8583,11 +7576,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "user",
-                    "password"
-                ],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8603,10 +7592,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "user"
-                ],
+                "required": ["type", "user"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8622,11 +7608,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "user",
-                    "password"
-                ],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8639,10 +7621,7 @@
                         "$ref": "#/components/schemas/Record_string.string_"
                     }
                 },
-                "required": [
-                    "type",
-                    "keyfileContents"
-                ],
+                "required": ["type", "keyfileContents"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8655,10 +7634,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "type",
-                    "personalAccessToken"
-                ],
+                "required": ["type", "personalAccessToken"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -8690,27 +7666,15 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "credentials",
-                    "name"
-                ],
+                "required": ["credentials", "name"],
                 "type": "object"
             },
             "OpenIdIdentityIssuerType": {
-                "enum": [
-                    "google",
-                    "okta",
-                    "oneLogin",
-                    "azuread",
-                    "oidc"
-                ],
+                "enum": ["google", "okta", "oneLogin", "azuread", "oidc"],
                 "type": "string"
             },
             "LocalIssuerTypes": {
-                "enum": [
-                    "email",
-                    "apiToken"
-                ],
+                "enum": ["email", "apiToken"],
                 "type": "string"
             },
             "LoginOptionTypes": {
@@ -8738,9 +7702,7 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "showOptions"
-                ],
+                "required": ["showOptions"],
                 "type": "object"
             },
             "ApiGetLoginOptionsResponse": {
@@ -8750,16 +7712,11 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ValidationErrorType": {
@@ -8775,11 +7732,7 @@
                 "type": "string"
             },
             "ValidationSourceType": {
-                "enum": [
-                    "chart",
-                    "dashboard",
-                    "table"
-                ],
+                "enum": ["chart", "dashboard", "table"],
                 "type": "string"
             },
             "ValidationResponseBase": {
@@ -8852,9 +7805,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "chartViews"
-                        ],
+                        "required": ["chartViews"],
                         "type": "object"
                     }
                 ]
@@ -8887,9 +7838,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "dashboardViews"
-                        ],
+                        "required": ["dashboardViews"],
                         "type": "object"
                     }
                 ]
@@ -8972,31 +7921,22 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "results",
-                    "status"
-                ],
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiValidationDismissResponse": {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "enum": [
-                            "ok"
-                        ],
+                        "enum": ["ok"],
                         "nullable": false
                     }
                 },
-                "required": [
-                    "status"
-                ],
+                "required": ["status"],
                 "type": "object"
             }
         },
@@ -9016,7 +7956,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1143.2",
+        "version": "0.1145.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -9044,16 +7984,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9071,9 +8006,7 @@
                     }
                 },
                 "description": "Get catalog items",
-                "tags": [
-                    "Catalog"
-                ],
+                "tags": ["Catalog"],
                 "security": [],
                 "parameters": [
                     {
@@ -9126,16 +8059,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9153,9 +8081,7 @@
                     }
                 },
                 "description": "Get catalog metadata for tables",
-                "tags": [
-                    "Catalog"
-                ],
+                "tags": ["Catalog"],
                 "security": [],
                 "parameters": [
                     {
@@ -9193,16 +8119,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9220,9 +8141,7 @@
                     }
                 },
                 "description": "Get catalog analytics for tables",
-                "tags": [
-                    "Catalog"
-                ],
+                "tags": ["Catalog"],
                 "security": [],
                 "parameters": [
                     {
@@ -9260,16 +8179,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9287,9 +8201,7 @@
                     }
                 },
                 "description": "Get catalog analytics for fields",
-                "tags": [
-                    "Catalog"
-                ],
+                "tags": ["Catalog"],
                 "security": [],
                 "parameters": [
                     {
@@ -9347,9 +8259,7 @@
                     }
                 },
                 "description": "Creates a comment on a dashboard tile",
-                "tags": [
-                    "Comments"
-                ],
+                "tags": ["Comments"],
                 "security": [],
                 "parameters": [
                     {
@@ -9411,9 +8321,7 @@
                     }
                 },
                 "description": "Gets all comments for a dashboard",
-                "tags": [
-                    "Comments"
-                ],
+                "tags": ["Comments"],
                 "security": [],
                 "parameters": [
                     {
@@ -9454,9 +8362,7 @@
                     }
                 },
                 "description": "Resolves a comment on a dashboard",
-                "tags": [
-                    "Comments"
-                ],
+                "tags": ["Comments"],
                 "security": [],
                 "parameters": [
                     {
@@ -9504,9 +8410,7 @@
                     }
                 },
                 "description": "Deletes a comment on a dashboard",
-                "tags": [
-                    "Comments"
-                ],
+                "tags": ["Comments"],
                 "security": [],
                 "parameters": [
                     {
@@ -9556,9 +8460,7 @@
                     }
                 },
                 "description": "Get a Csv",
-                "tags": [
-                    "Exports"
-                ],
+                "tags": ["Exports"],
                 "security": [],
                 "parameters": [
                     {
@@ -9599,9 +8501,7 @@
                     }
                 },
                 "description": "Promote dashboard to its upstream project",
-                "tags": [
-                    "Dashboards"
-                ],
+                "tags": ["Dashboards"],
                 "security": [],
                 "parameters": [
                     {
@@ -9642,9 +8542,7 @@
                     }
                 },
                 "description": "Get diff from dashboard to promote",
-                "tags": [
-                    "Dashboards"
-                ],
+                "tags": ["Dashboards"],
                 "security": [],
                 "parameters": [
                     {
@@ -9685,9 +8583,7 @@
                     }
                 },
                 "description": "Get the current dbt Cloud integration settings for a project",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": [
                     {
@@ -9726,9 +8622,7 @@
                     }
                 },
                 "description": "Update the dbt Cloud integration settings for a project",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": [
                     {
@@ -9767,9 +8661,7 @@
                     }
                 },
                 "description": "Remove the dbt Cloud integration settings for a project",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": [
                     {
@@ -9808,9 +8700,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -9848,16 +8738,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9874,9 +8759,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -9905,16 +8788,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9931,9 +8809,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -9970,16 +8846,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -9996,9 +8867,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -10046,23 +8915,16 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": [
-                                                "jobId"
-                                            ],
+                                            "required": ["jobId"],
                                             "type": "object"
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -10079,9 +8941,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -10260,16 +9120,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -10295,16 +9150,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -10321,9 +9171,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Git Integration"
-                ],
+                "tags": ["Git Integration"],
                 "security": [],
                 "parameters": [
                     {
@@ -10352,16 +9200,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -10378,9 +9221,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Git Integration"
-                ],
+                "tags": ["Git Integration"],
                 "security": [],
                 "parameters": [
                     {
@@ -10417,16 +9258,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -10443,9 +9279,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Git Integration"
-                ],
+                "tags": ["Git Integration"],
                 "security": [],
                 "parameters": [
                     {
@@ -10465,10 +9299,7 @@
                                 "properties": {
                                     "quoteChar": {
                                         "type": "string",
-                                        "enum": [
-                                            "\"",
-                                            "'"
-                                        ]
+                                        "enum": ["\"", "'"]
                                     },
                                     "customMetrics": {
                                         "items": {
@@ -10477,10 +9308,7 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": [
-                                    "quoteChar",
-                                    "customMetrics"
-                                ],
+                                "required": ["quoteChar", "customMetrics"],
                                 "type": "object"
                             }
                         }
@@ -10514,9 +9342,7 @@
                     }
                 },
                 "description": "Get access token for google drive",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": []
             }
@@ -10547,9 +9373,7 @@
                     }
                 },
                 "description": "Upload results from query to Google Sheet",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -10590,9 +9414,7 @@
                     }
                 },
                 "description": "Get group details",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10651,9 +9473,7 @@
                     }
                 },
                 "description": "Delete a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10691,9 +9511,7 @@
                     }
                 },
                 "description": "Update a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10743,9 +9561,7 @@
                     }
                 },
                 "description": "Add a Lightdash user to a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10793,9 +9609,7 @@
                     }
                 },
                 "description": "Remove a user from a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10845,9 +9659,7 @@
                     }
                 },
                 "description": "View members of a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10888,9 +9700,7 @@
                     }
                 },
                 "description": "Add project access to a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -10946,9 +9756,7 @@
                     }
                 },
                 "description": "Update project access for a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -11004,9 +9812,7 @@
                     }
                 },
                 "description": "Remove project access from a group",
-                "tags": [
-                    "User Groups"
-                ],
+                "tags": ["User Groups"],
                 "security": [],
                 "parameters": [
                     {
@@ -11052,9 +9858,7 @@
                     }
                 },
                 "description": "Get DbtSemanticLayer data",
-                "tags": [
-                    "DbtSemanticLayer"
-                ],
+                "tags": ["DbtSemanticLayer"],
                 "security": [],
                 "parameters": [
                     {
@@ -11086,9 +9890,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": [
-                                    "query"
-                                ],
+                                "required": ["query"],
                                 "type": "object",
                                 "description": "graphql query"
                             }
@@ -11123,9 +9925,7 @@
                     }
                 },
                 "description": "Gets notifications for a user based on the type",
-                "tags": [
-                    "Notifications"
-                ],
+                "tags": ["Notifications"],
                 "security": [],
                 "parameters": [
                     {
@@ -11165,9 +9965,7 @@
                     }
                 },
                 "description": "Update notification",
-                "tags": [
-                    "Notifications"
-                ],
+                "tags": ["Notifications"],
                 "security": [],
                 "parameters": [
                     {
@@ -11218,9 +10016,7 @@
                     }
                 },
                 "description": "Get the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
             },
@@ -11249,9 +10045,7 @@
                     }
                 },
                 "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -11292,9 +10086,7 @@
                     }
                 },
                 "description": "Update the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -11337,9 +10129,7 @@
                     }
                 },
                 "description": "Deletes an organization and all users inside that organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11380,9 +10170,7 @@
                     }
                 },
                 "description": "Gets all projects of the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
             }
@@ -11413,9 +10201,7 @@
                     }
                 },
                 "description": "Gets all the members of the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11456,9 +10242,7 @@
                     }
                 },
                 "description": "Get the member profile for a user in the current user's organization by uuid",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11497,10 +10281,7 @@
                     }
                 },
                 "description": "Updates the membership profile for a user in the current user's organization",
-                "tags": [
-                    "Roles & Permissions",
-                    "Organizations"
-                ],
+                "tags": ["Roles & Permissions", "Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11553,9 +10334,7 @@
                     }
                 },
                 "description": "Deletes a user from the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11596,9 +10375,7 @@
                     }
                 },
                 "description": "Gets the allowed email domains for the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
             },
@@ -11627,9 +10404,7 @@
                     }
                 },
                 "description": "Updates the allowed email domains for the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -11672,9 +10447,7 @@
                     }
                 },
                 "description": "Creates a new group in the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -11715,9 +10488,7 @@
                     }
                 },
                 "description": "Gets all the groups in the current user's organization",
-                "tags": [
-                    "Organizations"
-                ],
+                "tags": ["Organizations"],
                 "security": [],
                 "parameters": [
                     {
@@ -11759,9 +10530,7 @@
                     }
                 },
                 "description": "Get pinned items",
-                "tags": [
-                    "Content"
-                ],
+                "tags": ["Content"],
                 "security": [],
                 "parameters": [
                     {
@@ -11811,9 +10580,7 @@
                     }
                 },
                 "description": "Update pinned items order",
-                "tags": [
-                    "Content"
-                ],
+                "tags": ["Content"],
                 "security": [],
                 "parameters": [
                     {
@@ -11878,9 +10645,7 @@
                     }
                 },
                 "description": "Get a project of an organiztion",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -11920,9 +10685,7 @@
                     }
                 },
                 "description": "List all charts in a project",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -11963,9 +10726,7 @@
                     }
                 },
                 "description": "List all charts summaries in a project",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12006,9 +10767,7 @@
                     }
                 },
                 "description": "List all spaces in a project",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12047,10 +10806,7 @@
                     }
                 },
                 "description": "Create a new space inside a project",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -12101,10 +10857,7 @@
                     }
                 },
                 "description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
-                "tags": [
-                    "Roles & Permissions",
-                    "Projects"
-                ],
+                "tags": ["Roles & Permissions", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12142,10 +10895,7 @@
                     }
                 },
                 "description": "Grant a user access to a project",
-                "tags": [
-                    "Roles & Permissions",
-                    "Projects"
-                ],
+                "tags": ["Roles & Permissions", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12195,10 +10945,7 @@
                     }
                 },
                 "description": "Get a project explicit member's access.\nThere may be users that have access to the project via their organization membership.\n\nNOTE:\nWe don't use the API on the frontend. Instead, we can call the API\nso that we make sure of the user's access to the project.",
-                "tags": [
-                    "Roles & Permissions",
-                    "Projects"
-                ],
+                "tags": ["Roles & Permissions", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12246,10 +10993,7 @@
                     }
                 },
                 "description": "Update a user's access to a project",
-                "tags": [
-                    "Roles & Permissions",
-                    "Projects"
-                ],
+                "tags": ["Roles & Permissions", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12305,10 +11049,7 @@
                     }
                 },
                 "description": "Remove a user's access to a project",
-                "tags": [
-                    "Roles & Permissions",
-                    "Projects"
-                ],
+                "tags": ["Roles & Permissions", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12356,9 +11097,7 @@
                     }
                 },
                 "description": "List group access for projects",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12387,16 +11126,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -12414,10 +11148,7 @@
                     }
                 },
                 "description": "Run a raw sql query against the project's warehouse connection",
-                "tags": [
-                    "Exploring",
-                    "Projects"
-                ],
+                "tags": ["Exploring", "Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12441,9 +11172,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": [
-                                    "sql"
-                                ],
+                                "required": ["sql"],
                                 "type": "object",
                                 "description": "The query to run"
                             }
@@ -12478,9 +11207,7 @@
                     }
                 },
                 "description": "Calculate all metric totals from a metricQuery",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12522,15 +11249,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "status"
-                                    ],
+                                    "required": ["status"],
                                     "type": "object"
                                 }
                             }
@@ -12547,9 +11270,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12588,9 +11309,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12658,16 +11377,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -12684,9 +11398,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12726,9 +11438,7 @@
                     }
                 },
                 "description": "Update project metadata like upstreamProjectUuid\nwe don't trigger a compile, so not for updating warehouse or credentials",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -12778,9 +11488,7 @@
                     }
                 },
                 "description": "Run a query for underlying data results",
-                "tags": [
-                    "Exploring"
-                ],
+                "tags": ["Exploring"],
                 "security": [],
                 "parameters": [
                     {
@@ -12842,9 +11550,7 @@
                     }
                 },
                 "description": "Run a query for explore",
-                "tags": [
-                    "Exploring"
-                ],
+                "tags": ["Exploring"],
                 "security": [],
                 "parameters": [
                     {
@@ -12906,9 +11612,7 @@
                     }
                 },
                 "description": "Run a query for a chart",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -12963,9 +11667,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13038,9 +11740,7 @@
                     }
                 },
                 "description": "Get chart version history from last 30 days",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13081,9 +11781,7 @@
                     }
                 },
                 "description": "Get chart version",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13133,9 +11831,7 @@
                     }
                 },
                 "description": "Run a query for a chart version",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13185,9 +11881,7 @@
                     }
                 },
                 "description": "Rollback chart to version",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13237,9 +11931,7 @@
                     }
                 },
                 "description": "Calculate metric totals from a saved chart",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13296,9 +11988,7 @@
                     }
                 },
                 "description": "Promote chart to its upstream project",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13339,9 +12029,7 @@
                     }
                 },
                 "description": "Get diff from chart to promote",
-                "tags": [
-                    "Charts"
-                ],
+                "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
@@ -13382,9 +12070,7 @@
                     }
                 },
                 "description": "Get scheduled logs",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13424,9 +12110,7 @@
                     }
                 },
                 "description": "Get a scheduler",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13465,9 +12149,7 @@
                     }
                 },
                 "description": "Update a scheduler",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13504,15 +12186,11 @@
                                         "results": {},
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "status"
-                                    ],
+                                    "required": ["status"],
                                     "type": "object"
                                 }
                             }
@@ -13530,9 +12208,7 @@
                     }
                 },
                 "description": "Delete a scheduler",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13573,9 +12249,7 @@
                     }
                 },
                 "description": "Set scheduler enabled",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13599,9 +12273,7 @@
                                         "type": "boolean"
                                     }
                                 },
-                                "required": [
-                                    "enabled"
-                                ],
+                                "required": ["enabled"],
                                 "type": "object",
                                 "description": "the enabled flag"
                             }
@@ -13636,9 +12308,7 @@
                     }
                 },
                 "description": "Get scheduled jobs",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13679,9 +12349,7 @@
                     }
                 },
                 "description": "Get a generic job status\nThis method can be used when polling from the frontend",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [
                     {
@@ -13722,9 +12390,7 @@
                     }
                 },
                 "description": "Send a scheduler now before saving it",
-                "tags": [
-                    "Schedulers"
-                ],
+                "tags": ["Schedulers"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13766,9 +12432,7 @@
                     }
                 },
                 "description": "Get a share url from a short url id",
-                "tags": [
-                    "Share links"
-                ],
+                "tags": ["Share links"],
                 "security": [],
                 "parameters": [
                     {
@@ -13809,9 +12473,7 @@
                     }
                 },
                 "description": "Given a full URL generates a short url id that can be used for sharing",
-                "tags": [
-                    "Share links"
-                ],
+                "tags": ["Share links"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13854,9 +12516,7 @@
                     }
                 },
                 "description": "Get slack channels",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": []
             }
@@ -13887,9 +12547,7 @@
                     }
                 },
                 "description": "Update slack notification channel to send notifications to scheduled jobs fail",
-                "tags": [
-                    "Integrations"
-                ],
+                "tags": ["Integrations"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13930,9 +12588,7 @@
                     }
                 },
                 "description": "Get details for a space in a project",
-                "tags": [
-                    "Spaces"
-                ],
+                "tags": ["Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -13980,9 +12636,7 @@
                     }
                 },
                 "description": "Delete a space from a project",
-                "tags": [
-                    "Spaces"
-                ],
+                "tags": ["Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14030,10 +12684,7 @@
                     }
                 },
                 "description": "Update a space in a project",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14093,10 +12744,7 @@
                     }
                 },
                 "description": "Grant a user access to a space",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14155,10 +12803,7 @@
                     }
                 },
                 "description": "Remove a user's access to a space",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14217,10 +12862,7 @@
                     }
                 },
                 "description": "Grant a group access to a space",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14280,10 +12922,7 @@
                     }
                 },
                 "description": "Remove a group's access to a space",
-                "tags": [
-                    "Roles & Permissions",
-                    "Spaces"
-                ],
+                "tags": ["Roles & Permissions", "Spaces"],
                 "security": [],
                 "parameters": [
                     {
@@ -14341,9 +12980,7 @@
                         }
                     }
                 },
-                "tags": [
-                    "SSH Keypairs"
-                ],
+                "tags": ["SSH Keypairs"],
                 "security": [],
                 "parameters": []
             }
@@ -14374,9 +13011,7 @@
                     }
                 },
                 "description": "Get all user attributes",
-                "tags": [
-                    "User attributes"
-                ],
+                "tags": ["User attributes"],
                 "security": [],
                 "parameters": []
             },
@@ -14405,9 +13040,7 @@
                     }
                 },
                 "description": "Creates new user attribute",
-                "tags": [
-                    "User attributes"
-                ],
+                "tags": ["User attributes"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -14450,9 +13083,7 @@
                     }
                 },
                 "description": "Updates a user attribute",
-                "tags": [
-                    "User attributes"
-                ],
+                "tags": ["User attributes"],
                 "security": [],
                 "parameters": [
                     {
@@ -14503,9 +13134,7 @@
                     }
                 },
                 "description": "Remove a user attribute",
-                "tags": [
-                    "User attributes"
-                ],
+                "tags": ["User attributes"],
                 "security": [],
                 "parameters": [
                     {
@@ -14546,9 +13175,7 @@
                     }
                 },
                 "description": "Get authenticated user",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": []
             },
@@ -14577,9 +13204,7 @@
                     }
                 },
                 "description": "Register user",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -14620,9 +13245,7 @@
                     }
                 },
                 "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": []
             }
@@ -14653,9 +13276,7 @@
                     }
                 },
                 "description": "Get the verification status for the current user's primary email",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [
                     {
@@ -14696,9 +13317,7 @@
                     }
                 },
                 "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": []
             }
@@ -14729,9 +13348,7 @@
                     }
                 },
                 "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [
                     {
@@ -14772,9 +13389,7 @@
                     }
                 },
                 "description": "Delete user",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": []
             }
@@ -14797,16 +13412,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -14824,9 +13434,7 @@
                     }
                 },
                 "description": "Get user warehouse credentials",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": []
             },
@@ -14844,16 +13452,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -14871,9 +13474,7 @@
                     }
                 },
                 "description": "Create user warehouse credentials",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -14903,16 +13504,11 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": [
-                                                "ok"
-                                            ],
+                                            "enum": ["ok"],
                                             "nullable": false
                                         }
                                     },
-                                    "required": [
-                                        "results",
-                                        "status"
-                                    ],
+                                    "required": ["results", "status"],
                                     "type": "object"
                                 }
                             }
@@ -14930,9 +13526,7 @@
                     }
                 },
                 "description": "Update user warehouse credentials",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [
                     {
@@ -14980,9 +13574,7 @@
                     }
                 },
                 "description": "Delete user warehouse credentials",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [
                     {
@@ -15022,9 +13614,7 @@
                     }
                 },
                 "description": "Get login options for email",
-                "tags": [
-                    "My Account"
-                ],
+                "tags": ["My Account"],
                 "security": [],
                 "parameters": [
                     {
@@ -15064,9 +13654,7 @@
                     }
                 },
                 "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -15123,9 +13711,7 @@
                     }
                 },
                 "description": "Get validation results for a project. This will return the results of the latest validation job.",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {
@@ -15184,9 +13770,7 @@
                     }
                 },
                 "description": "Deletes a single validation error.",
-                "tags": [
-                    "Projects"
-                ],
+                "tags": ["Projects"],
                 "security": [],
                 "parameters": [
                     {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -27,21 +27,32 @@
                                 "description": "HTTP status code"
                             }
                         },
-                        "required": ["name", "statusCode"],
+                        "required": [
+                            "name",
+                            "statusCode"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["error"],
+                        "enum": [
+                            "error"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["error", "status"],
+                "required": [
+                    "error",
+                    "status"
+                ],
                 "type": "object",
                 "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
             },
             "FieldType": {
-                "enum": ["metric", "dimension"],
+                "enum": [
+                    "metric",
+                    "dimension"
+                ],
                 "type": "string"
             },
             "Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_": {
@@ -62,7 +73,12 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "label", "fieldType", "tableLabel"],
+                "required": [
+                    "name",
+                    "label",
+                    "fieldType",
+                    "tableLabel"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -81,7 +97,9 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "CatalogType.Field": {
-                "enum": ["field"],
+                "enum": [
+                    "field"
+                ],
                 "type": "string"
             },
             "CatalogField": {
@@ -113,7 +131,10 @@
                                 "$ref": "#/components/schemas/CatalogType.Field"
                             }
                         },
-                        "required": ["tableName", "type"],
+                        "required": [
+                            "tableName",
+                            "type"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -136,12 +157,18 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "label"],
+                "required": [
+                    "name",
+                    "label"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "InlineErrorType": {
-                "enum": ["METADATA_PARSE_ERROR", "NO_DIMENSIONS_FOUND"],
+                "enum": [
+                    "METADATA_PARSE_ERROR",
+                    "NO_DIMENSIONS_FOUND"
+                ],
                 "type": "string"
             },
             "InlineError": {
@@ -153,16 +180,26 @@
                         "$ref": "#/components/schemas/InlineErrorType"
                     }
                 },
-                "required": ["message", "type"],
+                "required": [
+                    "message",
+                    "type"
+                ],
                 "type": "object"
             },
             "CatalogType.Table": {
-                "enum": ["table"],
+                "enum": [
+                    "table"
+                ],
                 "type": "string"
             },
             "DbtModelJoinType": {
                 "type": "string",
-                "enum": ["inner", "full", "left", "right"]
+                "enum": [
+                    "inner",
+                    "full",
+                    "left",
+                    "right"
+                ]
             },
             "Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always_": {
                 "properties": {
@@ -182,7 +219,10 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["table", "sqlOn"],
+                "required": [
+                    "table",
+                    "sqlOn"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -197,7 +237,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["compiledSqlOn"],
+                        "required": [
+                            "compiledSqlOn"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -234,7 +276,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["type"],
+                        "required": [
+                            "type"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -256,7 +300,18 @@
                 "type": "array"
             },
             "CatalogType": {
-                "enum": ["table", "field"],
+                "enum": [
+                    "table",
+                    "field"
+                ],
+                "type": "string"
+            },
+            "CatalogFilter": {
+                "enum": [
+                    "tables",
+                    "dimensions",
+                    "metrics"
+                ],
                 "type": "string"
             },
             "CatalogMetadata": {
@@ -369,7 +424,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["charts"],
+                "required": [
+                    "charts"
+                ],
                 "type": "object"
             },
             "ApiCatalogAnalyticsResults": {
@@ -382,11 +439,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_Comment.text-or-replyTo-or-mentions-or-textHtml_": {
@@ -407,7 +469,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["text", "mentions", "textHtml"],
+                "required": [
+                    "text",
+                    "mentions",
+                    "textHtml"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -440,7 +506,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["name"],
+                        "required": [
+                            "name"
+                        ],
                         "type": "object"
                     },
                     "createdAt": {
@@ -483,22 +551,31 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiResolveComment": {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": [
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiCsvUrlResponse": {
@@ -515,20 +592,33 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["truncated", "status", "url"],
+                        "required": [
+                            "truncated",
+                            "status",
+                            "url"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "DashboardTileTypes": {
-                "enum": ["saved_chart", "markdown", "loom"],
+                "enum": [
+                    "saved_chart",
+                    "markdown",
+                    "loom"
+                ],
                 "type": "string"
             },
             "Required_CreateDashboardTileBase_": {
@@ -559,7 +649,14 @@
                         "type": "string"
                     }
                 },
-                "required": ["uuid", "type", "x", "y", "h", "w"],
+                "required": [
+                    "uuid",
+                    "type",
+                    "x",
+                    "y",
+                    "h",
+                    "w"
+                ],
                 "type": "object",
                 "description": "Make all properties in T required"
             },
@@ -567,7 +664,9 @@
                 "$ref": "#/components/schemas/Required_CreateDashboardTileBase_"
             },
             "DashboardTileTypes.SAVED_CHART": {
-                "enum": ["saved_chart"],
+                "enum": [
+                    "saved_chart"
+                ],
                 "type": "string"
             },
             "DashboardChartTileProperties": {
@@ -600,14 +699,19 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["savedChartUuid"],
+                        "required": [
+                            "savedChartUuid"
+                        ],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.SAVED_CHART"
                     }
                 },
-                "required": ["properties", "type"],
+                "required": [
+                    "properties",
+                    "type"
+                ],
                 "type": "object"
             },
             "DashboardChartTile": {
@@ -621,7 +725,9 @@
                 ]
             },
             "DashboardTileTypes.MARKDOWN": {
-                "enum": ["markdown"],
+                "enum": [
+                    "markdown"
+                ],
                 "type": "string"
             },
             "DashboardMarkdownTileProperties": {
@@ -635,14 +741,20 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["content", "title"],
+                        "required": [
+                            "content",
+                            "title"
+                        ],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.MARKDOWN"
                     }
                 },
-                "required": ["properties", "type"],
+                "required": [
+                    "properties",
+                    "type"
+                ],
                 "type": "object"
             },
             "DashboardMarkdownTile": {
@@ -656,7 +768,9 @@
                 ]
             },
             "DashboardTileTypes.LOOM": {
-                "enum": ["loom"],
+                "enum": [
+                    "loom"
+                ],
                 "type": "string"
             },
             "DashboardLoomTileProperties": {
@@ -673,14 +787,20 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["url", "title"],
+                        "required": [
+                            "url",
+                            "title"
+                        ],
                         "type": "object"
                     },
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes.LOOM"
                     }
                 },
-                "required": ["properties", "type"],
+                "required": [
+                    "properties",
+                    "type"
+                ],
                 "type": "object"
             },
             "DashboardLoomTile": {
@@ -715,7 +835,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["tableName", "fieldId"],
+                "required": [
+                    "tableName",
+                    "fieldId"
+                ],
                 "type": "object"
             },
             "ConditionalOperator": {
@@ -764,7 +887,11 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["operator", "id", "target"],
+                "required": [
+                    "operator",
+                    "id",
+                    "target"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -812,7 +939,11 @@
                         "type": "array"
                     }
                 },
-                "required": ["tableCalculations", "metrics", "dimensions"],
+                "required": [
+                    "tableCalculations",
+                    "metrics",
+                    "dimensions"
+                ],
                 "type": "object"
             },
             "UpdatedByUser": {
@@ -827,7 +958,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["userUuid", "firstName", "lastName"],
+                "required": [
+                    "userUuid",
+                    "firstName",
+                    "lastName"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -844,7 +979,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["order", "name", "uuid"],
+                "required": [
+                    "order",
+                    "name",
+                    "uuid"
+                ],
                 "type": "object"
             },
             "Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__": {
@@ -960,15 +1099,25 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "PromotionAction": {
-                "enum": ["no changes", "create", "update", "delete"],
+                "enum": [
+                    "no changes",
+                    "create",
+                    "update",
+                    "delete"
+                ],
                 "type": "string"
             },
             "Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__": {
@@ -1049,7 +1198,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["spaceSlug"],
+                        "required": [
+                            "spaceSlug"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -1073,7 +1224,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["fieldId"],
+                "required": [
+                    "fieldId"
+                ],
                 "type": "object"
             },
             "FilterRule": {
@@ -1099,7 +1252,11 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["operator", "id", "target"],
+                "required": [
+                    "operator",
+                    "id",
+                    "target"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -1125,7 +1282,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["or", "id"],
+                "required": [
+                    "or",
+                    "id"
+                ],
                 "type": "object"
             },
             "AndFilterGroup": {
@@ -1140,7 +1300,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["and", "id"],
+                "required": [
+                    "and",
+                    "id"
+                ],
                 "type": "object"
             },
             "Filters": {
@@ -1166,7 +1329,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["descending", "fieldId"],
+                "required": [
+                    "descending",
+                    "fieldId"
+                ],
                 "type": "object"
             },
             "CustomFormatType": {
@@ -1192,7 +1358,12 @@
                 "type": "string"
             },
             "Compact": {
-                "enum": ["thousands", "millions", "billions", "trillions"],
+                "enum": [
+                    "thousands",
+                    "millions",
+                    "billions",
+                    "trillions"
+                ],
                 "type": "string"
             },
             "CompactOrAlias": {
@@ -1270,12 +1441,20 @@
                         "$ref": "#/components/schemas/TimeFrames"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
             "TableCalculationType": {
-                "enum": ["number", "string", "date", "timestamp", "boolean"],
+                "enum": [
+                    "number",
+                    "string",
+                    "date",
+                    "timestamp",
+                    "boolean"
+                ],
                 "type": "string"
             },
             "TableCalculation": {
@@ -1300,7 +1479,11 @@
                         "format": "double"
                     }
                 },
-                "required": ["sql", "displayName", "name"],
+                "required": [
+                    "sql",
+                    "displayName",
+                    "name"
+                ],
                 "type": "object"
             },
             "MetricType": {
@@ -1322,7 +1505,15 @@
                 "type": "string"
             },
             "Format": {
-                "enum": ["km", "mi", "usd", "gbp", "eur", "id", "percent"],
+                "enum": [
+                    "km",
+                    "mi",
+                    "usd",
+                    "gbp",
+                    "eur",
+                    "id",
+                    "percent"
+                ],
                 "type": "string"
             },
             "MetricFilterRule": {
@@ -1343,7 +1534,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["fieldRef"],
+                        "required": [
+                            "fieldRef"
+                        ],
                         "type": "object"
                     },
                     "settings": {},
@@ -1354,7 +1547,11 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["operator", "id", "target"],
+                "required": [
+                    "operator",
+                    "id",
+                    "target"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -1416,16 +1613,27 @@
                         "$ref": "#/components/schemas/CustomFormat"
                     }
                 },
-                "required": ["type", "sql", "table", "name"],
+                "required": [
+                    "type",
+                    "sql",
+                    "table",
+                    "name"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
             "CustomDimensionType.BIN": {
-                "enum": ["bin"],
+                "enum": [
+                    "bin"
+                ],
                 "type": "string"
             },
             "BinType": {
-                "enum": ["fixed_number", "fixed_width", "custom_range"],
+                "enum": [
+                    "fixed_number",
+                    "fixed_width",
+                    "custom_range"
+                ],
                 "type": "string"
             },
             "BinRange": {
@@ -1442,7 +1650,10 @@
                 "type": "object"
             },
             "CustomDimensionType": {
-                "enum": ["bin", "sql"],
+                "enum": [
+                    "bin",
+                    "sql"
+                ],
                 "type": "string"
             },
             "CustomBinDimension": {
@@ -1492,11 +1703,19 @@
                 "additionalProperties": true
             },
             "CustomDimensionType.SQL": {
-                "enum": ["sql"],
+                "enum": [
+                    "sql"
+                ],
                 "type": "string"
             },
             "DimensionType": {
-                "enum": ["string", "number", "timestamp", "date", "boolean"],
+                "enum": [
+                    "string",
+                    "number",
+                    "timestamp",
+                    "date",
+                    "boolean"
+                ],
                 "type": "string"
             },
             "CustomSqlDimension": {
@@ -1550,7 +1769,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "label"],
+                "required": [
+                    "name",
+                    "label"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -1562,7 +1784,9 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": ["hasADateDimension"],
+                        "required": [
+                            "hasADateDimension"
+                        ],
                         "type": "object"
                     },
                     "timezone": {
@@ -1627,11 +1851,16 @@
                 "type": "object"
             },
             "ChartType.BIG_NUMBER": {
-                "enum": ["big_number"],
+                "enum": [
+                    "big_number"
+                ],
                 "type": "string"
             },
             "ComparisonFormatTypes": {
-                "enum": ["raw", "percentage"],
+                "enum": [
+                    "raw",
+                    "percentage"
+                ],
                 "type": "string"
             },
             "BigNumber": {
@@ -1672,11 +1901,15 @@
                         "$ref": "#/components/schemas/ChartType.BIG_NUMBER"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartType.CARTESIAN": {
-                "enum": ["cartesian"],
+                "enum": [
+                    "cartesian"
+                ],
                 "type": "string"
             },
             "Partial_CompleteCartesianChartLayout_": {
@@ -1723,7 +1956,11 @@
                     },
                     "align": {
                         "type": "string",
-                        "enum": ["auto", "left", "right"]
+                        "enum": [
+                            "auto",
+                            "left",
+                            "right"
+                        ]
                     },
                     "height": {
                         "type": "string"
@@ -1745,11 +1982,17 @@
                     },
                     "orient": {
                         "type": "string",
-                        "enum": ["horizontal", "vertical"]
+                        "enum": [
+                            "horizontal",
+                            "vertical"
+                        ]
                     },
                     "type": {
                         "type": "string",
-                        "enum": ["plain", "scroll"]
+                        "enum": [
+                            "plain",
+                            "scroll"
+                        ]
                     },
                     "show": {
                         "type": "boolean"
@@ -1790,7 +2033,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["value", "field"],
+                "required": [
+                    "value",
+                    "field"
+                ],
                 "type": "object"
             },
             "PivotReference": {
@@ -1805,25 +2051,38 @@
                         "type": "string"
                     }
                 },
-                "required": ["field"],
+                "required": [
+                    "field"
+                ],
                 "type": "object"
             },
             "CartesianSeriesType": {
-                "enum": ["line", "bar", "scatter", "area"],
+                "enum": [
+                    "line",
+                    "bar",
+                    "scatter",
+                    "area"
+                ],
                 "type": "string"
             },
             "MarkLineData": {
                 "properties": {
                     "dynamicValue": {
                         "type": "string",
-                        "enum": ["average"],
+                        "enum": [
+                            "average"
+                        ],
                         "nullable": false
                     },
                     "label": {
                         "properties": {
                             "position": {
                                 "type": "string",
-                                "enum": ["start", "middle", "end"]
+                                "enum": [
+                                    "start",
+                                    "middle",
+                                    "end"
+                                ]
                             },
                             "formatter": {
                                 "type": "string"
@@ -1837,7 +2096,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["color"],
+                        "required": [
+                            "color"
+                        ],
                         "type": "object"
                     },
                     "uuid": {
@@ -1859,7 +2120,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["uuid"],
+                "required": [
+                    "uuid"
+                ],
                 "type": "object"
             },
             "MarkLine": {
@@ -1885,7 +2148,11 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["type", "width", "color"],
+                        "required": [
+                            "type",
+                            "width",
+                            "color"
+                        ],
                         "type": "object"
                     },
                     "symbol": {
@@ -1898,7 +2165,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["data"],
+                "required": [
+                    "data"
+                ],
                 "type": "object"
             },
             "Series": {
@@ -1976,11 +2245,17 @@
                                 "$ref": "#/components/schemas/PivotReference"
                             }
                         },
-                        "required": ["yRef", "xRef"],
+                        "required": [
+                            "yRef",
+                            "xRef"
+                        ],
                         "type": "object"
                     }
                 },
-                "required": ["type", "encode"],
+                "required": [
+                    "type",
+                    "encode"
+                ],
                 "type": "object"
             },
             "Axis": {
@@ -2060,7 +2335,10 @@
                         "$ref": "#/components/schemas/CartesianChartLayout"
                     }
                 },
-                "required": ["eChartsConfig", "layout"],
+                "required": [
+                    "eChartsConfig",
+                    "layout"
+                ],
                 "type": "object"
             },
             "CartesianChartConfig": {
@@ -2072,11 +2350,15 @@
                         "$ref": "#/components/schemas/ChartType.CARTESIAN"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartType.CUSTOM": {
-                "enum": ["custom"],
+                "enum": [
+                    "custom"
+                ],
                 "type": "string"
             },
             "CustomVis": {
@@ -2097,16 +2379,24 @@
                         "$ref": "#/components/schemas/ChartType.CUSTOM"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartType.PIE": {
-                "enum": ["pie"],
+                "enum": [
+                    "pie"
+                ],
                 "type": "string"
             },
             "PieChartValueLabel": {
                 "type": "string",
-                "enum": ["hidden", "inside", "outside"],
+                "enum": [
+                    "hidden",
+                    "inside",
+                    "outside"
+                ],
                 "nullable": false
             },
             "Record_string.string_": {
@@ -2121,7 +2411,10 @@
             },
             "PieChartLegendPosition": {
                 "type": "string",
-                "enum": ["horizontal", "vertical"],
+                "enum": [
+                    "horizontal",
+                    "vertical"
+                ],
                 "nullable": false
             },
             "PieChart": {
@@ -2183,19 +2476,30 @@
                         "$ref": "#/components/schemas/ChartType.PIE"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartType.FUNNEL": {
-                "enum": ["funnel"],
+                "enum": [
+                    "funnel"
+                ],
                 "type": "string"
             },
             "FunnelChartDataInput": {
-                "enum": ["row", "column"],
+                "enum": [
+                    "row",
+                    "column"
+                ],
                 "type": "string"
             },
             "FunnelChartLabelPosition": {
-                "enum": ["inside", "left", "right"],
+                "enum": [
+                    "inside",
+                    "left",
+                    "right"
+                ],
                 "type": "string"
             },
             "FunnelChart": {
@@ -2235,11 +2539,15 @@
                         "$ref": "#/components/schemas/ChartType.FUNNEL"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartType.TABLE": {
-                "enum": ["table"],
+                "enum": [
+                    "table"
+                ],
                 "type": "string"
             },
             "Record_string.ColumnProperties_": {
@@ -2263,7 +2571,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["operator", "id"],
+                "required": [
+                    "operator",
+                    "id"
+                ],
                 "type": "object"
             },
             "ConditionalFormattingWithConditionalOperator": {
@@ -2281,7 +2592,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["values"],
+                        "required": [
+                            "values"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -2306,7 +2619,11 @@
                         "nullable": true
                     }
                 },
-                "required": ["rules", "color", "target"],
+                "required": [
+                    "rules",
+                    "color",
+                    "target"
+                ],
                 "type": "object"
             },
             "ConditionalFormattingWithRange": {
@@ -2320,7 +2637,10 @@
                         "format": "double"
                     }
                 },
-                "required": ["max", "min"],
+                "required": [
+                    "max",
+                    "min"
+                ],
                 "type": "object"
             },
             "ConditionalFormattingConfigWithColorRange": {
@@ -2332,7 +2652,9 @@
                         "properties": {
                             "steps": {
                                 "type": "number",
-                                "enum": [5],
+                                "enum": [
+                                    5
+                                ],
                                 "nullable": false
                             },
                             "end": {
@@ -2342,7 +2664,11 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["steps", "end", "start"],
+                        "required": [
+                            "steps",
+                            "end",
+                            "start"
+                        ],
                         "type": "object"
                     },
                     "target": {
@@ -2354,7 +2680,11 @@
                         "nullable": true
                     }
                 },
-                "required": ["rule", "color", "target"],
+                "required": [
+                    "rule",
+                    "color",
+                    "target"
+                ],
                 "type": "object"
             },
             "ConditionalFormattingConfig": {
@@ -2411,7 +2741,9 @@
                         "$ref": "#/components/schemas/ChartType.TABLE"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object"
             },
             "ChartConfig": {
@@ -2501,7 +2833,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["columns"],
+                        "required": [
+                            "columns"
+                        ],
                         "type": "object"
                     },
                     "chartConfig": {
@@ -2516,7 +2850,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["columnOrder"],
+                        "required": [
+                            "columnOrder"
+                        ],
                         "type": "object"
                     },
                     "colorPalette": {
@@ -2569,7 +2905,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["oldUuid", "spaceSlug"],
+                        "required": [
+                            "oldUuid",
+                            "spaceSlug"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -2586,7 +2925,10 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": ["data", "action"],
+                            "required": [
+                                "data",
+                                "action"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -2601,7 +2943,10 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": ["data", "action"],
+                            "required": [
+                                "data",
+                                "action"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -2616,13 +2961,20 @@
                                     "$ref": "#/components/schemas/PromotionAction"
                                 }
                             },
-                            "required": ["data", "action"],
+                            "required": [
+                                "data",
+                                "action"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": ["charts", "dashboards", "spaces"],
+                "required": [
+                    "charts",
+                    "dashboards",
+                    "spaces"
+                ],
                 "type": "object"
             },
             "ApiPromotionChangesResponse": {
@@ -2632,11 +2984,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_CreateDbtCloudIntegration.metricsJobId_": {
@@ -2646,7 +3003,9 @@
                         "description": "Job id for a dbt cloud job containing a compiled dbt project with available dbt metrics"
                     }
                 },
-                "required": ["metricsJobId"],
+                "required": [
+                    "metricsJobId"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -2661,11 +3020,15 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": [
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiDbtCloudSettingsDeleteSuccess": {
@@ -2673,11 +3036,15 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": [
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiSuccessEmpty": {
@@ -2685,11 +3052,15 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": [
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_Explore.SummaryExploreFields_": {
@@ -2710,7 +3081,11 @@
                         "type": "array"
                     }
                 },
-                "required": ["name", "label", "tags"],
+                "required": [
+                    "name",
+                    "label",
+                    "tags"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -2726,7 +3101,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["databaseName", "schemaName"],
+                "required": [
+                    "databaseName",
+                    "schemaName"
+                ],
                 "type": "object"
             },
             "Pick_ExploreError.SummaryExploreErrorFields_": {
@@ -2753,7 +3131,12 @@
                         "type": "array"
                     }
                 },
-                "required": ["name", "label", "tags", "errors"],
+                "required": [
+                    "name",
+                    "label",
+                    "tags",
+                    "errors"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -2803,7 +3186,10 @@
                 "type": "array"
             },
             "OrderFieldsByStrategy": {
-                "enum": ["LABEL", "INDEX"],
+                "enum": [
+                    "LABEL",
+                    "INDEX"
+                ],
                 "type": "string"
             },
             "Record_string.GroupType_": {
@@ -2859,7 +3245,13 @@
                         "type": "string"
                     }
                 },
-                "required": ["sqlTable", "schema", "database", "label", "name"],
+                "required": [
+                    "sqlTable",
+                    "schema",
+                    "database",
+                    "label",
+                    "name"
+                ],
                 "type": "object"
             },
             "Record_string.CompiledDimension_": {
@@ -2891,7 +3283,10 @@
                         "format": "double"
                     }
                 },
-                "required": ["character", "line"],
+                "required": [
+                    "character",
+                    "line"
+                ],
                 "type": "object"
             },
             "Source": {
@@ -2908,7 +3303,10 @@
                                 "$ref": "#/components/schemas/SourcePosition"
                             }
                         },
-                        "required": ["end", "start"],
+                        "required": [
+                            "end",
+                            "start"
+                        ],
                         "type": "object"
                     },
                     "range": {
@@ -2920,14 +3318,21 @@
                                 "$ref": "#/components/schemas/SourcePosition"
                             }
                         },
-                        "required": ["end", "start"],
+                        "required": [
+                            "end",
+                            "start"
+                        ],
                         "type": "object"
                     },
                     "path": {
                         "type": "string"
                     }
                 },
-                "required": ["content", "range", "path"],
+                "required": [
+                    "content",
+                    "range",
+                    "path"
+                ],
                 "type": "object"
             },
             "CompiledTable": {
@@ -2950,7 +3355,11 @@
                                 "$ref": "#/components/schemas/Record_string.CompiledDimension_"
                             }
                         },
-                        "required": ["lineageGraph", "metrics", "dimensions"],
+                        "required": [
+                            "lineageGraph",
+                            "metrics",
+                            "dimensions"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -3041,7 +3450,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["ownerLogin", "fullName", "name"],
+                "required": [
+                    "ownerLogin",
+                    "fullName",
+                    "name"
+                ],
                 "type": "object"
             },
             "GitIntegrationConfiguration": {
@@ -3050,7 +3463,9 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["enabled"],
+                "required": [
+                    "enabled"
+                ],
                 "type": "object"
             },
             "PullRequestCreated": {
@@ -3062,7 +3477,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["prUrl", "prTitle"],
+                "required": [
+                    "prUrl",
+                    "prTitle"
+                ],
                 "type": "object"
             },
             "ApiGdriveAccessTokenResponse": {
@@ -3072,11 +3490,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiJobScheduledResponse": {
@@ -3087,16 +3510,23 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["jobId"],
+                        "required": [
+                            "jobId"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "FilterGroupResponse": {
@@ -3111,7 +3541,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["or", "id"],
+                        "required": [
+                            "or",
+                            "id"
+                        ],
                         "type": "object"
                     },
                     {
@@ -3124,7 +3557,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["and", "id"],
+                        "required": [
+                            "and",
+                            "id"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -3151,7 +3587,9 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": ["hasADateDimension"],
+                        "required": [
+                            "hasADateDimension"
+                        ],
                         "type": "object"
                     },
                     "customDimensions": {
@@ -3278,7 +3716,12 @@
                         "description": "The group's UUID"
                     }
                 },
-                "required": ["organizationUuid", "createdAt", "name", "uuid"],
+                "required": [
+                    "organizationUuid",
+                    "createdAt",
+                    "name",
+                    "uuid"
+                ],
                 "type": "object"
             },
             "GroupMember": {
@@ -3301,7 +3744,12 @@
                         "format": "uuid"
                     }
                 },
-                "required": ["lastName", "firstName", "email", "userUuid"],
+                "required": [
+                    "lastName",
+                    "firstName",
+                    "email",
+                    "userUuid"
+                ],
                 "type": "object",
                 "description": "A summary for a Lightdash user within a group"
             },
@@ -3326,7 +3774,10 @@
                                 "description": "A list of the group's members."
                             }
                         },
-                        "required": ["memberUuids", "members"],
+                        "required": [
+                            "memberUuids",
+                            "members"
+                        ],
                         "type": "object"
                     }
                 ],
@@ -3346,11 +3797,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiGroupMembersResponse": {
@@ -3363,11 +3819,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_GroupMember.userUuid_": {
@@ -3378,7 +3839,9 @@
                         "format": "uuid"
                     }
                 },
-                "required": ["userUuid"],
+                "required": [
+                    "userUuid"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3418,7 +3881,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["role", "groupUuid", "projectUuid"],
+                "required": [
+                    "role",
+                    "groupUuid",
+                    "projectUuid"
+                ],
                 "type": "object"
             },
             "ApiCreateProjectGroupAccess": {
@@ -3428,11 +3895,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_CreateDBProjectGroupAccess.role_": {
@@ -3441,7 +3913,9 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": ["role"],
+                "required": [
+                    "role"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3452,11 +3926,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_DBProjectGroupAccess.role_": {
@@ -3465,7 +3944,9 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": ["role"],
+                "required": [
+                    "role"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3494,11 +3975,17 @@
                         "type": "string"
                     }
                 },
-                "required": ["viewed", "createdAt", "notificationId"],
+                "required": [
+                    "viewed",
+                    "createdAt",
+                    "notificationId"
+                ],
                 "type": "object"
             },
             "ApiNotificationResourceType.DashboardComments": {
-                "enum": ["dashboardComments"],
+                "enum": [
+                    "dashboardComments"
+                ],
                 "type": "string"
             },
             "NotificationDashboardTileCommentMetadata": {
@@ -3539,7 +4026,9 @@
                                 "$ref": "#/components/schemas/ApiNotificationResourceType.DashboardComments"
                             }
                         },
-                        "required": ["resourceType"],
+                        "required": [
+                            "resourceType"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -3560,15 +4049,22 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiNotificationResourceType": {
-                "enum": ["dashboardComments"],
+                "enum": [
+                    "dashboardComments"
+                ],
                 "type": "string"
             },
             "Pick_Notification.viewed_": {
@@ -3577,7 +4073,9 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["viewed"],
+                "required": [
+                    "viewed"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3611,7 +4109,10 @@
                         "format": "uuid"
                     }
                 },
-                "required": ["name", "organizationUuid"],
+                "required": [
+                    "name",
+                    "organizationUuid"
+                ],
                 "type": "object",
                 "description": "Details of a user's Organization"
             },
@@ -3622,11 +4123,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_Organization.name_": {
@@ -3636,7 +4142,9 @@
                         "description": "The name of the organization"
                     }
                 },
-                "required": ["name"],
+                "required": [
+                    "name"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3668,7 +4176,10 @@
                 "$ref": "#/components/schemas/Partial_Omit_Organization.organizationUuid-or-needsProject__"
             },
             "ProjectType": {
-                "enum": ["DEFAULT", "PREVIEW"],
+                "enum": [
+                    "DEFAULT",
+                    "PREVIEW"
+                ],
                 "type": "string"
             },
             "WarehouseTypes": {
@@ -3722,11 +4233,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object",
                 "description": "List of projects in the current organization"
             },
@@ -3796,11 +4312,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiOrganizationMemberProfile": {
@@ -3810,11 +4331,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "UUID": {
@@ -3829,23 +4355,33 @@
                         "$ref": "#/components/schemas/OrganizationMemberRole"
                     }
                 },
-                "required": ["role"],
+                "required": [
+                    "role"
+                ],
                 "type": "object"
             },
             "OrganizationMemberRole.EDITOR": {
-                "enum": ["editor"],
+                "enum": [
+                    "editor"
+                ],
                 "type": "string"
             },
             "OrganizationMemberRole.INTERACTIVE_VIEWER": {
-                "enum": ["interactive_viewer"],
+                "enum": [
+                    "interactive_viewer"
+                ],
                 "type": "string"
             },
             "OrganizationMemberRole.VIEWER": {
-                "enum": ["viewer"],
+                "enum": [
+                    "viewer"
+                ],
                 "type": "string"
             },
             "OrganizationMemberRole.MEMBER": {
-                "enum": ["member"],
+                "enum": [
+                    "member"
+                ],
                 "type": "string"
             },
             "AllowedEmailDomainsRole": {
@@ -3865,15 +4401,21 @@
                 ]
             },
             "ProjectMemberRole.EDITOR": {
-                "enum": ["editor"],
+                "enum": [
+                    "editor"
+                ],
                 "type": "string"
             },
             "ProjectMemberRole.INTERACTIVE_VIEWER": {
-                "enum": ["interactive_viewer"],
+                "enum": [
+                    "interactive_viewer"
+                ],
                 "type": "string"
             },
             "ProjectMemberRole.VIEWER": {
-                "enum": ["viewer"],
+                "enum": [
+                    "viewer"
+                ],
                 "type": "string"
             },
             "AllowedEmailDomainProjectsRole": {
@@ -3901,7 +4443,10 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["role", "projectUuid"],
+                            "required": [
+                                "role",
+                                "projectUuid"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -3934,11 +4479,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_AllowedEmailDomains.Exclude_keyofAllowedEmailDomains.organizationUuid__": {
@@ -3962,13 +4512,20 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["role", "projectUuid"],
+                            "required": [
+                                "role",
+                                "projectUuid"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
                     }
                 },
-                "required": ["role", "emailDomains", "projects"],
+                "required": [
+                    "role",
+                    "emailDomains",
+                    "projects"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -3986,7 +4543,9 @@
                         "description": "A friendly name for the group"
                     }
                 },
-                "required": ["name"],
+                "required": [
+                    "name"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4028,15 +4587,22 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ResourceViewItemType.DASHBOARD": {
-                "enum": ["dashboard"],
+                "enum": [
+                    "dashboard"
+                ],
                 "type": "string"
             },
             "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
@@ -4053,7 +4619,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["validationId", "createdAt", "error"],
+                "required": [
+                    "validationId",
+                    "createdAt",
+                    "error"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4127,7 +4697,11 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ResourceItemCategory": {
-                "enum": ["mostPopular", "recentlyUpdated", "pinned"],
+                "enum": [
+                    "mostPopular",
+                    "recentlyUpdated",
+                    "pinned"
+                ],
                 "type": "string"
             },
             "ResourceViewDashboardItem": {
@@ -4142,11 +4716,16 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.DASHBOARD"
                     }
                 },
-                "required": ["data", "type"],
+                "required": [
+                    "data",
+                    "type"
+                ],
                 "type": "object"
             },
             "ResourceViewItemType.CHART": {
-                "enum": ["chart"],
+                "enum": [
+                    "chart"
+                ],
                 "type": "string"
             },
             "ChartType": {
@@ -4244,11 +4823,16 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.CHART"
                     }
                 },
-                "required": ["data", "type"],
+                "required": [
+                    "data",
+                    "type"
+                ],
                 "type": "object"
             },
             "ResourceViewItemType.SPACE": {
-                "enum": ["space"],
+                "enum": [
+                    "space"
+                ],
                 "type": "string"
             },
             "Pick_Space.projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-organizationUuid_": {
@@ -4332,7 +4916,10 @@
                         "$ref": "#/components/schemas/ResourceViewItemType.SPACE"
                     }
                 },
-                "required": ["data", "type"],
+                "required": [
+                    "data",
+                    "type"
+                ],
                 "type": "object"
             },
             "PinnedItems": {
@@ -4358,15 +4945,24 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ResourceViewItemType": {
-                "enum": ["chart", "dashboard", "space"],
+                "enum": [
+                    "chart",
+                    "dashboard",
+                    "space"
+                ],
                 "type": "string"
             },
             "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
@@ -4380,7 +4976,10 @@
                         "nullable": true
                     }
                 },
-                "required": ["uuid", "pinnedListOrder"],
+                "required": [
+                    "uuid",
+                    "pinnedListOrder"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4393,11 +4992,16 @@
                         "$ref": "#/components/schemas/ResourceViewItemType"
                     }
                 },
-                "required": ["data", "type"],
+                "required": [
+                    "data",
+                    "type"
+                ],
                 "type": "object"
             },
             "DbtProjectType.DBT": {
-                "enum": ["dbt"],
+                "enum": [
+                    "dbt"
+                ],
                 "type": "string"
             },
             "DbtProjectEnvironmentVariable": {
@@ -4409,7 +5013,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["value", "key"],
+                "required": [
+                    "value",
+                    "key"
+                ],
                 "type": "object"
             },
             "DbtProjectType": {
@@ -4445,12 +5052,16 @@
                         "type": "string"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
             "DbtProjectType.DBT_CLOUD_IDE": {
-                "enum": ["dbt_cloud_ide"],
+                "enum": [
+                    "dbt_cloud_ide"
+                ],
                 "type": "string"
             },
             "DbtCloudIDEProjectConfig": {
@@ -4465,12 +5076,18 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "api_key", "environment_id"],
+                "required": [
+                    "type",
+                    "api_key",
+                    "environment_id"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
             "DbtProjectType.GITHUB": {
-                "enum": ["github"],
+                "enum": [
+                    "github"
+                ],
                 "type": "string"
             },
             "DbtGithubProjectConfig": {
@@ -4514,7 +5131,9 @@
                 "additionalProperties": true
             },
             "DbtProjectType.BITBUCKET": {
-                "enum": ["bitbucket"],
+                "enum": [
+                    "bitbucket"
+                ],
                 "type": "string"
             },
             "DbtBitBucketProjectConfig": {
@@ -4562,7 +5181,9 @@
                 "additionalProperties": true
             },
             "DbtProjectType.GITLAB": {
-                "enum": ["gitlab"],
+                "enum": [
+                    "gitlab"
+                ],
                 "type": "string"
             },
             "DbtGitlabProjectConfig": {
@@ -4606,7 +5227,9 @@
                 "additionalProperties": true
             },
             "DbtProjectType.AZURE_DEVOPS": {
-                "enum": ["azure_devops"],
+                "enum": [
+                    "azure_devops"
+                ],
                 "type": "string"
             },
             "DbtAzureDevOpsProjectConfig": {
@@ -4655,7 +5278,9 @@
                 "additionalProperties": true
             },
             "DbtProjectType.NONE": {
-                "enum": ["none"],
+                "enum": [
+                    "none"
+                ],
                 "type": "string"
             },
             "DbtNoneProjectConfig": {
@@ -4676,7 +5301,9 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -4706,11 +5333,21 @@
                 ]
             },
             "WarehouseTypes.SNOWFLAKE": {
-                "enum": ["snowflake"],
+                "enum": [
+                    "snowflake"
+                ],
                 "type": "string"
             },
             "WeekDay": {
-                "enum": [0, 1, 2, 3, 4, 5, 6],
+                "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
                 "type": "number"
             },
             "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.SensitiveCredentialsFieldNames__": {
@@ -4779,7 +5416,9 @@
                 "$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.REDSHIFT": {
-                "enum": ["redshift"],
+                "enum": [
+                    "redshift"
+                ],
                 "type": "string"
             },
             "Pick_CreateRedshiftCredentials.Exclude_keyofCreateRedshiftCredentials.SensitiveCredentialsFieldNames__": {
@@ -4842,7 +5481,13 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["type", "schema", "host", "port", "dbname"],
+                "required": [
+                    "type",
+                    "schema",
+                    "host",
+                    "port",
+                    "dbname"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4854,7 +5499,9 @@
                 "$ref": "#/components/schemas/Omit_CreateRedshiftCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.POSTGRES": {
-                "enum": ["postgres"],
+                "enum": [
+                    "postgres"
+                ],
                 "type": "string"
             },
             "Pick_CreatePostgresCredentials.Exclude_keyofCreatePostgresCredentials.SensitiveCredentialsFieldNames__": {
@@ -4920,7 +5567,13 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "schema", "host", "port", "dbname"],
+                "required": [
+                    "type",
+                    "schema",
+                    "host",
+                    "port",
+                    "dbname"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4932,7 +5585,9 @@
                 "$ref": "#/components/schemas/Omit_CreatePostgresCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.BIGQUERY": {
-                "enum": ["bigquery"],
+                "enum": [
+                    "bigquery"
+                ],
                 "type": "string"
             },
             "Pick_CreateBigqueryCredentials.Exclude_keyofCreateBigqueryCredentials.SensitiveCredentialsFieldNames__": {
@@ -4967,7 +5622,10 @@
                     },
                     "priority": {
                         "type": "string",
-                        "enum": ["interactive", "batch"]
+                        "enum": [
+                            "interactive",
+                            "batch"
+                        ]
                     },
                     "retries": {
                         "type": "number",
@@ -4981,7 +5639,11 @@
                         "format": "double"
                     }
                 },
-                "required": ["type", "project", "dataset"],
+                "required": [
+                    "type",
+                    "project",
+                    "dataset"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -4993,7 +5655,9 @@
                 "$ref": "#/components/schemas/Omit_CreateBigqueryCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.DATABRICKS": {
-                "enum": ["databricks"],
+                "enum": [
+                    "databricks"
+                ],
                 "type": "string"
             },
             "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
@@ -5025,7 +5689,12 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "database", "serverHostName", "httpPath"],
+                "required": [
+                    "type",
+                    "database",
+                    "serverHostName",
+                    "httpPath"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5037,7 +5706,9 @@
                 "$ref": "#/components/schemas/Omit_CreateDatabricksCredentials.SensitiveCredentialsFieldNames_"
             },
             "WarehouseTypes.TRINO": {
-                "enum": ["trino"],
+                "enum": [
+                    "trino"
+                ],
                 "type": "string"
             },
             "Pick_CreateTrinoCredentials.Exclude_keyofCreateTrinoCredentials.SensitiveCredentialsFieldNames__": {
@@ -5114,7 +5785,13 @@
                 ]
             },
             "SupportedDbtVersions": {
-                "enum": ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8"],
+                "enum": [
+                    "v1.4",
+                    "v1.5",
+                    "v1.6",
+                    "v1.7",
+                    "v1.8"
+                ],
                 "type": "string"
             },
             "Project": {
@@ -5164,11 +5841,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_SavedChart.uuid-or-name-or-description-or-spaceName-or-spaceUuid-or-projectUuid-or-organizationUuid-or-pinnedListUuid-or-dashboardUuid-or-dashboardName_": {
@@ -5254,7 +5936,10 @@
                         "nullable": true
                     }
                 },
-                "required": ["updatedAt", "pinnedListOrder"],
+                "required": [
+                    "updatedAt",
+                    "pinnedListOrder"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5277,7 +5962,10 @@
                         "format": "double"
                     }
                 },
-                "required": ["firstViewedAt", "views"],
+                "required": [
+                    "firstViewedAt",
+                    "views"
+                ],
                 "type": "object"
             },
             "SpaceQuery": {
@@ -5314,11 +6002,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiChartSummaryListResponse": {
@@ -5331,11 +6024,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-isPrivate-or-pinnedListUuid-or-pinnedListOrder-or-slug_": {
@@ -5382,7 +6080,11 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "SpaceMemberRole": {
-                "enum": ["viewer", "editor", "admin"],
+                "enum": [
+                    "viewer",
+                    "editor",
+                    "admin"
+                ],
                 "type": "string"
             },
             "SpaceShare": {
@@ -5460,7 +6162,11 @@
                                 "$ref": "#/components/schemas/SpaceShare"
                             }
                         },
-                        "required": ["dashboardCount", "chartCount", "access"],
+                        "required": [
+                            "dashboardCount",
+                            "chartCount",
+                            "access"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -5475,11 +6181,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ProjectMemberProfile": {
@@ -5523,11 +6234,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiGetProjectMemberResponse": {
@@ -5537,11 +6253,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "CreateProjectMember": {
@@ -5556,7 +6277,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["sendEmail", "role", "email"],
+                "required": [
+                    "sendEmail",
+                    "role",
+                    "email"
+                ],
                 "type": "object"
             },
             "UpdateProjectMember": {
@@ -5565,7 +6290,9 @@
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     }
                 },
-                "required": ["role"],
+                "required": [
+                    "role"
+                ],
                 "type": "object"
             },
             "ApiGetProjectGroupAccesses": {
@@ -5578,11 +6305,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Record_string._type-DimensionType--__": {
@@ -5607,7 +6339,10 @@
                         "$ref": "#/components/schemas/Record_string._type-DimensionType--__"
                     }
                 },
-                "required": ["rows", "fields"],
+                "required": [
+                    "rows",
+                    "fields"
+                ],
                 "type": "object"
             },
             "Record_string.number_": {
@@ -5622,15 +6357,26 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "DateGranularity": {
-                "enum": ["Day", "Week", "Month", "Quarter", "Year"],
+                "enum": [
+                    "Day",
+                    "Week",
+                    "Month",
+                    "Quarter",
+                    "Year"
+                ],
                 "type": "string"
             },
             "MetricQueryRequest": {
@@ -5644,7 +6390,9 @@
                                 "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
                             }
                         },
-                        "required": ["hasADateDimension"],
+                        "required": [
+                            "hasADateDimension"
+                        ],
                         "type": "object"
                     },
                     "granularity": {
@@ -5726,7 +6474,10 @@
                         "$ref": "#/components/schemas/MetricQueryRequest"
                     }
                 },
-                "required": ["explore", "metricQuery"],
+                "required": [
+                    "explore",
+                    "metricQuery"
+                ],
                 "type": "object"
             },
             "Record_string.DbtExposure_": {
@@ -5743,7 +6494,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "user"],
+                "required": [
+                    "type",
+                    "user"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5753,7 +6507,9 @@
                         "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5763,7 +6519,9 @@
                         "$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
                     }
                 },
-                "required": ["type"],
+                "required": [
+                    "type"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5829,7 +6587,9 @@
                         "format": "date-time"
                     }
                 },
-                "required": ["cacheHit"],
+                "required": [
+                    "cacheHit"
+                ],
                 "type": "object"
             },
             "Record_string.Item-or-AdditionalMetric_": {
@@ -5855,16 +6615,25 @@
                                 "$ref": "#/components/schemas/MetricQueryResponse"
                             }
                         },
-                        "required": ["rows", "cacheMetadata", "metricQuery"],
+                        "required": [
+                            "rows",
+                            "cacheMetadata",
+                            "metricQuery"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_LightdashUser.userUuid-or-firstName-or-lastName_": {
@@ -5879,7 +6648,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["userUuid", "firstName", "lastName"],
+                "required": [
+                    "userUuid",
+                    "firstName",
+                    "lastName"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -5925,7 +6698,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["history"],
+                "required": [
+                    "history"
+                ],
                 "type": "object"
             },
             "ApiGetChartHistoryResponse": {
@@ -5935,11 +6710,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "SavedChart": {
@@ -6004,7 +6784,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["columnOrder"],
+                        "required": [
+                            "columnOrder"
+                        ],
                         "type": "object"
                     },
                     "chartConfig": {
@@ -6019,7 +6801,9 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["columns"],
+                        "required": [
+                            "columns"
+                        ],
                         "type": "object"
                     },
                     "metricQuery": {
@@ -6104,11 +6888,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiPromoteChartResponse": {
@@ -6118,15 +6907,24 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "SchedulerFormat": {
-                "enum": ["csv", "image", "gsheets"],
+                "enum": [
+                    "csv",
+                    "image",
+                    "gsheets"
+                ],
                 "type": "string"
             },
             "SchedulerCsvOptions": {
@@ -6139,7 +6937,10 @@
                             },
                             {
                                 "type": "string",
-                                "enum": ["table", "all"]
+                                "enum": [
+                                    "table",
+                                    "all"
+                                ]
                             }
                         ]
                     },
@@ -6147,7 +6948,10 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["limit", "formatted"],
+                "required": [
+                    "limit",
+                    "formatted"
+                ],
                 "type": "object"
             },
             "SchedulerImageOptions": {
@@ -6216,11 +7020,18 @@
                         "$ref": "#/components/schemas/ThresholdOperator"
                     }
                 },
-                "required": ["value", "fieldId", "operator"],
+                "required": [
+                    "value",
+                    "fieldId",
+                    "operator"
+                ],
                 "type": "object"
             },
             "NotificationFrequency": {
-                "enum": ["always", "once"],
+                "enum": [
+                    "always",
+                    "once"
+                ],
                 "type": "string"
             },
             "SchedulerBase": {
@@ -6299,14 +7110,19 @@
                         "properties": {
                             "dashboardUuid": {
                                 "type": "number",
-                                "enum": [null],
+                                "enum": [
+                                    null
+                                ],
                                 "nullable": true
                             },
                             "savedChartUuid": {
                                 "type": "string"
                             }
                         },
-                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "required": [
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -6346,11 +7162,16 @@
                             },
                             "savedChartUuid": {
                                 "type": "number",
-                                "enum": [null],
+                                "enum": [
+                                    null
+                                ],
                                 "nullable": true
                             }
                         },
-                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "required": [
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -6444,13 +7265,20 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["targets"],
+                        "required": [
+                            "targets"
+                        ],
                         "type": "object"
                     }
                 ]
             },
             "SchedulerJobStatus": {
-                "enum": ["scheduled", "started", "completed", "error"],
+                "enum": [
+                    "scheduled",
+                    "started",
+                    "completed",
+                    "error"
+                ],
                 "type": "string"
             },
             "Record_string.any_": {
@@ -6465,7 +7293,11 @@
                     },
                     "targetType": {
                         "type": "string",
-                        "enum": ["email", "slack", "gsheets"]
+                        "enum": [
+                            "email",
+                            "slack",
+                            "gsheets"
+                        ]
                     },
                     "target": {
                         "type": "string"
@@ -6532,7 +7364,10 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["dashboardUuid", "name"],
+                            "required": [
+                                "dashboardUuid",
+                                "name"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -6547,7 +7382,10 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["savedChartUuid", "name"],
+                            "required": [
+                                "savedChartUuid",
+                                "name"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -6565,7 +7403,11 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["userUuid", "lastName", "firstName"],
+                            "required": [
+                                "userUuid",
+                                "lastName",
+                                "firstName"
+                            ],
                             "type": "object"
                         },
                         "type": "array"
@@ -6593,11 +7435,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiSchedulerAndTargetsResponse": {
@@ -6607,11 +7454,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ScheduledJobs": {
@@ -6624,7 +7476,10 @@
                         "format": "date-time"
                     }
                 },
-                "required": ["id", "date"],
+                "required": [
+                    "id",
+                    "date"
+                ],
                 "type": "object"
             },
             "ApiScheduledJobsResponse": {
@@ -6637,11 +7492,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiJobStatusResponse": {
@@ -6660,16 +7520,24 @@
                                 "$ref": "#/components/schemas/SchedulerJobStatus"
                             }
                         },
-                        "required": ["details", "status"],
+                        "required": [
+                            "details",
+                            "status"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiTestSchedulerResponse": {
@@ -6680,16 +7548,23 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["jobId"],
+                        "required": [
+                            "jobId"
+                        ],
                         "type": "object"
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ShareUrl": {
@@ -6723,7 +7598,11 @@
                         "description": "Unique shareable id"
                     }
                 },
-                "required": ["params", "path", "nanoid"],
+                "required": [
+                    "params",
+                    "path",
+                    "nanoid"
+                ],
                 "type": "object",
                 "description": "A ShareUrl maps a short shareable id to a full URL\nin the Lightdash UI. This allows very long URLs\nto be represented by short ids."
             },
@@ -6734,11 +7613,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_ShareUrl.path-or-params_": {
@@ -6751,7 +7635,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["path", "params"],
+                "required": [
+                    "path",
+                    "params"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -6768,7 +7655,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "id"],
+                "required": [
+                    "name",
+                    "id"
+                ],
                 "type": "object"
             },
             "ApiSlackChannelsResponse": {
@@ -6781,11 +7671,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiSlackCustomSettingsResponse": {
@@ -6793,11 +7688,16 @@
                     "results": {},
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "SlackChannelProjectMapping": {
@@ -6809,7 +7709,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["slackChannelId", "projectUuid"],
+                "required": [
+                    "slackChannelId",
+                    "projectUuid"
+                ],
                 "type": "object"
             },
             "SlackAppCustomSettings": {
@@ -6829,7 +7732,10 @@
                         "nullable": true
                     }
                 },
-                "required": ["appProfilePhotoUrl", "notificationChannel"],
+                "required": [
+                    "appProfilePhotoUrl",
+                    "notificationChannel"
+                ],
                 "type": "object"
             },
             "Pick_Dashboard.uuid-or-name-or-description-or-updatedAt-or-projectUuid-or-updatedByUser-or-organizationUuid-or-spaceUuid-or-views-or-firstViewedAt-or-pinnedListUuid-or-pinnedListOrder_": {
@@ -6933,7 +7839,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["spaceRole", "groupName", "groupUuid"],
+                "required": [
+                    "spaceRole",
+                    "groupName",
+                    "groupUuid"
+                ],
                 "type": "object"
             },
             "Space": {
@@ -7013,11 +7923,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_SpaceShare.userUuid-or-role_": {
@@ -7029,7 +7944,10 @@
                         "$ref": "#/components/schemas/SpaceMemberRole"
                     }
                 },
-                "required": ["userUuid", "role"],
+                "required": [
+                    "userUuid",
+                    "role"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7048,7 +7966,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["name"],
+                "required": [
+                    "name"
+                ],
                 "type": "object"
             },
             "UpdateSpace": {
@@ -7060,7 +7980,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["isPrivate", "name"],
+                "required": [
+                    "isPrivate",
+                    "name"
+                ],
                 "type": "object"
             },
             "AddSpaceUserAccess": {
@@ -7072,7 +7995,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["spaceRole", "userUuid"],
+                "required": [
+                    "spaceRole",
+                    "userUuid"
+                ],
                 "type": "object"
             },
             "AddSpaceGroupAccess": {
@@ -7084,7 +8010,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["spaceRole", "groupUuid"],
+                "required": [
+                    "spaceRole",
+                    "groupUuid"
+                ],
                 "type": "object"
             },
             "Pick_SshKeyPair.publicKey_": {
@@ -7093,7 +8022,9 @@
                         "type": "string"
                     }
                 },
-                "required": ["publicKey"],
+                "required": [
+                    "publicKey"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7104,11 +8035,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "UserAttributeValue": {
@@ -7123,7 +8059,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["value", "email", "userUuid"],
+                "required": [
+                    "value",
+                    "email",
+                    "userUuid"
+                ],
                 "type": "object"
             },
             "GroupAttributeValue": {
@@ -7135,7 +8075,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["value", "groupUuid"],
+                "required": [
+                    "value",
+                    "groupUuid"
+                ],
                 "type": "object"
             },
             "UserAttribute": {
@@ -7194,11 +8137,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiCreateUserAttributeResponse": {
@@ -7208,11 +8156,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_UserAttribute.name-or-description-or-attributeDefault_": {
@@ -7228,7 +8181,10 @@
                         "nullable": true
                     }
                 },
-                "required": ["name", "attributeDefault"],
+                "required": [
+                    "name",
+                    "attributeDefault"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7241,7 +8197,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["userUuid", "value"],
+                "required": [
+                    "userUuid",
+                    "value"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7275,7 +8234,10 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["groups", "users"],
+                        "required": [
+                            "groups",
+                            "users"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -7339,11 +8301,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object",
                 "description": "Shows the authenticated user"
             },
@@ -7354,11 +8321,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ActivateUser": {
@@ -7373,7 +8345,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["password", "lastName", "firstName"],
+                "required": [
+                    "password",
+                    "lastName",
+                    "firstName"
+                ],
                 "type": "object"
             },
             "ActivateUserWithInviteCode": {
@@ -7387,7 +8363,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["inviteCode"],
+                        "required": [
+                            "inviteCode"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -7412,7 +8390,12 @@
                         "type": "string"
                     }
                 },
-                "required": ["password", "email", "lastName", "firstName"],
+                "required": [
+                    "password",
+                    "email",
+                    "lastName",
+                    "firstName"
+                ],
                 "type": "object"
             },
             "RegisterOrActivateUser": {
@@ -7438,7 +8421,10 @@
                         "description": "Time that the passcode was created"
                     }
                 },
-                "required": ["numberOfAttempts", "createdAt"],
+                "required": [
+                    "numberOfAttempts",
+                    "createdAt"
+                ],
                 "type": "object"
             },
             "EmailStatus": {
@@ -7453,7 +8439,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["isVerified", "email"],
+                "required": [
+                    "isVerified",
+                    "email"
+                ],
                 "type": "object"
             },
             "EmailOneTimePasswordExpiring": {
@@ -7474,7 +8463,11 @@
                                 "format": "date-time"
                             }
                         },
-                        "required": ["isMaxAttempts", "isExpired", "expiresAt"],
+                        "required": [
+                            "isMaxAttempts",
+                            "isExpired",
+                            "expiresAt"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -7503,11 +8496,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object",
                 "description": "Shows the current verification status of an email address"
             },
@@ -7524,7 +8522,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["membersCount", "name", "organizationUuid"],
+                "required": [
+                    "membersCount",
+                    "name",
+                    "organizationUuid"
+                ],
                 "type": "object"
             },
             "ApiUserAllowedOrganizationsResponse": {
@@ -7537,11 +8539,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "Pick_CreateRedshiftCredentials.type-or-user-or-password_": {
@@ -7556,7 +8563,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "user", "password"],
+                "required": [
+                    "type",
+                    "user",
+                    "password"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7572,7 +8583,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "user", "password"],
+                "required": [
+                    "type",
+                    "user",
+                    "password"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7588,7 +8603,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "user"],
+                "required": [
+                    "type",
+                    "user"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7604,7 +8622,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "user", "password"],
+                "required": [
+                    "type",
+                    "user",
+                    "password"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7617,7 +8639,10 @@
                         "$ref": "#/components/schemas/Record_string.string_"
                     }
                 },
-                "required": ["type", "keyfileContents"],
+                "required": [
+                    "type",
+                    "keyfileContents"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7630,7 +8655,10 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "personalAccessToken"],
+                "required": [
+                    "type",
+                    "personalAccessToken"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7662,15 +8690,27 @@
                         "type": "string"
                     }
                 },
-                "required": ["credentials", "name"],
+                "required": [
+                    "credentials",
+                    "name"
+                ],
                 "type": "object"
             },
             "OpenIdIdentityIssuerType": {
-                "enum": ["google", "okta", "oneLogin", "azuread", "oidc"],
+                "enum": [
+                    "google",
+                    "okta",
+                    "oneLogin",
+                    "azuread",
+                    "oidc"
+                ],
                 "type": "string"
             },
             "LocalIssuerTypes": {
-                "enum": ["email", "apiToken"],
+                "enum": [
+                    "email",
+                    "apiToken"
+                ],
                 "type": "string"
             },
             "LoginOptionTypes": {
@@ -7698,7 +8738,9 @@
                         "type": "array"
                     }
                 },
-                "required": ["showOptions"],
+                "required": [
+                    "showOptions"
+                ],
                 "type": "object"
             },
             "ApiGetLoginOptionsResponse": {
@@ -7708,11 +8750,16 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ValidationErrorType": {
@@ -7728,7 +8775,11 @@
                 "type": "string"
             },
             "ValidationSourceType": {
-                "enum": ["chart", "dashboard", "table"],
+                "enum": [
+                    "chart",
+                    "dashboard",
+                    "table"
+                ],
                 "type": "string"
             },
             "ValidationResponseBase": {
@@ -7801,7 +8852,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["chartViews"],
+                        "required": [
+                            "chartViews"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -7834,7 +8887,9 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["dashboardViews"],
+                        "required": [
+                            "dashboardViews"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -7917,22 +8972,31 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": [
+                    "results",
+                    "status"
+                ],
                 "type": "object"
             },
             "ApiValidationDismissResponse": {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "enum": ["ok"],
+                        "enum": [
+                            "ok"
+                        ],
                         "nullable": false
                     }
                 },
-                "required": ["status"],
+                "required": [
+                    "status"
+                ],
                 "type": "object"
             }
         },
@@ -7980,11 +9044,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8002,7 +9071,9 @@
                     }
                 },
                 "description": "Get catalog items",
-                "tags": ["Catalog"],
+                "tags": [
+                    "Catalog"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8028,6 +9099,14 @@
                         "schema": {
                             "$ref": "#/components/schemas/CatalogType"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/CatalogFilter"
+                        }
                     }
                 ]
             }
@@ -8047,11 +9126,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8069,7 +9153,9 @@
                     }
                 },
                 "description": "Get catalog metadata for tables",
-                "tags": ["Catalog"],
+                "tags": [
+                    "Catalog"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8107,11 +9193,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8129,7 +9220,9 @@
                     }
                 },
                 "description": "Get catalog analytics for tables",
-                "tags": ["Catalog"],
+                "tags": [
+                    "Catalog"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8167,11 +9260,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8189,7 +9287,9 @@
                     }
                 },
                 "description": "Get catalog analytics for fields",
-                "tags": ["Catalog"],
+                "tags": [
+                    "Catalog"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8247,7 +9347,9 @@
                     }
                 },
                 "description": "Creates a comment on a dashboard tile",
-                "tags": ["Comments"],
+                "tags": [
+                    "Comments"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8309,7 +9411,9 @@
                     }
                 },
                 "description": "Gets all comments for a dashboard",
-                "tags": ["Comments"],
+                "tags": [
+                    "Comments"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8350,7 +9454,9 @@
                     }
                 },
                 "description": "Resolves a comment on a dashboard",
-                "tags": ["Comments"],
+                "tags": [
+                    "Comments"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8398,7 +9504,9 @@
                     }
                 },
                 "description": "Deletes a comment on a dashboard",
-                "tags": ["Comments"],
+                "tags": [
+                    "Comments"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8448,7 +9556,9 @@
                     }
                 },
                 "description": "Get a Csv",
-                "tags": ["Exports"],
+                "tags": [
+                    "Exports"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8489,7 +9599,9 @@
                     }
                 },
                 "description": "Promote dashboard to its upstream project",
-                "tags": ["Dashboards"],
+                "tags": [
+                    "Dashboards"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8530,7 +9642,9 @@
                     }
                 },
                 "description": "Get diff from dashboard to promote",
-                "tags": ["Dashboards"],
+                "tags": [
+                    "Dashboards"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8571,7 +9685,9 @@
                     }
                 },
                 "description": "Get the current dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8610,7 +9726,9 @@
                     }
                 },
                 "description": "Update the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8649,7 +9767,9 @@
                     }
                 },
                 "description": "Remove the dbt Cloud integration settings for a project",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8688,7 +9808,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8726,11 +9848,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8747,7 +9874,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8776,11 +9905,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8797,7 +9931,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8834,11 +9970,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8855,7 +9996,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -8903,16 +10046,23 @@
                                                     "type": "string"
                                                 }
                                             },
-                                            "required": ["jobId"],
+                                            "required": [
+                                                "jobId"
+                                            ],
                                             "type": "object"
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -8929,7 +10079,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9108,11 +10260,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -9138,11 +10295,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -9159,7 +10321,9 @@
                         }
                     }
                 },
-                "tags": ["Git Integration"],
+                "tags": [
+                    "Git Integration"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9188,11 +10352,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -9209,7 +10378,9 @@
                         }
                     }
                 },
-                "tags": ["Git Integration"],
+                "tags": [
+                    "Git Integration"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9246,11 +10417,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -9267,7 +10443,9 @@
                         }
                     }
                 },
-                "tags": ["Git Integration"],
+                "tags": [
+                    "Git Integration"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9287,7 +10465,10 @@
                                 "properties": {
                                     "quoteChar": {
                                         "type": "string",
-                                        "enum": ["\"", "'"]
+                                        "enum": [
+                                            "\"",
+                                            "'"
+                                        ]
                                     },
                                     "customMetrics": {
                                         "items": {
@@ -9296,7 +10477,10 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": ["quoteChar", "customMetrics"],
+                                "required": [
+                                    "quoteChar",
+                                    "customMetrics"
+                                ],
                                 "type": "object"
                             }
                         }
@@ -9330,7 +10514,9 @@
                     }
                 },
                 "description": "Get access token for google drive",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -9361,7 +10547,9 @@
                     }
                 },
                 "description": "Upload results from query to Google Sheet",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -9402,7 +10590,9 @@
                     }
                 },
                 "description": "Get group details",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9461,7 +10651,9 @@
                     }
                 },
                 "description": "Delete a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9499,7 +10691,9 @@
                     }
                 },
                 "description": "Update a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9549,7 +10743,9 @@
                     }
                 },
                 "description": "Add a Lightdash user to a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9597,7 +10793,9 @@
                     }
                 },
                 "description": "Remove a user from a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9647,7 +10845,9 @@
                     }
                 },
                 "description": "View members of a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9688,7 +10888,9 @@
                     }
                 },
                 "description": "Add project access to a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9744,7 +10946,9 @@
                     }
                 },
                 "description": "Update project access for a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9800,7 +11004,9 @@
                     }
                 },
                 "description": "Remove project access from a group",
-                "tags": ["User Groups"],
+                "tags": [
+                    "User Groups"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9846,7 +11052,9 @@
                     }
                 },
                 "description": "Get DbtSemanticLayer data",
-                "tags": ["DbtSemanticLayer"],
+                "tags": [
+                    "DbtSemanticLayer"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9878,7 +11086,9 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["query"],
+                                "required": [
+                                    "query"
+                                ],
                                 "type": "object",
                                 "description": "graphql query"
                             }
@@ -9913,7 +11123,9 @@
                     }
                 },
                 "description": "Gets notifications for a user based on the type",
-                "tags": ["Notifications"],
+                "tags": [
+                    "Notifications"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -9953,7 +11165,9 @@
                     }
                 },
                 "description": "Update notification",
-                "tags": ["Notifications"],
+                "tags": [
+                    "Notifications"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10004,7 +11218,9 @@
                     }
                 },
                 "description": "Get the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": []
             },
@@ -10033,7 +11249,9 @@
                     }
                 },
                 "description": "Creates a new organization, the current user becomes the Admin of the new organization.\nThis is only available to users that are not already in an organization.",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -10074,7 +11292,9 @@
                     }
                 },
                 "description": "Update the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -10117,7 +11337,9 @@
                     }
                 },
                 "description": "Deletes an organization and all users inside that organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10158,7 +11380,9 @@
                     }
                 },
                 "description": "Gets all projects of the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -10189,7 +11413,9 @@
                     }
                 },
                 "description": "Gets all the members of the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10230,7 +11456,9 @@
                     }
                 },
                 "description": "Get the member profile for a user in the current user's organization by uuid",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10269,7 +11497,10 @@
                     }
                 },
                 "description": "Updates the membership profile for a user in the current user's organization",
-                "tags": ["Roles & Permissions", "Organizations"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10322,7 +11553,9 @@
                     }
                 },
                 "description": "Deletes a user from the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10363,7 +11596,9 @@
                     }
                 },
                 "description": "Gets the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": []
             },
@@ -10392,7 +11627,9 @@
                     }
                 },
                 "description": "Updates the allowed email domains for the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -10435,7 +11672,9 @@
                     }
                 },
                 "description": "Creates a new group in the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -10476,7 +11715,9 @@
                     }
                 },
                 "description": "Gets all the groups in the current user's organization",
-                "tags": ["Organizations"],
+                "tags": [
+                    "Organizations"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10518,7 +11759,9 @@
                     }
                 },
                 "description": "Get pinned items",
-                "tags": ["Content"],
+                "tags": [
+                    "Content"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10568,7 +11811,9 @@
                     }
                 },
                 "description": "Update pinned items order",
-                "tags": ["Content"],
+                "tags": [
+                    "Content"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10633,7 +11878,9 @@
                     }
                 },
                 "description": "Get a project of an organiztion",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10673,7 +11920,9 @@
                     }
                 },
                 "description": "List all charts in a project",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10714,7 +11963,9 @@
                     }
                 },
                 "description": "List all charts summaries in a project",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10755,7 +12006,9 @@
                     }
                 },
                 "description": "List all spaces in a project",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10794,7 +12047,10 @@
                     }
                 },
                 "description": "Create a new space inside a project",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10845,7 +12101,10 @@
                     }
                 },
                 "description": "Get access list for a project. This is a list of users that have been explictly granted access to the project.\nThere may be other users that have access to the project via their organization membership.",
-                "tags": ["Roles & Permissions", "Projects"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10883,7 +12142,10 @@
                     }
                 },
                 "description": "Grant a user access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10933,7 +12195,10 @@
                     }
                 },
                 "description": "Get a project explicit member's access.\nThere may be users that have access to the project via their organization membership.\n\nNOTE:\nWe don't use the API on the frontend. Instead, we can call the API\nso that we make sure of the user's access to the project.",
-                "tags": ["Roles & Permissions", "Projects"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -10981,7 +12246,10 @@
                     }
                 },
                 "description": "Update a user's access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11037,7 +12305,10 @@
                     }
                 },
                 "description": "Remove a user's access to a project",
-                "tags": ["Roles & Permissions", "Projects"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11085,7 +12356,9 @@
                     }
                 },
                 "description": "List group access for projects",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11114,11 +12387,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -11136,7 +12414,10 @@
                     }
                 },
                 "description": "Run a raw sql query against the project's warehouse connection",
-                "tags": ["Exploring", "Projects"],
+                "tags": [
+                    "Exploring",
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11160,7 +12441,9 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["sql"],
+                                "required": [
+                                    "sql"
+                                ],
                                 "type": "object",
                                 "description": "The query to run"
                             }
@@ -11195,7 +12478,9 @@
                     }
                 },
                 "description": "Calculate all metric totals from a metricQuery",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11237,11 +12522,15 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["status"],
+                                    "required": [
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -11258,7 +12547,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11297,7 +12588,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11365,11 +12658,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -11386,7 +12684,9 @@
                         }
                     }
                 },
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11426,7 +12726,9 @@
                     }
                 },
                 "description": "Update project metadata like upstreamProjectUuid\nwe don't trigger a compile, so not for updating warehouse or credentials",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11476,7 +12778,9 @@
                     }
                 },
                 "description": "Run a query for underlying data results",
-                "tags": ["Exploring"],
+                "tags": [
+                    "Exploring"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11538,7 +12842,9 @@
                     }
                 },
                 "description": "Run a query for explore",
-                "tags": ["Exploring"],
+                "tags": [
+                    "Exploring"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11600,7 +12906,9 @@
                     }
                 },
                 "description": "Run a query for a chart",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11655,7 +12963,9 @@
                         }
                     }
                 },
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11728,7 +13038,9 @@
                     }
                 },
                 "description": "Get chart version history from last 30 days",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11769,7 +13081,9 @@
                     }
                 },
                 "description": "Get chart version",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11819,7 +13133,9 @@
                     }
                 },
                 "description": "Run a query for a chart version",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11869,7 +13185,9 @@
                     }
                 },
                 "description": "Rollback chart to version",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11919,7 +13237,9 @@
                     }
                 },
                 "description": "Calculate metric totals from a saved chart",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -11976,7 +13296,9 @@
                     }
                 },
                 "description": "Promote chart to its upstream project",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12017,7 +13339,9 @@
                     }
                 },
                 "description": "Get diff from chart to promote",
-                "tags": ["Charts"],
+                "tags": [
+                    "Charts"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12058,7 +13382,9 @@
                     }
                 },
                 "description": "Get scheduled logs",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12098,7 +13424,9 @@
                     }
                 },
                 "description": "Get a scheduler",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12137,7 +13465,9 @@
                     }
                 },
                 "description": "Update a scheduler",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12174,11 +13504,15 @@
                                         "results": {},
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["status"],
+                                    "required": [
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -12196,7 +13530,9 @@
                     }
                 },
                 "description": "Delete a scheduler",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12237,7 +13573,9 @@
                     }
                 },
                 "description": "Set scheduler enabled",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12261,7 +13599,9 @@
                                         "type": "boolean"
                                     }
                                 },
-                                "required": ["enabled"],
+                                "required": [
+                                    "enabled"
+                                ],
                                 "type": "object",
                                 "description": "the enabled flag"
                             }
@@ -12296,7 +13636,9 @@
                     }
                 },
                 "description": "Get scheduled jobs",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12337,7 +13679,9 @@
                     }
                 },
                 "description": "Get a generic job status\nThis method can be used when polling from the frontend",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12378,7 +13722,9 @@
                     }
                 },
                 "description": "Send a scheduler now before saving it",
-                "tags": ["Schedulers"],
+                "tags": [
+                    "Schedulers"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -12420,7 +13766,9 @@
                     }
                 },
                 "description": "Get a share url from a short url id",
-                "tags": ["Share links"],
+                "tags": [
+                    "Share links"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12461,7 +13809,9 @@
                     }
                 },
                 "description": "Given a full URL generates a short url id that can be used for sharing",
-                "tags": ["Share links"],
+                "tags": [
+                    "Share links"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -12504,7 +13854,9 @@
                     }
                 },
                 "description": "Get slack channels",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -12535,7 +13887,9 @@
                     }
                 },
                 "description": "Update slack notification channel to send notifications to scheduled jobs fail",
-                "tags": ["Integrations"],
+                "tags": [
+                    "Integrations"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -12576,7 +13930,9 @@
                     }
                 },
                 "description": "Get details for a space in a project",
-                "tags": ["Spaces"],
+                "tags": [
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12624,7 +13980,9 @@
                     }
                 },
                 "description": "Delete a space from a project",
-                "tags": ["Spaces"],
+                "tags": [
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12672,7 +14030,10 @@
                     }
                 },
                 "description": "Update a space in a project",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12732,7 +14093,10 @@
                     }
                 },
                 "description": "Grant a user access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12791,7 +14155,10 @@
                     }
                 },
                 "description": "Remove a user's access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12850,7 +14217,10 @@
                     }
                 },
                 "description": "Grant a group access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12910,7 +14280,10 @@
                     }
                 },
                 "description": "Remove a group's access to a space",
-                "tags": ["Roles & Permissions", "Spaces"],
+                "tags": [
+                    "Roles & Permissions",
+                    "Spaces"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -12968,7 +14341,9 @@
                         }
                     }
                 },
-                "tags": ["SSH Keypairs"],
+                "tags": [
+                    "SSH Keypairs"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -12999,7 +14374,9 @@
                     }
                 },
                 "description": "Get all user attributes",
-                "tags": ["User attributes"],
+                "tags": [
+                    "User attributes"
+                ],
                 "security": [],
                 "parameters": []
             },
@@ -13028,7 +14405,9 @@
                     }
                 },
                 "description": "Creates new user attribute",
-                "tags": ["User attributes"],
+                "tags": [
+                    "User attributes"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13071,7 +14450,9 @@
                     }
                 },
                 "description": "Updates a user attribute",
-                "tags": ["User attributes"],
+                "tags": [
+                    "User attributes"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13122,7 +14503,9 @@
                     }
                 },
                 "description": "Remove a user attribute",
-                "tags": ["User attributes"],
+                "tags": [
+                    "User attributes"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13163,7 +14546,9 @@
                     }
                 },
                 "description": "Get authenticated user",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": []
             },
@@ -13192,7 +14577,9 @@
                     }
                 },
                 "description": "Register user",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13233,7 +14620,9 @@
                     }
                 },
                 "description": "Create a new one-time passcode for the current user's primary email.\nThe user will receive an email with the passcode.",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -13264,7 +14653,9 @@
                     }
                 },
                 "description": "Get the verification status for the current user's primary email",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13305,7 +14696,9 @@
                     }
                 },
                 "description": "List the organizations that the current user can join.\nThis is based on the user's primary email domain and the organization's allowed email domains.",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -13336,7 +14729,9 @@
                     }
                 },
                 "description": "Add the current user to an organization that accepts users with a verified email domain.\nThis will fail if the organization email domain does not match the user's primary email domain.",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13377,7 +14772,9 @@
                     }
                 },
                 "description": "Delete user",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": []
             }
@@ -13400,11 +14797,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -13422,7 +14824,9 @@
                     }
                 },
                 "description": "Get user warehouse credentials",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": []
             },
@@ -13440,11 +14844,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -13462,7 +14871,9 @@
                     }
                 },
                 "description": "Create user warehouse credentials",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [],
                 "requestBody": {
@@ -13492,11 +14903,16 @@
                                         },
                                         "status": {
                                             "type": "string",
-                                            "enum": ["ok"],
+                                            "enum": [
+                                                "ok"
+                                            ],
                                             "nullable": false
                                         }
                                     },
-                                    "required": ["results", "status"],
+                                    "required": [
+                                        "results",
+                                        "status"
+                                    ],
                                     "type": "object"
                                 }
                             }
@@ -13514,7 +14930,9 @@
                     }
                 },
                 "description": "Update user warehouse credentials",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13562,7 +14980,9 @@
                     }
                 },
                 "description": "Delete user warehouse credentials",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13602,7 +15022,9 @@
                     }
                 },
                 "description": "Get login options for email",
-                "tags": ["My Account"],
+                "tags": [
+                    "My Account"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13642,7 +15064,9 @@
                     }
                 },
                 "description": "Validate content inside a project. This will start a validation job and return the job id.\n\nValidation jobs scan all charts and dashboards inside a project to find any broken references\nto metrics or dimensions that aren't available. Results are available after the job is completed.",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13699,7 +15123,9 @@
                     }
                 },
                 "description": "Get validation results for a project. This will return the results of the latest validation job.",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {
@@ -13758,7 +15184,9 @@
                     }
                 },
                 "description": "Deletes a single validation error.",
-                "tags": ["Projects"],
+                "tags": [
+                    "Projects"
+                ],
                 "security": [],
                 "parameters": [
                     {

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -1,8 +1,10 @@
 import {
     CatalogField,
+    CatalogFilter,
     CatalogTable,
     CatalogType,
     Explore,
+    FieldType,
     NotFoundError,
     UnexpectedServerError,
 } from '@lightdash/common';
@@ -33,6 +35,7 @@ export class CatalogModel {
         projectUuid,
         exploreName,
         type,
+        filter,
         limit = 50,
         excludeUnmatched = true,
         searchRankFunction = getFullTextSearchRankCalcSql,
@@ -40,6 +43,7 @@ export class CatalogModel {
         searchQuery: string;
         projectUuid: string;
         exploreName?: string;
+        filter?: CatalogFilter;
         type?: CatalogType;
         limit?: number;
         excludeUnmatched?: boolean;
@@ -85,6 +89,20 @@ export class CatalogModel {
                 `${CatalogTableName}.type`,
                 type,
             );
+        }
+        if (filter) {
+            if (filter === CatalogFilter.Dimensions) {
+                catalogItemsQuery = catalogItemsQuery.andWhere(
+                    `${CatalogTableName}.field_type`,
+                    FieldType.DIMENSION,
+                );
+            }
+            if (filter === CatalogFilter.Metrics) {
+                catalogItemsQuery = catalogItemsQuery.andWhere(
+                    `${CatalogTableName}.field_type`,
+                    FieldType.METRIC,
+                );
+            }
         }
 
         if (excludeUnmatched) {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -796,14 +796,7 @@ export class ProjectModel {
                                     .delete();
 
                                 const inserts = await this.database
-                                    .batchInsert(
-                                        CatalogTableName,
-                                        catalogItems.map((catalogItem) => ({
-                                            ...omit(catalogItem, [
-                                                'field_type',
-                                            ]),
-                                        })),
-                                    )
+                                    .batchInsert(CatalogTableName, catalogItems)
                                     .returning('*')
                                     .transacting(trx);
 

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -3,6 +3,7 @@ import {
     ApiCatalogSearch,
     CatalogAnalytics,
     CatalogField,
+    CatalogFilter,
     CatalogMetadata,
     CatalogTable,
     CatalogType,
@@ -181,6 +182,8 @@ export class CatalogService<
         projectUuid: string,
         query: string,
         userAttributes: UserAttributeValueMap,
+        type?: CatalogType,
+        filter?: CatalogFilter,
     ): Promise<(CatalogTable | CatalogField)[]> {
         const tablesConfiguration =
             await this.projectModel.getTablesConfiguration(projectUuid);
@@ -200,6 +203,8 @@ export class CatalogService<
                         this.catalogModel.search({
                             projectUuid,
                             searchQuery: query,
+                            filter,
+                            type,
                         }),
                 );
                 // Filter table selection
@@ -236,7 +241,7 @@ export class CatalogService<
     async getCatalog(
         user: SessionUser,
         projectUuid: string,
-        { search, type }: ApiCatalogSearch,
+        { search, type, filter }: ApiCatalogSearch,
     ) {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -294,7 +299,13 @@ export class CatalogService<
 
         if (search) {
             // On search we don't show explore errors, because they are not indexed
-            return this.searchCatalog(projectUuid, search, userAttributes);
+            return this.searchCatalog(
+                projectUuid,
+                search,
+                userAttributes,
+                type,
+                filter,
+            );
         }
         if (type === CatalogType.Field)
             return CatalogService.getCatalogFields(

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -17,6 +17,12 @@ export enum CatalogType {
     Field = 'field',
 }
 
+export enum CatalogFilter {
+    Tables = 'tables',
+    Dimensions = 'dimensions',
+    Metrics = 'metrics',
+}
+
 export type CatalogSelection = {
     group: string;
     table?: string;
@@ -26,6 +32,7 @@ export type CatalogSelection = {
 export type ApiCatalogSearch = {
     search?: string;
     type?: CatalogType;
+    filter?: CatalogFilter;
 };
 export type CatalogField = Pick<
     Field,

--- a/packages/frontend/src/features/catalog/components/CatalogFilterSearch.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFilterSearch.tsx
@@ -1,0 +1,108 @@
+import { CatalogFilter } from '@lightdash/common';
+import {
+    Divider,
+    Group,
+    Popover,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine/core';
+import { IconBookmark, IconChevronDown } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+type Props = {
+    filter: CatalogFilter | undefined;
+    setFilter: (filter: CatalogFilter | undefined) => void;
+};
+
+export const CatalogFilterSearch: FC<Props> = ({ filter, setFilter }) => {
+    const filterLabels = useMemo(
+        () => [
+            {
+                label: 'All item types',
+                type: undefined,
+            },
+            {
+                label: 'Tables',
+                type: CatalogFilter.Tables,
+            },
+            {
+                label: 'Metrics',
+                type: CatalogFilter.Metrics,
+            },
+            {
+                label: 'Dimensions',
+                type: CatalogFilter.Dimensions,
+            },
+        ],
+        [],
+    );
+    const activeFilterLabel = useMemo(
+        () =>
+            filterLabels.find((l) => l.type === filter && !!filter)?.label ??
+            'All',
+        [filter, filterLabels],
+    );
+
+    return (
+        <Popover radius="md" shadow="sm">
+            <Popover.Target>
+                <UnstyledButton
+                    h={36}
+                    px="xs"
+                    fz="sm"
+                    sx={(theme) => ({
+                        border: `1px solid ${theme.colors.gray[3]}`,
+                        borderRight: 'none',
+                        borderTopLeftRadius: theme.radius.md,
+                        borderBottomLeftRadius: theme.radius.md,
+                        backgroundColor: theme.fn.lighten(
+                            theme.colors.gray[1],
+                            0.8,
+                        ),
+                    })}
+                >
+                    <Group spacing="two">
+                        <Text c={filter ? 'gray.8' : 'gray.6'} fw={450}>
+                            {activeFilterLabel}
+                        </Text>
+                        <MantineIcon color="gray.6" icon={IconChevronDown} />
+                    </Group>
+                </UnstyledButton>
+            </Popover.Target>
+            <Popover.Dropdown p={0}>
+                <Stack spacing="two">
+                    <Stack spacing="xs">
+                        <Text p="xs" pb={0} fw={400} c="gray.6" fz={11}>
+                            Search by:{' '}
+                        </Text>
+                        <Divider color="gray.2" />
+                    </Stack>
+
+                    <Stack spacing="xs" py="xs">
+                        {filterLabels.map(({ type, label }) => (
+                            <UnstyledButton
+                                key={type}
+                                fz="sm"
+                                fw={450}
+                                px="sm"
+                                onClick={() => {
+                                    setFilter(type);
+                                }}
+                            >
+                                <Group spacing="two">
+                                    <MantineIcon
+                                        color="gray.6"
+                                        icon={IconBookmark}
+                                    />
+                                    <Text c="gray.7">{label}</Text>
+                                </Group>
+                            </UnstyledButton>
+                        ))}
+                    </Stack>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};

--- a/packages/frontend/src/features/catalog/components/CatalogFilterSearch.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFilterSearch.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     UnstyledButton,
 } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { IconBookmark, IconChevronDown } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -17,6 +18,8 @@ type Props = {
 };
 
 export const CatalogFilterSearch: FC<Props> = ({ filter, setFilter }) => {
+    const [isPopoverOpen, { open: openPopover, close: closePopover }] =
+        useDisclosure();
     const filterLabels = useMemo(
         () => [
             {
@@ -46,7 +49,15 @@ export const CatalogFilterSearch: FC<Props> = ({ filter, setFilter }) => {
     );
 
     return (
-        <Popover radius="md" shadow="sm">
+        <Popover
+            radius="md"
+            shadow="sm"
+            opened={isPopoverOpen}
+            offset={{
+                mainAxis: 0,
+                crossAxis: 16,
+            }}
+        >
             <Popover.Target>
                 <UnstyledButton
                     h={36}
@@ -62,6 +73,8 @@ export const CatalogFilterSearch: FC<Props> = ({ filter, setFilter }) => {
                             0.8,
                         ),
                     })}
+                    onClick={openPopover}
+                    onBlurCapture={closePopover}
                 >
                     <Group spacing="two">
                         <Text c={filter ? 'gray.8' : 'gray.6'} fw={450}>
@@ -72,35 +85,40 @@ export const CatalogFilterSearch: FC<Props> = ({ filter, setFilter }) => {
                 </UnstyledButton>
             </Popover.Target>
             <Popover.Dropdown p={0}>
-                <Stack spacing="two">
-                    <Stack spacing="xs">
-                        <Text p="xs" pb={0} fw={400} c="gray.6" fz={11}>
-                            Search by:{' '}
-                        </Text>
-                        <Divider color="gray.2" />
-                    </Stack>
+                <Stack spacing="xs">
+                    <Text p="xs" pb={0} fw={400} c="gray.6" fz={11}>
+                        Search by:{' '}
+                    </Text>
+                    <Divider color="gray.2" />
+                </Stack>
 
-                    <Stack spacing="xs" py="xs">
-                        {filterLabels.map(({ type, label }) => (
-                            <UnstyledButton
-                                key={type}
-                                fz="sm"
-                                fw={450}
-                                px="sm"
-                                onClick={() => {
-                                    setFilter(type);
-                                }}
-                            >
-                                <Group spacing="two">
-                                    <MantineIcon
-                                        color="gray.6"
-                                        icon={IconBookmark}
-                                    />
-                                    <Text c="gray.7">{label}</Text>
-                                </Group>
-                            </UnstyledButton>
-                        ))}
-                    </Stack>
+                <Stack spacing={0}>
+                    {filterLabels.map(({ type, label }) => (
+                        <UnstyledButton
+                            key={type}
+                            fz="sm"
+                            fw={450}
+                            p="sm"
+                            py="xs"
+                            onClick={() => {
+                                setFilter(type);
+                                closePopover();
+                            }}
+                            sx={(theme) => ({
+                                '&:hover': {
+                                    backgroundColor: theme.colors.gray[1],
+                                },
+                            })}
+                        >
+                            <Group spacing="two">
+                                <MantineIcon
+                                    color="gray.6"
+                                    icon={IconBookmark}
+                                />
+                                <Text c="gray.7">{label}</Text>
+                            </Group>
+                        </UnstyledButton>
+                    ))}
                 </Stack>
             </Popover.Dropdown>
         </Popover>

--- a/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogPanel.tsx
@@ -1,19 +1,16 @@
 import {
     CatalogType,
     type CatalogField,
+    type CatalogFilter,
     type CatalogSelection,
     type CatalogTable,
 } from '@lightdash/common';
 import {
     ActionIcon,
-    Badge,
     Box,
     Button,
-    Checkbox,
-    Divider,
     Group,
     Paper,
-    Popover,
     Stack,
     Text,
     TextInput,
@@ -22,7 +19,6 @@ import {
 import { useDebouncedValue, useHotkeys } from '@mantine/hooks';
 
 import {
-    IconAdjustmentsHorizontal,
     IconReportSearch,
     IconSearch,
     IconTable,
@@ -37,6 +33,7 @@ import { useCatalogContext } from '../context/CatalogProvider';
 import { useCatalog } from '../hooks/useCatalog';
 import { useCatalogAnalytics } from '../hooks/useCatalogAnalytics';
 import { useCatalogMetadata } from '../hooks/useCatalogMetadata';
+import { CatalogFilterSearch } from './CatalogFilterSearch';
 import { CatalogTree } from './CatalogTree';
 
 const TABLES_WITH_ERRORS_GROUP_NAME = 'Tables with errors';
@@ -105,18 +102,6 @@ function getSelectionList(tree: CatalogTreeType): CatalogSelection[] {
     return selectionList;
 }
 
-enum FilterType {
-    Dimensions = 'dimensions',
-    Metrics = 'metrics',
-    HideGroupedTables = 'hideGroupedTables',
-}
-
-type FilterState = {
-    dimensions: boolean;
-    metrics: boolean;
-    hideGroupedTables: boolean;
-};
-
 export const CatalogPanel: FC = () => {
     const [, startTransition] = useTransition();
     const {
@@ -138,6 +123,7 @@ export const CatalogPanel: FC = () => {
     const [completeSearch, setCompleteSearch] = useState<string>('');
     const [debouncedSearch] = useDebouncedValue(completeSearch, 300);
 
+    const [filter, setFilter] = useState<CatalogFilter | undefined>(undefined);
     const {
         data: catalogResults,
         isFetched: catalogFetched,
@@ -145,16 +131,8 @@ export const CatalogPanel: FC = () => {
         isLoading: catalogLoading,
     } = useCatalog({
         projectUuid,
-        type: CatalogType.Table,
+        filter: search.length >= 3 ? filter : undefined,
         search: debouncedSearch,
-    });
-
-    const [filtersOpen, setFiltersOpen] = useState(false);
-
-    const [filters, setFilters] = useState({
-        dimensions: false,
-        metrics: false,
-        hideGroupedTables: false,
     });
 
     const { mutate: getMetadata } = useCatalogMetadata(projectUuid, (data) => {
@@ -190,24 +168,6 @@ export const CatalogPanel: FC = () => {
         setCompleteSearch('');
     }, [setSearch, setCompleteSearch]);
 
-    const toggleFilter = useCallback(
-        (filter: FilterType) => {
-            setFilters((prev: FilterState) => ({
-                ...prev,
-                [filter]: !prev[filter],
-            }));
-        },
-        [setFilters],
-    );
-
-    const clearFilters = useCallback(() => {
-        setFilters({
-            dimensions: false,
-            metrics: false,
-            hideGroupedTables: false,
-        });
-    }, [setFilters]);
-
     // TODO: should this transform be in the backend?
     const catalogTree: CatalogTreeType = useMemo(() => {
         if (catalogResults) {
@@ -232,14 +192,7 @@ export const CatalogPanel: FC = () => {
                             'groupLabel' in item && item.groupLabel
                                 ? item.groupLabel
                                 : 'Ungrouped tables';
-                        // If grouped tables are hidden, don't add them to the tree
-                        if (
-                            groupName !== 'Ungrouped tables' &&
-                            filters.hideGroupedTables
-                        ) {
-                            return acc;
-                        }
-                        // Add to the tree if not filtered out
+
                         if (!acc[groupName]) {
                             acc[groupName] = { name: groupName, tables: {} };
                         }
@@ -254,29 +207,7 @@ export const CatalogPanel: FC = () => {
                         'tableGroupLabel' in item && item.tableGroupLabel
                             ? item.tableGroupLabel
                             : 'Ungrouped tables';
-                    // Filter out dimensions and metrics if
-                    // the filter for the other is active
-                    if (
-                        filters.dimensions &&
-                        !filters.metrics &&
-                        item.fieldType === 'metric'
-                    ) {
-                        return acc;
-                    }
-                    if (
-                        filters.metrics &&
-                        !filters.dimensions &&
-                        item.fieldType === 'dimension'
-                    ) {
-                        return acc;
-                    }
-                    // Filter out ungrouped tables
-                    if (
-                        groupName !== 'Ungrouped tables' &&
-                        filters.hideGroupedTables
-                    ) {
-                        return acc;
-                    }
+
                     // Add to the tree if not filtered out
                     if (!acc[groupName]) {
                         acc[groupName] = { name: groupName, tables: {} };
@@ -296,12 +227,7 @@ export const CatalogPanel: FC = () => {
             return sortTree(unsortedTree);
         }
         return {};
-    }, [
-        catalogResults,
-        filters.dimensions,
-        filters.hideGroupedTables,
-        filters.metrics,
-    ]);
+    }, [catalogResults]);
 
     const selectionList = useMemo(
         () => getSelectionList(catalogTree),
@@ -479,7 +405,11 @@ export const CatalogPanel: FC = () => {
                     </Box>
                 </Group>
 
-                <Group spacing="xs" align="start">
+                <Group spacing="none" align="start">
+                    <CatalogFilterSearch
+                        filter={filter}
+                        setFilter={setFilter}
+                    />
                     <TextInput
                         w={'50%'}
                         icon={<MantineIcon icon={IconSearch} />}
@@ -504,7 +434,10 @@ export const CatalogPanel: FC = () => {
                         onChange={(e) => handleSearchChange(e.target.value)}
                         styles={(theme) => ({
                             input: {
-                                borderRadius: theme.radius.md,
+                                borderTopRightRadius: theme.radius.md,
+                                borderBottomRightRadius: theme.radius.md,
+                                borderTopLeftRadius: 0,
+                                borderBottomLeftRadius: 0,
                                 border: `1px solid ${theme.colors.gray[3]}`,
                             },
                             description: {
@@ -515,190 +448,6 @@ export const CatalogPanel: FC = () => {
                             },
                         })}
                     />
-                    <Group>
-                        <Popover
-                            shadow="xs"
-                            position="bottom-start"
-                            opened={filtersOpen}
-                            onClose={() => setFiltersOpen(false)}
-                        >
-                            <Button.Group>
-                                <Popover.Target>
-                                    <Button
-                                        variant="default"
-                                        size="sm"
-                                        leftIcon={
-                                            <MantineIcon
-                                                icon={IconAdjustmentsHorizontal}
-                                            />
-                                        }
-                                        onClick={() => {
-                                            setFiltersOpen((prev) => !prev);
-                                        }}
-                                    >
-                                        <Group noWrap spacing="xs">
-                                            <Text>Filter</Text>
-                                            {filters.dimensions && (
-                                                <Badge
-                                                    fw={500}
-                                                    size="xs"
-                                                    radius="md"
-                                                    color="indigo"
-                                                    styles={{
-                                                        root: {
-                                                            textTransform:
-                                                                'none',
-                                                        },
-                                                    }}
-                                                >
-                                                    Dimensions
-                                                </Badge>
-                                            )}
-                                            {filters.metrics && (
-                                                <Badge
-                                                    fw={500}
-                                                    size="xs"
-                                                    color="orange"
-                                                    styles={{
-                                                        root: {
-                                                            textTransform:
-                                                                'none',
-                                                        },
-                                                    }}
-                                                >
-                                                    Metrics
-                                                </Badge>
-                                            )}
-
-                                            {filters.hideGroupedTables && (
-                                                <Badge
-                                                    fw={500}
-                                                    size="xs"
-                                                    color="gray.8"
-                                                    styles={{
-                                                        root: {
-                                                            textTransform:
-                                                                'none',
-                                                        },
-                                                    }}
-                                                >
-                                                    Hide grouped tables
-                                                </Badge>
-                                            )}
-                                        </Group>
-                                    </Button>
-                                </Popover.Target>
-                                {(filters.dimensions ||
-                                    filters.metrics ||
-                                    filters.hideGroupedTables) && (
-                                    <Button
-                                        variant="default"
-                                        size="sm"
-                                        onClick={clearFilters}
-                                        p="xs"
-                                    >
-                                        <MantineIcon
-                                            color="gray"
-                                            icon={IconX}
-                                        />
-                                    </Button>
-                                )}
-                            </Button.Group>
-
-                            <Popover.Dropdown fz="xs">
-                                <Stack spacing="sm">
-                                    <Text c="gray.6" fw={500}>
-                                        Result type
-                                    </Text>
-                                    <Stack spacing="xs">
-                                        <Checkbox
-                                            checked={filters.dimensions}
-                                            onChange={() => {
-                                                toggleFilter(
-                                                    FilterType.Dimensions,
-                                                );
-                                            }}
-                                            label={
-                                                <Badge
-                                                    fw={500}
-                                                    radius="md"
-                                                    color="indigo"
-                                                    styles={{
-                                                        root: {
-                                                            textTransform:
-                                                                'none',
-                                                        },
-                                                    }}
-                                                >
-                                                    Dimensions
-                                                </Badge>
-                                            }
-                                        />
-
-                                        <Checkbox
-                                            checked={filters.metrics}
-                                            onChange={() => {
-                                                toggleFilter(
-                                                    FilterType.Metrics,
-                                                );
-                                            }}
-                                            label={
-                                                <Badge
-                                                    fw={500}
-                                                    color="orange"
-                                                    styles={{
-                                                        root: {
-                                                            textTransform:
-                                                                'none',
-                                                        },
-                                                    }}
-                                                >
-                                                    Metrics
-                                                </Badge>
-                                            }
-                                        />
-                                    </Stack>
-
-                                    <Divider c="gray.1" />
-                                    <Stack spacing="xs">
-                                        <Checkbox
-                                            checked={filters.hideGroupedTables}
-                                            onChange={() => {
-                                                toggleFilter(
-                                                    FilterType.HideGroupedTables,
-                                                );
-                                            }}
-                                            label={
-                                                <Text
-                                                    fz="xs"
-                                                    fw={500}
-                                                    c="gray.7"
-                                                >
-                                                    Hide grouped tables
-                                                </Text>
-                                            }
-                                        />
-                                    </Stack>
-
-                                    <Button
-                                        size="xs"
-                                        ml="auto"
-                                        sx={(theme) => ({
-                                            backgroundColor:
-                                                theme.colors.gray[8],
-                                            '&:hover': {
-                                                backgroundColor:
-                                                    theme.colors.gray[9],
-                                            },
-                                        })}
-                                        onClick={() => setFiltersOpen(false)}
-                                    >
-                                        Close
-                                    </Button>
-                                </Stack>
-                            </Popover.Dropdown>
-                        </Popover>
-                    </Group>
                 </Group>
             </Stack>
 

--- a/packages/frontend/src/features/catalog/hooks/useCatalog.ts
+++ b/packages/frontend/src/features/catalog/hooks/useCatalog.ts
@@ -1,7 +1,8 @@
 import {
+    CatalogFilter,
+    CatalogType,
     type ApiCatalogResults,
     type ApiError,
-    type CatalogType,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
@@ -10,21 +11,54 @@ import useQueryError from '../../../hooks/useQueryError';
 export type GetCatalogParams = {
     projectUuid: string;
     search?: string;
-    type?: CatalogType;
+    type?: CatalogType | undefined;
+    filter: CatalogFilter | undefined;
 };
 
-const fetchCatalog = async ({ projectUuid, search, type }: GetCatalogParams) =>
+const fetchCatalog = async ({
+    projectUuid,
+    search,
+    type,
+    filter,
+}: GetCatalogParams) =>
     lightdashApi<ApiCatalogResults>({
-        url: `/projects/${projectUuid}/dataCatalog?type=${type}&search=${search}`,
+        url: `/projects/${projectUuid}/dataCatalog?${
+            type ? `type=${type}` : ''
+        }${search && search.length > 2 ? `&search=${search}` : ''}${
+            filter ? `&filter=${filter}` : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
 
-export const useCatalog = ({ projectUuid, search, type }: GetCatalogParams) => {
+export const useCatalog = ({
+    projectUuid,
+    search,
+    filter,
+}: GetCatalogParams) => {
     const setErrorResponse = useQueryError();
+    let type: CatalogType | undefined = undefined;
+
+    if (search && search.length > 2) {
+        if (
+            filter === CatalogFilter.Dimensions ||
+            filter === CatalogFilter.Metrics
+        ) {
+            type = CatalogType.Field;
+        } else if (filter === CatalogFilter.Tables) {
+            type = CatalogType.Table;
+        }
+    }
+
     return useQuery<ApiCatalogResults, ApiError>({
-        queryKey: ['catalog', projectUuid, type, search],
-        queryFn: () => fetchCatalog({ projectUuid, search, type }),
+        queryKey: ['catalog', projectUuid, type, filter, search],
+        queryFn: () =>
+            fetchCatalog({
+                projectUuid,
+                search,
+                type,
+                filter,
+            }),
         retry: false,
         enabled: !search || search.length > 2,
         onError: (result) => setErrorResponse(result),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10326](https://github.com/lightdash/lightdash/issues/10326)

### Description:

- Enables searching just for `tables` or `metrics` or `dimensions`
- These are only enabled when search value is > 2

Overall changes
- Added migration file that includes `field_type` column to `catalog_search` - this is useful for filtering out fields by type: `dimension` or `metric`. These are added when the user compiles the project
- Search accepts `type` and `filter` which will take that into account when searching 
  - if the filter is `table` then it will search only by the table type
  - if the filter is `dimension` or `metric`, it will only search by fields **and** by `field_type`
- Removed previous filter logic on the FE because we changed a few things in its behaviour
  - we only accept one filter at a time
  - we process the search on the BE 

Demo:


https://github.com/lightdash/lightdash/assets/7611706/2c4cf04b-ab7e-4d46-aef2-06112c58925a



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
