### PR TITLE
feat: sql runner fields copy to clipboard

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -56,16 +56,17 @@ const TableFieldIcon: FC<{
 });
 
 const TableField: FC<{
+    activeTable: string;
     field: WarehouseTableField;
     search: string | undefined;
-}> = memo(({ field, search }) => {
+}> = memo(({ activeTable, field, search }) => {
     const { ref: hoverRef, hovered } = useHover();
     const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
     return (
         <Group spacing={'xs'} noWrap ref={hoverRef}>
             {hovered ? (
                 <Box display={hovered ? 'block' : 'none'}>
-                    <CopyButton value={field.name}>
+                    <CopyButton value={`${activeTable}.${field.name}`}>
                         {({ copied, copy }) => (
                             <ActionIcon size={16} onClick={copy} bg="gray.1">
                                 <MantineIcon
@@ -172,7 +173,7 @@ export const TableFields: FC = () => {
                     <Text c="gray.4">No table selected</Text>
                 </Center>
             )}
-            {isSuccess && tableFields && (
+            {isSuccess && tableFields && activeTable && (
                 <ScrollArea
                     offsetScrollbars
                     variant="primary"
@@ -184,6 +185,7 @@ export const TableFields: FC = () => {
                         {tableFields.map((field) => (
                             <TableField
                                 key={field.name}
+                                activeTable={activeTable}
                                 field={field}
                                 search={search}
                             />

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -94,9 +94,9 @@ const TableField: FC<{
                     p={4}
                     fz={13}
                     c="gray.7"
-                    sx={() => ({
+                    sx={{
                         flex: 1,
-                    })}
+                    }}
                     highlight={search || ''}
                     truncate
                 >

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -1,7 +1,9 @@
 import { type DimensionType } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     Center,
+    CopyButton,
     Group,
     Highlight,
     Loader,
@@ -11,12 +13,13 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     Icon123,
     IconAbc,
     IconCalendar,
     IconClockHour4,
+    IconCopy,
     IconQuestionMark,
     IconSearch,
     IconX,
@@ -56,10 +59,28 @@ const TableField: FC<{
     field: WarehouseTableField;
     search: string | undefined;
 }> = memo(({ field, search }) => {
-    const { ref, isTruncated } = useIsTruncated<HTMLDivElement>();
+    const { ref: hoverRef, hovered } = useHover();
+    const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
     return (
-        <Group spacing={'xs'} noWrap>
-            <TableFieldIcon fieldType={field.type} />
+        <Group spacing={'xs'} noWrap ref={hoverRef}>
+            {hovered ? (
+                <Box display={hovered ? 'block' : 'none'}>
+                    <CopyButton value={field.name}>
+                        {({ copied, copy }) => (
+                            <ActionIcon size={16} onClick={copy} bg="gray.1">
+                                <MantineIcon
+                                    icon={IconCopy}
+                                    color={copied ? 'green' : 'blue'}
+                                    onClick={copy}
+                                />
+                            </ActionIcon>
+                        )}
+                    </CopyButton>
+                </Box>
+            ) : (
+                <TableFieldIcon fieldType={field.type} />
+            )}
+
             <Tooltip
                 withinPortal
                 variant="xs"
@@ -67,7 +88,7 @@ const TableField: FC<{
                 disabled={!isTruncated}
             >
                 <Highlight
-                    ref={ref}
+                    ref={truncatedRef}
                     component={Text}
                     fw={500}
                     p={4}
@@ -141,7 +162,6 @@ export const TableFields: FC = () => {
                         onChange={(e) => setSearch(e.target.value)}
                         styles={(theme) => ({
                             input: {
-                                borderRadius: theme.radius.md,
                                 border: `1px solid ${theme.colors.gray[3]}`,
                             },
                         })}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10612

### Description:

switches the icon with a `CopyButton` on hover of a table field. 
happy to go over other suggestions (for example, on top of `type`?) 

Another thing I tried was to display this icon next to the name, but not sure if it would be annoying to have the icon appear on different places on the x axis.

demo: 

https://github.com/lightdash/lightdash/assets/7611706/8e9eba27-c85f-44f2-b2b7-d065e2ce1f1c



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
