### PR TITLE
feat: stream data to sql runner page

### DIFF
--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -32,7 +32,7 @@ const getSchedulerLogs = async (projectUuid: string) =>
         body: undefined,
     });
 
-const getSchedulerJobStatus = async (jobId: string) =>
+export const getSchedulerJobStatus = async (jobId: string) =>
     lightdashApi<ApiJobStatusResponse['results']>({
         url: `/schedulers/job/${jobId}/status`,
         method: 'GET',

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -54,8 +54,6 @@ export const ContentPanel: FC<Props> = ({
         isLoading,
     } = useSqlQueryRun();
 
-    console.log('queryResults', queryResults);
-
     return (
         <Stack
             spacing="none"

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -23,7 +23,6 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import Table from '../../../components/common/Table';
 import { getRawValueCell } from '../../../hooks/useColumns';
 import { useSqlQueryRun } from '../hooks/useSqlQueryRun';
-import { useAppSelector } from '../store/hooks';
 
 type Props = {
     isChartConfigOpen: boolean;
@@ -39,7 +38,6 @@ export const ContentPanel: FC<Props> = ({
     closeChartConfig,
 }) => {
     const [sql, setSql] = useState<string>('');
-    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const { ref: wrapperRef, height: wrapperHeight } = useElementSize();
     const [resultsHeight, setResultsHeight] = useState(MIN_RESULTS_HEIGHT);
     const maxResultsHeight = useMemo(() => wrapperHeight - 58, [wrapperHeight]);
@@ -106,7 +104,6 @@ export const ContentPanel: FC<Props> = ({
                                 onClick={() => {
                                     if (!sql) return;
                                     runSqlQuery({
-                                        projectUuid,
                                         sql,
                                     });
                                 }}

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -41,7 +41,6 @@ export const useSqlQueryRun = () => {
         ApiJobScheduledResponse['results'],
         ApiError,
         {
-            projectUuid: string;
             sql: SqlRunnerBody['sql'];
         }
     >(({ sql }) => scheduleSqlJob({ projectUuid, sql }), {

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -67,7 +67,7 @@ export const useSqlQueryRun = () => {
                     data?.status === SchedulerJobStatus.ERROR
                 )
                     return false;
-                return 2000;
+                return 1000;
             },
             onSuccess: (data) => {
                 if (data?.status === SchedulerJobStatus.ERROR) {

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -26,6 +26,14 @@ const scheduleSqlJob = async ({
         body: JSON.stringify({ sql }),
     });
 
+/**
+ * Gets the SQL query results from the server
+ *
+ * Steps:
+ * 1. Schedule the SQL query job
+ * 2. Get the status of the scheduled job
+ * 3. Fetch the results of the job
+ */
 export const useSqlQueryRun = () => {
     const { showToastError } = useToaster();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -151,9 +151,15 @@ export const useSqlQueryRun = () => {
 
     const isLoading = useMemo(
         () =>
-            scheduledDeliveryJobStatus?.status === SchedulerJobStatus.STARTED &&
+            sqlQueryRunMutation.isLoading ||
+            (scheduledDeliveryJobStatus?.status ===
+                SchedulerJobStatus.STARTED &&
+                isResultsLoading),
+        [
+            sqlQueryRunMutation.isLoading,
+            scheduledDeliveryJobStatus?.status,
             isResultsLoading,
-        [scheduledDeliveryJobStatus?.status, isResultsLoading],
+        ],
     );
 
     return {

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -27,7 +27,7 @@ const scheduleSqlJob = async ({
     });
 
 export const useSqlQueryRun = () => {
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastError } = useToaster();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const queryClient = useQueryClient();
     const sqlQueryRunMutation = useMutation<
@@ -62,11 +62,6 @@ export const useSqlQueryRun = () => {
                 return 2000;
             },
             onSuccess: (data) => {
-                if (data?.status === SchedulerJobStatus.COMPLETED) {
-                    showToastSuccess({
-                        title: 'SQL query ran successfully',
-                    });
-                }
                 if (data?.status === SchedulerJobStatus.ERROR) {
                     showToastError({
                         title: 'Could not run SQL query',

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -1,0 +1,165 @@
+import {
+    SchedulerJobStatus,
+    type ApiError,
+    type ApiJobScheduledResponse,
+    type ApiJobStatusResponse,
+    type ResultRow,
+    type SqlRunnerBody,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { getSchedulerJobStatus } from '../../scheduler/hooks/useScheduler';
+import { useAppSelector } from '../store/hooks';
+
+const scheduleSqlJob = async ({
+    projectUuid,
+    sql,
+}: {
+    projectUuid: string;
+    sql: SqlRunnerBody['sql'];
+}) =>
+    lightdashApi<ApiJobScheduledResponse['results']>({
+        url: `/projects/${projectUuid}/sqlRunner/run`,
+        method: 'POST',
+        body: JSON.stringify({ sql }),
+    });
+
+export const useSqlQueryRun = () => {
+    const { showToastError, showToastSuccess } = useToaster();
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const queryClient = useQueryClient();
+    const sqlQueryRunMutation = useMutation<
+        ApiJobScheduledResponse['results'],
+        ApiError,
+        {
+            projectUuid: string;
+            sql: SqlRunnerBody['sql'];
+        }
+    >(({ sql }) => scheduleSqlJob({ projectUuid, sql }), {
+        mutationKey: ['sqlRunner', 'run'],
+    });
+
+    const { data: sqlQueryJob } = sqlQueryRunMutation;
+
+    const { data: scheduledDeliveryJobStatus } = useQuery<
+        ApiJobStatusResponse['results'] | undefined,
+        ApiError
+    >(
+        ['jobStatus', sqlQueryJob?.jobId],
+        () => {
+            if (!sqlQueryJob?.jobId) return;
+            return getSchedulerJobStatus(sqlQueryJob.jobId);
+        },
+        {
+            refetchInterval: (data) => {
+                if (
+                    data?.status === SchedulerJobStatus.COMPLETED ||
+                    data?.status === SchedulerJobStatus.ERROR
+                )
+                    return false;
+                return 2000;
+            },
+            onSuccess: (data) => {
+                if (data?.status === SchedulerJobStatus.COMPLETED) {
+                    showToastSuccess({
+                        title: 'SQL query ran successfully',
+                    });
+                }
+                if (data?.status === SchedulerJobStatus.ERROR) {
+                    showToastError({
+                        title: 'Could not run SQL query',
+                        subtitle: data.details?.error,
+                    });
+                }
+            },
+            onError: async () => {
+                await queryClient.cancelQueries([
+                    'jobStatus',
+                    sqlQueryJob?.jobId,
+                ]);
+            },
+            enabled: Boolean(sqlQueryJob && sqlQueryJob?.jobId !== undefined),
+        },
+    );
+
+    const { data: sqlQueryResults, isLoading: isResultsLoading } = useQuery<
+        ResultRow[] | undefined,
+        ApiError
+    >(
+        ['sqlQueryResults', sqlQueryJob?.jobId],
+        async () => {
+            const url = scheduledDeliveryJobStatus?.details?.fileUrl;
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+            const rb = response.body;
+            const reader = rb?.getReader();
+
+            const stream = new ReadableStream({
+                async start(controller) {
+                    async function push() {
+                        while (true) {
+                            const nextChunk = await reader?.read();
+                            if (nextChunk?.done) {
+                                controller.close();
+                                break;
+                            }
+                            controller.enqueue(nextChunk?.value);
+                        }
+                    }
+
+                    await push();
+                },
+            });
+
+            const responseStream = new Response(stream, {
+                headers: { 'Content-Type': 'application/json' },
+            });
+            const result = await responseStream.text();
+
+            // Split the JSON strings by newline
+            const jsonStrings = result.trim().split('\n');
+            const jsonObjects = jsonStrings
+                .map((jsonString) => {
+                    try {
+                        return JSON.parse(jsonString);
+                    } catch (e) {
+                        throw new Error('Error parsing JSON');
+                    }
+                })
+                .filter((obj) => obj !== null);
+
+            return jsonObjects;
+        },
+        {
+            onError: () => {
+                showToastError({
+                    title: 'Could not fetch SQL query results',
+                });
+            },
+            enabled: Boolean(
+                scheduledDeliveryJobStatus?.status ===
+                    SchedulerJobStatus.COMPLETED &&
+                    scheduledDeliveryJobStatus?.details?.fileUrl !== undefined,
+            ),
+        },
+    );
+
+    const isLoading = useMemo(
+        () =>
+            scheduledDeliveryJobStatus?.status === SchedulerJobStatus.STARTED &&
+            isResultsLoading,
+        [scheduledDeliveryJobStatus?.status, isResultsLoading],
+    );
+
+    return {
+        ...sqlQueryRunMutation,
+        isLoading,
+        data: sqlQueryResults,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10552](https://github.com/lightdash/lightdash/issues/10552)

### Description:

- Creates hook `useSqlQueryRun` hook that does the following: 
- schedules run query job
- polls a query job status until it's complete or errors
- after a successful job it reads the streamed results, processes them into a `ResultRow[]` format

The component `ContentPanel` will keep track of what the user types on the `sql` + it will set the button as loading until the job settles. 


You can try with this: 

```sql

SELECT *
     FROM "postgres"."jaffle"."users" LIMIT 25

```

Demo:

https://github.com/lightdash/lightdash/assets/7611706/80735faa-eacc-4533-860a-fe846e9c2f8b



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
