### PR TITLE
feat: truncate tables and allow copying table reference

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -28,7 +28,6 @@ const TableItem: FC<{
     database: string;
     isActive: boolean;
 }> = memo(({ table, search, schema, database, isActive }) => {
-    console.log('im rendering');
     const { ref: hoverRef, hovered } = useHover();
     const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
     const dispatch = useAppDispatch();

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -38,18 +38,18 @@ const TableItem: FC<{
                 onClick={() => {
                     dispatch(toggleActiveTable(table));
                 }}
-                fw={500}
                 w="100%"
                 p={4}
-                fz={13}
-                c={isActive ? 'gray.8' : 'gray.7'}
-                bg={isActive ? 'gray.1' : 'transparent'}
                 sx={(theme) => ({
+                    fontWeight: 500,
+                    fontSize: 13,
                     borderRadius: theme.radius.sm,
+                    color: isActive ? 'gray.8' : 'gray.7',
+                    backgroundColor: isActive ? 'gray.1' : 'transparent',
+                    flex: 1,
                     '&:hover': {
                         backgroundColor: theme.colors.gray[1],
                     },
-                    flex: 1,
                 })}
             >
                 <Tooltip

--- a/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
@@ -25,7 +25,11 @@ type TablesBySchema =
     | undefined;
 
 export const useTables = ({ projectUuid, search }: GetTablesParams) => {
-    return useQuery<ApiWarehouseCatalog, ApiError, TablesBySchema>({
+    return useQuery<
+        ApiWarehouseCatalog,
+        ApiError,
+        { database: string; tablesBySchema: TablesBySchema } | undefined
+    >({
         queryKey: ['sqlRunner', 'tables', projectUuid],
         queryFn: () =>
             fetchTables({
@@ -40,7 +44,11 @@ export const useTables = ({ projectUuid, search }: GetTablesParams) => {
                 })),
             );
 
-            if (!search) return tablesBySchema;
+            if (!search)
+                return {
+                    database: Object.keys(data)[0],
+                    tablesBySchema,
+                };
 
             const searchResults: TablesBySchema = tablesBySchema
                 .map((schemaData) => {
@@ -73,7 +81,11 @@ export const useTables = ({ projectUuid, search }: GetTablesParams) => {
 
             if (searchResults.length === 0) {
                 return undefined;
-            } else return searchResults;
+            } else
+                return {
+                    database: Object.keys(data)[0],
+                    tablesBySchema: searchResults,
+                };
         },
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #10687, closes #10686

### Description:

- Memoizes `TableItem` (now when we click on a table we're not rendering all table items again) - this is done by passing the `isActive` prop instead of computing that on the component-level.
- Adds `ScrollArea`, only vertical ,and with variant primary to mimick what we have for `TableFields`
- On hover, we let the user copy to clipboard, the database+schema+table so that it can just be referenced easily on the SQL editor.

demo on truncation:

https://github.com/lightdash/lightdash/assets/7611706/2d7f6f67-6498-4311-8dc9-1cc0e6a84ca9

demo on copying: 

https://github.com/lightdash/lightdash/assets/7611706/4624f207-1f16-4684-80b3-86592901041b


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
