### PR TITLE
fix: wait for `loading_chart_overlay` before screenshotting dashboard

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -529,6 +529,20 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
+                    if (lightdashPage === LightdashPage.DASHBOARD) {
+                        const loadingChartOverlays = await page
+                            .locator('.loading_chart_overlay')
+                            .all();
+                        await Promise.all(
+                            loadingChartOverlays.map((loadingChartOverlay) =>
+                                loadingChartOverlay.waitFor({
+                                    state: 'hidden',
+                                    timeout: 60000,
+                                }),
+                            ),
+                        );
+                    }
+
                     // If some charts are still loading even though their API requests have finished(or past the timeout), we wait for them to finish
                     // Reference: https://playwright.dev/docs/api/class-locator#locator-all
                     const loadingCharts = await page

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -120,6 +120,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             })}
         >
             <LoadingOverlay
+                className="loading_chart_overlay"
                 visible={isLoading ?? false}
                 zIndex={getDefaultZIndex('modal') - 10}
             />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10526 

### Description:

When loading tiles in a dashboard, we render a `loadingoverlay`, so I've added a classname to it and we also wait for these to be hidden before screenshotting.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
