### PR TITLE
fix: viewers can see saved SQL chart 

### DIFF
--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -111,6 +111,7 @@ export class SqlRunnerController extends BaseController {
     /**
      * Get results from a file stored locally
      * @param fileId the fileId for the file
+     * @param projectUuid the uuid for the project
      * @param req express request
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -206,20 +207,11 @@ export class SqlRunnerController extends BaseController {
     ): Promise<ApiSqlChartWithResults> {
         this.setStatus(200);
 
-        const chart = await this.services
-            .getSavedSqlService()
-            .getSqlChart(req.user!, projectUuid, uuid);
-
         return {
             status: 'ok',
-            results: {
-                jobId: (
-                    await this.services
-                        .getProjectService()
-                        .scheduleSqlJob(req.user!, projectUuid, chart.sql)
-                ).jobId,
-                chart,
-            },
+            results: await this.services
+                .getSavedSqlService()
+                .getChartWithResultJob(req.user!, projectUuid, uuid),
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2067,8 +2067,8 @@ export class ProjectService extends BaseService {
         );
         if (
             user.ability.cannot(
-                'manage',
-                subject('SqlRunner', { organizationUuid, projectUuid }),
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -11,6 +11,7 @@ import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
 
 type SavedSqlServiceArguments = {
@@ -18,6 +19,7 @@ type SavedSqlServiceArguments = {
     projectModel: ProjectModel;
     spaceModel: SpaceModel;
     savedSqlModel: SavedSqlModel;
+    schedulerClient: SchedulerClient;
 };
 
 export class SavedSqlService extends BaseService {
@@ -29,12 +31,53 @@ export class SavedSqlService extends BaseService {
 
     private readonly savedSqlModel: SavedSqlModel;
 
+    private readonly schedulerClient: SchedulerClient;
+
     constructor(args: SavedSqlServiceArguments) {
         super();
         this.analytics = args.analytics;
         this.projectModel = args.projectModel;
         this.spaceModel = args.spaceModel;
         this.savedSqlModel = args.savedSqlModel;
+        this.schedulerClient = args.schedulerClient;
+    }
+
+    private async hasAccess(
+        user: SessionUser,
+        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        {
+            spaceUuid,
+            projectUuid,
+            organizationUuid,
+        }: { spaceUuid: string; projectUuid: string; organizationUuid: string },
+    ) {
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
+
+        return user.ability.can(
+            action,
+            subject('SavedChart', {
+                organizationUuid,
+                projectUuid,
+                isPrivate: space.isPrivate,
+                access,
+            }),
+        );
+    }
+
+    private async hasSavedChartAccess(
+        user: SessionUser,
+        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        savedChart: SqlChart,
+    ) {
+        return this.hasAccess(user, action, {
+            spaceUuid: savedChart.space.uuid,
+            projectUuid: savedChart.project.projectUuid,
+            organizationUuid: savedChart.organization.organizationUuid,
+        });
     }
 
     async getSqlChart(
@@ -53,25 +96,12 @@ export class SavedSqlService extends BaseService {
         } else {
             throw new Error('Either savedSqlUuid or slug must be provided');
         }
-        const space = await this.spaceModel.getSpaceSummary(
-            savedChart.space.uuid,
+        const hasViewAccess = await this.hasSavedChartAccess(
+            user,
+            'view',
+            savedChart,
         );
-        const access = await this.spaceModel.getUserSpaceAccess(
-            user.userUuid,
-            savedChart.space.uuid,
-        );
-
-        if (
-            user.ability.cannot(
-                'view',
-                subject('SavedChart', {
-                    organizationUuid: savedChart.organization.organizationUuid,
-                    projectUuid: savedChart.project.projectUuid,
-                    isPrivate: space.isPrivate,
-                    access,
-                }),
-            )
-        ) {
+        if (!hasViewAccess) {
             throw new ForbiddenError("You don't have access to this chart");
         }
         return savedChart;
@@ -93,23 +123,13 @@ export class SavedSqlService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        const space = await this.spaceModel.getSpaceSummary(sqlChart.spaceUuid);
-        const { isPrivate } = space;
-        const access = await this.spaceModel.getUserSpaceAccess(
-            user.userUuid,
-            sqlChart.spaceUuid,
-        );
-        if (
-            user.ability.cannot(
-                'create',
-                subject('SavedChart', {
-                    organizationUuid,
-                    projectUuid,
-                    isPrivate,
-                    access,
-                }),
-            )
-        ) {
+        const hasCreateAccess = await this.hasAccess(user, 'create', {
+            spaceUuid: sqlChart.spaceUuid,
+            projectUuid,
+            organizationUuid,
+        });
+
+        if (!hasCreateAccess) {
             throw new ForbiddenError(
                 "You don't have permission to create this chart",
             );
@@ -138,24 +158,13 @@ export class SavedSqlService extends BaseService {
         const savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
             projectUuid,
         });
-        const space = await this.spaceModel.getSpaceSummary(
-            savedChart.space.uuid,
-        );
 
-        if (
-            user.ability.cannot(
-                'update',
-                subject('SavedChart', {
-                    organizationUuid: savedChart.organization.organizationUuid,
-                    projectUuid: savedChart.project.projectUuid,
-                    isPrivate: space.isPrivate,
-                    access: await this.spaceModel.getUserSpaceAccess(
-                        user.userUuid,
-                        savedChart.space.uuid,
-                    ),
-                }),
-            )
-        ) {
+        const hasUpdateAccess = await this.hasSavedChartAccess(
+            user,
+            'update',
+            savedChart,
+        );
+        if (!hasUpdateAccess) {
             throw new ForbiddenError(
                 "You don't have permission to update this chart",
             );
@@ -166,24 +175,16 @@ export class SavedSqlService extends BaseService {
             sqlChart.unversionedData &&
             savedChart.space.uuid !== sqlChart.unversionedData.spaceUuid
         ) {
-            const newSpace = await this.spaceModel.getSpaceSummary(
-                sqlChart.unversionedData.spaceUuid,
+            const hasUpdateAccessToNewSpace = await this.hasAccess(
+                user,
+                'update',
+                {
+                    spaceUuid: sqlChart.unversionedData.spaceUuid,
+                    organizationUuid: savedChart.organization.organizationUuid,
+                    projectUuid: savedChart.project.projectUuid,
+                },
             );
-            if (
-                user.ability.cannot(
-                    'update',
-                    subject('SavedChart', {
-                        organizationUuid:
-                            savedChart.organization.organizationUuid,
-                        projectUuid: savedChart.project.projectUuid,
-                        isPrivate: newSpace.isPrivate,
-                        access: await this.spaceModel.getUserSpaceAccess(
-                            user.userUuid,
-                            sqlChart.unversionedData.spaceUuid,
-                        ),
-                    }),
-                )
-            ) {
+            if (!hasUpdateAccessToNewSpace) {
                 throw new ForbiddenError(
                     "You don't have permission to move this chart to the new space",
                 );
@@ -202,29 +203,50 @@ export class SavedSqlService extends BaseService {
         projectUuid: string,
         savedSqlUuid: string,
     ): Promise<void> {
-        const sqlChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
+        const savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
             projectUuid,
         });
-        const space = await this.spaceModel.getSpaceSummary(
-            sqlChart.space.uuid,
+        const hasDeleteAccess = await this.hasSavedChartAccess(
+            user,
+            'delete',
+            savedChart,
         );
-        const access = await this.spaceModel.getUserSpaceAccess(
-            user.userUuid,
-            sqlChart.space.uuid,
-        );
-        if (
-            user.ability.cannot(
-                'delete',
-                subject('SavedChart', {
-                    organizationUuid: sqlChart.organization.organizationUuid,
-                    projectUuid: sqlChart.project.projectUuid,
-                    isPrivate: space.isPrivate,
-                    access,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        if (!hasDeleteAccess) {
+            throw new ForbiddenError(
+                "You don't have permission to delete this chart",
+            );
         }
         await this.savedSqlModel.delete(savedSqlUuid);
+    }
+
+    async getChartWithResultJob(
+        user: SessionUser,
+        projectUuid: string,
+        savedSqlUuid: string,
+    ) {
+        const savedChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
+            projectUuid,
+        });
+
+        const hasViewAccess = await this.hasSavedChartAccess(
+            user,
+            'view',
+            savedChart,
+        );
+        if (!hasViewAccess) {
+            throw new ForbiddenError("You don't have access to this chart");
+        }
+
+        const jobId = await this.schedulerClient.runSql({
+            userUuid: user.userUuid,
+            organizationUuid: savedChart.organization.organizationUuid,
+            projectUuid: savedChart.project.projectUuid,
+            sql: savedChart.sql,
+        });
+
+        return {
+            jobId,
+            chart: savedChart,
+        };
     }
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -640,6 +640,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
+                    schedulerClient: this.clients.getSchedulerClient(),
                 }),
         );
     }

--- a/packages/e2e/cypress/e2e/api/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/api/sqlRunner.cy.ts
@@ -264,7 +264,7 @@ describe.skip(`Load testing`, () => {
     });
 });
 
-describe.only(`Saved SQL chart`, () => {
+describe(`Saved SQL chart`, () => {
     beforeEach(() => {
         cy.login();
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem: Only users that could manage CustomSQL could view the saved charts. 

Changes:

- Amend permission check when requesting results 
- Reuse permission check logic

Note: Not updating e2e tests in this PR. We need to seed a SQL chart to simplify e2e tests and cover these scenarios. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
