### PR TITLE
fix: saving chat within dashboard as save as overrides dashboard

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -11,7 +11,10 @@ import { uuid4 } from '@sentry/utils';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import { z } from 'zod';
-import { appendNewTilesToBottom } from '../../../../hooks/dashboard/useDashboard';
+import {
+    appendNewTilesToBottom,
+    useDashboardQuery,
+} from '../../../../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
@@ -46,7 +49,9 @@ export const SaveToDashboard: FC<Props> = ({
     });
     const { getEditingDashboardInfo } = useDashboardStorage();
     const editingDashboardInfo = getEditingDashboardInfo();
-
+    const { data: selectedDashboard } = useDashboardQuery(
+        dashboardUuid || undefined,
+    );
     useEffect(() => {
         if (
             dashboardInfoFromStorage.name &&
@@ -112,8 +117,13 @@ export const SaveToDashboard: FC<Props> = ({
                 },
                 ...getDefaultChartTileSize(savedData.chartConfig?.type),
             };
+            const existingTiles =
+                unsavedDashboardTiles?.length > 0
+                    ? unsavedDashboardTiles
+                    : selectedDashboard?.tiles;
+
             setUnsavedDashboardTiles(
-                appendNewTilesToBottom(unsavedDashboardTiles ?? [], [newTile]),
+                appendNewTilesToBottom(existingTiles || [], [newTile]),
             );
 
             clearIsEditingDashboardChart();
@@ -136,6 +146,7 @@ export const SaveToDashboard: FC<Props> = ({
             showToastSuccess,
             dashboardName,
             activeTabUuid,
+            selectedDashboard?.tiles,
         ],
     );
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10865

### Description:

With this fix, we've introduced a new edge case:
If the user is editing a dashboard and deletes all the tiles , without saving, then edit or create a chart iwthin dashboard. Then after saving that chart within dashboard, it will get all the `saved` tiles instead of the `unsaved tiles` because unsavedTiles.length === 0 
 
 I think this is a rare edge case and it good trade off. 
 
<!-- Add a description of the changes proposed in the pull request. -->
Before:

[Screencast from 29-07-24 09:19:19.webm](https://github.com/user-attachments/assets/b55a765a-6aac-4d56-8f92-3752dcbb1e4e)

After:

[Screencast from 29-07-24 09:26:39.webm](https://github.com/user-attachments/assets/23f19f8d-6683-4199-955c-266c8da8154a)

<!-- Even better add

 a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
