### PR TITLE
fix: bar chart loading state

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -106,6 +106,7 @@ export const DashboardSqlChartTile: FC<Props> = ({
                                 height: '100%',
                                 width: '100%',
                             }}
+                            isLoading={isLoading}
                         />
                     )}
                 </TileBase>

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -355,6 +355,7 @@ export const ContentPanel: FC<Props> = ({
                                                 <BarChart
                                                     data={queryResults}
                                                     config={barChartConfig}
+                                                    isLoading={isLoading}
                                                 />
                                             )}
                                     </>

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
@@ -8,14 +8,21 @@ import { useBarChart } from '../../transformers/useBarChart';
 type BarChartProps = {
     data: ResultsAndColumns;
     config: BarChartConfig;
+    isLoading: boolean;
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 
-const BarChart: FC<BarChartProps> = ({ data, config, style }) => {
+const BarChart: FC<BarChartProps> = ({
+    data,
+    config,
+    style,
+    isLoading: isLoadingProp,
+}) => {
     const {
-        loading,
+        loading: transformLoading,
         error,
         value: spec,
     } = useBarChart(data.results, data.columns, config);
+    const loading = isLoadingProp || transformLoading;
 
     if (error) {
         return <Center>Error: {error.message}</Center>;

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/BarChart.tsx
@@ -11,11 +11,11 @@ type BarChartProps = {
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 
 const BarChart: FC<BarChartProps> = ({ data, config, style }) => {
-    const { error, value: spec } = useBarChart(
-        data.results,
-        data.columns,
-        config,
-    );
+    const {
+        loading,
+        error,
+        value: spec,
+    } = useBarChart(data.results, data.columns, config);
 
     if (error) {
         return <Center>Error: {error.message}</Center>;
@@ -26,7 +26,7 @@ const BarChart: FC<BarChartProps> = ({ data, config, style }) => {
             {spec && (
                 <EChartsReact
                     option={spec}
-                    notMerge
+                    showLoading={loading}
                     opts={{
                         renderer: 'svg',
                         width: 'auto',

--- a/packages/frontend/src/features/sqlRunner/transformers/useBarChart.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useBarChart.ts
@@ -65,9 +65,8 @@ export const useBarChart = (
         [transformer],
     );
 
-    const state = useAsync(async () => {
-        return barChart.getEchartsSpec(config.fieldConfig, config.display);
-    }, [config, barChart]);
-
-    return state;
+    return useAsync(
+        async () => barChart.getEchartsSpec(config.fieldConfig, config.display),
+        [config, barChart],
+    );
 };


### PR DESCRIPTION
Closes: #10856

Adds loading state + merge transitions

## Before

https://github.com/user-attachments/assets/6227cd79-4f88-4f20-b0a6-defbd8029b98


## After

https://github.com/user-attachments/assets/d8364648-5264-4fd9-9f98-dc915f84bc29



