### PR TITLE
feat: allow adding sql charts to dashboard

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -789,8 +789,6 @@ export class DashboardModel {
         const tableCalculationFilters = view?.filters?.tableCalculations;
         view.filters.tableCalculations = tableCalculationFilters || [];
 
-        console.log(JSON.stringify(tiles, null, 2));
-
         return {
             organizationUuid: dashboard.organization_uuid,
             projectUuid: dashboard.project_uuid,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -252,7 +252,7 @@ export class DashboardModel {
                     dashboard_tile_uuid: uuid,
                     saved_sql_uuid: properties.savedSqlUuid,
                     hide_title: properties.hideTitle,
-                    title: properties.title,
+                    title: properties.title ?? properties.chartName,
                 })),
             );
         }
@@ -789,6 +789,8 @@ export class DashboardModel {
         const tableCalculationFilters = view?.filters?.tableCalculations;
         view.filters.tableCalculations = tableCalculationFilters || [];
 
+        console.log(JSON.stringify(tiles, null, 2));
+
         return {
             organizationUuid: dashboard.organization_uuid,
             projectUuid: dashboard.project_uuid,
@@ -873,7 +875,7 @@ export class DashboardModel {
                                 type: DashboardTileTypes.SQL_CHART,
                                 properties: {
                                     ...commonProperties,
-                                    chartName: name,
+                                    chartName: name ?? title ?? '',
                                     savedSqlUuid: saved_sql_uuid,
                                 },
                             };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -115,6 +115,7 @@ import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
 } from './types/catalog';
+import { type ApiChartContentResponse } from './types/content';
 import { type ApiPromotionChangesResponse } from './types/promotion';
 import {
     type ApiCreateSqlChart,
@@ -657,7 +658,8 @@ type ApiResults =
     | ApiOrganizationMemberProfiles['results']
     | ApiSqlChart['results']
     | ApiCreateSqlChart['results']
-    | ApiUpdateSqlChart['results'];
+    | ApiUpdateSqlChart['results']
+    | ApiChartContentResponse['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -12,7 +12,8 @@ export const BASE_API_URL =
         ? `http://test.lightdash/`
         : import.meta.env.BASE_URL;
 
-const apiPrefix = `${BASE_API_URL}api/v1`;
+const API_PREFIX = `${BASE_API_URL}api/v1`;
+export const API_PREFIX_V2 = `${BASE_API_URL}api/v2`;
 
 const defaultHeaders = {
     'Content-Type': 'application/json',
@@ -38,12 +39,14 @@ type LightdashApiProps = {
     url: string;
     body: BodyInit | null | undefined;
     headers?: Record<string, string> | undefined;
+    apiPrefix?: string;
 };
 export const lightdashApi = async <T extends ApiResponse['results']>({
     method,
     url,
     body,
     headers,
+    apiPrefix = API_PREFIX,
 }: LightdashApiProps): Promise<T> => {
     let sentryTrace: string | undefined;
     // Manually create a span for the fetch request to be able to trace it in Sentry. This also enables Distributed Tracing.

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -28,7 +28,11 @@ interface Props
  * Add support for description and title
  */
 
-export const DashboardSqlChartTile: FC<Props> = ({ tile, isEditMode }) => {
+export const DashboardSqlChartTile: FC<Props> = ({
+    tile,
+    isEditMode,
+    onDelete,
+}) => {
     const { projectUuid } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
@@ -86,7 +90,7 @@ export const DashboardSqlChartTile: FC<Props> = ({ tile, isEditMode }) => {
                         tile.properties.title || tile.properties.chartName || ''
                     }
                     // TODO: see if we can remove these
-                    onDelete={() => {}}
+                    onDelete={onDelete}
                     onEdit={() => {}}
                 >
                     {data.chart.config.type === ChartKind.TABLE && (

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -1,8 +1,8 @@
 import {
+    ChartKind,
     ChartSourceType,
     DashboardTileTypes,
     defaultTileSize,
-    type ChartKind,
     type Dashboard,
 } from '@lightdash/common';
 import {
@@ -48,7 +48,9 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
                     position="top-start"
                 >
                     <Group spacing="xs">
-                        <ChartIcon chartKind={chartKind} />
+                        <ChartIcon
+                            chartKind={chartKind ?? ChartKind.VERTICAL_BAR}
+                        />
                         <Text c="gray.8" fw={500} fz="xs">
                             {label}
                         </Text>

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlChartAndResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlChartAndResults.tsx
@@ -7,7 +7,7 @@ import {
     type SqlChart,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { getSchedulerJobStatus } from '../../scheduler/hooks/useScheduler';
@@ -46,23 +46,25 @@ export const useSqlChartAndResults = ({
         ApiSqlChartWithResults['results'],
         ApiError
     >(
-        ['sqlChartAndResults', projectUuid],
+        ['sqlChartAndResults', projectUuid, savedSqlUuid],
         () =>
             scheduleSavedSqlChartJobAndGetResults({
                 projectUuid,
                 savedSqlUuid: savedSqlUuid!,
             }),
         {
-            onSuccess: (data) => {
-                if (data.chart) {
-                    setChart(data.chart);
-                }
-            },
             enabled: Boolean(savedSqlUuid),
         },
     );
 
     const { data: sqlChartAndResultsJob } = sqlChartAndResultsQuery;
+
+    useEffect(() => {
+        // Set the chart if it exists
+        if (sqlChartAndResultsJob?.chart) {
+            setChart(sqlChartAndResultsJob.chart);
+        }
+    }, [sqlChartAndResultsJob]);
 
     const { data: scheduledDeliveryJobStatus } = useQuery<
         ApiJobStatusResponse['results'] | undefined,
@@ -99,7 +101,7 @@ export const useSqlChartAndResults = ({
         ResultRow[] | undefined,
         ApiError
     >(
-        ['sqlQueryResults', sqlChartAndResultsJob?.jobId],
+        ['sqlChartQueryResults', sqlChartAndResultsJob?.jobId],
         async () => {
             const url = scheduledDeliveryJobStatus?.details?.fileUrl;
             const response = await fetch(url, {
@@ -161,9 +163,6 @@ export const useSqlChartAndResults = ({
                     SchedulerJobStatus.COMPLETED &&
                     scheduledDeliveryJobStatus?.details?.fileUrl !== undefined,
             ),
-            onSuccess: (data) => {
-                console.log('success', data);
-            },
         },
     );
 
@@ -172,11 +171,13 @@ export const useSqlChartAndResults = ({
             sqlChartAndResultsQuery.isLoading ||
             (scheduledDeliveryJobStatus?.status ===
                 SchedulerJobStatus.STARTED &&
-                isResultsLoading),
+                isResultsLoading) ||
+            chart === undefined,
         [
             sqlChartAndResultsQuery.isLoading,
             scheduledDeliveryJobStatus?.status,
             isResultsLoading,
+            chart,
         ],
     );
 

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlChartAndResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlChartAndResults.tsx
@@ -70,7 +70,7 @@ export const useSqlChartAndResults = ({
         ApiJobStatusResponse['results'] | undefined,
         ApiError
     >(
-        ['jobStatus', sqlChartAndResultsJob?.jobId],
+        ['jobStatus', sqlChartAndResultsJob?.jobId, savedSqlUuid],
         () => {
             if (!sqlChartAndResultsJob?.jobId) return;
             return getSchedulerJobStatus(sqlChartAndResultsJob.jobId);
@@ -101,7 +101,7 @@ export const useSqlChartAndResults = ({
         ResultRow[] | undefined,
         ApiError
     >(
-        ['sqlChartQueryResults', sqlChartAndResultsJob?.jobId],
+        ['sqlChartQueryResults', savedSqlUuid, sqlChartAndResultsJob?.jobId],
         async () => {
             const url = scheduledDeliveryJobStatus?.details?.fileUrl;
             const response = await fetch(url, {
@@ -172,12 +172,11 @@ export const useSqlChartAndResults = ({
             (scheduledDeliveryJobStatus?.status ===
                 SchedulerJobStatus.STARTED &&
                 isResultsLoading) ||
-            chart === undefined,
+            isResultsLoading,
         [
             sqlChartAndResultsQuery.isLoading,
             scheduledDeliveryJobStatus?.status,
             isResultsLoading,
-            chart,
         ],
     );
 

--- a/packages/frontend/src/hooks/useChartSummariesV2.ts
+++ b/packages/frontend/src/hooks/useChartSummariesV2.ts
@@ -1,0 +1,30 @@
+import {
+    ContentType,
+    type ApiChartContentResponse,
+    type ApiError,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const getChartSummariesInProjectV2 = async (projectUuid: string) => {
+    return lightdashApi<ApiChartContentResponse['results']>({
+        apiPrefix: '/api/v2',
+        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.CHART}&pageSize=${Number.MAX_SAFE_INTEGER}`, // TODO: remove pageSize max once we have pagination
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useChartSummariesV2 = (projectUuid: string) => {
+    return useQuery<
+        ApiChartContentResponse['results'],
+        ApiError,
+        ApiChartContentResponse['results']['data']
+    >({
+        queryKey: ['project', projectUuid, 'chart-summaries-v2'],
+        queryFn: () => getChartSummariesInProjectV2(projectUuid),
+        select(data) {
+            return data.data;
+        },
+    });
+};

--- a/packages/frontend/src/hooks/useChartSummariesV2.ts
+++ b/packages/frontend/src/hooks/useChartSummariesV2.ts
@@ -4,11 +4,11 @@ import {
     type ApiError,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { lightdashApi } from '../api';
+import { API_PREFIX_V2, lightdashApi } from '../api';
 
 const getChartSummariesInProjectV2 = async (projectUuid: string) => {
     return lightdashApi<ApiChartContentResponse['results']>({
-        apiPrefix: '/api/v2',
+        apiPrefix: API_PREFIX_V2,
         url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.CHART}&pageSize=${Number.MAX_SAFE_INTEGER}`, // TODO: remove pageSize max once we have pagination
         method: 'GET',
         body: undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10744

### Description:

Allows adding tiles to a dashboard that are SQL charts

Uses the new v2 endpoint: `useChartSummariesV2` and allows `lightdashApi` to have a different prefix.
I've also added a chart icon to each select item when adding chart tiles to the dashboard

Improved loading state of `useSqlChartAndResults` hook and when setting the `chart` data if the job is cached.



Demo

https://github.com/user-attachments/assets/86030e9e-75a8-4c40-80cb-6e54790951d8




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
