### PR TITLE
fix: filter out models that are not selected to be displayed in lightdash

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -88,7 +88,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
 
         // Validate models in the manifest - models with invalid metadata will compile to failed Explores
         const models = Object.values(manifest.nodes).filter(
-            (node: any) => node.resource_type === 'model',
+            (node: any) => node.resource_type === 'model' && node.meta !== null,
         ) as DbtRawModelNode[];
         const manifestVersion = GetDbtManifestVersion(this.dbtVersion);
         Logger.debug(

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -14,6 +14,7 @@ import {
     getItemId,
     InlineErrorType,
     isExploreError,
+    isTableEnabled,
     isValidationTargetValid,
     OrganizationMemberRole,
     RequestMethod,
@@ -118,60 +119,9 @@ export class ValidationService extends BaseService {
             return [];
         }
 
-        const isTableEnabled = (explore: Explore | ExploreError) => {
-            switch (tablesConfiguration.tableSelection.type) {
-                case TableSelectionType.ALL:
-                    return true;
-                case TableSelectionType.WITH_TAGS:
-                    const hasSelectedJoinedExploredWithTags = explores.some(
-                        (e) =>
-                            e.joinedTables?.some(
-                                (jt) => jt.table === explore.name,
-                            ) &&
-                            e.tags?.some((tag) =>
-                                tablesConfiguration.tableSelection.value?.includes(
-                                    tag,
-                                ),
-                            ),
-                    );
-                    const exploreIsSelectedWithTags = explore.tags?.some(
-                        (tag) =>
-                            tablesConfiguration.tableSelection.value?.includes(
-                                tag,
-                            ),
-                    );
-                    return (
-                        hasSelectedJoinedExploredWithTags ||
-                        exploreIsSelectedWithTags
-                    );
-
-                case TableSelectionType.WITH_NAMES:
-                    const hasSelectedJoinedExplored = explores.some(
-                        (e) =>
-                            e.joinedTables?.some(
-                                (jt) => jt.table === explore.name,
-                            ) &&
-                            tablesConfiguration.tableSelection.value?.includes(
-                                e.name,
-                            ),
-                    );
-                    const exploreIsSelected =
-                        tablesConfiguration.tableSelection.value?.includes(
-                            explore.name,
-                        );
-
-                    return hasSelectedJoinedExplored || exploreIsSelected;
-                default:
-                    return assertUnreachable(
-                        tablesConfiguration.tableSelection.type,
-                        'Invalid table selection type',
-                    );
-            }
-        };
-
         const errors = explores.reduce<CreateTableValidation[]>(
             (acc, explore) => {
-                if (!isTableEnabled(explore)) {
+                if (!isTableEnabled(explores, explore, tablesConfiguration)) {
                     this.logger.debug(
                         `Table ${explore.name} is disabled, skipping validation`,
                     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10733 

### Description:

- Filters out the models that are not selected to be displayed in lightdash after calling `compileAllExplores`

https://github.com/user-attachments/assets/73b884b8-0d31-4278-b824-7fd26933e30d

In this example, `my_third_dbt_model` has null column description for the `id` column. Since this model is not selected to be displayed in lightdash we should ignore it's errors.

### Steps to reproduce:

1. Create a new project project via the UI using the following settings: https://lightdash.slack.com/archives/C02GQKJK84Q/p1721036344999769?thread_ts=1721031134.661579&cid=C02GQKJK84Q
2. Only select my_second_dbt_model and my_first_dbt_model to be displayed in lightdash in settings > table configuration
3. Run the project validator

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
