### PR TITLE
chore: add placeholder modal to save sql chart

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header.tsx
@@ -2,27 +2,47 @@ import { ActionIcon, Group, Paper, Title, Tooltip } from '@mantine/core';
 import { IconDeviceFloppy, IconLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useAppDispatch } from '../store/hooks';
+import { toggleModal } from '../store/sqlRunnerSlice';
+import { SaveSqlChartModal } from './SaveSqlChartModal';
 
 export const Header: FC = () => {
+    const dispatch = useAppDispatch();
     return (
-        <Paper shadow="none" radius={0} px="md" py="sm" withBorder>
-            <Group position="apart">
-                <Title order={2} c="gray.6">
-                    Untitled SQL Query
-                </Title>
-                <Group spacing="md">
-                    <Tooltip variant="xs" label="Save chart" position="bottom">
-                        <ActionIcon size="xs">
-                            <MantineIcon icon={IconDeviceFloppy} />
-                        </ActionIcon>
-                    </Tooltip>
-                    <Tooltip variant="xs" label="Share URL" position="bottom">
-                        <ActionIcon size="xs">
-                            <MantineIcon icon={IconLink} />
-                        </ActionIcon>
-                    </Tooltip>
+        <>
+            <Paper shadow="none" radius={0} px="md" py="sm" withBorder>
+                <Group position="apart">
+                    <Title order={2} c="gray.6">
+                        Untitled SQL Query
+                    </Title>
+                    <Group spacing="md">
+                        <Tooltip
+                            variant="xs"
+                            label="Save chart"
+                            position="bottom"
+                        >
+                            <ActionIcon size="xs">
+                                <MantineIcon
+                                    icon={IconDeviceFloppy}
+                                    onClick={() =>
+                                        dispatch(toggleModal('saveChartModal'))
+                                    }
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                        <Tooltip
+                            variant="xs"
+                            label="Share URL"
+                            position="bottom"
+                        >
+                            <ActionIcon size="xs">
+                                <MantineIcon icon={IconLink} />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Group>
                 </Group>
-            </Group>
-        </Paper>
+            </Paper>
+            <SaveSqlChartModal />
+        </>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -1,0 +1,82 @@
+import { Button, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconChartBar } from '@tabler/icons-react';
+import { z } from 'zod';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { toggleModal } from '../store/sqlRunnerSlice';
+
+const validationSchema = z.object({
+    name: z.string().min(1),
+});
+
+type FormValues = z.infer<typeof validationSchema>;
+
+export const SaveSqlChartModal = () => {
+    const dispatch = useAppDispatch();
+    const isOpen = useAppSelector(
+        (state) => state.sqlRunner.modals.saveChartModal.isOpen,
+    );
+
+    const onClose = () => dispatch(toggleModal('saveChartModal'));
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            name: '',
+        },
+        validate: zodResolver(validationSchema),
+    });
+
+    const handleOnSubmit = () => {
+        // TODO: save chart
+    };
+
+    return (
+        <Modal
+            opened={isOpen}
+            onClose={onClose}
+            keepMounted={false}
+            title={
+                <Group spacing="xs">
+                    <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
+                    <Text fw={500}>Save chart</Text>
+                </Group>
+            }
+            styles={(theme) => ({
+                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
+                body: { padding: 0 },
+            })}
+        >
+            <form onSubmit={form.onSubmit(handleOnSubmit)}>
+                <Stack p="md">
+                    <Stack spacing="xs">
+                        <TextInput
+                            label="Enter a memorable name for your chart"
+                            placeholder="eg. How many weekly active users do we have?"
+                            required
+                            {...form.getInputProps('name')}
+                        />
+                    </Stack>
+                </Stack>
+
+                <Group
+                    position="right"
+                    w="100%"
+                    sx={(theme) => ({
+                        borderTop: `1px solid ${theme.colors.gray[4]}`,
+                        bottom: 0,
+                        padding: theme.spacing.md,
+                    })}
+                >
+                    <Button onClick={onClose} variant="outline">
+                        Cancel
+                    </Button>
+
+                    <Button type="submit" disabled={!form.values.name}>
+                        Save
+                    </Button>
+                </Group>
+            </form>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -14,6 +14,11 @@ export interface SqlRunnerState {
 
     resultsTableConfig: TableChartSqlConfig | undefined;
     chartConfig: BarChartConfig;
+    modals: {
+        saveChartModal: {
+            isOpen: boolean;
+        };
+    };
 }
 
 const initialState: SqlRunnerState = {
@@ -36,6 +41,11 @@ const initialState: SqlRunnerState = {
             y: [],
         },
         series: [],
+    },
+    modals: {
+        saveChartModal: {
+            isOpen: false,
+        },
     },
 };
 
@@ -91,6 +101,13 @@ export const sqlRunnerSlice = createSlice({
         ) => {
             state.activeTable = action.payload;
         },
+        toggleModal: (
+            state,
+            action: PayloadAction<keyof SqlRunnerState['modals']>,
+        ) => {
+            state.modals[action.payload].isOpen =
+                !state.modals[action.payload].isOpen;
+        },
     },
 });
 
@@ -100,4 +117,5 @@ export const {
     setInitialResultsTableConfig,
     updateResultsTableFieldConfigLabel,
     setSelectedChartType,
+    toggleModal,
 } = sqlRunnerSlice.actions;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10677 

### Description:

- Adds `modals` state to store as well as a `toggleModal` action
- Displays placeholder modal for saving a SQL chart

demo: 


https://github.com/lightdash/lightdash/assets/7611706/c7ae45d0-aa47-4176-9dbc-381621950dd6





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
