### PR TITLE
fix: allow downgrade of individual user space permissions when in group

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -761,7 +761,6 @@ export class SpaceModel {
         return Object.entries(groupBy(access, 'space_uuid')).reduce<
             Record<string, SpaceShare[]>
         >((acc, [spaceUuid, spaceAccess]) => {
-            console.log(spaceAccess);
             acc[spaceUuid] = spaceAccess.reduce<SpaceShare[]>(
                 (
                     acc2,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -761,6 +761,7 @@ export class SpaceModel {
         return Object.entries(groupBy(access, 'space_uuid')).reduce<
             Record<string, SpaceShare[]>
         >((acc, [spaceUuid, spaceAccess]) => {
+            console.log(spaceAccess);
             acc[spaceUuid] = spaceAccess.reduce<SpaceShare[]>(
                 (
                     acc2,
@@ -819,13 +820,14 @@ export class SpaceModel {
                     if (highestRole.role === ProjectMemberRole.ADMIN) {
                         spaceRole = SpaceMemberRole.ADMIN;
                     } else if (user_with_direct_access) {
+                        // if user has explicit user role in space use that, otherwise try find the highest group role
                         spaceRole =
-                            getHighestSpaceRole([
-                                space_role ?? undefined,
-                                ...space_group_roles.map(
+                            space_role ??
+                            getHighestSpaceRole(
+                                space_group_roles.map(
                                     (role) => role ?? undefined,
                                 ),
-                            ]) ?? space_role;
+                            );
                     } else if (!is_private && !user_with_direct_access) {
                         spaceRole = convertProjectRoleToSpaceRole(
                             highestRole.role,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10165 

### Description:

- Returns user space access instead of group access when user has `space_user_access`, only return the highest group access when user doesn't have explicit user access

Before:

https://github.com/lightdash/lightdash/assets/22939015/8098a8db-a223-4e8f-8d63-4efd2bfe43bc

After:

https://github.com/lightdash/lightdash/assets/22939015/9f4dc14c-e85b-4391-b24f-edd4ee809b6e

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
