### PR TITLE
fix: auto join org to apply okta group

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -624,7 +624,9 @@ export class UserModel {
             .select('*', 'organizations.created_at as organization_created_at');
 
         if (user === undefined) {
-            throw new NotFoundError(`Cannot find user with uuid ${userUuid}`);
+            throw new NotFoundError(
+                `Cannot find user with uuid ${userUuid} and org ${organizationUuid}`,
+            );
         }
         const lightdashUser = mapDbUserDetailsToLightdashUser(user);
         const projectRoles = await this.getUserProjectRoles(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -62,6 +62,7 @@ const emailClient = {
 
 const organizationModel = {
     get: jest.fn(async () => organisation),
+    getAllowedOrgsForDomain: jest.fn(async () => []),
 };
 
 const createUserService = (lightdashConfig: LightdashConfig) =>

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -600,7 +600,7 @@ export class UserService extends BaseService {
             openIdUser.openId.groups.length;
         let { organizationUuid } = createdUser;
         if (
-            !createdUser.organizationUuid &&
+            !organizationUuid &&
             !inviteCode &&
             hasGroups &&
             allowedOrgs.length === 1


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash-internal-work/issues/1889

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
So, what's happening: 

- users on the org are not joining via invitation
- org has a whitelisted domain, so the user joins automatically the org
- however, when we check for groups, the user hasn't joined the group yet
- on /joinOrg we don't have information about the group

How this fixes it.

- Targeted fix: if `  !createdUser.organizationUuid && !inviteCode &&  hasGroups &&  allowedOrgs.length === 1`
- Join the org
- Then apply group

![Screenshot from 2024-07-16 09-52-57](https://github.com/user-attachments/assets/921e6308-f27b-490a-af9c-0c318339c322)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
