### PR TITLE
feat: display field descriptions

### DIFF
--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -1,7 +1,7 @@
 import { FieldType, type CatalogField } from '@lightdash/common';
-import { Badge, Box, Grid, Highlight } from '@mantine/core';
+import { Badge, Grid, Highlight } from '@mantine/core';
 import { Icon123, IconAbc } from '@tabler/icons-react';
-import React, { useEffect, useState, type FC } from 'react';
+import React, { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 
@@ -19,27 +19,8 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
     isSelected = false,
     onClick,
 }) => {
-    const { ref: descriptionRef, isTruncated: isDescriptionTruncated } =
-        useIsTruncated<HTMLDivElement>();
+    const { ref: descriptionRef } = useIsTruncated<HTMLDivElement>();
     const [hovered, setHovered] = useState<boolean | undefined>(false);
-
-    // Highlighting is clamped if the highlighted text is not fully visible
-    // We then apply styling to the ellipsis to indicate that some substring in the description is highlighted
-    const [isHighlightClamped, setIsHighlightClamped] = useState(false);
-    useEffect(() => {
-        if (descriptionRef.current && searchString) {
-            const highlightedElements =
-                descriptionRef.current.querySelectorAll('mark');
-            highlightedElements.forEach((element) => {
-                if (
-                    element.offsetTop + element.offsetHeight >
-                    descriptionRef.current.offsetHeight
-                ) {
-                    setIsHighlightClamped(true);
-                }
-            });
-        }
-    }, [descriptionRef, searchString, isDescriptionTruncated]);
 
     return (
         <Grid
@@ -70,7 +51,7 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
                             ? IconAbc
                             : Icon123
                     }
-                    // TODO: update when new icons are added
+                    // TODO: Add icon for field type and for subtype
                     color={
                         field.fieldType === FieldType.DIMENSION
                             ? 'blue'
@@ -92,33 +73,17 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
 
             <Grid.Col span={'auto'}>
                 {!isSelected ? (
-                    <Box pos="relative">
-                        <Highlight
-                            ref={descriptionRef}
-                            fz="13px"
-                            w="auto"
-                            c="gray.7"
-                            lineClamp={2}
-                            highlight={searchString}
-                            highlightColor="yellow"
-                            sx={(theme) => ({
-                                ...(isHighlightClamped && {
-                                    '&::after': {
-                                        content: '""',
-                                        position: 'absolute',
-                                        bottom: 0,
-                                        right: 0,
-                                        height: 10,
-                                        width: 10,
-                                        background: theme.colors.yellow[2],
-                                        opacity: 0.8,
-                                    },
-                                }),
-                            })}
-                        >
-                            {field.description || ''}
-                        </Highlight>
-                    </Box>
+                    <Highlight
+                        ref={descriptionRef}
+                        fz="13px"
+                        w="auto"
+                        c="gray.7"
+                        lineClamp={2}
+                        highlight={searchString}
+                        highlightColor="yellow"
+                    >
+                        {field.description || ''}
+                    </Highlight>
                 ) : (
                     <Badge color="violet">previewing</Badge>
                 )}

--- a/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogFieldListItem.tsx
@@ -1,8 +1,9 @@
 import { FieldType, type CatalogField } from '@lightdash/common';
-import { Box, Group, Highlight } from '@mantine/core';
+import { Badge, Box, Grid, Highlight } from '@mantine/core';
 import { Icon123, IconAbc } from '@tabler/icons-react';
-import React, { useState, type FC } from 'react';
+import React, { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useIsTruncated } from '../../../hooks/useIsTruncated';
 
 type Props = {
     field: CatalogField;
@@ -18,65 +19,110 @@ export const CatalogFieldListItem: FC<React.PropsWithChildren<Props>> = ({
     isSelected = false,
     onClick,
 }) => {
+    const { ref: descriptionRef, isTruncated: isDescriptionTruncated } =
+        useIsTruncated<HTMLDivElement>();
     const [hovered, setHovered] = useState<boolean | undefined>(false);
 
-    return (
-        <>
-            <Group
-                noWrap
-                sx={(theme) => ({
-                    cursor: 'pointer',
-                    borderRadius: theme.radius.sm,
-                    backgroundColor: hovered
-                        ? theme.colors.gray[1]
-                        : 'transparent',
-                    border: `2px solid ${
-                        isSelected ? theme.colors.blue[6] : 'transparent'
-                    }`,
-                })}
-                onMouseEnter={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
-                onClick={onClick}
-                py="two"
-                mr="xs"
-            >
-                <Box miw={150}>
-                    <Group
-                        spacing="xs"
-                        noWrap
-                        w="fit-content"
-                        px="xs"
-                        sx={(theme) => ({
-                            border: `1px solid ${theme.colors.gray[2]}`,
-                            borderRadius: theme.radius.md,
-                        })}
-                    >
-                        <MantineIcon
-                            icon={
-                                // TODO: Add icon for field type and for subtype
-                                field.fieldType === FieldType.DIMENSION
-                                    ? IconAbc
-                                    : Icon123
-                            }
-                            // TODO: update when new icons are added
-                            color={
-                                field.fieldType === FieldType.DIMENSION
-                                    ? 'blue'
-                                    : 'orange'
-                            }
-                        />
+    // Highlighting is clamped if the highlighted text is not fully visible
+    // We then apply styling to the ellipsis to indicate that some substring in the description is highlighted
+    const [isHighlightClamped, setIsHighlightClamped] = useState(false);
+    useEffect(() => {
+        if (descriptionRef.current && searchString) {
+            const highlightedElements =
+                descriptionRef.current.querySelectorAll('mark');
+            highlightedElements.forEach((element) => {
+                if (
+                    element.offsetTop + element.offsetHeight >
+                    descriptionRef.current.offsetHeight
+                ) {
+                    setIsHighlightClamped(true);
+                }
+            });
+        }
+    }, [descriptionRef, searchString, isDescriptionTruncated]);
 
+    return (
+        <Grid
+            gutter="xs"
+            columns={24}
+            sx={(theme) => ({
+                cursor: 'pointer',
+                // Mantine's grid applies a negative margin to the container. That breaks the border radius & hover effects
+                margin: 0,
+                alignItems: 'center',
+                borderRadius: theme.radius.sm,
+                backgroundColor: hovered ? theme.colors.gray[1] : 'transparent',
+                border: `2px solid ${
+                    isSelected ? theme.colors.blue[6] : 'transparent'
+                }`,
+            })}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            onClick={onClick}
+            py="two"
+            mr="xs"
+        >
+            <Grid.Col span={'content'}>
+                <MantineIcon
+                    icon={
+                        // TODO: Add icon for field type and for subtype
+                        field.fieldType === FieldType.DIMENSION
+                            ? IconAbc
+                            : Icon123
+                    }
+                    // TODO: update when new icons are added
+                    color={
+                        field.fieldType === FieldType.DIMENSION
+                            ? 'blue'
+                            : 'orange'
+                    }
+                />
+            </Grid.Col>
+
+            <Grid.Col span={10}>
+                <Highlight
+                    highlight={searchString}
+                    highlightColor="yellow"
+                    fw={500}
+                    fz="sm"
+                >
+                    {field.label ?? ''}
+                </Highlight>
+            </Grid.Col>
+
+            <Grid.Col span={'auto'}>
+                {!isSelected ? (
+                    <Box pos="relative">
                         <Highlight
+                            ref={descriptionRef}
+                            fz="13px"
+                            w="auto"
+                            c="gray.7"
+                            lineClamp={2}
                             highlight={searchString}
                             highlightColor="yellow"
-                            fw={500}
-                            fz="sm"
+                            sx={(theme) => ({
+                                ...(isHighlightClamped && {
+                                    '&::after': {
+                                        content: '""',
+                                        position: 'absolute',
+                                        bottom: 0,
+                                        right: 0,
+                                        height: 10,
+                                        width: 10,
+                                        background: theme.colors.yellow[2],
+                                        opacity: 0.8,
+                                    },
+                                }),
+                            })}
                         >
-                            {field.label ?? ''}
+                            {field.description || ''}
                         </Highlight>
-                    </Group>
-                </Box>
-            </Group>
-        </>
+                    </Box>
+                ) : (
+                    <Badge color="violet">previewing</Badge>
+                )}
+            </Grid.Col>
+        </Grid>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10492](https://github.com/lightdash/lightdash/issues/10492)

### Description:

Use a `Grid` to display the 3 elements of a field item row: `icon` - `label` - `description`
This approach is very similar to `CatalogTableListItem`

<img width="1254" alt="Screenshot 2024-06-26 at 13 50 59" src="https://github.com/lightdash/lightdash/assets/7611706/414592c4-c6c8-49e5-a3a9-a866ac708a15">




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
