### PR TITLE
fix: focus on editable text on pencil icon click

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/common/EditableText.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/EditableText.tsx
@@ -1,25 +1,34 @@
 import { Box, TextInput, type TextInputProps } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPencil } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = TextInputProps & { lighter?: boolean };
 
 export const EditableText: FC<Props> = ({ lighter, ...props }) => {
     const { hovered, ref } = useHover();
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleIconClick = () => {
+        inputRef.current?.focus();
+    };
+
     return (
         <Box ref={ref}>
             <TextInput
                 size="xs"
                 {...props}
+                ref={inputRef}
                 rightSection={
                     <MantineIcon
                         style={{
                             visibility: hovered ? 'initial' : 'hidden',
+                            cursor: 'pointer',
                         }}
                         color="gray.6"
                         icon={IconPencil}
+                        onClick={handleIconClick}
                     />
                 }
                 styles={(theme) => ({
@@ -28,17 +37,14 @@ export const EditableText: FC<Props> = ({ lighter, ...props }) => {
                         background: 'transparent',
                         fontWeight: 500,
                         paddingLeft: 4,
-
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
-
                         ':hover': {
                             whiteSpace: 'normal',
                             overflow: 'visible',
                             background: theme.colors.gray[lighter ? '1' : '2'],
                         },
-
                         '::placeholder': {
                             color: theme.colors.gray[lighter ? '5' : '6'],
                         },


### PR DESCRIPTION
solves issue #10618

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #10618  -->
#10618 
### Description:
<!-- You can edit the text now even if you clicked in the pen icon -->

<!-- Even better add a screenshot / gif / loom -->


https://github.com/lightdash/lightdash/assets/143312648/f132126b-31e3-4144-af2d-d1e09a69cb01



### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
