### PR TITLE
fix: sort v2 content by last_updated_at

### DIFF
--- a/packages/backend/src/database/pagination/index.ts
+++ b/packages/backend/src/database/pagination/index.ts
@@ -27,6 +27,7 @@ export default class KnexPaginate {
                 .clone()
                 .clear('select')
                 .clear('group')
+                .clear('order')
                 .count<{ count: string }[]>()
                 .first();
             const dataPromise = query.clone().offset(offset).limit(pageSize);

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -50,6 +50,8 @@ export class ContentModel {
             void query.unionAll(config.getSummaryQuery(this.database, filters));
         });
 
+        void query.orderBy('last_updated_at', 'DESC');
+
         const { pagination, data } = await KnexPaginate.paginate(
             query,
             paginateArgs,

--- a/packages/e2e/cypress/e2e/api/content.cy.ts
+++ b/packages/e2e/cypress/e2e/api/content.cy.ts
@@ -69,6 +69,39 @@ describe('Lightdash catalog all tables and fields', () => {
             });
         });
     });
+
+    describe('Test order', () => {
+        it('Should return charts and dashboards sorted by last_updated_at', () => {
+            cy.request(`${apiUrl}/content?pageSize=999`).then((resp) => {
+                expect(resp.status).to.eq(200);
+                content = resp.body.results.data;
+                const sortedByLastUpdated = [...content].sort(
+                    (a, b) => a.lastUpdatedAt - b.lastUpdatedAt,
+                );
+                expect(sortedByLastUpdated.map((d) => d.uuid)).to.deep.eq(
+                    content.map((d) => d.uuid),
+                );
+
+                const sortedByViews = [...content].sort(
+                    (a, b) => a.views - b.views,
+                );
+                expect(sortedByViews.map((d) => d.uuid)).to.not.deep.eq(
+                    content.map((d) => d.uuid),
+                );
+
+                // Check the list of content returns charts and dashboards mixed together
+                const nextContentIsDifferent = (type: string) =>
+                    content.some((d, i) => {
+                        if (d.contentType === type) {
+                            return content[i + 1]?.contentType !== type;
+                        }
+                        return false;
+                    });
+                expect(nextContentIsDifferent('dashboard')).to.be.eq(true);
+                expect(nextContentIsDifferent('chart')).to.be.eq(true);
+            });
+        });
+    });
     describe('Filter by spaceUuids', () => {
         it('Filter by existing spaceUuid', () => {
             cy.request(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10809](https://github.com/lightdash/lightdash/issues/10809)
Closes: [#10761](https://github.com/lightdash/lightdash/issues/10761)
### Description:

- complete dashboard content query to include first/last version
- add hardcoded orderby `last_updated_at`
- added new e2e test
<!-- Add a description of the changes proposed in the pull request. -->


Before:
![Screenshot from 2024-07-26 09-24-07](https://github.com/user-attachments/assets/feb14612-8769-4ce9-936b-367d859ba772)

![Screenshot from 2024-07-26 08-32-13](https://github.com/user-attachments/assets/0e4ee150-0767-4655-9bfe-8a4850ba133e)

After:
![Screenshot from 2024-07-26 09-27-18](https://github.com/user-attachments/assets/92a2f7c2-2814-4896-bb59-ab388eb5296a)
![Screenshot from 2024-07-26 09-27-03](https://github.com/user-attachments/assets/d048ddbc-7bbc-448d-909e-c93434ef840b)

![Screenshot from 2024-07-26 09-50-47](https://github.com/user-attachments/assets/c071c9e8-c34c-4fbc-beee-d5ed35fe4276)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
