### PR TITLE
fix: increase limit on number of members shown per group

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
@@ -168,7 +168,7 @@ const GroupsView: FC = () => {
     const [search, setSearch] = useState('');
 
     const { data: groups, isInitialLoading: isLoadingGroups } =
-        useOrganizationGroups({ search, includeMembers: 100 }); // TODO: pagination
+        useOrganizationGroups({ search, includeMembers: 2000 }); // TODO: pagination
 
     const handleDelete = useCallback(() => {
         if (groupToDelete) {

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
@@ -32,6 +32,8 @@ import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import CreateGroupModal from './CreateGroupModal';
 
+const GROUP_MEMBERS_PER_PAGE = 2000;
+
 const GroupListItem: FC<{
     disabled?: boolean;
     group: GroupWithMembers;
@@ -168,7 +170,10 @@ const GroupsView: FC = () => {
     const [search, setSearch] = useState('');
 
     const { data: groups, isInitialLoading: isLoadingGroups } =
-        useOrganizationGroups({ search, includeMembers: 2000 }); // TODO: pagination
+        useOrganizationGroups({
+            search,
+            includeMembers: GROUP_MEMBERS_PER_PAGE, // TODO: pagination
+        });
 
     const handleDelete = useCallback(() => {
         if (groupToDelete) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10536 

### Description:

Increase the number of members returned when viewing group membership. This is a partial/temporary fix. We should also make this a paginated list on the FE.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
