### PR TITLE
style: fix content panel width and height on large column table results

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -235,7 +235,8 @@ export const ContentPanel: FC<Props> = ({
                         px="md"
                         py="sm"
                         withBorder
-                        style={{ flex: 1 }}
+                        sx={{ flex: 1, overflow: 'auto' }}
+                        h="100%"
                     >
                         {selectedChartType === SqlRunnerChartType.TABLE && (
                             <Table data={queryResults} />

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
@@ -1,4 +1,5 @@
 import { type ResultRow, type TableChartSqlConfig } from '@lightdash/common';
+import { Flex } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import { type FC } from 'react';
 import { SMALL_TEXT_LENGTH } from '../../../../components/common/LightTable';
@@ -7,7 +8,6 @@ import { VirtualizedArea } from '../../../../components/common/Table/ScrollableT
 import {
     Table as TableStyled,
     TableContainer,
-    TableScrollableWrapper,
     TABLE_HEADER_BG,
     Tr,
 } from '../../../../components/common/Table/Table.styles';
@@ -25,7 +25,7 @@ export const Table: FC<Props> = ({ data }) => {
         (state) => state.sqlRunner.resultsTableConfig,
     );
     const {
-        tableContainerRef,
+        tableWrapperRef,
         getColumnsCount,
         getTableData,
         paddingTop,
@@ -36,8 +36,16 @@ export const Table: FC<Props> = ({ data }) => {
     const { headerGroups, virtualRows, rowModelRows } = getTableData();
 
     return (
-        <TableContainer>
-            <TableScrollableWrapper ref={tableContainerRef}>
+        <TableContainer $shouldExpand>
+            <Flex
+                ref={tableWrapperRef}
+                dir="column"
+                miw="100%"
+                sx={{
+                    flex: 1,
+                    overflow: 'auto',
+                }}
+            >
                 <TableStyled>
                     <thead>
                         {headerGroups.map((headerGroup) =>
@@ -114,7 +122,7 @@ export const Table: FC<Props> = ({ data }) => {
                         )}
                     </tbody>
                 </TableStyled>
-            </TableScrollableWrapper>
+            </Flex>
         </TableContainer>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
@@ -26,10 +26,10 @@ export const useTableDataTransformer = (
 
     const getRowHeight = useCallback(() => ROW_HEIGHT_PX, []);
 
-    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const tableWrapperRef = useRef<HTMLDivElement>(null);
 
     const virtualizer = useVirtualizer({
-        getScrollElement: () => tableContainerRef.current,
+        getScrollElement: () => tableWrapperRef.current,
         count: transformer.getRowsCount(),
         estimateSize: () => getRowHeight(),
         overscan: 25,
@@ -59,7 +59,7 @@ export const useTableDataTransformer = (
             : 0;
 
     return {
-        tableContainerRef,
+        tableWrapperRef,
         columns,
         rows,
         getRowHeight,

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -52,6 +52,7 @@ const SqlRunnerNew = () => {
                 spacing="none"
                 p={0}
                 style={{ flex: 1 }}
+                w="100%"
             >
                 {!isLeftSidebarOpen && (
                     <Paper


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10679

### Description:

Adds wrapper with the proper `flex` styling
Uses containers' `h`s and `w`s to apply correct overflow
Removes usage of `TableScrollableWrapper` - needed to add one more style: `flex: 1` but also used Mantine's `Flex` component to make less changes and avoid using Styled Components.

Demo: 

https://github.com/lightdash/lightdash/assets/7611706/5be70408-3251-41de-8e0c-441d66db1f64



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
