### PR TITLE
fix: pass empty array when null or undefined to resultHandler

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -221,7 +221,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             // stream initial data
             streamCallback({
                 fields,
-                rows: resultHandler(schema, queryResult.value.data),
+                rows: resultHandler(schema, queryResult.value.data ?? []),
             });
             // Using `await` in this loop ensures data chunks are fetched and processed sequentially.
             // This maintains order and data integrity.
@@ -231,7 +231,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
                 // stream next chunk of data
                 streamCallback({
                     fields,
-                    rows: resultHandler(schema, queryResult.value.data),
+                    rows: resultHandler(schema, queryResult.value.data ?? []),
                 });
             }
         } catch (e: any) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Checks if results data is `undefined` and passes empty array in that case

Before https://github.com/lightdash/lightdash/commit/a2847ca36d643593aa87781f760c94eae1ef0258 it already included the check: https://github.com/lightdash/lightdash/blob/c33ecc12d7578fdf0fa5030844443e2ddcf5ab41/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts#L199



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
