### PR TITLE
feat: add new sql runner page with tables

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -38,6 +38,7 @@ import ShareRedirect from './pages/ShareRedirect';
 import Space from './pages/Space';
 import Spaces from './pages/Spaces';
 import SqlRunner from './pages/SqlRunner';
+import SqlRunnerNew from './pages/SqlRunnerNew';
 import UserActivity from './pages/UserActivity';
 import VerifyEmailPage from './pages/VerifyEmail';
 
@@ -223,6 +224,12 @@ const Routes: FC = () => {
                                         <TrackPage name={PageName.SQL_RUNNER}>
                                             <SqlRunner />
                                         </TrackPage>
+                                    </Route>
+
+                                    <Route path="/projects/:projectUuid/sqlRunnerNew">
+                                        <NavBar />
+
+                                        <SqlRunnerNew />
                                     </Route>
 
                                     <Route path="/projects/:projectUuid/dbtsemanticlayer">

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -226,7 +226,7 @@ const Routes: FC = () => {
                                         </TrackPage>
                                     </Route>
 
-                                    <Route path="/projects/:projectUuid/sqlRunnerNew">
+                                    <Route path="/projects/:projectUuid/sql-runner-new">
                                         <NavBar />
 
                                         <SqlRunnerNew />

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -1,0 +1,32 @@
+import { ActionIcon, Group, Stack, Title, Tooltip } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { type Dispatch, type FC, type SetStateAction } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { Tables } from './Tables';
+
+type Props = {
+    projectUuid: string;
+    setSidebarOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
+    return (
+        <Stack h="100vh" spacing="xs">
+            <Group position="apart">
+                <Title order={5} fz="sm" c="gray.6">
+                    SQL RUNNER
+                </Title>
+                <Tooltip variant="xs" label="Close sidebar" position="left">
+                    <ActionIcon size="xs">
+                        <MantineIcon
+                            icon={IconArrowLeft}
+                            onClick={() => setSidebarOpen(false)}
+                        />
+                    </ActionIcon>
+                </Tooltip>
+            </Group>
+
+            <Tables projectUuid={projectUuid} />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,0 +1,58 @@
+import { LoadingOverlay, Stack, Text, UnstyledButton } from '@mantine/core';
+import { useState, type FC } from 'react';
+import { useTables } from '../hooks/useTables';
+
+type Props = {
+    projectUuid: string;
+};
+
+export const Tables: FC<Props> = ({ projectUuid }) => {
+    const [activeTable, setActiveTable] = useState<string | undefined>();
+    const { data, isLoading } = useTables({ projectUuid });
+
+    return (
+        <>
+            <LoadingOverlay visible={isLoading} />
+            {data &&
+                Object.entries(data).map(([, schemas]) =>
+                    Object.entries(schemas).map(([schema, tables]) => (
+                        <Stack key={schema} spacing="none">
+                            <Text p={6} fw={700} fz="md" c="gray.7">
+                                {schema}
+                            </Text>
+                            {Object.keys(tables).map((table) => (
+                                <UnstyledButton
+                                    key={table}
+                                    onClick={() => {
+                                        setActiveTable(table);
+                                    }}
+                                    fw={500}
+                                    p={4}
+                                    fz={13}
+                                    c={
+                                        activeTable === table
+                                            ? 'gray.8'
+                                            : 'gray.7'
+                                    }
+                                    bg={
+                                        activeTable === table
+                                            ? 'gray.1'
+                                            : 'transparent'
+                                    }
+                                    sx={(theme) => ({
+                                        borderRadius: theme.radius.sm,
+                                        '&:hover': {
+                                            backgroundColor:
+                                                theme.colors.gray[1],
+                                        },
+                                    })}
+                                >
+                                    {table}
+                                </UnstyledButton>
+                            ))}
+                        </Stack>
+                    )),
+                )}
+        </>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
@@ -1,0 +1,25 @@
+import { type ApiError, type ApiWarehouseCatalog } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+export type GetTablesParams = {
+    projectUuid: string;
+};
+
+const fetchTables = async ({ projectUuid }: GetTablesParams) =>
+    lightdashApi<ApiWarehouseCatalog>({
+        url: `/projects/${projectUuid}/sqlRunner/tables`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useTables = ({ projectUuid }: GetTablesParams) => {
+    return useQuery<ApiWarehouseCatalog, ApiError>({
+        queryKey: ['sqlRunner', 'tables', projectUuid],
+        queryFn: () =>
+            fetchTables({
+                projectUuid,
+            }),
+        retry: false,
+    });
+};

--- a/packages/frontend/src/features/sqlRunner/index.ts
+++ b/packages/frontend/src/features/sqlRunner/index.ts
@@ -1,0 +1,1 @@
+export * from './components/Sidebar';

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -1,0 +1,41 @@
+import { ActionIcon, Box, Group } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import MantineIcon from '../components/common/MantineIcon';
+import Page from '../components/common/Page/Page';
+import { Sidebar } from '../features/sqlRunner';
+
+const SqlRunnerNewPage = () => {
+    const params = useParams<{ projectUuid: string }>();
+    const selectedProjectUuid = params.projectUuid;
+    const [isSidebarOpen, setSidebarOpen] = useState(true);
+
+    return (
+        <Page
+            title="SQL Runner"
+            withFullHeight
+            withPaddedContent
+            isSidebarOpen={isSidebarOpen}
+            sidebar={
+                <Sidebar
+                    projectUuid={selectedProjectUuid}
+                    setSidebarOpen={setSidebarOpen}
+                />
+            }
+        >
+            <Group>
+                {!isSidebarOpen && (
+                    <ActionIcon size="xs">
+                        <MantineIcon
+                            icon={IconArrowRight}
+                            onClick={() => setSidebarOpen(true)}
+                        />
+                    </ActionIcon>
+                )}
+                <Box>Sql Runner new</Box>
+            </Group>
+        </Page>
+    );
+};
+export default SqlRunnerNewPage;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10551 

### Description:

- Adds new route `/sqlRunnerNew`
- Adds Sidebar (can be open and closed) - another PR will be open to handle the mount/unmount. We shouldn't do this and the `Transition` applied to the main Sidebar component should be replaced with a raw implementation 
- Gets `tables` from `useTables` hook and renders grouped by `schema`

NOTE: another PR will be open to handle the fields for each table


DEMO:


https://github.com/lightdash/lightdash/assets/7611706/88fc355f-6e5e-4e5b-93d2-3a89904a3580





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
