### PR TITLE
chore: return column types on sql runner results job

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -38,6 +38,7 @@ import {
     SchedulerLog,
     SessionUser,
     SlackNotificationPayload,
+    SQLColumn,
     sqlRunnerJob,
     SqlRunnerPayload,
     ThresholdOperator,
@@ -850,12 +851,12 @@ export default class SchedulerTask {
         }
     }
 
-    private async logWrapper(
+    private async logWrapper<TRecordValues = string>(
         baseLog: Pick<
             SchedulerLog,
             'task' | 'jobId' | 'scheduledTime' | 'details'
         >,
-        func: () => Promise<Record<string, string> | undefined>, // Returns extra details for the log
+        func: () => Promise<Record<string, TRecordValues> | undefined>, // Returns extra details for the log
     ) {
         try {
             await this.schedulerService.logSchedulerJob({
@@ -886,7 +887,7 @@ export default class SchedulerTask {
         scheduledTime: Date,
         payload: SqlRunnerPayload,
     ) {
-        await this.logWrapper(
+        await this.logWrapper<string | SQLColumn[]>(
             {
                 task: sqlRunnerJob,
                 jobId,
@@ -894,13 +895,13 @@ export default class SchedulerTask {
                 details: { createdByUserUuid: payload.userUuid },
             },
             async () => {
-                const fileUrl =
+                const { fileUrl, columns } =
                     await this.projectService.streamSqlQueryIntoFile(
                         payload.userUuid,
                         payload.projectUuid,
                         payload.sql,
                     );
-                return { fileUrl };
+                return { fileUrl, columns };
             },
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -123,6 +123,7 @@ import { type ApiPromotionChangesResponse } from './types/promotion';
 import {
     type ApiCreateSqlChart,
     type ApiSqlChart,
+    type ApiSqlRunnerJobStatusResponse,
     type ApiUpdateSqlChart,
 } from './types/sqlRunner';
 import { TimeFrames } from './types/timeFrames';
@@ -663,7 +664,8 @@ type ApiResults =
     | ApiCreateSqlChart['results']
     | ApiUpdateSqlChart['results']
     | ApiContentResponse['results']
-    | ApiChartContentResponse['results'];
+    | ApiChartContentResponse['results']
+    | ApiSqlRunnerJobStatusResponse['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -1,9 +1,13 @@
 import { type Dashboard } from './dashboard';
+import { type DimensionType } from './field';
 import { type Organization } from './organization';
 import { type Project } from './projects';
 import { type ResultRow } from './results';
 import { ChartKind } from './savedCharts';
-import { type ApiJobScheduledResponse } from './scheduler';
+import {
+    type ApiJobScheduledResponse,
+    type SchedulerJobStatus,
+} from './scheduler';
 import { type Space } from './space';
 import { type LightdashUser } from './user';
 
@@ -21,6 +25,17 @@ export type SqlRunnerBody = {
 export type SqlRunnerResults = ResultRow[];
 
 export const sqlRunnerJob = 'sqlRunner';
+
+export type ApiSqlRunnerJobStatusResponse = {
+    status: 'ok';
+    results: {
+        status: SchedulerJobStatus;
+        details: {
+            fileUrl: string;
+            columns: SQLColumn[];
+        };
+    };
+};
 
 export type SqlTableConfig = {
     columns: {
@@ -157,4 +172,9 @@ export type ApiSqlChartWithResults = {
         jobId: ApiJobScheduledResponse['results']['jobId'];
         chart: SqlChart;
     };
+};
+
+export type SQLColumn = {
+    reference: string;
+    type: DimensionType;
 };

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -32,8 +32,12 @@ const getSchedulerLogs = async (projectUuid: string) =>
         body: undefined,
     });
 
-export const getSchedulerJobStatus = async (jobId: string) =>
-    lightdashApi<ApiJobStatusResponse['results']>({
+export const getSchedulerJobStatus = async <
+    T = ApiJobStatusResponse['results'],
+>(
+    jobId: string,
+) =>
+    lightdashApi<T extends ApiJobStatusResponse['results'] ? T : never>({
         url: `/schedulers/job/${jobId}/status`,
         method: 'GET',
         body: undefined,

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -103,8 +103,6 @@ export const ContentPanel: FC<Props> = ({
         },
     });
 
-    console.log(queryResults);
-
     // Run query on cmd + enter
     useHotkeys([
         [

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -94,14 +94,16 @@ export const ContentPanel: FC<Props> = ({
         isLoading,
     } = useSqlQueryRun({
         onSuccess: (data) => {
-            if (data) {
-                dispatch(setInitialResultsAndSeries(data));
+            if (data?.results) {
+                dispatch(setInitialResultsAndSeries(data.results));
                 if (resultsHeight === MIN_RESULTS_HEIGHT) {
                     setResultsHeight(inputSectionHeight / 2);
                 }
             }
         },
     });
+
+    console.log(queryResults);
 
     // Run query on cmd + enter
     useHotkeys([
@@ -325,7 +327,7 @@ export const ContentPanel: FC<Props> = ({
                             </Group>
                         </Paper>
 
-                        {queryResults && !isLoading && (
+                        {queryResults?.results && !isLoading && (
                             <Paper
                                 shadow="none"
                                 radius={0}
@@ -345,14 +347,14 @@ export const ContentPanel: FC<Props> = ({
                                         {selectedChartType ===
                                             ChartKind.TABLE && (
                                             <Table
-                                                data={queryResults}
+                                                data={queryResults.results}
                                                 config={tableVisConfig}
                                             />
                                         )}
                                         {selectedChartType ===
                                             ChartKind.VERTICAL_BAR && (
                                             <BarChart
-                                                data={queryResults}
+                                                data={queryResults.results}
                                                 config={barChartConfig}
                                             />
                                         )}
@@ -361,7 +363,7 @@ export const ContentPanel: FC<Props> = ({
                                 {activeVisTab === VisTabs.RESULTS && (
                                     <>
                                         <Table
-                                            data={queryResults}
+                                            data={queryResults.results}
                                             config={resultsTableConfig}
                                         />
                                     </>

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
@@ -1,12 +1,11 @@
-import { type BarChartConfig } from '@lightdash/common';
+import { type BarChartConfig, type ResultRow } from '@lightdash/common';
 import EChartsReact, { type EChartsReactProps } from 'echarts-for-react';
 import { type FC } from 'react';
-import { type useSqlQueryRun } from '../../hooks/useSqlQueryRun';
 import { useBarChartDataTransformer } from '../../transformers/useBarChartDataTransformer';
 
 type BarChartProps = {
-    data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>;
-    config?: BarChartConfig;
+    data: ResultRow[];
+    config: BarChartConfig | undefined;
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 
 const BarChart: FC<BarChartProps> = ({ data, config, style }) => {

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/Table.tsx
@@ -15,11 +15,10 @@ import {
     TABLE_HEADER_BG,
     Tr,
 } from '../../../../components/common/Table/Table.styles';
-import { type useSqlQueryRun } from '../../hooks/useSqlQueryRun';
 import { useTableDataTransformer } from '../../transformers/useTableDataTransformer';
 
 type Props = {
-    data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>;
+    data: ResultRow[];
     config?: TableChartSqlConfig | SqlTableConfig;
 };
 

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -66,7 +66,9 @@ export const useSqlQueryRun = ({
         ['jobStatus', sqlQueryJob?.jobId],
         () => {
             if (!sqlQueryJob?.jobId) return;
-            return getSchedulerJobStatus(sqlQueryJob.jobId);
+            return getSchedulerJobStatus<ApiSqlRunnerJobStatusResponse>(
+                sqlQueryJob.jobId,
+            );
         },
         {
             refetchInterval: (data, query) => {

--- a/packages/frontend/src/features/sqlRunner/transformers/TableDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/TableDataTransformer.ts
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import { type ColumnDef } from '@tanstack/react-table';
 import { getRawValueCell } from '../../../hooks/useColumns';
-import { type useSqlQueryRun } from '../hooks/useSqlQueryRun';
 export class TableDataTransformer {
     private transformer: SqlRunnerResultsTransformer;
 
@@ -14,7 +13,7 @@ export class TableDataTransformer {
     private config: SqlTableConfig | undefined;
 
     constructor(
-        private data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>,
+        private data: ResultRow[],
         private tableChartSqlConfig: SqlTableConfig | undefined,
     ) {
         this.config = this.tableChartSqlConfig;

--- a/packages/frontend/src/features/sqlRunner/transformers/useBarChartDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useBarChartDataTransformer.ts
@@ -1,12 +1,12 @@
 import {
     BarChartDataTransformer,
     type BarChartConfig,
+    type ResultRow,
 } from '@lightdash/common';
 import { useMemo } from 'react';
-import { type useSqlQueryRun } from '../hooks/useSqlQueryRun';
 
 export const useBarChartDataTransformer = (
-    data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>,
+    data: ResultRow[],
     config?: BarChartConfig,
 ) => {
     const transformer = useMemo(

--- a/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useTableDataTransformer.ts
@@ -1,13 +1,12 @@
-import { type SqlTableConfig } from '@lightdash/common';
+import { type ResultRow, type SqlTableConfig } from '@lightdash/common';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useMemo, useRef } from 'react';
 import { ROW_HEIGHT_PX } from '../../../components/common/Table/Table.styles';
-import { type useSqlQueryRun } from '../hooks/useSqlQueryRun';
 import { TableDataTransformer } from './TableDataTransformer';
 
 export const useTableDataTransformer = (
-    data: NonNullable<ReturnType<typeof useSqlQueryRun>['data']>,
+    data: ResultRow[],
     config: SqlTableConfig | undefined,
 ) => {
     const transformer = useMemo(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Why we need this:
https://github.com/lightdash/lightdash/pull/10801#discussion_r1688383916
So that we can apply dimensionType-specific logic to each config layout option

- Adds `columns` to sql runner job task
- Improves types and allows `logWrapper` to accept a generic (it will help with different response types for different jobs)
- Add `columns` on `select` of `useSqlQueryRun`
- Updated the transformers to reference `ResultRow[]` instead of the return type of the hook (initially I thought the hook type would be beneficial, but it's not that reliable)



Screenshot:

<img width="1903" alt="Screenshot 2024-07-24 at 11 05 29" src="https://github.com/user-attachments/assets/02aa1ba3-0e99-4f44-af81-9e5abf0baa4e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
