### PR TITLE
fix: fix markdown tooltip with descriptions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -13,6 +13,14 @@ models:
 
       This table has basic information about a customer, as well as some derived
       facts based on a customer's orders
+
+      --- 
+      Fields: 
+      - `customer_id`: This is a unique identifier for a customer
+      - `first_name`: Customer's first name. PII.
+      - `last_name`: Customer's last name. PII.
+      ...
+
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
@@ -20,7 +28,12 @@ models:
           - unique
           - not_null
       - name: first_name
-        description: Customer's first name. PII.
+        description: | 
+          # First name 
+          --- 
+          Customer's first name. PII.
+          ---
+          Supports URLs
         meta:
           dimension:
             type: string

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -58,7 +58,8 @@ export const ItemDetailPreview: FC<{
      * It's better to err on the side of caution, and show the 'Read more' option even
      * if unnecessarily so.
      */
-    const isTruncated = description.length > 180;
+    const isTruncated =
+        description.length > 180 || description.split('\n').length > 2;
 
     return (
         <Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/10705

### Description:

What the issue is: 

when using `---` or `break lines` on markdown, we introduce new lines, but the number of characters doesn't increase match, we only show the `see full description`if `description.length > 180` . 

I updated the code to also check if number of lines > 2 


<!-- Add a description of the changes proposed in the pull request. -->
Before:
![image](https://github.com/user-attachments/assets/df6cbf71-5db6-456b-a3b5-6fa96f57d9ec)


After:
![Screenshot from 2024-07-24 16-27-43](https://github.com/user-attachments/assets/78dadc76-52b0-4a73-9a8d-ae6a2c9ded6f)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
