### PR TITLE
fix: alias join on the same table

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -88,7 +88,8 @@ const getReferencedTable = (
 ) =>
     Object.values(tables).find((table) => {
         const nameMatch =
-            table.name === refTable || table.originalName === refTable;
+            (table.name === currentTable && table.originalName === refTable) ||
+            table.name === refTable;
         if (nameMatch) return true;
 
         if (!joinAliases?.[currentTable]) return false;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10534](https://github.com/lightdash/lightdash/issues/10534)

### Description:

- Fixes joining twice with on the same table picking the wrong table join. Previously it was finding the first that matched the original name which could result in the incorrect join being picked up.

Before:

https://github.com/lightdash/lightdash/assets/22939015/b1b7946f-b9b7-41c3-ab13-bb2167649531

After:

https://github.com/lightdash/lightdash/assets/22939015/5a2bfe09-2b99-4482-ad3e-dd5e4c327678


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
