### PR TITLE
feat: add space breadcrumb before saved chart

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header.tsx
@@ -3,6 +3,7 @@ import { ActionIcon, Group, Paper, Tooltip } from '@mantine/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { TitleBreadCrumbs } from '../../../components/Explorer/SavedChartsHeader/TitleBreadcrumbs';
 import { EditableText } from '../../../components/VisualizationConfigs/common/EditableText';
 import { useUpdateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -13,9 +14,10 @@ import ShareSqlLinkButton from './ShareSqlLinkButton';
 export const Header: FC = () => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
-    const savedChartUuid = useAppSelector(
-        (state) => state.sqlRunner.savedChartUuid,
+    const savedSqlUuid = useAppSelector(
+        (state) => state.sqlRunner.savedSqlUuid,
     );
+    const space = useAppSelector((state) => state.sqlRunner.space);
     const name = useAppSelector((state) => state.sqlRunner.name);
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const config = useAppSelector((state) =>
@@ -25,7 +27,7 @@ export const Header: FC = () => {
     );
     const { mutate } = useUpdateSqlChartMutation(
         projectUuid,
-        savedChartUuid || '',
+        savedSqlUuid || '',
     );
 
     const isSaveModalOpen = useAppSelector(
@@ -39,15 +41,24 @@ export const Header: FC = () => {
         <>
             <Paper shadow="none" radius={0} px="md" py="xs" withBorder>
                 <Group position="apart">
-                    <EditableText
-                        size="lg"
-                        placeholder={DEFAULT_NAME}
-                        value={name}
-                        w={400}
-                        onChange={(e) =>
-                            dispatch(updateName(e.currentTarget.value))
-                        }
-                    />
+                    <Group spacing="two">
+                        {space && (
+                            <TitleBreadCrumbs
+                                projectUuid={projectUuid}
+                                spaceUuid={space.uuid}
+                                spaceName={space.name}
+                            />
+                        )}
+                        <EditableText
+                            size="md"
+                            w={400}
+                            placeholder={DEFAULT_NAME}
+                            value={name}
+                            onChange={(e) =>
+                                dispatch(updateName(e.currentTarget.value))
+                            }
+                        />
+                    </Group>
                     <Group spacing="md">
                         <Tooltip
                             variant="xs"
@@ -58,7 +69,7 @@ export const Header: FC = () => {
                                 <MantineIcon
                                     icon={IconDeviceFloppy}
                                     onClick={() => {
-                                        if (savedChartUuid) {
+                                        if (savedSqlUuid) {
                                             if (config && sql) {
                                                 mutate({
                                                     versionedData: {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -20,7 +20,13 @@ export const DEFAULT_NAME = 'Untitled SQL Query';
 export interface SqlRunnerState {
     projectUuid: string;
     activeTable: string | undefined;
-    savedChartUuid: string | undefined;
+    savedSqlUuid: string | undefined;
+    space:
+        | {
+              uuid: string;
+              name: string;
+          }
+        | undefined;
     name: string;
     description: string;
 
@@ -45,7 +51,8 @@ export interface SqlRunnerState {
 const initialState: SqlRunnerState = {
     projectUuid: '',
     activeTable: undefined,
-    savedChartUuid: undefined,
+    savedSqlUuid: undefined,
+    space: undefined,
     name: '',
     description: '',
     sql: '',
@@ -155,9 +162,10 @@ export const sqlRunnerSlice = createSlice({
             state.activeVisTab = action.payload;
         },
         setSaveChartData: (state, action: PayloadAction<SqlChart>) => {
-            state.savedChartUuid = action.payload.savedSqlUuid;
+            state.savedSqlUuid = action.payload.savedSqlUuid;
             state.name = action.payload.name;
             state.description = action.payload.description || '';
+            state.space = action.payload.space;
 
             state.sql = action.payload.sql;
             state.selectedChartType =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10783

### Description:

Specify saved chart space `name` and `uuid` 
user can click on it to go the space it belongs to

Small rename from `savedChartUuid` to `savedSqlUuid` to match the original type

Screenshot:
<img width="286" alt="Screenshot 2024-07-19 at 17 08 56" src="https://github.com/user-attachments/assets/d97e9196-a57d-4f98-8858-f0d273f952e4">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
