### PR TITLE
feat: expose WarehouseClient method to stream results

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -15,6 +15,7 @@ import {
     SupportedDbtAdapter,
     TimeFrames,
     WarehouseClient,
+    WarehouseResults,
     WarehouseTypes,
 } from '@lightdash/common';
 
@@ -31,6 +32,13 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
+    streamQuery(query, streamCallback) {
+        streamCallback({
+            fields: {},
+            rows: [],
+        });
+        return Promise.resolve();
+    },
     runQuery: () =>
         Promise.resolve({
             fields: {},
@@ -65,6 +73,13 @@ export const bigqueryClientMock: WarehouseClient = {
             },
         },
     }),
+    streamQuery(query, streamCallback) {
+        streamCallback({
+            fields: {},
+            rows: [],
+        });
+        return Promise.resolve();
+    },
     runQuery: () =>
         Promise.resolve({
             fields: {},

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -26,6 +26,13 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
+    streamQuery: (_query, streamCallback) => {
+        streamCallback({
+            fields: {},
+            rows: [],
+        });
+        return Promise.resolve();
+    },
     runQuery: () =>
         Promise.resolve({
             fields: {},

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -14,6 +14,11 @@ export type WarehouseCatalog = {
     };
 };
 
+export type WarehouseResults = {
+    fields: Record<string, { type: DimensionType }>;
+    rows: Record<string, any>[];
+};
+
 export interface WarehouseClient {
     credentials: CreateWarehouseCredentials;
     getCatalog: (
@@ -24,14 +29,27 @@ export interface WarehouseClient {
         }[],
     ) => Promise<WarehouseCatalog>;
 
+    streamQuery(
+        query: string,
+        streamCallback: (data: WarehouseResults) => void,
+        options: {
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void>;
+
+    /**
+     * Runs a query and returns all the results
+     * @param sql
+     * @param tags
+     * @param timezone
+     * @deprecated Use streamQuery() instead to avoid loading all results into memory
+     */
     runQuery(
         sql: string,
         tags?: Record<string, string>,
         timezone?: string,
-    ): Promise<{
-        fields: Record<string, { type: DimensionType }>;
-        rows: Record<string, any>[];
-    }>;
+    ): Promise<WarehouseResults>;
 
     test(): Promise<void>;
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -15,10 +15,11 @@ import {
     SupportedDbtAdapter,
     WarehouseConnectionError,
     WarehouseQueryError,
+    WarehouseResults,
 } from '@lightdash/common';
 import { pipeline, Transform, Writable } from 'stream';
 import { WarehouseCatalog, WarehouseTableSchema } from '../types';
-import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
+import WarehouseBaseClient from './WarehouseBaseClient';
 
 export enum BigqueryFieldType {
     STRING = 'STRING',
@@ -127,7 +128,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
 
     async streamQuery(
         query: string,
-        streamCallback: (data: Results) => void,
+        streamCallback: (data: WarehouseResults) => void,
         options: {
             tags?: Record<string, string>;
             timezone?: string;
@@ -196,29 +197,6 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         }
-    }
-
-    async runQuery(
-        query: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
-        let fields: Results['fields'] = {};
-        const rows: Results['rows'] = [];
-
-        await this.streamQuery(
-            query,
-            (data) => {
-                fields = data.fields;
-                rows.push(...data.rows);
-            },
-            {
-                tags,
-                timezone,
-            },
-        );
-
-        return { fields, rows };
     }
 
     static async getTableMetadata(

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -18,7 +18,7 @@ import {
 } from '@lightdash/common';
 import { pipeline, Transform, Writable } from 'stream';
 import { WarehouseCatalog, WarehouseTableSchema } from '../types';
-import WarehouseBaseClient from './WarehouseBaseClient';
+import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
 
 export enum BigqueryFieldType {
     STRING = 'STRING',
@@ -125,14 +125,15 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         }
     }
 
-    async runQuery(
+    async streamQuery(
         query: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
+        streamCallback: (data: Results) => void,
+        options: {
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void> {
         try {
-            const rows: Record<string, any>[] = [];
-
             const [job] = await this.client.createQueryJob({
                 query,
                 useLegacySql: false,
@@ -144,7 +145,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 jobTimeoutMs:
                     this.credentials.timeoutSeconds &&
                     this.credentials.timeoutSeconds * 1000,
-                labels: tags,
+                labels: options?.tags,
             });
 
             // Get the full api response but we can request zero rows
@@ -165,37 +166,59 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 }
                 return acc;
             }, {});
-            const writePromise = new Promise<{ fields: {}; rows: any[] }>(
-                (resolve, reject) => {
-                    pipeline(
-                        job.getQueryResultsStream(),
-                        new Transform({
-                            objectMode: true,
-                            transform(chunk, encoding, callback) {
-                                callback(null, parseRow(chunk));
-                            },
-                        }),
-                        new Writable({
-                            objectMode: true,
-                            write(chunk, encoding, callback) {
-                                rows.push(chunk);
-                                callback();
-                            },
-                        }),
-                        async (err) => {
-                            if (err) {
-                                reject(err);
-                            }
-                            resolve({ fields, rows });
-                        },
-                    );
-                },
-            );
 
-            return await writePromise;
+            const streamPromise = new Promise<void>((resolve, reject) => {
+                pipeline(
+                    job.getQueryResultsStream(),
+                    new Transform({
+                        objectMode: true,
+                        transform(chunk, _encoding, callback) {
+                            callback(null, parseRow(chunk));
+                        },
+                    }),
+                    new Writable({
+                        objectMode: true,
+                        write(chunk, _encoding, callback) {
+                            streamCallback({ fields, rows: [chunk] });
+                            callback();
+                        },
+                    }),
+                    async (err) => {
+                        if (err) {
+                            reject(err);
+                        }
+                        resolve();
+                    },
+                );
+            });
+
+            await streamPromise;
         } catch (e) {
             throw new WarehouseQueryError(e.message);
         }
+    }
+
+    async runQuery(
+        query: string,
+        tags?: Record<string, string>,
+        timezone?: string,
+    ) {
+        let fields: Results['fields'] = {};
+        const rows: Results['rows'] = [];
+
+        await this.streamQuery(
+            query,
+            (data) => {
+                fields = data.fields;
+                rows.push(...data.rows);
+            },
+            {
+                tags,
+                timezone,
+            },
+        );
+
+        return { fields, rows };
     }
 
     static async getTableMetadata(

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.mock.ts
@@ -1,0 +1,110 @@
+import { TTypeId as DatabricksDataTypes } from '@databricks/sql/thrift/TCLIService_types';
+import { CreateDatabricksCredentials, WarehouseTypes } from '@lightdash/common';
+
+export const credentials: CreateDatabricksCredentials = {
+    type: WarehouseTypes.DATABRICKS,
+    database: 'database',
+    serverHostName: 'serverHostName',
+    httpPath: 'httpPath',
+    personalAccessToken: 'personalAccessToken',
+};
+
+export const schema = {
+    columns: [
+        {
+            columnName: 'myStringColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.STRING_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myNumberColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.INT_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myDateColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.DATE_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myTimestampColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.TIMESTAMP_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myBooleanColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.BOOLEAN_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myArrayColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.ARRAY_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            columnName: 'myObjectColumn',
+            typeDesc: {
+                types: [
+                    {
+                        primitiveEntry: {
+                            type: DatabricksDataTypes.STRUCT_TYPE,
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+};
+export const rows: Record<string, any>[] = [
+    {
+        myStringColumn: 'string value',
+        myNumberColumn: 100,
+        myDateColumn: new Date('2021-03-10'),
+        myTimestampColumn: new Date('1990-03-02T08:30:00.010Z'),
+        myBooleanColumn: false,
+        myArrayColumn: ['1', '2', '3'],
+        myObjectColumn: { test: '1' },
+    },
+];

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -1,0 +1,32 @@
+import { DatabricksWarehouseClient } from './DatabricksWarehouseClient';
+import { credentials, rows, schema } from './DatabricksWarehouseClient.mock';
+import { expectedFields } from './WarehouseClient.mock';
+
+jest.mock('@databricks/sql', () => ({
+    ...jest.requireActual('@databricks/sql'),
+    DBSQLClient: jest.fn(() => ({
+        connect: jest.fn(() => ({
+            openSession: jest.fn(() => ({
+                executeStatement: jest.fn(() => ({
+                    getSchema: jest.fn(async () => schema),
+                    fetchChunk: jest.fn(async () => rows),
+                    hasMoreRows: jest.fn(async () => false),
+                    close: jest.fn(async () => undefined),
+                })),
+                close: jest.fn(async () => undefined),
+            })),
+            close: jest.fn(async () => undefined),
+        })),
+    })),
+}));
+
+describe('DatabricksWarehouseClient', () => {
+    it('expect query fields and rows', async () => {
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        const results = await warehouse.runQuery('fake sql');
+
+        expect(results.fields).toEqual(expectedFields);
+        expect(results.rows[0]).toEqual(rows[0]);
+    });
+});

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -14,9 +14,10 @@ import {
     SupportedDbtAdapter,
     WarehouseConnectionError,
     WarehouseQueryError,
+    WarehouseResults,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
-import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
+import WarehouseBaseClient from './WarehouseBaseClient';
 
 type SchemaResult = {
     TABLE_CAT: string;
@@ -228,7 +229,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
 
     async streamQuery(
         sql: string,
-        streamCallback: (data: Results) => void,
+        streamCallback: (data: WarehouseResults) => void,
         options: {
             tags?: Record<string, string>;
             timezone?: string;
@@ -288,29 +289,6 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             if (query) await query.close();
             await close();
         }
-    }
-
-    async runQuery(
-        sql: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
-        let fields: Results['fields'] = {};
-        const rows: Results['rows'] = [];
-
-        await this.streamQuery(
-            sql,
-            (data) => {
-                fields = data.fields;
-                rows.push(...data.rows);
-            },
-            {
-                tags,
-                timezone,
-            },
-        );
-
-        return { fields, rows };
     }
 
     async getCatalog(

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -6,6 +6,7 @@ import {
     MetricType,
     SupportedDbtAdapter,
     WarehouseQueryError,
+    WarehouseResults,
 } from '@lightdash/common';
 import { readFileSync } from 'fs';
 import path from 'path';
@@ -14,7 +15,7 @@ import { PoolConfig, QueryResult } from 'pg';
 import { Writable } from 'stream';
 import { rootCertificates } from 'tls';
 import QueryStream from './PgQueryStream';
-import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
+import WarehouseBaseClient from './WarehouseBaseClient';
 
 const POSTGRES_CA_BUNDLES = [
     ...rootCertificates,
@@ -165,7 +166,7 @@ export class PostgresClient<
 
     async streamQuery(
         sql: string,
-        streamCallback: (data: Results) => void,
+        streamCallback: (data: WarehouseResults) => void,
         options: {
             tags?: Record<string, string>;
             timezone?: string;
@@ -280,29 +281,6 @@ export class PostgresClient<
                     console.info('Failed to end postgres pool');
                 });
             });
-    }
-
-    async runQuery(
-        sql: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
-        let fields: Results['fields'] = {};
-        const rows: Results['rows'] = [];
-
-        await this.streamQuery(
-            sql,
-            (data) => {
-                fields = data.fields;
-                rows.push(...data.rows);
-            },
-            {
-                tags,
-                timezone,
-            },
-        );
-
-        return { fields, rows };
     }
 
     async getCatalog(

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -14,7 +14,7 @@ import { PoolConfig, QueryResult } from 'pg';
 import { Writable } from 'stream';
 import { rootCertificates } from 'tls';
 import QueryStream from './PgQueryStream';
-import WarehouseBaseClient from './WarehouseBaseClient';
+import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
 
 const POSTGRES_CA_BUNDLES = [
     ...rootCertificates,
@@ -149,7 +149,7 @@ export class PostgresClient<
         return alteredQuery;
     }
 
-    private convertQueryResultFields(
+    static convertQueryResultFields(
         fields: QueryResult<any>['fields'],
     ): Record<string, { type: DimensionType }> {
         return fields.reduce(
@@ -163,16 +163,16 @@ export class PostgresClient<
         );
     }
 
-    async runQuery(
+    async streamQuery(
         sql: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
+        streamCallback: (data: Results) => void,
+        options: {
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void> {
         let pool: pg.Pool | undefined;
-        return new Promise<{
-            fields: Record<string, { type: DimensionType }>;
-            rows: Record<string, any>[];
-        }>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             pool = new pg.Pool({
                 ...this.config,
                 connectionTimeoutMillis: 5000,
@@ -214,17 +214,14 @@ export class PostgresClient<
                     // CodeQL: This will raise a security warning because user defined raw SQL is being passed into the database module.
                     //         In this case this is exactly what we want to do. We're hitting the user's warehouse not the application's database.
                     const stream = client.query(
-                        new QueryStream(this.getSQLWithMetadata(sql, tags)),
+                        new QueryStream(
+                            this.getSQLWithMetadata(sql, options?.tags),
+                        ),
                     );
-                    const rows: any[] = [];
-                    let fields: QueryResult<any>['fields'] = [];
                     // release the client when the stream is finished
                     stream.on('end', () => {
                         done();
-                        resolve({
-                            rows,
-                            fields: this.convertQueryResultFields(fields),
-                        });
+                        resolve();
                     });
                     stream.on('error', (err2) => {
                         reject(err2);
@@ -242,8 +239,12 @@ export class PostgresClient<
                                     encoding,
                                     callback,
                                 ) {
-                                    rows.push(chunk.row);
-                                    fields = chunk.fields;
+                                    streamCallback({
+                                        fields: PostgresClient.convertQueryResultFields(
+                                            chunk.fields,
+                                        ),
+                                        rows: [chunk.row],
+                                    });
                                     callback();
                                 },
                             }),
@@ -254,12 +255,12 @@ export class PostgresClient<
                         });
                 };
 
-                if (timezone) {
+                if (options?.timezone) {
                     console.debug(
-                        `Setting postgres session timezone ${timezone}`,
+                        `Setting postgres session timezone ${options?.timezone}`,
                     );
                     client
-                        .query(`SET timezone TO '${timezone}';`)
+                        .query(`SET timezone TO '${options?.timezone}';`)
                         .then(() => {
                             runQuery();
                         })
@@ -279,6 +280,29 @@ export class PostgresClient<
                     console.info('Failed to end postgres pool');
                 });
             });
+    }
+
+    async runQuery(
+        sql: string,
+        tags?: Record<string, string>,
+        timezone?: string,
+    ) {
+        let fields: Results['fields'] = {};
+        const rows: Results['rows'] = [];
+
+        await this.streamQuery(
+            sql,
+            (data) => {
+                fields = data.fields;
+                rows.push(...data.rows);
+            },
+            {
+                tags,
+                timezone,
+            },
+        );
+
+        return { fields, rows };
     }
 
     async getCatalog(

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -6,6 +6,7 @@ import {
     SupportedDbtAdapter,
     WarehouseConnectionError,
     WarehouseQueryError,
+    WarehouseResults,
 } from '@lightdash/common';
 import {
     BasicAuth,
@@ -15,7 +16,7 @@ import {
     Trino,
 } from 'trino-client';
 import { WarehouseCatalog } from '../types';
-import WarehouseBaseClient, { Results } from './WarehouseBaseClient';
+import WarehouseBaseClient from './WarehouseBaseClient';
 
 export enum TrinoTypes {
     BOOLEAN = 'boolean',
@@ -170,7 +171,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
 
     async streamQuery(
         sql: string,
-        streamCallback: (data: Results) => void,
+        streamCallback: (data: WarehouseResults) => void,
         options: {
             tags?: Record<string, string>;
             timezone?: string;
@@ -238,29 +239,6 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
         } finally {
             await close();
         }
-    }
-
-    async runQuery(
-        sql: string,
-        tags?: Record<string, string>,
-        timezone?: string,
-    ) {
-        let fields: Results['fields'] = {};
-        const rows: Results['rows'] = [];
-
-        await this.streamQuery(
-            sql,
-            (data) => {
-                fields = data.fields;
-                rows.push(...data.rows);
-            },
-            {
-                tags,
-                timezone,
-            },
-        );
-
-        return { fields, rows };
     }
 
     async getCatalog(requests: TableInfo[]): Promise<WarehouseCatalog> {

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -9,6 +9,11 @@ import {
 import { WarehouseClient } from '../types';
 import { getDefaultMetricSql } from '../utils/sql';
 
+export type Results = {
+    fields: Record<string, { type: DimensionType }>;
+    rows: Record<string, any>[];
+};
+
 export default class WarehouseBaseClient<T extends CreateWarehouseCredentials>
     implements WarehouseClient
 {
@@ -39,10 +44,18 @@ export default class WarehouseBaseClient<T extends CreateWarehouseCredentials>
         throw new Error('Warehouse method not implemented.');
     }
 
-    async runQuery(sql: string): Promise<{
-        fields: Record<string, { type: DimensionType }>;
-        rows: Record<string, any>[];
-    }> {
+    async streamQuery(
+        query: string,
+        streamCallback: (data: Results) => void,
+        options: {
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void> {
+        throw new Error('Warehouse method not implemented.');
+    }
+
+    async runQuery(sql: string): Promise<Results> {
         throw new Error('Warehouse method not implemented.');
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10537](https://github.com/lightdash/lightdash/issues/10537)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
<!-- Even better add a screenshot / gif / loom -->

Expose new WarehouseClient method `streamQuery` and deprecate `runQuery`.
Note that we are still using `runQuery` and all rows loaded in memory. We will incrementally refactor our code to use the new streaming method.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-api test-backend test-frontend