### PR TITLE
chore: add context analytic events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -154,11 +154,16 @@ type UserJoinOrganizationEvent = BaseTrack & {
 
 export enum QueryExecutionContext {
     DASHBOARD = 'dashboardView',
+    AUTOREFRESHED_DASHBOARD = 'autorefreshedDashboard',
     EXPLORE = 'exploreView',
     CHART = 'chartView',
     VIEW_UNDERLYING_DATA = 'viewUnderlyingData',
     CSV = 'csvDownload',
     GSHEETS = 'gsheets',
+    SCHEDULED_GSHEETS_CHART = 'scheduledGsheetsChart',
+    SCHEDULED_GSHEETS_DASHBOARD = 'scheduledGsheetsDashboard',
+    SCHEDULED_CHART = 'scheduledChart',
+    SCHEDULED_DASHBOARD = 'scheduledDashboard',
     CALCULATE_TOTAL = 'calculateTotal',
 }
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -192,6 +192,7 @@ type QueryExecutionEvent = BaseTrack & {
         numCustomSqlDimensions: number;
         dateZoomGranularity: string | null;
         timezone?: string;
+        chartId?: string;
     };
 };
 

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -80,6 +80,7 @@ export class SavedChartController extends BaseController {
             dashboardSorts: SortField[];
             dashboardUuid: string;
             granularity?: DateGranularity;
+            autoRefresh?: boolean;
         },
         @Path() chartUuid: string,
         @Request() req: express.Request,
@@ -97,6 +98,7 @@ export class SavedChartController extends BaseController {
                     dashboardSorts: body.dashboardSorts,
                     granularity: body.granularity,
                     dashboardUuid: body.dashboardUuid,
+                    autoRefresh: body.autoRefresh,
                 }),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12631,6 +12631,7 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        autoRefresh: { dataType: 'boolean' },
                         granularity: { ref: 'DateGranularity' },
                         dashboardUuid: { dataType: 'string', required: true },
                         dashboardSorts: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8969,7 +8969,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1182.0",
+        "version": "0.1184.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -12724,6 +12724,9 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
+                                    "autoRefresh": {
+                                        "type": "boolean"
+                                    },
                                     "granularity": {
                                         "$ref": "#/components/schemas/DateGranularity"
                                     },

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1348,6 +1348,7 @@ export default class SchedulerTask {
                 const { rows } = await this.projectService.getResultsForChart(
                     user,
                     savedChartUuid,
+                    QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
                 );
 
                 if (thresholds !== undefined && thresholds.length > 0) {
@@ -1465,6 +1466,7 @@ export default class SchedulerTask {
                             await this.projectService.getResultsForChart(
                                 user,
                                 chartUuid,
+                                QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
                             );
                         const explore = await this.projectService.getExplore(
                             user,
@@ -1690,6 +1692,7 @@ export default class SchedulerTask {
                         await this.projectService.getResultsForChart(
                             user,
                             savedChartUuid,
+                            QueryExecutionContext.SCHEDULED_CHART,
                         );
 
                     if (

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -953,6 +953,7 @@ export default class SchedulerTask {
                 exploreName: payload.exploreId,
                 csvLimit: undefined,
                 context: QueryExecutionContext.GSHEETS,
+                chartUuid: undefined,
             });
             const refreshToken = await this.userService.getRefreshToken(
                 payload.userUuid,

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -782,6 +782,7 @@ export class CsvService extends BaseService {
                 exploreName: exploreId,
                 csvLimit,
                 context: QueryExecutionContext.CSV,
+                chartUuid: undefined,
             });
             const numberRows = rows.length;
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -431,6 +431,7 @@ export class CsvService extends BaseService {
             csvLimit: getSchedulerCsvLimit(options),
             context: QueryExecutionContext.CSV,
             granularity: dateZoomGranularity,
+            chartUuid,
         });
         const numberRows = rows.length;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1193,6 +1193,7 @@ export class ProjectService extends BaseService {
         dashboardSorts,
         granularity,
         dashboardUuid,
+        autoRefresh,
     }: {
         user: SessionUser;
         chartUuid: string;
@@ -1201,6 +1202,7 @@ export class ProjectService extends BaseService {
         invalidateCache?: boolean;
         dashboardSorts: SortField[];
         granularity?: DateGranularity;
+        autoRefresh?: boolean;
     }): Promise<ApiChartAndResults> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
@@ -1294,7 +1296,9 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 exploreName: savedChart.tableName,
                 csvLimit: undefined,
-                context: QueryExecutionContext.DASHBOARD,
+                context: autoRefresh
+                    ? QueryExecutionContext.AUTOREFRESHED_DASHBOARD
+                    : QueryExecutionContext.DASHBOARD,
                 queryTags,
                 invalidateCache,
                 explore,
@@ -1483,6 +1487,7 @@ export class ProjectService extends BaseService {
     async getResultsForChart(
         user: SessionUser,
         chartUuid: string,
+        context: QueryExecutionContext,
     ): Promise<{ rows: Record<string, any>[]; cacheMetadata: CacheMetadata }> {
         return wrapSentryTransaction(
             'getResultsForChartWithWarehouseQuery',
@@ -1501,7 +1506,7 @@ export class ProjectService extends BaseService {
                     projectUuid: chart.projectUuid,
                     exploreName: exploreId,
                     csvLimit: undefined,
-                    context: QueryExecutionContext.GSHEETS,
+                    context,
                 });
             },
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1095,6 +1095,7 @@ export class ProjectService extends BaseService {
             csvLimit,
             context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
             queryTags,
+            chartUuid: undefined,
         });
     }
 
@@ -1175,6 +1176,7 @@ export class ProjectService extends BaseService {
                 queryTags,
                 invalidateCache,
                 explore,
+                chartUuid,
             });
 
         return {
@@ -1303,6 +1305,7 @@ export class ProjectService extends BaseService {
                 invalidateCache,
                 explore,
                 granularity,
+                chartUuid,
             });
 
         const metricQueryDimensions = [
@@ -1392,6 +1395,7 @@ export class ProjectService extends BaseService {
             context: QueryExecutionContext.EXPLORE,
             queryTags,
             granularity: dateZoomGranularity,
+            chartUuid: undefined,
         });
     }
 
@@ -1406,6 +1410,7 @@ export class ProjectService extends BaseService {
         invalidateCache,
         explore: validExplore,
         granularity,
+        chartUuid,
     }: {
         user: SessionUser;
         metricQuery: MetricQuery;
@@ -1417,6 +1422,7 @@ export class ProjectService extends BaseService {
         invalidateCache?: boolean;
         explore?: Explore;
         granularity?: DateGranularity;
+        chartUuid: string | undefined;
     }): Promise<ApiQueryResults> {
         return wrapSentryTransaction(
             'ProjectService.runQueryAndFormatRows',
@@ -1438,6 +1444,7 @@ export class ProjectService extends BaseService {
                         invalidateCache,
                         explore,
                         granularity,
+                        chartUuid,
                     });
                 span.setAttribute('rows', rows.length);
 
@@ -1507,6 +1514,7 @@ export class ProjectService extends BaseService {
                     exploreName: exploreId,
                     csvLimit: undefined,
                     context,
+                    chartUuid,
                 });
             },
         );
