### PR TITLE
style: update preview project badge and layout

### DIFF
--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -182,7 +182,7 @@ const ProjectSwitcher = () => {
                             {item.type === ProjectType.PREVIEW && (
                                 <Badge
                                     color="orange"
-                                    variant="outline"
+                                    variant="light"
                                     size="xs"
                                 >
                                     Preview

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -174,14 +174,20 @@ const ProjectSwitcher = () => {
                         key={item.projectUuid}
                         onClick={() => handleProjectChange(item.projectUuid)}
                     >
-                        <Group spacing="sm">
+                        <Group
+                            spacing="sm"
+                            style={{ justifyContent: 'space-between' }}
+                        >
+                            <Text style={{ flexGrow: 1 }}>{item.name}</Text>
                             {item.type === ProjectType.PREVIEW && (
-                                <Badge color="blue" variant="filled" size="xs">
+                                <Badge
+                                    color="orange"
+                                    variant="outline"
+                                    size="xs"
+                                >
                                     Preview
                                 </Badge>
                             )}
-
-                            <Text>{item.name}</Text>
                         </Group>
                     </Menu.Item>
                 ))}

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -1,14 +1,65 @@
-import { ProjectType } from '@lightdash/common';
-import { Badge, Button, Group, Menu, Text } from '@mantine/core';
+import { ProjectType, type OrganizationProject } from '@lightdash/common';
+import { Badge, Button, Group, Menu, Text, Tooltip } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import useToaster from '../../hooks/toaster/useToaster';
 import {
     useActiveProjectUuid,
     useUpdateActiveProjectMutation,
 } from '../../hooks/useActiveProject';
+import { useIsTruncated } from '../../hooks/useIsTruncated';
 import { useProjects } from '../../hooks/useProjects';
+
+const InactiveProjectItem: FC<{
+    item: OrganizationProject;
+    handleProjectChange: (newUuid: string) => void;
+}> = ({ item, handleProjectChange }) => {
+    const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
+    return (
+        <Menu.Item
+            key={item.projectUuid}
+            onClick={() => handleProjectChange(item.projectUuid)}
+        >
+            <Group spacing="sm" position="apart" noWrap>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label={item.name}
+                    maw={300}
+                    disabled={!isTruncated}
+                    color="dark"
+                    multiline
+                >
+                    <Text
+                        ref={truncatedRef}
+                        c="gray.2"
+                        fz="xs"
+                        fw={500}
+                        truncate
+                        maw={350}
+                    >
+                        {item.name}
+                    </Text>
+                </Tooltip>
+                {item.type === ProjectType.PREVIEW && (
+                    <Badge
+                        color="yellow.1"
+                        variant="light"
+                        size="xs"
+                        radius="sm"
+                        fw={400}
+                        sx={{
+                            textTransform: 'none',
+                        }}
+                    >
+                        Preview
+                    </Badge>
+                )}
+            </Group>
+        </Menu.Item>
+    );
+};
 
 const swappableProjectRoutes = (activeProjectUuid: string) => [
     `/projects/${activeProjectUuid}/home`,
@@ -168,28 +219,13 @@ const ProjectSwitcher = () => {
                 </Button>
             </Menu.Target>
 
-            <Menu.Dropdown>
+            <Menu.Dropdown maw={400}>
                 {inactiveProjects.map((item) => (
-                    <Menu.Item
+                    <InactiveProjectItem
                         key={item.projectUuid}
-                        onClick={() => handleProjectChange(item.projectUuid)}
-                    >
-                        <Group
-                            spacing="sm"
-                            style={{ justifyContent: 'space-between' }}
-                        >
-                            <Text style={{ flexGrow: 1 }}>{item.name}</Text>
-                            {item.type === ProjectType.PREVIEW && (
-                                <Badge
-                                    color="orange"
-                                    variant="light"
-                                    size="xs"
-                                >
-                                    Preview
-                                </Badge>
-                            )}
-                        </Group>
-                    </Menu.Item>
+                        item={item}
+                        handleProjectChange={handleProjectChange}
+                    />
                 ))}
             </Menu.Dropdown>
         </Menu>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <-- reference the related issue e.g. #10702  -->

closes issue #10702 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

was asked to make the badges be on the right side so that projects which dont have the preview badges also would look uniform with the ones that do && change the style of badge to outline & color to 🍊 . I did. see below video.

<-- Even better add a screenshot / gif / loom -->


https://github.com/user-attachments/assets/da3c091d-7153-4310-8d22-b933d107b14c




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
