### PR TITLE
fix: warning icon should be displayed when user can not use custom d…

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -825,7 +825,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                             >
                                                 <Group>
                                                     Explore from here
-                                                    {!cannotUseCustomDimensions && (
+                                                    {cannotUseCustomDimensions && (
                                                         <MantineIcon
                                                             icon={
                                                                 IconAlertTriangle


### PR DESCRIPTION
…imensions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:   #10807

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
<img width="828" alt="image (2)" src="https://github.com/user-attachments/assets/11323385-da64-4b3b-a079-d629a0ec97e1">

this warning icon is showing up when i'm opening the chart as admin and gone when i'm opening the chart as viewer, this logic should be flipped.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
