### PR TITLE
chore: upgrade immer to latest

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -63,7 +63,7 @@
         "echarts": "^5.4.3",
         "echarts-for-react": "^3.0.2",
         "fuse.js": "^6.5.3",
-        "immer": "^9.0.15",
+        "immer": "^10.1.1",
         "jspdf": "^2.5.1",
         "lodash": "^4.17.21",
         "monaco-editor": "^0.44.0",

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -25,7 +25,7 @@ import {
     type PopoverProps,
 } from '@mantine/core';
 import { IconRotate2 } from '@tabler/icons-react';
-import produce from 'immer';
+import { produce } from 'immer';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import FieldIcon from '../../common/Filters/FieldIcon';

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/utils/index.ts
@@ -3,7 +3,7 @@ import {
     FilterOperator,
     type DashboardFilterRule,
 } from '@lightdash/common';
-import produce from 'immer';
+import { produce } from 'immer';
 import isEqual from 'lodash/isEqual';
 
 export const hasFilterValueSet = (filterRule: DashboardFilterRule) => {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mantine/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
 import { IconMarkdown, IconVideo } from '@tabler/icons-react';
-import produce from 'immer';
+import { produce } from 'immer';
 import MantineIcon from '../../common/MantineIcon';
 import LoomTileForm, { getLoomId } from './LoomTileForm';
 import MarkdownTileForm, {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -14,7 +14,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Divider } from '@mantine/core';
-import produce from 'immer';
+import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import { getSeriesGroupedByField } from '../../../../hooks/cartesianChartConfig/utils';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -25,7 +25,7 @@ import {
     Stack,
 } from '@mantine/core';
 import { IconPercentage, IconPlus } from '@tabler/icons-react';
-import produce from 'immer';
+import { produce } from 'immer';
 import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import FilterNumberInput from '../../common/Filters/FilterInputs/FilterNumberInput';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -7,7 +7,7 @@ import {
     type FilterableItem,
 } from '@lightdash/common';
 import { Accordion } from '@mantine/core';
-import produce from 'immer';
+import { produce } from 'immer';
 import { useCallback, useMemo } from 'react';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigTable';
 import { useVisualizationContext } from '../../LightdashVisualization/VisualizationProvider';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -12,7 +12,7 @@ import {
 import { Anchor, Box, SimpleGrid, Stack, Text } from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
 import { IconGripVertical } from '@tabler/icons-react';
-import produce from 'immer';
+import { produce } from 'immer';
 import orderBy from 'lodash/orderBy';
 import { useMemo, type FC } from 'react';
 import { Link, useParams } from 'react-router-dom';

--- a/packages/frontend/src/providers/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/ExplorerProvider.tsx
@@ -30,7 +30,7 @@ import {
     type TableChartConfig,
     type TimeZone,
 } from '@lightdash/common';
-import produce from 'immer';
+import { produce } from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
 import {
     useCallback,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12498,10 +12498,10 @@ ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-immer@^9.0.15:
-  version "9.0.15"
-  resolved "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz"
-  integrity sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A
Relates to: #10515 

### Description:

Upgrades `immer` to latest before introducing `redux-toolkit`.
Have a look at the breaking changes
https://github.com/immerjs/immer/releases/tag/v10.0.0

Changes are
- named import `{ produce }`
- ensure every value passed to `produce(...)` is not a promise

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
