### PR TITLE
chore: refactor sql runner redux state to have entire sql chart data

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header.tsx
@@ -24,11 +24,13 @@ export const Header: FC = () => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const savedSqlUuid = useAppSelector(
-        (state) => state.sqlRunner.savedSqlUuid,
+        (state) => state.sqlRunner.savedSqlChart?.savedSqlUuid,
     );
-    const space = useAppSelector((state) => state.sqlRunner.space);
+    const space = useAppSelector(
+        (state) => state.sqlRunner.savedSqlChart?.space,
+    );
     const name = useAppSelector((state) => state.sqlRunner.name);
-    const slug = useAppSelector((state) => state.sqlRunner.slug);
+    const slug = useAppSelector((state) => state.sqlRunner.savedSqlChart?.slug);
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const config = useAppSelector((state) =>
         state.sqlRunner.selectedChartType === ChartKind.TABLE

--- a/packages/frontend/src/features/sqlRunner/components/HeaderViewMode.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/HeaderViewMode.tsx
@@ -15,12 +15,14 @@ export const HeaderViewMode: FC = () => {
     const dispatch = useAppDispatch();
     const { user } = useApp();
     const savedSqlUuid = useAppSelector(
-        (state) => state.sqlRunner.savedSqlUuid,
+        (state) => state.sqlRunner.savedSqlChart?.savedSqlUuid,
     );
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
-    const space = useAppSelector((state) => state.sqlRunner.space);
+    const space = useAppSelector(
+        (state) => state.sqlRunner.savedSqlChart?.space,
+    );
     const name = useAppSelector((state) => state.sqlRunner.name);
-    const slug = useAppSelector((state) => state.sqlRunner.slug);
+    const slug = useAppSelector((state) => state.sqlRunner.savedSqlChart?.slug);
     const isDeleteModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.deleteChartModal.isOpen,
     );

--- a/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
@@ -12,7 +12,7 @@ import {
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { SqlRunnerResultsTransformerFE } from '../transformers/useBarChart';
-import { setSaveChartData, setSqlRunnerResults } from './sqlRunnerSlice';
+import { setSavedChartData, setSqlRunnerResults } from './sqlRunnerSlice';
 
 type InitialState = {
     defaultLayout: SqlTransformBarChartConfig | undefined;
@@ -199,7 +199,7 @@ export const barChartConfigSlice = createSlice({
                 }
             }
         });
-        builder.addCase(setSaveChartData, (state, action) => {
+        builder.addCase(setSavedChartData, (state, action) => {
             if (action.payload.config.type === ChartKind.VERTICAL_BAR) {
                 state.config = action.payload.config;
             }

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -132,7 +132,7 @@ export const sqlRunnerSlice = createSlice({
                 state.activeSidebarTab = SidebarTabs.TABLES;
             }
         },
-        setSaveChartData: (state, action: PayloadAction<SqlChart>) => {
+        setSavedChartData: (state, action: PayloadAction<SqlChart>) => {
             state.savedSqlChart = action.payload;
             state.name = action.payload.name;
             state.description = action.payload.description || '';
@@ -171,7 +171,7 @@ export const {
     updateName,
     setSql,
     setActiveEditorTab,
-    setSaveChartData,
+    setSavedChartData,
     setSelectedChartType,
     toggleModal,
     loadState,

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -24,23 +24,13 @@ export const DEFAULT_NAME = 'Untitled SQL Query';
 export interface SqlRunnerState {
     projectUuid: string;
     activeTable: string | undefined;
-    savedSqlUuid: string | undefined;
-    slug: string | undefined;
-    space:
-        | {
-              uuid: string;
-              name: string;
-          }
-        | undefined;
+    savedSqlChart: SqlChart | undefined;
     name: string;
     description: string;
-
     sql: string;
-
     activeSidebarTab: SidebarTabs;
     activeEditorTab: EditorTabs;
     selectedChartType: ChartKind | undefined;
-
     resultsTableConfig: SqlTableConfig | undefined;
     modals: {
         saveChartModal: {
@@ -53,18 +43,14 @@ export interface SqlRunnerState {
             isOpen: boolean;
         };
     };
-
     quoteChar: string;
-
     sqlColumns: SqlColumn[] | undefined;
 }
 
 const initialState: SqlRunnerState = {
     projectUuid: '',
     activeTable: undefined,
-    savedSqlUuid: undefined,
-    slug: undefined,
-    space: undefined,
+    savedSqlChart: undefined,
     name: '',
     description: '',
     sql: '',
@@ -147,12 +133,9 @@ export const sqlRunnerSlice = createSlice({
             }
         },
         setSaveChartData: (state, action: PayloadAction<SqlChart>) => {
-            state.savedSqlUuid = action.payload.savedSqlUuid;
-            state.slug = action.payload.slug;
+            state.savedSqlChart = action.payload;
             state.name = action.payload.name;
             state.description = action.payload.description || '';
-            state.space = action.payload.space;
-
             state.sql = action.payload.sql;
             state.selectedChartType =
                 action.payload.config.type === ChartKind.TABLE

--- a/packages/frontend/src/features/sqlRunner/store/tableVisSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/tableVisSlice.ts
@@ -1,7 +1,7 @@
 import { ChartKind, type TableChartSqlConfig } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { setSaveChartData, setSqlRunnerResults } from './sqlRunnerSlice';
+import { setSavedChartData, setSqlRunnerResults } from './sqlRunnerSlice';
 
 const initialState: { config: TableChartSqlConfig | undefined } = {
     config: undefined,
@@ -61,7 +61,7 @@ export const tableVisSlice = createSlice({
                 };
             }
         });
-        builder.addCase(setSaveChartData, (state, action) => {
+        builder.addCase(setSavedChartData, (state, action) => {
             if (action.payload.config.type === ChartKind.TABLE) {
                 state.config = action.payload.config;
             }

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -19,7 +19,7 @@ import {
     loadState,
     setProjectUuid,
     setQuoteChar,
-    setSaveChartData,
+    setSavedChartData,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
 import { useProject } from '../hooks/useProject';
 import useSearchParams from '../hooks/useSearchParams';
@@ -52,7 +52,7 @@ const SqlRunnerNew = () => {
         projectUuid,
         slug: params.slug,
         onSuccess: (data) => {
-            dispatch(setSaveChartData(data));
+            dispatch(setSavedChartData(data));
         },
     });
     useEffect(() => {

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -33,7 +33,7 @@ const ViewSqlChart = () => {
     const [activeTab, setActiveTab] = useState<TabOption>(TabOption.CHART);
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const savedSqlUuid = useAppSelector(
-        (state) => state.sqlRunner.savedSqlUuid,
+        (state) => state.sqlRunner.savedSqlChart?.savedSqlUuid,
     );
     const selectedChartType = useAppSelector(
         (state) => state.sqlRunner.selectedChartType,

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -18,7 +18,7 @@ import {
 } from '../features/sqlRunner/store/hooks';
 import {
     setProjectUuid,
-    setSaveChartData,
+    setSavedChartData,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
 
 enum TabOption {
@@ -59,7 +59,7 @@ const ViewSqlChart = () => {
         projectUuid,
         slug: params.slug,
         onSuccess: (data) => {
-            dispatch(setSaveChartData(data));
+            dispatch(setSavedChartData(data));
         },
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We need to store the entire saved SQL chart in the redux state as we need most (if not all) information for different parts of the page. The `savedSqlChart` property should be treated as "read only".

The properties that are editable(name, SQL, config) should also be stored as separate properties in the redux state as treated as the "unsaved/dirty" state.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
