### PR TITLE
feat: save sql chart feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -33,4 +33,7 @@ export enum FeatureFlags {
 
     /* Send local timezone to the warehouse session */
     EnableUserTimezones = 'enable-user-timezones',
+
+    /* Allow users to save SQL charts */
+    SaveSqlChart = 'save-sql-chart',
 }

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -48,7 +48,6 @@ export const DashboardSqlChartTile: FC<Props> = ({
             <TileBase
                 isEditMode={isEditMode}
                 chartName={tile.properties.chartName ?? ''}
-                titleHref={`/projects/${projectUuid}/sql-runner-new/saved/${tile.properties.savedSqlUuid}/`}
                 // TODO: complete this
                 belongsToDashboard={false}
                 tile={tile}
@@ -84,8 +83,7 @@ export const DashboardSqlChartTile: FC<Props> = ({
                 <TileBase
                     isEditMode={isEditMode}
                     chartName={tile.properties.chartName ?? ''}
-                    // TODO: Fix this link - should we use uuid or slug?
-                    titleHref={`/projects/${projectUuid}/sql-runner-new/saved/${tile.properties.savedSqlUuid}`}
+                    titleHref={`/projects/${projectUuid}/sql-runner-new/saved/${data.chart.slug}`}
                     tile={tile}
                     title={
                         tile.properties.title || tile.properties.chartName || ''

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { FeatureFlags } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
 import {
     IconFolder,
@@ -11,6 +12,7 @@ import {
 } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
 import { Link, useHistory } from 'react-router-dom';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import { useApp } from '../../providers/AppProvider';
 import { Can } from '../common/Authorization';
 import LargeMenuItem from '../common/LargeMenuItem';
@@ -30,6 +32,8 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
     const [isCreateSpaceOpen, setIsCreateSpaceOpen] = useState<boolean>(false);
     const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
         useState<boolean>(false);
+
+    const canSaveSqlChart = useFeatureFlagEnabled(FeatureFlags.SaveSqlChart);
 
     return (
         <>
@@ -91,7 +95,11 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 component={Link}
                                 title="Query using SQL runner"
                                 description="Access your database to run ad-hoc queries."
-                                to={`/projects/${projectUuid}/sqlRunner`}
+                                to={`/projects/${projectUuid}/${
+                                    canSaveSqlChart
+                                        ? 'sql-runner-new'
+                                        : 'sqlRunner'
+                                }`}
                                 icon={IconTerminal2}
                             />
                         </Can>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10845](https://github.com/lightdash/lightdash/issues/10845) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Changes:
- saved SQL chart endpoints throw error if user doesn't have feature flag
- app navigation points to /sql-runner-new if feature flag is enabled
- fix URL from dashboard tile to SQL runner page

Note that e2e should still pass as they access to current SQL runner page via the URL instead the UI.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
