### PR TITLE
feat: allow for title editing of sql chart tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -31,6 +31,7 @@ interface Props
 export const DashboardSqlChartTile: FC<Props> = ({
     tile,
     isEditMode,
+    onEdit,
     onDelete,
 }) => {
     const { projectUuid } = useParams<{
@@ -89,9 +90,8 @@ export const DashboardSqlChartTile: FC<Props> = ({
                     title={
                         tile.properties.title || tile.properties.chartName || ''
                     }
-                    // TODO: see if we can remove these
                     onDelete={onDelete}
-                    onEdit={() => {}}
+                    onEdit={onEdit}
                 >
                     {data.chart.config.type === ChartKind.TABLE && (
                         <Table data={data.results} config={data.chart.config} />

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -312,7 +312,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             </ChartContainer>
 
             {isEditingTileContent &&
-                (tile.type === DashboardTileTypes.SAVED_CHART ? (
+                (tile.type === DashboardTileTypes.SAVED_CHART ||
+                tile.type === DashboardTileTypes.SQL_CHART ? (
                     <ChartUpdateModal
                         opened={isEditingTileContent}
                         tile={tile}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -1,4 +1,9 @@
-import { type DashboardChartTile } from '@lightdash/common';
+import {
+    isDashboardChartTileType,
+    isDashboardSqlChartTile,
+    type DashboardChartTile,
+    type DashboardSqlChartTile,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -12,7 +17,7 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconChartAreaLine, IconEye, IconEyeOff } from '@tabler/icons-react';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { useParams } from 'react-router-dom';
 import { useChartSummaries } from '../../../hooks/useChartSummaries';
 import MantineIcon from '../../common/MantineIcon';
@@ -25,7 +30,7 @@ interface ChartUpdateModalProps extends ModalProps {
         newChartUuid: string,
         shouldHideTitle: boolean,
     ) => void;
-    tile: DashboardChartTile;
+    tile: DashboardChartTile | DashboardSqlChartTile;
 }
 
 const ChartUpdateModal = ({
@@ -37,7 +42,9 @@ const ChartUpdateModal = ({
 }: ChartUpdateModalProps) => {
     const form = useForm({
         initialValues: {
-            uuid: tile.properties.savedChartUuid,
+            uuid: isDashboardSqlChartTile(tile)
+                ? tile.properties.savedSqlUuid
+                : tile.properties.savedChartUuid,
             title: tile.properties.title,
             hideTitle,
         },
@@ -61,16 +68,7 @@ const ChartUpdateModal = ({
     return (
         <Modal
             onClose={() => onClose?.()}
-            title={
-                <Flex align="center" gap="xs">
-                    <MantineIcon
-                        icon={IconChartAreaLine}
-                        size="lg"
-                        color="blue.8"
-                    />
-                    <Title order={4}>Edit tile content</Title>
-                </Flex>
-            }
+            title={<Title order={4}>Edit tile content</Title>}
             withCloseButton
             className="non-draggable"
             {...modalProps}
@@ -103,38 +101,39 @@ const ChartUpdateModal = ({
                             />
                         </ActionIcon>
                     </Flex>
-                    {!tile.properties.belongsToDashboard && (
-                        <Select
-                            styles={(theme) => ({
-                                separator: {
-                                    position: 'sticky',
-                                    top: 0,
-                                    backgroundColor: 'white',
-                                },
-                                separatorLabel: {
-                                    color: theme.colors.gray[6],
-                                    fontWeight: 500,
-                                },
-                            })}
-                            id="savedChartUuid"
-                            name="savedChartUuid"
-                            label="Select chart"
-                            data={(savedCharts || []).map(
-                                ({ uuid, name, spaceName }) => {
-                                    return {
-                                        value: uuid,
-                                        label: name,
-                                        group: spaceName,
-                                    };
-                                },
-                            )}
-                            disabled={isInitialLoading}
-                            withinPortal
-                            {...form.getInputProps('uuid')}
-                            searchable
-                            placeholder="Search..."
-                        />
-                    )}
+                    {isDashboardChartTileType(tile) &&
+                        tile.properties.belongsToDashboard && (
+                            <Select
+                                styles={(theme) => ({
+                                    separator: {
+                                        position: 'sticky',
+                                        top: 0,
+                                        backgroundColor: 'white',
+                                    },
+                                    separatorLabel: {
+                                        color: theme.colors.gray[6],
+                                        fontWeight: 500,
+                                    },
+                                })}
+                                id="savedChartUuid"
+                                name="savedChartUuid"
+                                label="Select chart"
+                                data={(savedCharts || []).map(
+                                    ({ uuid, name, spaceName }) => {
+                                        return {
+                                            value: uuid,
+                                            label: name,
+                                            group: spaceName,
+                                        };
+                                    },
+                                )}
+                                disabled={isInitialLoading}
+                                withinPortal
+                                {...form.getInputProps('uuid')}
+                                searchable
+                                placeholder="Search..."
+                            />
+                        )}
                     <Group spacing="xs" position="right" mt="md">
                         <Button onClick={() => onClose?.()} variant="outline">
                             Cancel


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10765

### Description:

- Removed an icon from the edit tile content (it didn't make much sense)
- Can change and hide a sql chart tile


demo:

https://github.com/user-attachments/assets/178ae03b-fb7e-4012-b2c2-c4f53f7e9fbc



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
