### PR TITLE
fix: space e2e test

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -27,11 +27,9 @@ describe('Space', () => {
         cy.contains('Enter a memorable name for your chart');
 
         cy.get('.mantine-Modal-body').find('button').should('be.disabled');
-
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
-            .wait(0)
-            .focus()
-            .clear()
+            .should('have.value', ``) // Wait until the input is cleared
+            .wait(100)
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -27,9 +27,8 @@ describe('Space', () => {
         cy.contains('Enter a memorable name for your chart');
 
         cy.get('.mantine-Modal-body').find('button').should('be.disabled');
+        cy.contains('Select a space to save the chart directly to'); // Wait until it finishes loading, otherwise the input will be cleared
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
-            .should('have.value', ``) // Wait until the input is cleared
-            .wait(100)
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -7,7 +7,7 @@ describe('Space', () => {
         cy.login();
     });
 
-    it('I can create a private space with private content', () => {
+    it.only('I can create a private space with private content', () => {
         const timestamp = new Date().toISOString();
 
         // Create private space
@@ -24,11 +24,17 @@ describe('Space', () => {
         cy.contains('Total order amount').click();
         cy.contains('Status').click();
         cy.contains('Save chart').click();
-        cy.findByPlaceholderText(
-            'eg. How many weekly active users do we have?',
-        ).type(`Private chart ${timestamp}`);
+        cy.contains('Enter a memorable name for your chart');
+        cy.get('[data-testid="ChartCreateModal/NameInput"]').type(
+            `Private chart ${timestamp}`,
+        );
+
         // Saves to space by default
-        cy.get('.mantine-Modal-body').find('button').contains('Save').click();
+        cy.get('.mantine-Modal-body')
+            .find('button')
+            .should('not.be.disabled')
+            .contains('Save')
+            .click();
 
         // Go back to space using breadcrumbs
         cy.contains('Private space').click();

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -29,6 +29,9 @@ describe('Space', () => {
         cy.get('.mantine-Modal-body').find('button').should('be.disabled');
 
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
+            .wait(0)
+            .focus()
+            .clear()
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -25,9 +25,12 @@ describe('Space', () => {
         cy.contains('Status').click();
         cy.contains('Save chart').click();
         cy.contains('Enter a memorable name for your chart');
-        cy.get('[data-testid="ChartCreateModal/NameInput"]').type(
-            `Private chart ${timestamp}`,
-        );
+
+        cy.get('.mantine-Modal-body').find('button').should('be.disabled');
+
+        cy.get('[data-testid="ChartCreateModal/NameInput"]')
+            .type(`Private chart ${timestamp}`)
+            .should('have.value', `Private chart ${timestamp}`);
 
         // Saves to space by default
         cy.get('.mantine-Modal-body')

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -7,7 +7,7 @@ describe('Space', () => {
         cy.login();
     });
 
-    it.only('I can create a private space with private content', () => {
+    it('I can create a private space with private content', () => {
         const timestamp = new Date().toISOString();
 
         // Create private space


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
What the issue is:

We have request happening in the modal to get the spaces, when the request finishes, the input is reset. 

On render the request takes longer than expected, and the typing is quick, which means some parts of the text gets deleted. 

See video: 

[Screencast from 25-07-24 16:48:33.webm](https://github.com/user-attachments/assets/858937e3-f6f5-4a3c-8493-0b95171d6b32)

This PR fixes this issue by waiting for some text to appear before typing.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
