### PR TITLE
chore: Prohibit null of some properties in `lightdash-dbt-2.0.json`

### DIFF
--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -87,13 +87,16 @@
                                                 ]
                                             },
                                             "label": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "minLength": 1
                                             },
                                             "description": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "minLength": 1
                                             },
                                             "sql": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "minLength": 1
                                             },
                                             "hidden": {
                                                 "type": "boolean"
@@ -184,13 +187,16 @@
                                                             ]
                                                         },
                                                         "label": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "minLength": 1
                                                         },
                                                         "description": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "minLength": 1
                                                         },
                                                         "sql": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "minLength": 1
                                                         },
                                                         "hidden": {
                                                             "type": "boolean"
@@ -223,13 +229,16 @@
                                             "type": "object",
                                             "properties": {
                                                 "label": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "minLength": 1
                                                 },
                                                 "description": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "minLength": 1
                                                 },
                                                 "sql": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "minLength": 1
                                                 },
                                                 "hidden": {
                                                     "type": "boolean"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: xxx

I didn't create an issue for the pull request. Please let me know, if I should create one.

### Description:

I have changed `lightdash-dbt-2.0.json` to prohibit null values of some properties in dimensions and metrics. For instance, null value of the `label` property for a dimension is allowed. So, we can add constraints to check if it isn't null using `"minLength": 1`.

```
    columns:
      - name: revenue_gbp_total_est
        description: 'Total estimated revenue in GBP based on forecasting done by the finance team.'
        meta:
          dimension:
            type: string
            label: 
```

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
