### PR TITLE
feat: run query on cmd+enter

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -1,7 +1,7 @@
+import { ChartKind } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
-    Button,
     Divider,
     Group,
     Loader,
@@ -11,21 +11,18 @@ import {
     Title,
     Tooltip,
 } from '@mantine/core';
-import { useElementSize } from '@mantine/hooks';
+import { useElementSize, useHotkeys } from '@mantine/hooks';
 import {
     IconAdjustmentsCog,
     IconLayoutNavbarCollapse,
     IconLayoutNavbarExpand,
-    IconPlayerPlay,
 } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { ResizableBox } from 'react-resizable';
 import MantineIcon from '../../../components/common/MantineIcon';
+import RunSqlQueryButton from '../../../components/SqlRunner/RunSqlQueryButton';
 import { useSqlQueryRun } from '../hooks/useSqlQueryRun';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-
-import { ChartKind } from '@lightdash/common';
-
 import {
     setActiveVisTab,
     setInitialResultsAndSeries,
@@ -102,6 +99,17 @@ export const ContentPanel: FC<Props> = ({
         },
     });
 
+    // Run query on cmd + enter
+    useHotkeys([
+        [
+            'mod + enter',
+            () => {
+                if (sql) runSqlQuery({ sql });
+            },
+            { preventDefault: true },
+        ],
+    ]);
+
     return (
         <Stack
             spacing="none"
@@ -156,20 +164,15 @@ export const ContentPanel: FC<Props> = ({
                                     />
                                 </ActionIcon>
                             </Tooltip>
-
-                            <Button
-                                size="xs"
-                                leftIcon={<MantineIcon icon={IconPlayerPlay} />}
-                                loading={isLoading}
-                                onClick={() => {
+                            <RunSqlQueryButton
+                                isLoading={isLoading}
+                                onSubmit={() => {
                                     if (!sql) return;
                                     runSqlQuery({
                                         sql,
                                     });
                                 }}
-                            >
-                                Run query
-                            </Button>
+                            />
                         </Group>
                     </Group>
                 </Paper>
@@ -195,6 +198,7 @@ export const ContentPanel: FC<Props> = ({
                         <SqlEditor
                             sql={sql}
                             onSqlChange={(newSql) => dispatch(setSql(newSql))}
+                            onSubmit={() => runSqlQuery({ sql })}
                         />
                     </Box>
                 </Paper>

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -1,13 +1,18 @@
 import { WarehouseTypes } from '@lightdash/common';
 import { Loader } from '@mantine/core';
-import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
+import Editor, {
+    type BeforeMount,
+    type EditorProps,
+    type Monaco,
+    type OnMount,
+} from '@monaco-editor/react';
 import {
     bigqueryLanguageDefinition,
     snowflakeLanguageDefinition,
 } from '@popsql/monaco-sql-languages';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { LanguageIdEnum, setupLanguageFeatures } from 'monaco-sql-languages';
-import React, { useCallback, useMemo, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { useProject } from '../../../hooks/useProject';
 import { useAppSelector } from '../store/hooks';
@@ -78,20 +83,38 @@ const registerMonacoLanguage = (monaco: Monaco, language: string) => {
 export const SqlEditor: FC<{
     sql: string;
     onSqlChange: (value: string) => void;
-}> = ({ sql, onSqlChange }) => {
+    onSubmit?: () => void;
+}> = ({ sql, onSqlChange, onSubmit }) => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const { data, isLoading } = useProject(projectUuid);
+    const editorRef = useRef<Parameters<OnMount>['0'] | null>(null);
+    const sqlRef = useRef(sql);
+    const onSubmitRef = useRef(onSubmit);
+
+    useEffect(() => {
+        sqlRef.current = sql;
+        onSubmitRef.current = onSubmit;
+    }, [sql, onSubmit]);
 
     const language = useMemo(
         () => getLanguage(data?.warehouseConnection?.type),
         [data],
     );
-    const beforeMount = useCallback(
-        (monaco: Monaco) => {
+
+    const beforeMount: BeforeMount = useCallback(
+        (monaco) => {
             registerMonacoLanguage(monaco, language);
         },
         [language],
     );
+
+    const onMount: OnMount = useCallback((editor, monaco) => {
+        editorRef.current = editor;
+        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+            // When the editor is mounted, the onSubmit callback should be set to the latest value, otherwise it will be set to the initial value on the first render
+            onSubmitRef.current?.();
+        });
+    }, []);
 
     if (isLoading) {
         return <Loader color="gray" size="xs" />;
@@ -110,6 +133,7 @@ export const SqlEditor: FC<{
         <Editor
             loading={<Loader color="gray" size="xs" />}
             beforeMount={beforeMount}
+            onMount={onMount}
             language={language}
             value={sql}
             onChange={(value) => onSqlChange(value ?? '')}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10738

### Description:

allows to run a query with cmd+enter outside and inside the sql editor

Followed this suggestion to get to a working solution: https://github.com/suren-atoyan/monaco-react/issues/328#issuecomment-1079967898

demo:


https://github.com/user-attachments/assets/18fc4a0f-1756-4f2b-8b7b-3a69f2a0a5d3



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
