### PR TITLE
chore: show SQL errors in SQL runner

### DIFF
--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -26,14 +26,29 @@ export type SqlRunnerResults = ResultRow[];
 
 export const sqlRunnerJob = 'sqlRunner';
 
+type SqlRunnerJobStatusSuccessDetails = {
+    fileUrl: string;
+    columns: SQLColumn[];
+};
+
+type SqlRunnerJobStatusErrorDetails = {
+    error: string;
+    createdByUserUuid: string;
+};
+
+export function isErrorDetails(
+    results?: ApiSqlRunnerJobStatusResponse['results']['details'],
+): results is SqlRunnerJobStatusErrorDetails {
+    return (results as SqlRunnerJobStatusErrorDetails).error !== undefined;
+}
+
 export type ApiSqlRunnerJobStatusResponse = {
     status: 'ok';
     results: {
         status: SchedulerJobStatus;
-        details: {
-            fileUrl: string;
-            columns: SQLColumn[];
-        };
+        details:
+            | SqlRunnerJobStatusSuccessDetails
+            | SqlRunnerJobStatusErrorDetails;
     };
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10844

### Description:

Show SQL errors on the FE. Since the polling request returns successfully, we werent treating it as an error, even when it contained error details about the job. This shows the error details when they are there. 

🤔 Should we restructure the API to return this as an error (non-200)?

<img width="492" alt="Screenshot 2024-07-26 at 11 50 53" src="https://github.com/user-attachments/assets/8c0173f7-d2e4-4f90-a79c-3b252eceeb24">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
