### PR TITLE
chore: add results and chart tabs

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -7,6 +7,7 @@ import {
     Loader,
     Paper,
     Stack,
+    Tabs,
     Title,
     Tooltip,
 } from '@mantine/core';
@@ -24,7 +25,13 @@ import { useSqlQueryRun } from '../hooks/useSqlQueryRun';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 
 import { ChartKind } from '@lightdash/common';
-import { setInitialResultsAndSeries, setSql } from '../store/sqlRunnerSlice';
+
+import {
+    setActiveVisTab,
+    setInitialResultsAndSeries,
+    setSql,
+    VisTabs,
+} from '../store/sqlRunnerSlice';
 import { SqlEditor } from './SqlEditor';
 import BarChart from './visualizations/BarChart';
 import { Table } from './visualizations/Table';
@@ -58,8 +65,22 @@ export const ContentPanel: FC<Props> = ({
     );
 
     const sql = useAppSelector((state) => state.sqlRunner.sql);
+    const activeVisTab = useAppSelector(
+        (state) => state.sqlRunner.activeVisTab,
+    );
+
     const selectedChartType = useAppSelector(
         (state) => state.sqlRunner.selectedChartType,
+    );
+
+    // Static results table
+    const resultsTableConfig = useAppSelector(
+        (state) => state.sqlRunner.resultsTableConfig,
+    );
+
+    // configurable table
+    const tableVisConfig = useAppSelector(
+        (state) => state.sqlRunner.tableChartConfig,
     );
 
     const {
@@ -192,16 +213,41 @@ export const ContentPanel: FC<Props> = ({
                         setResultsHeight(data.size.height)
                     }
                 >
-                    <Paper shadow="none" radius={0} px="md" py="sm" withBorder>
-                        <Group position="apart">
-                            <Group spacing="xs">
-                                <Title order={5} c="gray.6">
-                                    Results/Chart panel
-                                </Title>
-                                {isLoading && <Loader size="xs" />}
-                            </Group>
+                    <Paper
+                        shadow="none"
+                        radius={0}
+                        px="md"
+                        pb={0}
+                        pt="sm"
+                        withBorder
+                    >
+                        <Group position="apart" pb={0} noWrap>
+                            <Tabs
+                                value={activeVisTab}
+                                onTabChange={(val: VisTabs) => {
+                                    dispatch(setActiveVisTab(val));
+                                }}
+                                // Negative margin to ge the tab indicator on the border
+                                mb={-2}
+                            >
+                                <Tabs.List>
+                                    <Tabs.Tab
+                                        value={VisTabs.CHART}
+                                        disabled={isLoading}
+                                    >
+                                        Chart
+                                    </Tabs.Tab>
+                                    <Tabs.Tab
+                                        value={VisTabs.RESULTS}
+                                        disabled={isLoading}
+                                    >
+                                        Results
+                                    </Tabs.Tab>
+                                    {isLoading && <Loader mt="xs" size="xs" />}
+                                </Tabs.List>
+                            </Tabs>
 
-                            <Group spacing="md">
+                            <Group spacing="md" pb="sm" noWrap>
                                 <Tooltip
                                     key={String(isResultsHeightMoreThanHalf)}
                                     variant="xs"
@@ -263,11 +309,27 @@ export const ContentPanel: FC<Props> = ({
                             sx={{ flex: 1, overflow: 'auto' }}
                             h="100%"
                         >
-                            {selectedChartType === ChartKind.TABLE && (
-                                <Table data={queryResults} />
+                            {activeVisTab === VisTabs.CHART && (
+                                <>
+                                    {selectedChartType === ChartKind.TABLE && (
+                                        <Table
+                                            data={queryResults}
+                                            config={tableVisConfig}
+                                        />
+                                    )}
+                                    {selectedChartType ===
+                                        ChartKind.VERTICAL_BAR && (
+                                        <BarChart data={queryResults} />
+                                    )}
+                                </>
                             )}
-                            {selectedChartType === ChartKind.VERTICAL_BAR && (
-                                <BarChart data={queryResults} />
+                            {activeVisTab === VisTabs.RESULTS && (
+                                <>
+                                    <Table
+                                        data={queryResults}
+                                        config={resultsTableConfig}
+                                    />
+                                </>
                             )}
                         </Paper>
                     )}

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
@@ -1,4 +1,8 @@
-import { type ResultRow, type TableChartSqlConfig } from '@lightdash/common';
+import {
+    type ResultRow,
+    type SqlTableConfig,
+    type TableChartSqlConfig,
+} from '@lightdash/common';
 import { Flex } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import { type FC } from 'react';
@@ -12,26 +16,21 @@ import {
     Tr,
 } from '../../../../components/common/Table/Table.styles';
 import { type useSqlQueryRun } from '../../hooks/useSqlQueryRun';
-import { useAppSelector } from '../../store/hooks';
 import { useTableDataTransformer } from '../../transformers/useTableDataTransformer';
 
 type Props = {
     data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>;
-    config?: TableChartSqlConfig;
+    config?: TableChartSqlConfig | SqlTableConfig;
 };
 
-export const Table: FC<Props> = ({ data }) => {
-    const resultsTableConfig = useAppSelector(
-        (state) => state.sqlRunner.tableChartConfig,
-    );
-
+export const Table: FC<Props> = ({ data, config }) => {
     const {
         tableWrapperRef,
         getColumnsCount,
         getTableData,
         paddingTop,
         paddingBottom,
-    } = useTableDataTransformer(data, resultsTableConfig);
+    } = useTableDataTransformer(data, config);
 
     const columnsCount = getColumnsCount();
     const { headerGroups, virtualRows, rowModelRows } = getTableData();

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -10,6 +10,11 @@ import {
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
+export enum VisTabs {
+    CHART = 'chart',
+    RESULTS = 'results',
+}
+
 export interface SqlRunnerState {
     projectUuid: string;
     activeTable: string | undefined;
@@ -17,6 +22,7 @@ export interface SqlRunnerState {
     name: string;
     sql: string;
 
+    activeVisTab: VisTabs;
     selectedChartType: ChartKind;
 
     resultsTableConfig: SqlTableConfig | undefined;
@@ -36,6 +42,7 @@ const initialState: SqlRunnerState = {
     savedChartUuid: undefined,
     name: 'Untitled SQL Query',
     sql: '',
+    activeVisTab: VisTabs.CHART,
     selectedChartType: ChartKind.VERTICAL_BAR,
     resultsTableConfig: undefined,
     barChartConfig: undefined,
@@ -130,6 +137,9 @@ export const sqlRunnerSlice = createSlice({
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
         },
+        setActiveVisTab: (state, action: PayloadAction<VisTabs>) => {
+            state.activeVisTab = action.payload;
+        },
         setSaveChartData: (state, action: PayloadAction<SqlChart>) => {
             state.savedChartUuid = action.payload.savedSqlUuid;
             state.name = action.payload.name;
@@ -202,6 +212,7 @@ export const {
     setProjectUuid,
     setInitialResultsAndSeries,
     setSql,
+    setActiveVisTab,
     setSaveChartData,
     updateTableChartFieldConfigLabel,
     updateChartAxisLabel,

--- a/packages/frontend/src/features/sqlRunner/transformers/TableDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/TableDataTransformer.ts
@@ -1,7 +1,7 @@
 import {
     SqlRunnerResultsTransformer,
     type ResultRow,
-    type TableChartSqlConfig,
+    type SqlTableConfig,
 } from '@lightdash/common';
 import { type ColumnDef } from '@tanstack/react-table';
 import { getRawValueCell } from '../../../hooks/useColumns';
@@ -11,11 +11,11 @@ export class TableDataTransformer {
 
     private columns: ColumnDef<ResultRow, any>[];
 
-    private config: TableChartSqlConfig | undefined;
+    private config: SqlTableConfig | undefined;
 
     constructor(
         private data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>,
-        private tableChartSqlConfig: TableChartSqlConfig | undefined,
+        private tableChartSqlConfig: SqlTableConfig | undefined,
     ) {
         this.config = this.tableChartSqlConfig;
         this.transformer = new SqlRunnerResultsTransformer({ data: this.data });

--- a/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
@@ -1,4 +1,4 @@
-import { type TableChartSqlConfig } from '@lightdash/common';
+import { type SqlTableConfig } from '@lightdash/common';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useMemo, useRef } from 'react';
@@ -8,7 +8,7 @@ import { TableDataTransformer } from './TableDataTransformer';
 
 export const useTableDataTransformer = (
     data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>,
-    config: TableChartSqlConfig | undefined,
+    config: SqlTableConfig | undefined,
 ) => {
     const transformer = useMemo(
         () => new TableDataTransformer(data, config),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10711

### Description:

Add tabs for 'Chart' and 'Results'. The results tab will always show a static, non-configurable table showing all results. The chart tab can be any viz. 

<img width="1374" alt="Screenshot 2024-07-15 at 16 48 45" src="https://github.com/user-attachments/assets/602e6508-9d9d-458a-a305-490b77f5f4dd">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
