### PR TITLE
fix: show edit button tooltip when user doesn't have permission to edit

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -587,6 +587,36 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         [showComments, isCommentsMenuOpen, tileUuid],
     );
 
+    const editButtonTooltipLabel = useMemo(() => {
+        const canManageChartSpace = user.data?.ability?.can(
+            'manage',
+            subject('Space', {
+                organizationUuid: chart.organizationUuid,
+                projectUuid: chart.projectUuid,
+                spaceUuid: chart.spaceUuid,
+            }),
+        );
+
+        if (!canManageChartSpace) {
+            return (
+                <Text>
+                    Cannot edit chart belonging to space:{' '}
+                    <Text span fw={500}>
+                        {chart.spaceName}
+                    </Text>
+                </Text>
+            );
+        }
+
+        return <Text>You do not have permission to edit this chart</Text>;
+    }, [
+        chart.organizationUuid,
+        chart.projectUuid,
+        chart.spaceName,
+        chart.spaceUuid,
+        user.data?.ability,
+    ]);
+
     return (
         <>
             <TileBase
@@ -722,14 +752,27 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                             <Tooltip
                                 disabled={!isEditMode}
                                 label="Finish editing dashboard to use these actions"
+                                variant="xs"
                             >
                                 <Box>
-                                    {userCanManageChart && (
-                                        <EditChartMenuItem
-                                            tile={props.tile}
-                                            disabled={isEditMode}
-                                        />
-                                    )}
+                                    <Tooltip
+                                        disabled={
+                                            userCanManageChart || isEditMode
+                                        }
+                                        label={editButtonTooltipLabel}
+                                        position="top-start"
+                                        variant="xs"
+                                    >
+                                        <Box>
+                                            <EditChartMenuItem
+                                                tile={props.tile}
+                                                disabled={
+                                                    isEditMode ||
+                                                    !userCanManageChart
+                                                }
+                                            />
+                                        </Box>
+                                    </Tooltip>
 
                                     {userCanManageExplore && chartPathname && (
                                         <Menu.Item


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[10611](https://github.com/lightdash/lightdash/issues/10611)

### Description:

- Shows disabled button with tooltip in dashboard tile options when user cannot edit chart

![image](https://github.com/lightdash/lightdash/assets/22939015/12209bc5-ded7-4475-8adb-85c987ce87f0)


**Steps to reproduce:**
1. Create a new user
2. Share `Jaffle shop` space with the user using `can view` permissions
3. Create a new space
4. Share space with the new user using `can edit` permissions
5. Add a new chart to the created space
6. Add a new dashboard to the created space (should contain the new chart in this space + a chart in jaffle shop)
7. Go to dashboard
8. Click on the "three dots" menu of each chart to see the options

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
