### PR TITLE
chore: add SqlRunnerResultsTransformer class

### DIFF
--- a/packages/common/src/transformers/ResultTransformers/SqlRunnerResultsTransformer.ts
+++ b/packages/common/src/transformers/ResultTransformers/SqlRunnerResultsTransformer.ts
@@ -1,0 +1,17 @@
+import { type SqlRunnerResults } from '../../types/sqlRunner';
+
+export class SqlRunnerResultsTransformer {
+    private readonly data: SqlRunnerResults;
+
+    constructor(args: { data: SqlRunnerResults }) {
+        this.data = args.data;
+    }
+
+    public getRows() {
+        return this.data;
+    }
+
+    public getColumns() {
+        return Object.keys(this.data[0]);
+    }
+}

--- a/packages/common/src/transformers/ResultTransformers/index.ts
+++ b/packages/common/src/transformers/ResultTransformers/index.ts
@@ -1,2 +1,3 @@
 export * from './AbstractResultTransformer';
 export * from './ExplorerResultsTransformer';
+export * from './SqlRunnerResultsTransformer';

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -1,3 +1,5 @@
+import { type ResultRow } from './results';
+
 export type SqlRunnerPayload = {
     projectUuid: string;
     sql: string;
@@ -8,5 +10,7 @@ export type SqlRunnerPayload = {
 export type SqlRunnerBody = {
     sql: string;
 };
+
+export type SqlRunnerResults = ResultRow[];
 
 export const sqlRunnerJob = 'sqlRunner';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10636 

### Description:

Adds `SqlRunnerResultsTransformer` that exposes two methods
- getRows
- getColumns

Added type `SqlRunnerResults`

Usage in `ContentPanel` would look something like: 

```tsx
 const {
        mutate: runSqlQuery,
        data: queryResults,
        isLoading,
    } = useSqlQueryRun();

// But without the `undefined`
    const tableTest = queryResults
        ? new SqlRunnerResultsTransformer({ data: queryResults })
        : undefined;


```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
