### PR TITLE
feat: parse postgres numerics & int8s to JS numbers

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -12,7 +12,7 @@ import {
 import { readFileSync } from 'fs';
 import path from 'path';
 import * as pg from 'pg';
-import { PoolConfig, QueryResult } from 'pg';
+import { PoolConfig, QueryResult, types } from 'pg';
 import { Writable } from 'stream';
 import { rootCertificates } from 'tls';
 import QueryStream from './PgQueryStream';
@@ -22,6 +22,9 @@ const POSTGRES_CA_BUNDLES = [
     ...rootCertificates,
     readFileSync(path.resolve(__dirname, './ca-bundle-aws-rds-global.pem')),
 ];
+
+types.setTypeParser(types.builtins.NUMERIC, (value) => parseFloat(value));
+types.setTypeParser(types.builtins.INT8, (value) => parseInt(value, 10));
 
 export enum PostgresTypes {
     INTEGER = 'integer',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Handle `Int8`s and `NUMERIC`s in Postgres by parsing them to JS `Number`s 

How to verify this

**Before this change**

Go to `customers` with the SQL runner (old/new)
Query `customers` and see the value of `customer_lifetime_value`
It returns as a string 


**After this change**

A number is returned

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
