### PR TITLE
fix: handle resize height and apply correct overflows

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import {
     ActionIcon,
     Box,
     Divider,
-    Flex,
     Group,
     Stack,
     Title,
@@ -32,12 +31,9 @@ const MAX_RESIZABLE_BOX_HEIGHT_PX = 500;
 
 export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
     const [activeTable, setActiveTable] = useState<string | undefined>();
-    const [resizableBoxHeight, setResizableBoxHeight] = useState(
-        DEFAULT_RESIZABLE_BOX_HEIGHT_PX,
-    );
 
     return (
-        <Stack h="100%" spacing="xs">
+        <Stack spacing="xs" sx={{ flex: 1, overflow: 'hidden' }}>
             <Group position="apart">
                 <Title order={5} fz="sm" c="gray.6">
                     SQL RUNNER
@@ -52,56 +48,49 @@ export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
                 </Tooltip>
             </Group>
 
-            <Flex direction="column" justify="space-between" h="100%">
-                <Box
-                    sx={{
-                        height: `calc(100% - ${resizableBoxHeight}px)`,
-                        overflowY: 'hidden',
-                    }}
-                >
-                    <Tables
-                        activeTable={activeTable}
-                        setActiveTable={setActiveTable}
-                        projectUuid={projectUuid}
-                    />
-                </Box>
-                <Box pos="relative">
-                    <ResizableBox
-                        height={resizableBoxHeight}
-                        minConstraints={[
-                            SIDEBAR_MIN_WIDTH,
-                            MIN_RESIZABLE_BOX_HEIGHT_PX,
-                        ]}
-                        maxConstraints={[
-                            SIDEBAR_MAX_WIDTH,
-                            MAX_RESIZABLE_BOX_HEIGHT_PX,
-                        ]}
-                        resizeHandles={['n']}
-                        axis="y"
-                        onResize={(_, data) =>
-                            setResizableBoxHeight(data.size.height)
-                        }
-                        handle={
-                            <Divider
-                                h={5}
-                                bg="gray.3"
-                                pos="absolute"
-                                top={-2}
-                                left={0}
-                                right={0}
-                                sx={{
-                                    cursor: 'ns-resize',
-                                }}
+            <Stack sx={{ flex: 1, overflow: 'hidden' }}>
+                <Tables
+                    activeTable={activeTable}
+                    setActiveTable={setActiveTable}
+                    projectUuid={projectUuid}
+                />
+
+                {activeTable && (
+                    <Box pos="relative">
+                        <ResizableBox
+                            height={DEFAULT_RESIZABLE_BOX_HEIGHT_PX}
+                            minConstraints={[
+                                SIDEBAR_MIN_WIDTH,
+                                MIN_RESIZABLE_BOX_HEIGHT_PX,
+                            ]}
+                            maxConstraints={[
+                                SIDEBAR_MAX_WIDTH,
+                                MAX_RESIZABLE_BOX_HEIGHT_PX,
+                            ]}
+                            resizeHandles={['n']}
+                            axis="y"
+                            handle={
+                                <Divider
+                                    h={5}
+                                    bg="gray.3"
+                                    pos="absolute"
+                                    top={-2}
+                                    left={0}
+                                    right={0}
+                                    sx={{
+                                        cursor: 'ns-resize',
+                                    }}
+                                />
+                            }
+                        >
+                            <TableFields
+                                projectUuid={projectUuid}
+                                activeTable={activeTable}
                             />
-                        }
-                    >
-                        <TableFields
-                            projectUuid={projectUuid}
-                            activeTable={activeTable}
-                        />
-                    </ResizableBox>
-                </Box>
-            </Flex>
+                        </ResizableBox>
+                    </Box>
+                )}
+            </Stack>
         </Stack>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -26,11 +26,18 @@ type Props = {
     setSidebarOpen: Dispatch<SetStateAction<boolean>>;
 };
 
+const DEFAULT_RESIZABLE_BOX_HEIGHT_PX = 250;
+const MIN_RESIZABLE_BOX_HEIGHT_PX = 150;
+const MAX_RESIZABLE_BOX_HEIGHT_PX = 500;
+
 export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
     const [activeTable, setActiveTable] = useState<string | undefined>();
+    const [resizableBoxHeight, setResizableBoxHeight] = useState(
+        DEFAULT_RESIZABLE_BOX_HEIGHT_PX,
+    );
 
     return (
-        <Stack h="100vh" spacing="xs">
+        <Stack h="100%" spacing="xs">
             <Group position="apart">
                 <Title order={5} fz="sm" c="gray.6">
                     SQL RUNNER
@@ -46,7 +53,12 @@ export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
             </Group>
 
             <Flex direction="column" justify="space-between" h="100%">
-                <Box>
+                <Box
+                    sx={{
+                        height: `calc(100% - ${resizableBoxHeight}px)`,
+                        overflowY: 'hidden',
+                    }}
+                >
                     <Tables
                         activeTable={activeTable}
                         setActiveTable={setActiveTable}
@@ -55,14 +67,23 @@ export const Sidebar: FC<Props> = ({ projectUuid, setSidebarOpen }) => {
                 </Box>
                 <Box pos="relative">
                     <ResizableBox
-                        height={400}
-                        minConstraints={[SIDEBAR_MIN_WIDTH, 100]}
-                        maxConstraints={[SIDEBAR_MAX_WIDTH, 500]}
+                        height={resizableBoxHeight}
+                        minConstraints={[
+                            SIDEBAR_MIN_WIDTH,
+                            MIN_RESIZABLE_BOX_HEIGHT_PX,
+                        ]}
+                        maxConstraints={[
+                            SIDEBAR_MAX_WIDTH,
+                            MAX_RESIZABLE_BOX_HEIGHT_PX,
+                        ]}
                         resizeHandles={['n']}
                         axis="y"
+                        onResize={(_, data) =>
+                            setResizableBoxHeight(data.size.height)
+                        }
                         handle={
                             <Divider
-                                h={3}
+                                h={5}
                                 bg="gray.3"
                                 pos="absolute"
                                 top={-2}

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,9 +1,9 @@
 import {
     ActionIcon,
-    Box,
     Center,
     Highlight,
     Loader,
+    ScrollArea,
     Stack,
     Text,
     TextInput,
@@ -89,60 +89,56 @@ export const TableFields: FC<Props> = ({ projectUuid, activeTable }) => {
                 </Center>
             )}
             {isSuccess && tableFields && (
-                <>
-                    <Box
-                        sx={{
-                            overflowY: 'scroll',
-                            flexGrow: 1,
-                        }}
-                    >
-                        <Stack spacing={0}>
-                            {tableFields.map((field) => (
-                                <UnstyledButton
-                                    key={field}
-                                    fw={500}
-                                    p={4}
-                                    fz={13}
-                                    c={
-                                        activeFields && activeFields.has(field)
-                                            ? 'gray.8'
-                                            : 'gray.7'
-                                    }
-                                    bg={
-                                        activeFields && activeFields.has(field)
-                                            ? 'gray.1'
-                                            : 'transparent'
-                                    }
-                                    onClick={() => {
-                                        setActiveFields((prev) => {
-                                            const newSet = new Set(prev);
-                                            if (newSet.has(field)) {
-                                                newSet.delete(field);
-                                            } else {
-                                                newSet.add(field);
-                                            }
-                                            return newSet;
-                                        });
-                                    }}
-                                    sx={(theme) => ({
-                                        borderRadius: theme.radius.sm,
-                                        '&:hover': {
-                                            backgroundColor:
-                                                theme.colors.gray[1],
-                                        },
-                                    })}
+                <ScrollArea
+                    className="only-vertical"
+                    sx={{ flex: 1 }}
+                    type="auto"
+                >
+                    <Stack spacing="none">
+                        {tableFields.map((field) => (
+                            <UnstyledButton
+                                key={field}
+                                fw={500}
+                                p={4}
+                                fz={13}
+                                c={
+                                    activeFields && activeFields.has(field)
+                                        ? 'gray.8'
+                                        : 'gray.7'
+                                }
+                                bg={
+                                    activeFields && activeFields.has(field)
+                                        ? 'gray.1'
+                                        : 'transparent'
+                                }
+                                onClick={() => {
+                                    setActiveFields((prev) => {
+                                        const newSet = new Set(prev);
+                                        if (newSet.has(field)) {
+                                            newSet.delete(field);
+                                        } else {
+                                            newSet.add(field);
+                                        }
+                                        return newSet;
+                                    });
+                                }}
+                                sx={(theme) => ({
+                                    borderRadius: theme.radius.sm,
+                                    '&:hover': {
+                                        backgroundColor: theme.colors.gray[1],
+                                    },
+                                })}
+                            >
+                                <Highlight
+                                    component={Text}
+                                    highlight={search || ''}
                                 >
-                                    <Highlight
-                                        component={Text}
-                                        highlight={search || ''}
-                                    >
-                                        {field}
-                                    </Highlight>
-                                </UnstyledButton>
-                            ))}
-                        </Stack>
-                    </Box>
-                </>
+                                    {field}
+                                </Highlight>
+                            </UnstyledButton>
+                        ))}
+                    </Stack>
+                </ScrollArea>
             )}
             {isSuccess && !tableFields && (
                 <Center p="sm">

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -91,9 +91,9 @@ export const TableFields: FC<Props> = ({ projectUuid, activeTable }) => {
             {isSuccess && tableFields && (
                 <>
                     <Box
-                        h="100%"
                         sx={{
-                            overflowY: 'auto',
+                            overflowY: 'scroll',
+                            flexGrow: 1,
                         }}
                     >
                         <Stack spacing={0}>

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -68,7 +68,12 @@ export const Tables: FC<Props> = ({
             {isSuccess &&
                 data &&
                 data.map(({ schema, tables }) => (
-                    <Stack key={schema} spacing="none">
+                    <Stack
+                        key={schema}
+                        spacing="none"
+                        h="calc(100% - 30px)"
+                        sx={{ overflowY: 'scroll', flexGrow: 1 }}
+                    >
                         <Text p={6} fw={700} fz="md" c="gray.7">
                             {schema}
                         </Text>

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -3,6 +3,7 @@ import {
     Center,
     Highlight,
     Loader,
+    ScrollArea,
     Stack,
     Text,
     TextInput,
@@ -68,46 +69,53 @@ export const Tables: FC<Props> = ({
             {isSuccess &&
                 data &&
                 data.map(({ schema, tables }) => (
-                    <Stack
+                    <ScrollArea
+                        className="only-vertical"
+                        sx={{ flex: 1 }}
+                        type="auto"
                         key={schema}
-                        spacing="none"
-                        h="calc(100% - 30px)"
-                        sx={{ overflowY: 'scroll', flexGrow: 1 }}
                     >
-                        <Text p={6} fw={700} fz="md" c="gray.7">
-                            {schema}
-                        </Text>
-                        {Object.keys(tables).map((table) => (
-                            <UnstyledButton
-                                key={table}
-                                onClick={() => {
-                                    setActiveTable(table);
-                                }}
-                                fw={500}
-                                p={4}
-                                fz={13}
-                                c={activeTable === table ? 'gray.8' : 'gray.7'}
-                                bg={
-                                    activeTable === table
-                                        ? 'gray.1'
-                                        : 'transparent'
-                                }
-                                sx={(theme) => ({
-                                    borderRadius: theme.radius.sm,
-                                    '&:hover': {
-                                        backgroundColor: theme.colors.gray[1],
-                                    },
-                                })}
-                            >
-                                <Highlight
-                                    component={Text}
-                                    highlight={search || ''}
+                        <Stack spacing="none">
+                            <Text p={6} fw={700} fz="md" c="gray.7">
+                                {schema}
+                            </Text>
+                            {Object.keys(tables).map((table) => (
+                                <UnstyledButton
+                                    key={table}
+                                    onClick={() => {
+                                        setActiveTable(table);
+                                    }}
+                                    fw={500}
+                                    p={4}
+                                    fz={13}
+                                    c={
+                                        activeTable === table
+                                            ? 'gray.8'
+                                            : 'gray.7'
+                                    }
+                                    bg={
+                                        activeTable === table
+                                            ? 'gray.1'
+                                            : 'transparent'
+                                    }
+                                    sx={(theme) => ({
+                                        borderRadius: theme.radius.sm,
+                                        '&:hover': {
+                                            backgroundColor:
+                                                theme.colors.gray[1],
+                                        },
+                                    })}
                                 >
-                                    {table}
-                                </Highlight>
-                            </UnstyledButton>
-                        ))}
-                    </Stack>
+                                    <Highlight
+                                        component={Text}
+                                        highlight={search || ''}
+                                    >
+                                        {table}
+                                    </Highlight>
+                                </UnstyledButton>
+                            ))}
+                        </Stack>
+                    </ScrollArea>
                 ))}
             {isSuccess && !data && (
                 <Center p="sm">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- Computes height of `ResizableBox` and substracts that from the `Tables`' height.
- Some overflow scrolls
- Changed `Sidebar` height from `100vh` to `100%`

demo:


https://github.com/lightdash/lightdash/assets/7611706/2d78c9ae-e505-4be0-b4a5-f81221d9e5d7





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
