### PR TITLE
chore: make sql runner name and description updatable

### DIFF
--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -110,7 +110,7 @@ export type CreateSqlChart = {
     name: string;
     description: string | null;
     sql: string;
-    config: SqlRunnerChartConfig;
+    config: SqlRunnerChartConfig | {};
     spaceUuid: string;
 };
 

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -46,7 +46,7 @@ export type BarChartConfig = {
         version: number;
     };
     type: ChartKind.VERTICAL_BAR;
-    style: {
+    style?: {
         legend:
             | {
                   position: 'top' | 'bottom' | 'left' | 'right';
@@ -54,7 +54,7 @@ export type BarChartConfig = {
               }
             | undefined;
     };
-    axes: {
+    axes?: {
         x: {
             reference: string;
             label?: string;
@@ -65,7 +65,7 @@ export type BarChartConfig = {
             label: string;
         }[];
     };
-    series: {
+    series?: {
         reference: string;
         yIndex: number;
         name: string;
@@ -110,7 +110,7 @@ export type CreateSqlChart = {
     name: string;
     description: string | null;
     sql: string;
-    config: SqlRunnerChartConfig | {};
+    config: SqlRunnerChartConfig;
     spaceUuid: string;
 };
 

--- a/packages/frontend/src/features/sqlRunner/components/Header.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header.tsx
@@ -1,11 +1,12 @@
 import { ChartKind } from '@lightdash/common';
-import { ActionIcon, Group, Paper, Title, Tooltip } from '@mantine/core';
+import { ActionIcon, Group, Paper, Tooltip } from '@mantine/core';
 import { IconDeviceFloppy, IconLink } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { EditableText } from '../../../components/VisualizationConfigs/common/EditableText';
 import { useUpdateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { toggleModal } from '../store/sqlRunnerSlice';
+import { DEFAULT_NAME, toggleModal, updateName } from '../store/sqlRunnerSlice';
 import { SaveSqlChartModal } from './SaveSqlChartModal';
 
 export const Header: FC = () => {
@@ -25,13 +26,27 @@ export const Header: FC = () => {
         projectUuid,
         savedChartUuid || '',
     );
+
+    const isSaveModalOpen = useAppSelector(
+        (state) => state.sqlRunner.modals.saveChartModal.isOpen,
+    );
+    const onCloseSaveModal = useCallback(() => {
+        dispatch(toggleModal('saveChartModal'));
+    }, [dispatch]);
+
     return (
         <>
-            <Paper shadow="none" radius={0} px="md" py="sm" withBorder>
+            <Paper shadow="none" radius={0} px="md" py="xs" withBorder>
                 <Group position="apart">
-                    <Title order={2} c="gray.6">
-                        {name}
-                    </Title>
+                    <EditableText
+                        size="lg"
+                        placeholder={DEFAULT_NAME}
+                        value={name}
+                        w={400}
+                        onChange={(e) =>
+                            dispatch(updateName(e.currentTarget.value))
+                        }
+                    />
                     <Group spacing="md">
                         <Tooltip
                             variant="xs"
@@ -72,7 +87,11 @@ export const Header: FC = () => {
                     </Group>
                 </Group>
             </Paper>
-            <SaveSqlChartModal />
+            <SaveSqlChartModal
+                key={`${isSaveModalOpen}-saveChartModal`}
+                isOpen={isSaveModalOpen}
+                onClose={onCloseSaveModal}
+            />
         </>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/Header.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header.tsx
@@ -89,7 +89,7 @@ export const Header: FC = () => {
             </Paper>
             <SaveSqlChartModal
                 key={`${isSaveModalOpen}-saveChartModal`}
-                isOpen={isSaveModalOpen}
+                opened={isSaveModalOpen}
                 onClose={onCloseSaveModal}
             />
         </>

--- a/packages/frontend/src/features/sqlRunner/components/RightSidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/RightSidebar.tsx
@@ -91,7 +91,7 @@ export const RightSidebar: FC<Props> = ({ setSidebarOpen }) => {
                         onChange={(e) => {
                             dispatch(
                                 updateChartAxisLabel({
-                                    reference: chartConfig.axes.x.reference,
+                                    reference: chartConfig.axes?.x.reference,
                                     label: e.target.value,
                                 }),
                             );
@@ -105,7 +105,7 @@ export const RightSidebar: FC<Props> = ({ setSidebarOpen }) => {
                         onChange={(e) => {
                             dispatch(
                                 updateChartAxisLabel({
-                                    reference: chartConfig.axes.y[0].reference,
+                                    reference: chartConfig.axes?.y[0].reference,
                                     label: e.target.value,
                                 }),
                             );
@@ -114,20 +114,21 @@ export const RightSidebar: FC<Props> = ({ setSidebarOpen }) => {
                     <Title order={6} fz="sm" c="gray.6">
                         Series
                     </Title>
-                    {chartConfig.series.map(({ name, reference }, index) => (
-                        <EditableText
-                            key={reference}
-                            value={name ?? reference}
-                            onChange={(e) => {
-                                dispatch(
-                                    updateChartSeriesLabel({
-                                        index: index,
-                                        name: e.target.value,
-                                    }),
-                                );
-                            }}
-                        />
-                    ))}
+                    {chartConfig.series &&
+                        chartConfig.series.map(({ name, reference }, index) => (
+                            <EditableText
+                                key={reference}
+                                value={name ?? reference}
+                                onChange={(e) => {
+                                    dispatch(
+                                        updateChartSeriesLabel({
+                                            index: index,
+                                            name: e.target.value,
+                                        }),
+                                    );
+                                }}
+                            />
+                        ))}
                 </Stack>
             )}
         </Stack>

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     Textarea,
     TextInput,
+    type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconChartBar } from '@tabler/icons-react';
@@ -25,12 +26,9 @@ const validationSchema = z.object({
 
 type FormValues = z.infer<typeof validationSchema>;
 
-type Props = {
-    isOpen: boolean;
-    onClose: () => void;
-};
+type Props = Pick<ModalProps, 'opened' | 'onClose'>;
 
-export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
+export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
@@ -82,7 +80,11 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
             name: form.values.name,
             description: form.values.description,
             sql: sql,
-            config: config || {},
+            // TODO: should initial version get generated on the BE?
+            config: config || {
+                metadata: { version: 1 },
+                type: ChartKind.VERTICAL_BAR,
+            },
             // TODO: add space selection
             spaceUuid: spaces[0].uuid,
         });
@@ -101,7 +103,7 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
 
     return (
         <Modal
-            opened={isOpen}
+            opened={opened}
             onClose={onClose}
             keepMounted={false}
             title={

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -1,5 +1,13 @@
 import { ChartKind } from '@lightdash/common';
-import { Button, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+} from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useEffect, type FC } from 'react';
@@ -12,6 +20,7 @@ import { updateName } from '../store/sqlRunnerSlice';
 
 const validationSchema = z.object({
     name: z.string().min(1),
+    description: z.string(),
 });
 
 type FormValues = z.infer<typeof validationSchema>;
@@ -27,10 +36,12 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
 
     const name = useAppSelector((state) => state.sqlRunner.name);
+    const description = useAppSelector((state) => state.sqlRunner.description);
 
     const form = useForm<FormValues>({
         initialValues: {
             name: '',
+            description: '',
         },
         validate: zodResolver(validationSchema),
     });
@@ -39,7 +50,10 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
         if (!form.values.name && name) {
             form.setFieldValue('name', name);
         }
-    }, [name, form]);
+        if (!form.values.description && description) {
+            form.setFieldValue('description', description);
+        }
+    }, [name, form, description]);
 
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const config = useAppSelector((state) =>
@@ -66,7 +80,7 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
         }
         await createSavedSqlChart({
             name: form.values.name,
-            description: 'A test saved chart',
+            description: form.values.description,
             sql: sql,
             config: config || {},
             // TODO: add space selection
@@ -78,6 +92,7 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
         config,
         createSavedSqlChart,
         dispatch,
+        form.values.description,
         form.values.name,
         onClose,
         spaces,
@@ -108,6 +123,10 @@ export const SaveSqlChartModal: FC<Props> = ({ isOpen, onClose }) => {
                             placeholder="eg. How many weekly active users do we have?"
                             required
                             {...form.getInputProps('name')}
+                        />
+                        <Textarea
+                            label="Description"
+                            {...form.getInputProps('description')}
                         />
                     </Stack>
                 </Stack>

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -181,13 +181,19 @@ export const sqlRunnerSlice = createSlice({
                 return;
             }
             const { reference, label } = action.payload;
-            if (state.barChartConfig.axes.x.reference === reference) {
+            if (state.barChartConfig?.axes?.x.reference === reference) {
                 state.barChartConfig.axes.x.label = label;
             } else {
-                const index = state.barChartConfig.axes.y.findIndex(
+                const index = state.barChartConfig?.axes?.y.findIndex(
                     (axis) => axis.reference === reference,
                 );
-                state.barChartConfig.axes.y[index].label = label;
+
+                if (
+                    index !== undefined &&
+                    state.barChartConfig?.axes?.y[index]
+                ) {
+                    state.barChartConfig.axes.y[index].label = label;
+                }
             }
         },
         updateChartSeriesLabel: (
@@ -196,7 +202,12 @@ export const sqlRunnerSlice = createSlice({
         ) => {
             if (!state.barChartConfig) return;
             const { index, name } = action.payload;
-            state.barChartConfig.series[index].name = name;
+            if (
+                state.barChartConfig.series &&
+                state.barChartConfig.series[index]
+            ) {
+                state.barChartConfig.series[index].name = name;
+            }
         },
         setSelectedChartType: (state, action: PayloadAction<ChartKind>) => {
             state.selectedChartType = action.payload;

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -15,6 +15,8 @@ export enum VisTabs {
     RESULTS = 'results',
 }
 
+export const DEFAULT_NAME = 'Untitled SQL Query';
+
 export interface SqlRunnerState {
     projectUuid: string;
     activeTable: string | undefined;
@@ -40,7 +42,7 @@ const initialState: SqlRunnerState = {
     projectUuid: '',
     activeTable: undefined,
     savedChartUuid: undefined,
-    name: 'Untitled SQL Query',
+    name: '',
     sql: '',
     activeVisTab: VisTabs.CHART,
     selectedChartType: ChartKind.VERTICAL_BAR,
@@ -134,6 +136,9 @@ export const sqlRunnerSlice = createSlice({
                 };
             }
         },
+        updateName: (state, action: PayloadAction<string>) => {
+            state.name = action.payload;
+        },
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
         },
@@ -211,6 +216,7 @@ export const {
     toggleActiveTable,
     setProjectUuid,
     setInitialResultsAndSeries,
+    updateName,
     setSql,
     setActiveVisTab,
     setSaveChartData,

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -175,9 +175,9 @@ export const sqlRunnerSlice = createSlice({
         },
         updateChartAxisLabel: (
             state,
-            action: PayloadAction<{ reference: string; label: string }>,
+            action: PayloadAction<{ reference?: string; label: string }>,
         ) => {
-            if (!state.barChartConfig) {
+            if (!state.barChartConfig || !action.payload.reference) {
                 return;
             }
             const { reference, label } = action.payload;

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -22,6 +22,8 @@ export interface SqlRunnerState {
     activeTable: string | undefined;
     savedChartUuid: string | undefined;
     name: string;
+    description: string;
+
     sql: string;
 
     activeVisTab: VisTabs;
@@ -43,6 +45,7 @@ const initialState: SqlRunnerState = {
     activeTable: undefined,
     savedChartUuid: undefined,
     name: '',
+    description: '',
     sql: '',
     activeVisTab: VisTabs.CHART,
     selectedChartType: ChartKind.VERTICAL_BAR,
@@ -148,6 +151,8 @@ export const sqlRunnerSlice = createSlice({
         setSaveChartData: (state, action: PayloadAction<SqlChart>) => {
             state.savedChartUuid = action.payload.savedSqlUuid;
             state.name = action.payload.name;
+            state.description = action.payload.description || '';
+
             state.sql = action.payload.sql;
             state.selectedChartType =
                 action.payload.config.type === ChartKind.TABLE


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10726 

### Description:

- Makes it possible to update the SQL runner name in place. 
- That name then gets used in the modal.
- Makes it possible to enter a description when saving
- Note that the description is currently not displayed anywhere. 

Note that once save, these can't be updated. We dont have them in the versioned types. I wasn't sure whether to add them or not -- the way that types are set up it looks intentional. Is there any reason these should be kept out of versioning? If so that's fine, but we have to change some things to plumb updated to name and description through. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
