### PR TITLE
fix: handle SIGTERM gracefully on scheduler

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -150,6 +150,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-psycopg2 \
     python3-venv \
     git \
+    dumb-init \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -176,4 +177,4 @@ COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
 
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/prod-entrypoint.sh"]
-CMD ["yarn", "workspace", "backend", "start"]
+CMD ["node", "packages/backend/dist/index.js"]

--- a/dockerfile
+++ b/dockerfile
@@ -176,5 +176,5 @@ ENV LIGHTDASH_CONFIG_FILE /usr/app/lightdash.yml
 COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/bin/prod-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/usr/bin/prod-entrypoint.sh"]
 CMD ["node", "packages/backend/dist/index.js"]


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-cloud/issues/400

- `yarn workspace ...` as the docker command does not handle SIGTERM
- `node scheduler.js` handles SIGTERM but won't kill the container
- `dumb-init node scheduler.js` handles SIGTERM

Also updated logging on the shutdown for the scheduler.

https://github.com/lightdash/lightdash/assets/11660098/063bb6f0-d748-4ee9-865d-7a2d52a53242


@ZeRego not sure if you still need changes for your docker-compose setup to work? I noticed you made a change on #10482 
