### PR TITLE
fix: Table Calculation Modal (save and cancel) buttons

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -56,7 +56,7 @@ export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
 
     return (
         <>
-            <ScrollArea h={isFullScreen ? '95%' : '150px'}>
+            <ScrollArea h={isFullScreen ? '95%' : '75px'}>
                 <SqlEditor
                     mode="sql"
                     theme="github"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -33,6 +33,7 @@ export const SqlEditor = styled(AceEditor)<
     & > .ace_gutter {
         background-color: ${({ gutterBackgroundColor }) =>
             gutterBackgroundColor};
+        z-index: 0;
     }
     ${({ isFullScreen }) =>
         isFullScreen

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -158,6 +158,9 @@ const TableCalculationModal: FC<Props> = ({
                 body: {
                     paddingBottom: 0,
                 },
+                content: {
+                    maxHeight: '70vh !important',
+                },
             }}
             fullScreen={isFullscreen}
         >

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -155,6 +155,9 @@ const TableCalculationModal: FC<Props> = ({
                     fontSize: theme.fontSizes.md,
                     fontWeight: 700,
                 },
+                body: {
+                    paddingBottom: 0,
+                },
             }}
             fullScreen={isFullscreen}
         >
@@ -224,7 +227,22 @@ const TableCalculationModal: FC<Props> = ({
                             data={Object.values(TableCalculationType)}
                         ></Select>
                     </Tooltip>
-                    <Group position="apart">
+                </Stack>
+
+                <Stack
+                    sx={() => ({
+                        position: 'sticky',
+                        backgroundColor: 'white',
+                        bottom: 0,
+                        zIndex: 2,
+                    })}
+                >
+                    <Group
+                        position="apart"
+                        sx={() => ({
+                            padding: theme.spacing.md,
+                        })}
+                    >
                         <ActionIcon
                             variant="outline"
                             onClick={toggleFullscreen}


### PR DESCRIPTION
Closes: #10884 

### Description:
Hello,
Today, When we open the Table Calculation Modal, save and cancel button appears only when scrolled.
I added a wrapper element that has `position:sticky` as seen in the file:
packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
Additionally, there is one change done in the file:  
packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
The ace editor's left grey bar was overlapping on the Modals footer (Element with sticky position) as we scrolled down. So I had to adjust the z-index here in SQLForm.tsx

Current UI/UX:
<img width="815" alt="Screenshot 2024-07-30 at 5 25 02 PM" src="https://github.com/user-attachments/assets/68aad205-8839-423c-870c-7c981c416283">

New Behaviour:
<img width="1017" alt="Screenshot 2024-07-30 at 5 25 38 PM" src="https://github.com/user-attachments/assets/d594e6f8-58e9-45ee-b551-32be327a7ddc">

cc: @TuringLovesDeathMetal @ZeRego 

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
