### PR TITLE
fix: bigquery month name sort

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -1403,18 +1403,18 @@ export const COMPILED_MONTH_NAME_DIMENSION: CompiledDimension = {
 
 export const MONTH_NAME_SORT_SQL = `(
     CASE
-        WHEN "table1".dim1 = 'January' THEN 1
-        WHEN "table1".dim1 = 'February' THEN 2
-        WHEN "table1".dim1 = 'March' THEN 3
-        WHEN "table1".dim1 = 'April' THEN 4
-        WHEN "table1".dim1 = 'May' THEN 5
-        WHEN "table1".dim1 = 'June' THEN 6
-        WHEN "table1".dim1 = 'July' THEN 7
-        WHEN "table1".dim1 = 'August' THEN 8
-        WHEN "table1".dim1 = 'September' THEN 9
-        WHEN "table1".dim1 = 'October' THEN 10
-        WHEN "table1".dim1 = 'November' THEN 11
-        WHEN "table1".dim1 = 'December' THEN 12
+        WHEN "table1_dim1" = 'January' THEN 1
+        WHEN "table1_dim1" = 'February' THEN 2
+        WHEN "table1_dim1" = 'March' THEN 3
+        WHEN "table1_dim1" = 'April' THEN 4
+        WHEN "table1_dim1" = 'May' THEN 5
+        WHEN "table1_dim1" = 'June' THEN 6
+        WHEN "table1_dim1" = 'July' THEN 7
+        WHEN "table1_dim1" = 'August' THEN 8
+        WHEN "table1_dim1" = 'September' THEN 9
+        WHEN "table1_dim1" = 'October' THEN 10
+        WHEN "table1_dim1" = 'November' THEN 11
+        WHEN "table1_dim1" = 'December' THEN 12
         ELSE 0
     END
     )`;

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -925,7 +925,9 @@ const ignoreIndentation = (sql: string) => sql.replace(/\s+/g, ' ');
 describe('Time frame sorting', () => {
     it('sortMonthName SQL', () => {
         expect(
-            ignoreIndentation(sortMonthName(COMPILED_MONTH_NAME_DIMENSION)),
+            ignoreIndentation(
+                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"'),
+            ),
         ).toStrictEqual(ignoreIndentation(MONTH_NAME_SORT_SQL));
     });
     it('sortDayOfWeekName SQL for undefined startOfWeek', () => {

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -249,22 +249,26 @@ const getJoinType = (type: DbtModelJoinType = 'left') => {
     }
 };
 
-export const sortMonthName = (dimension: CompiledDimension) => {
-    const fieldSql = `${dimension.compiledSql}`;
+export const sortMonthName = (
+    dimension: CompiledDimension,
+    fieldQuoteChar: string,
+) => {
+    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
+
     return `(
         CASE
-            WHEN ${fieldSql} = 'January' THEN 1
-            WHEN ${fieldSql} = 'February' THEN 2
-            WHEN ${fieldSql} = 'March' THEN 3
-            WHEN ${fieldSql} = 'April' THEN 4
-            WHEN ${fieldSql} = 'May' THEN 5
-            WHEN ${fieldSql} = 'June' THEN 6
-            WHEN ${fieldSql} = 'July' THEN 7
-            WHEN ${fieldSql} = 'August' THEN 8
-            WHEN ${fieldSql} = 'September' THEN 9
-            WHEN ${fieldSql} = 'October' THEN 10
-            WHEN ${fieldSql} = 'November' THEN 11
-            WHEN ${fieldSql} = 'December' THEN 12
+            WHEN ${fieldId} = 'January' THEN 1
+            WHEN ${fieldId} = 'February' THEN 2
+            WHEN ${fieldId} = 'March' THEN 3
+            WHEN ${fieldId} = 'April' THEN 4
+            WHEN ${fieldId} = 'May' THEN 5
+            WHEN ${fieldId} = 'June' THEN 6
+            WHEN ${fieldId} = 'July' THEN 7
+            WHEN ${fieldId} = 'August' THEN 8
+            WHEN ${fieldId} = 'September' THEN 9
+            WHEN ${fieldId} = 'October' THEN 10
+            WHEN ${fieldId} = 'November' THEN 11
+            WHEN ${fieldId} = 'December' THEN 12
             ELSE 0
         END
         )`;
@@ -274,20 +278,20 @@ export const sortDayOfWeekName = (
     startOfWeek: WeekDay | null | undefined,
     fieldQuoteChar: string,
 ) => {
-    const filedId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
+    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
     const calculateDayIndex = (dayNumber: number) => {
         if (startOfWeek === null || startOfWeek === undefined) return dayNumber; // startOfWeek can be 0, so don't do !startOfWeek
         return ((dayNumber + 7 - (startOfWeek + 2)) % 7) + 1;
     };
     return `(
         CASE
-            WHEN ${filedId} = 'Sunday' THEN ${calculateDayIndex(1)}
-            WHEN ${filedId} = 'Monday' THEN ${calculateDayIndex(2)}
-            WHEN ${filedId} = 'Tuesday' THEN ${calculateDayIndex(3)}
-            WHEN ${filedId} = 'Wednesday' THEN ${calculateDayIndex(4)}
-            WHEN ${filedId} = 'Thursday' THEN ${calculateDayIndex(5)}
-            WHEN ${filedId} = 'Friday' THEN ${calculateDayIndex(6)}
-            WHEN ${filedId} = 'Saturday' THEN ${calculateDayIndex(7)}
+            WHEN ${fieldId} = 'Sunday' THEN ${calculateDayIndex(1)}
+            WHEN ${fieldId} = 'Monday' THEN ${calculateDayIndex(2)}
+            WHEN ${fieldId} = 'Tuesday' THEN ${calculateDayIndex(3)}
+            WHEN ${fieldId} = 'Wednesday' THEN ${calculateDayIndex(4)}
+            WHEN ${fieldId} = 'Thursday' THEN ${calculateDayIndex(5)}
+            WHEN ${fieldId} = 'Friday' THEN ${calculateDayIndex(6)}
+            WHEN ${fieldId} = 'Saturday' THEN ${calculateDayIndex(7)}
             ELSE 0
         END
     )`;
@@ -915,7 +919,12 @@ export const buildQuery = ({
             sortedDimension &&
             sortedDimension.timeInterval === TimeFrames.MONTH_NAME
         ) {
-            return sortMonthName(sortedDimension);
+            shouldWrapQueryCTE = true;
+
+            return sortMonthName(
+                sortedDimension,
+                getFieldQuoteChar(warehouseClient.credentials.type),
+            );
         }
         if (
             sortedDimension &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/10793
### Description:
<!-- Add a description of the changes proposed in the pull request. -->
CTE with month name sort 

![Screenshot from 2024-07-23 15-54-06](https://github.com/user-attachments/assets/da1912c5-001d-4925-bb9a-20bcd3b627c5)
![Screenshot from 2024-07-23 15-54-16](https://github.com/user-attachments/assets/a36c4e83-d47c-42b9-9306-597bd8f8b212)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
