### PR TITLE
fix: dashboard tile resize handler visibility

### DIFF
--- a/packages/frontend/src/styles/react-grid.css
+++ b/packages/frontend/src/styles/react-grid.css
@@ -36,6 +36,10 @@
     user-select: none;
 }
 
+.react-grid-item.react-resizable-hide > .react-resizable-handle {
+    display: none;
+}
+
 .react-grid-item:not(.react-resizable-hide) > .react-resizable-handle {
     position: absolute;
     width: 20px;


### PR DESCRIPTION
### Description:

It turns out that the `react-resizable` package, introduced recently, is the same package that the `react-grid-layout` package uses underneath to resize tiles.

The `react-resizable` CSS import is conflicting with our own modified `react-grid.css`.

Regression change: https://github.com/lightdash/lightdash/commit/2ddd7567dc32d720ebffb95ca49744dbf7b9d20c#diff-e4f4c3d05237e4dfb5e48d715e10af4beed2cbec2f93f6b7d5d9e68e6666b2b7R17


### before:


https://github.com/user-attachments/assets/2d3a6ae8-e1f6-4677-a80b-a4d4567abac1


### after:


https://github.com/user-attachments/assets/e19b5360-3898-4d4c-81ef-daedbdda8831


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
