### PR TITLE
chore: use exit 0 on terminus shutdown to signal kubernetes

### DIFF
--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -188,6 +188,7 @@ export default class SchedulerApp {
             onShutdown: async () => {
                 Logger.info('Shutdown complete');
             },
+            useExit0: true,
             logger: Logger.error,
             sendFailuresDuringShutdown: true,
             onSendFailureDuringShutdown: async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash-cloud/pull/473

### Description:

- From the `terminus` docs, they recommend adding `useExit0` to signal kubernetes that the container exited gracefully: https://github.com/godaddy/terminus?tab=readme-ov-file#how-to-set-terminus-up-with-kubernetes

Similar issue on `terminus` repo: https://github.com/godaddy/terminus/issues/209
PR that fixed it by adding `useExit0`: https://github.com/godaddy/terminus/pull/212

The following videos show how our worker and backend pods are terminated - grace period is set to default of 30 and we're not using init containers from https://github.com/lightdash/lightdash-cloud/pull/473, this is our CURRENT setup

For the backend one, you'll be able to see that right after a pod starts and has both containers running, the `old` pod terminates instantly (this is the correct behaviour)

**current backend**

https://github.com/user-attachments/assets/64f3d182-5d9b-4d5e-97c2-1761eabd01e4

For the worker pod, you'll see that after the new pod starts, the new one stays in `terminating` state for 30s

**current worker**

https://github.com/user-attachments/assets/ade1817e-3c61-4729-86e7-2c8eba520844

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