@@ -1645,6 +1653,7 @@ export class ProjectService extends BaseService {
         invalidateCache,
         explore: loadedExplore,
         granularity,
+        chartUuid,
     }: {
         user: SessionUser;
         metricQuery: MetricQuery;
@@ -1656,6 +1665,7 @@ export class ProjectService extends BaseService {
         invalidateCache?: boolean;
         explore?: Explore;
         granularity?: DateGranularity;
+        chartUuid: string | undefined; // for analytics
     }): Promise<{
         rows: Record<string, any>[];
         cacheMetadata: CacheMetadata;
@@ -1834,6 +1844,7 @@ export class ProjectService extends BaseService {
                             ...(queryTags?.dashboard_uuid
                                 ? { dashboardId: queryTags.dashboard_uuid }
                                 : {}),
+                            chartId: chartUuid,
                         },
                     });
                     this.logger.debug(

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -62,6 +62,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
             (c) => c.clearCacheAndFetch,
         );
 
+        const setIsAutoRefresh = useDashboardContext((c) => c.setIsAutoRefresh);
         const isOneAtLeastFetching = isFetching > 0;
 
         const invalidateAndSetRefreshTime = useCallback(async () => {
@@ -166,6 +167,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                             fz="xs"
                             onClick={() => {
                                 setRefreshInterval(undefined);
+                                setIsAutoRefresh(false);
                             }}
                             disabled={refreshInterval === undefined}
                             bg={
@@ -190,6 +192,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                                     const valNum = +value;
                                     setRefreshInterval(valNum);
                                     onIntervalChange(valNum);
+                                    setIsAutoRefresh(true);
                                     showToastSuccess({
                                         title: `Your dashboard will refresh every ${
                                             REFRESH_INTERVAL_OPTIONS.find(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -9,7 +9,7 @@ const useDashboardChart = (tileUuid: string, savedChartUuid: string | null) => {
     const chartSort = useDashboardContext((c) => c.chartSort);
     const tileSort = chartSort[tileUuid] || [];
     const granularity = useDashboardContext((c) => c.dateZoomGranularity);
-
+    const isAutoRefresh = useDashboardContext((c) => c.isAutoRefresh);
     return useChartAndResults(
         savedChartUuid,
         dashboardUuid ?? null,
@@ -17,6 +17,7 @@ const useDashboardChart = (tileUuid: string, savedChartUuid: string | null) => {
         tileSort,
         invalidateCache,
         granularity,
+        isAutoRefresh,
     );
 };
 

--- a/packages/frontend/src/hooks/useQueryResults.tsx
+++ b/packages/frontend/src/hooks/useQueryResults.tsx
@@ -52,6 +52,7 @@ const getChartAndResults = async ({
     invalidateCache,
     dashboardSorts,
     granularity,
+    autoRefresh,
 }: {
     chartUuid?: string;
     dashboardUuid: string;
@@ -59,8 +60,9 @@ const getChartAndResults = async ({
     invalidateCache?: boolean;
     dashboardSorts: SortField[];
     granularity?: DateGranularity;
-}) =>
-    lightdashApi<ApiChartAndResults>({
+    autoRefresh?: boolean;
+}) => {
+    return lightdashApi<ApiChartAndResults>({
         url: `/saved/${chartUuid}/chart-and-results`,
         method: 'POST',
         body: JSON.stringify({
@@ -69,9 +71,10 @@ const getChartAndResults = async ({
             dashboardSorts,
             granularity,
             ...(invalidateCache && { invalidateCache: true }),
+            autoRefresh,
         }),
     });
-
+};
 const getQueryResults = async ({
     projectUuid,
     tableId,
@@ -211,6 +214,7 @@ export const useChartAndResults = (
     dashboardSorts: SortField[],
     invalidateCache?: boolean,
     granularity?: DateGranularity,
+    autoRefresh?: boolean,
 ) => {
     const setChartsWithDateZoomApplied = useDashboardContext(
         (c) => c.setChartsWithDateZoomApplied,
@@ -229,8 +233,16 @@ export const useChartAndResults = (
             dashboardFilters,
             invalidateCache,
             sortKey,
+            autoRefresh,
         ],
-        [chartUuid, dashboardUuid, dashboardFilters, invalidateCache, sortKey],
+        [
+            chartUuid,
+            dashboardUuid,
+            dashboardFilters,
+            invalidateCache,
+            sortKey,
+            autoRefresh,
+        ],
     );
     const apiChartAndResults =
         queryClient.getQueryData<ApiChartAndResults>(queryKey);
@@ -249,6 +261,7 @@ export const useChartAndResults = (
                 invalidateCache,
                 dashboardSorts,
                 granularity,
+                autoRefresh,
             }),
         [
             chartUuid,
@@ -257,6 +270,7 @@ export const useChartAndResults = (
             invalidateCache,
             dashboardSorts,
             granularity,
+            autoRefresh,
         ],
     );
 

--- a/packages/frontend/src/providers/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/DashboardProvider.tsx
@@ -91,6 +91,8 @@ type DashboardContext = {
     addResultsCacheTime: (cacheMetadata: CacheMetadata) => void;
     oldestCacheTime: Date | undefined;
     invalidateCache: boolean | undefined;
+    isAutoRefresh: boolean;
+    setIsAutoRefresh: (autoRefresh: boolean) => void;
     clearCacheAndFetch: () => void;
     allFilterableFieldsMap: Record<string, FilterableDimension>;
     allFilterableFields: FilterableDimension[] | undefined;
@@ -136,6 +138,8 @@ export const DashboardProvider: React.FC<
     const { dashboardUuid } = useParams<{
         dashboardUuid: string;
     }>();
+
+    const [isAutoRefresh, setIsAutoRefresh] = useState<boolean>(false);
 
     const {
         data: dashboard,
@@ -637,6 +641,8 @@ export const DashboardProvider: React.FC<
         oldestCacheTime,
         invalidateCache,
         clearCacheAndFetch,
+        isAutoRefresh,
+        setIsAutoRefresh,
         allFilterableFieldsMap,
         allFilterableFields: dashboardAvailableFiltersData?.allFilterableFields,
         isLoadingDashboardFilters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Partially Closes:  #10773

## Out of scope (to be done in a separate PR): 
- [ ] AI co-pilot queries
- [ ] API-triggered query executions (are there multiple ways to do this? Do we need a secondary field wiht more context of which API call is executing this? Or is that overkill?)


### Description:

- [x] Added `chartId` property to all queryexecuted events (if they don't have a chartuuid , this property will be undefined) 
<!-- Add a description of the changes proposed in the pull request. -->
#### SQL runner 

> No changes were done on the sql runner

SQL runner queries trigger the lightdash_server.sql.executed event

New sql runner also run `lightdash_server.sql.executed` with an extra `streaming` flag 

#### scheduled charts
Triggered on SchedulerTask -> handleScheduledDelivery, added `scheduledChart` context to query query.executed

#### scheduled dashboards
Triggered on SchedulerTask -> handleScheduledDelivery, added `scheduledDashboard` context to query.executed


#### Extra: gsheets

Kept `gsheets` context for uploading results to gsheets
Added `scheduledGsheetsChart` and `scheduledGsheetsDashboard` for scheduled gsheets

####     automatic dashboard refresh 

Added `autorefreshedDashboard` context to queries triggered from autorefresh (this was harder to implement that it seems) 

![Screenshot from 2024-07-24 09-47-37](https://github.com/user-attachments/assets/6fb1b5ce-871f-49d0-aa55-8368aebb5d93)
No autorefresh: 
![Screenshot from 2024-07-24 09-47-45](https://github.com/user-attachments/assets/87411d45-58ac-43a3-9f6e-aafa401b9f16)





<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
