### PR TITLE
feat: added a copy button to the sql bar

### DIFF
--- a/packages/frontend/src/components/common/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard.tsx
@@ -1,7 +1,9 @@
 import {
+    ActionIcon,
     Box,
     Button,
     Card,
+    CopyButton,
     Flex,
     Group,
     Title,
@@ -10,7 +12,12 @@ import {
     type ButtonProps,
     type PopoverProps,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import {
+    IconCheck,
+    IconChevronDown,
+    IconChevronRight,
+    IconClipboard,
+} from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import MantineIcon from './MantineIcon';
 
@@ -48,6 +55,7 @@ interface CollapsableCardProps {
     headerElement?: JSX.Element;
     rightHeaderElement?: React.ReactNode;
     isVisualizationCard?: boolean;
+    // sql?: string;
 }
 
 const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
@@ -61,6 +69,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
     headerElement,
     rightHeaderElement,
     minHeight = 300,
+    // sql,
 }) => {
     const handleToggle = useCallback(
         (value: boolean) => onToggle?.(value),
@@ -124,6 +133,30 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                     </Title>
                     <Group spacing="xs">{headerElement}</Group>
                 </Group>
+
+                {!isOpen && title === 'SQL' && (
+                    <CopyButton value="{sql}" timeout={1000}>
+                        {({ copied, copy }) => (
+                            <Tooltip
+                                label={copied ? 'Copied to clipboard!' : 'Copy'}
+                                withArrow
+                                position="right"
+                                color={copied ? 'green' : 'dark'}
+                            >
+                                <ActionIcon
+                                    color={copied ? 'teal' : 'gray'}
+                                    onClick={copy}
+                                >
+                                    {copied ? (
+                                        <IconCheck size="1rem" />
+                                    ) : (
+                                        <IconClipboard size="1rem" />
+                                    )}
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
+                    </CopyButton>
+                )}
 
                 {rightHeaderElement && (
                     <>

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -329,6 +329,7 @@ const SqlRunnerPage = () => {
                     onToggle={(value) =>
                         handleCardExpand(SqlRunnerCards.SQL, value)
                     }
+                    //sql={sql}
                 >
                     <SqlRunnerInput
                         sql={sql}


### PR DESCRIPTION
Closes: #10602 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Hey,
So I added the copy sql button as shown in the below video. BUT, I am unable to get the the value of the sql (of what to copy). I tried importing it from `SqlRunner.txt` , but I was unable to because of some scope errors and also I dont know if its the right file to import from or not. So please, let me know from where I can import that sql.

<-- Even better add a screenshot / gif / loom -->


https://github.com/user-attachments/assets/3dc99271-e1d5-4a9d-9375-78eedc8f749b



### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
