### PR TITLE
style: Add divider to Run Query Group Button

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -75,7 +75,13 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                     leftIcon={<MantineIcon icon={IconPlayerPlay} />}
                     loading={isLoading}
                     onClick={onClick}
-                    sx={{ flex: 1 }}
+                    sx={(theme) => ({
+                        flex: 1,
+                        borderRight: `1px solid ${theme.fn.rgba(
+                            theme.colors.gray[5],
+                            0.6,
+                        )}`,
+                    })}
                 >
                     Run query ({limit})
                 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9476

### Description:
Added right border to the run query button which will act as a divider between Run query and down arrowhead. 
- Used gray color and RGBA for giving border color **transparent**  effect which makes divider clear and subtle. 

<!-- Even better add a screenshot / gif / loom -->
![image](https://github.com/user-attachments/assets/b1cef8b4-891a-42d3-96d0-cf5f5130d9cb)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
