### PR TITLE
chore: load sample sql if empty with warehouse quotes

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -19,7 +19,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import { useTables } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { toggleActiveTable } from '../store/sqlRunnerSlice';
+import { setSql, toggleActiveTable } from '../store/sqlRunnerSlice';
 
 const TableItem: FC<{
     table: string;
@@ -31,11 +31,20 @@ const TableItem: FC<{
     const { ref: hoverRef, hovered } = useHover();
     const { ref: truncatedRef, isTruncated } = useIsTruncated<HTMLDivElement>();
     const dispatch = useAppDispatch();
+    const sql = useAppSelector((state) => state.sqlRunner.sql);
+    const quoteChar = useAppSelector((state) => state.sqlRunner.quoteChar);
 
+    const quotedTable = `${quoteChar}${database}${quoteChar}.${quoteChar}${schema}${quoteChar}.${quoteChar}${table}${quoteChar}`;
     return (
         <Box ref={hoverRef} pos="relative">
             <UnstyledButton
                 onClick={() => {
+                    if (!sql) {
+                        dispatch(
+                            setSql(`SELECT * FROM ${quotedTable} LIMIT 10`),
+                        );
+                    }
+
                     dispatch(toggleActiveTable(table));
                 }}
                 w="100%"
@@ -85,7 +94,7 @@ const TableItem: FC<{
                 right={8}
                 display={hovered ? 'block' : 'none'}
             >
-                <CopyButton value={`${database}.${schema}.${table}`}>
+                <CopyButton value={`${quotedTable}`}>
                     {({ copied, copy }) => (
                         <ActionIcon size={16} onClick={copy} bg="gray.1">
                             <MantineIcon

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -38,6 +38,8 @@ export interface SqlRunnerState {
             isOpen: boolean;
         };
     };
+
+    quoteChar: string;
 }
 
 const initialState: SqlRunnerState = {
@@ -57,6 +59,7 @@ const initialState: SqlRunnerState = {
             isOpen: false,
         },
     },
+    quoteChar: '"',
 };
 
 export const sqlRunnerSlice = createSlice({
@@ -228,6 +231,9 @@ export const sqlRunnerSlice = createSlice({
             state.modals[action.payload].isOpen =
                 !state.modals[action.payload].isOpen;
         },
+        setQuoteChar: (state, action: PayloadAction<string>) => {
+            state.quoteChar = action.payload;
+        },
     },
 });
 
@@ -245,4 +251,5 @@ export const {
     setSelectedChartType,
     toggleModal,
     loadState,
+    setQuoteChar,
 } = sqlRunnerSlice.actions;

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -1,3 +1,4 @@
+import { getFieldQuoteChar } from '@lightdash/common';
 import { ActionIcon, Group, Paper, Tooltip } from '@mantine/core';
 import { IconDatabase } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
@@ -18,8 +19,10 @@ import {
 import {
     loadState,
     setProjectUuid,
+    setQuoteChar,
     setSaveChartData,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
+import { useProject } from '../hooks/useProject';
 import useSearchParams from '../hooks/useSearchParams';
 import { useGetShare } from '../hooks/useShare';
 
@@ -33,6 +36,7 @@ const SqlRunnerNew = () => {
     const { data: sqlRunnerState } = useGetShare(state || undefined);
     const [isLeftSidebarOpen, setLeftSidebarOpen] = useState(true);
     const [isRightSidebarOpen, setRightSidebarOpen] = useState(false);
+    const { data: project } = useProject(projectUuid);
 
     useEffect(() => {
         if (sqlRunnerState) {
@@ -53,6 +57,15 @@ const SqlRunnerNew = () => {
             dispatch(setSaveChartData(data));
         },
     });
+    useEffect(() => {
+        if (project?.warehouseConnection?.type) {
+            dispatch(
+                setQuoteChar(
+                    getFieldQuoteChar(project?.warehouseConnection?.type),
+                ),
+            );
+        }
+    }, [dispatch, project?.warehouseConnection?.type]);
 
     if (!projectUuid) {
         return null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: https://github.com/lightdash/lightdash/issues/10616


-  add default SQL. eg SELECT * FROM lightdash-analytics.prod.github_daily LIMIT 25
-  Add quoting when coping a table (e.g. when I click pages it should copy `database.table.pages`

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
[Screencast from 19-07-24 10:06:09.webm](https://github.com/user-attachments/assets/f9b2c24b-71ca-4916-abc1-5bdba9d2b2e6)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
