### PR TITLE
fix: embedding guide link

### DIFF
--- a/docs/docs/references/embedding.mdx
+++ b/docs/docs/references/embedding.mdx
@@ -27,7 +27,7 @@ Embedding is available for all Lightdash Cloud customers - [reach out here to en
 
 :::
 
-For more of a deep dive into setting up and using embedding in Lightdash, check out our [`How to embed content` guide](https://docs.lightdash.com/guides/how-to-embed-content).
+For more of a deep dive into setting up and using embedding in Lightdash, check out our [`How to embed content` guide](../guides/how-to-embed-content.mdx).
 
 ## Embed secret
 

--- a/docs/docs/references/embedding.mdx
+++ b/docs/docs/references/embedding.mdx
@@ -27,7 +27,7 @@ Embedding is available for all Lightdash Cloud customers - [reach out here to en
 
 :::
 
-For more of a deep dive into setting up and using embedding in Lightdash, check out our [`How to embed content` guide](../guides/how-to-embed-content).
+For more of a deep dive into setting up and using embedding in Lightdash, check out our [`How to embed content` guide](https://docs.lightdash.com/guides/how-to-embed-content).
 
 ## Embed secret
 


### PR DESCRIPTION
Fix embedding guide link which was broken
