### PR TITLE
feat: update profile.yml directory logic and nunjucks template

### DIFF
--- a/packages/cli/src/dbt/profile.ts
+++ b/packages/cli/src/dbt/profile.ts
@@ -1,6 +1,7 @@
 import { CreateWarehouseCredentials, ParseError } from '@lightdash/common';
-import { promises as fs } from 'fs';
+import { accessSync, constants, promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
+import { homedir } from 'os';
 import * as path from 'path';
 import { convertBigquerySchema } from './targets/Bigquery';
 import { convertDatabricksSchema } from './targets/databricks';
@@ -67,5 +68,19 @@ export const warehouseCredentialsFromDbtTarget = async (
             throw new ParseError(
                 `Sorry! Lightdash doesn't yet support ${target.type} dbt targets`,
             );
+    }
+};
+
+export const findDbtDefaultProfile = (): string => {
+    if (process.env.DBT_PROFILES_DIR) {
+        return process.env.DBT_PROFILES_DIR;
+    }
+    // Check in Current Working Directory
+    const profilePathFromCwd = path.join(process.cwd(), 'profiles.yml');
+    try {
+        accessSync(profilePathFromCwd, constants.F_OK);
+        return process.cwd();
+    } catch (e: unknown) {
+        return path.join(homedir(), '.dbt');
     }
 };

--- a/packages/cli/src/dbt/profiles.test.ts
+++ b/packages/cli/src/dbt/profiles.test.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findDbtDefaultProfile } from './profile';
+
+jest.mock('os');
+jest.mock('fs');
+jest.mock('path');
+
+describe('Profile', () => {
+    const { env, cwd } = process;
+    const mockAccessSync = fs.accessSync as jest.MockedFunction<
+        typeof fs.accessSync
+    >;
+    const mockHomedir = os.homedir as jest.MockedFunction<typeof os.homedir>;
+    const mockJoin = path.join as jest.MockedFunction<typeof path.join>;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        jest.resetModules();
+        process.cwd = jest.fn(() => '/current/dir');
+        mockHomedir.mockReturnValue('/root');
+        mockJoin.mockImplementation((...paths) => paths.join('/'));
+        process.env = { ...env };
+    });
+
+    afterEach(() => {
+        process.env = env;
+        process.cwd = cwd;
+    });
+
+    describe('findDbtDefaultProfile', () => {
+        test('should return path from DBT_PROFILE_DIR when set', () => {
+            process.env.DBT_PROFILES_DIR = '/path/to/profiles';
+            const result = findDbtDefaultProfile();
+            expect(result).toBe('/path/to/profiles');
+        });
+        test('should return cwd when profile.yml exists and DBT_PROFILE_DIR is undefined', () => {
+            delete process.env.DBT_PROFILES_DIR;
+            mockAccessSync.mockImplementation(() => undefined);
+            expect(findDbtDefaultProfile()).toBe('/current/dir');
+            expect(mockAccessSync).toHaveBeenCalledWith(
+                '/current/dir/profiles.yml',
+                fs.constants.F_OK,
+            );
+        });
+        test('should return homedir when profile.yml does not exist in cwd', () => {
+            delete process.env.DBT_PROFILE_DIR;
+            mockAccessSync.mockImplementation(() => {
+                throw new Error('File not found');
+            });
+            expect(findDbtDefaultProfile()).toBe('/root/.dbt');
+            expect(mockAccessSync).toHaveBeenCalledWith(
+                '/current/dir/profiles.yml',
+                fs.constants.F_OK,
+            );
+            expect(mockHomedir).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/cli/src/dbt/templating.test.ts
+++ b/packages/cli/src/dbt/templating.test.ts
@@ -54,6 +54,13 @@ describe('Templating', () => {
                     ),
                 ).toBe('default_value');
             });
+            test('should convert env_var function and fallback to default value using keyword default', () => {
+                expect(
+                    renderProfilesYml(
+                        "{{ env_var('DBT_USER', default='default_value') }}",
+                    ),
+                ).toBe('default_value');
+            });
         });
         describe('var()', () => {
             test('should convert var functions and return env var values', () => {

--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -6,7 +6,15 @@ nunjucksEnv.addFilter('as_number', (str) => parseFloat(str));
 
 // jinja global functions
 const nunjucksContext = {
-    env_var: (key: string, fallback?: string) => process.env[key] ?? fallback,
+    env_var: (key: string, options?: string | { default?: string }) => {
+        let fallbackValue: string | undefined;
+        if (typeof options === 'string') {
+            fallbackValue = options;
+        } else if (typeof options === 'object') {
+            fallbackValue = options.default;
+        }
+        return process.env[key] ?? fallbackValue;
+    },
     var: (key: string) =>
         JSON.parse(process.argv[process.argv.indexOf('--vars') + 1])[key],
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import { LightdashError, ValidationTarget } from '@lightdash/common';
 import { InvalidArgumentError, Option, program } from 'commander';
-import * as os from 'os';
-import * as path from 'path';
+import { findDbtDefaultProfile } from './dbt/profile';
 import { compileHandler } from './handlers/compile';
 import { refreshHandler } from './handlers/dbt/refresh';
 import { dbtRunHandler } from './handlers/dbt/run';
@@ -29,10 +28,7 @@ const OPTIMIZED_NODE_VERSION = 20;
 const { version: VERSION } = require('../package.json');
 
 const defaultProjectDir = process.env.DBT_PROJECT_DIR || '.';
-const defaultProfilesDir =
-    process.env.DBT_PROFILES_DIR ||
-    process.cwd() ||
-    path.join(os.homedir(), '.dbt');
+const defaultProfilesDir: string = findDbtDefaultProfile();
 
 function parseIntArgument(value: string) {
     const parsedValue = parseInt(value, 10);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,9 @@ const { version: VERSION } = require('../package.json');
 
 const defaultProjectDir = process.env.DBT_PROJECT_DIR || '.';
 const defaultProfilesDir =
-    process.env.DBT_PROFILES_DIR || path.join(os.homedir(), '.dbt');
+    process.env.DBT_PROFILES_DIR ||
+    process.cwd() ||
+    path.join(os.homedir(), '.dbt');
 
 function parseIntArgument(value: string) {
     const parsedValue = parseInt(value, 10);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10649 and #10674  <!-- reference the related issue e.g. #150 -->

### Description:
Lightdash now checks for profile.yml file in parallel logic to how dbt finds profile.yml file using following precedence.
1. `--profiles-dir` option.
2. `DBT_PROFILES_DIR` environment variable.
3. Current working directory using `process.cwd()` which gives directory from which Lightdash process is started. 
4. `~/.dbt/` directory.

note: 
`yarn link` cannot be used to do manually testing of cwd feature as using `yarn lightdash dbt run`  will change the cwd to directory in which package.json is present hence cwd feature will not work. 

### **Bonus Point Issue :** 
`[object object]` error was occurring due to conversion of obejct to string inside `packages/cli/src/dbt/templating.ts`
Now Nunjucks template handles object and insures output is of always of expected type. 

Now `default` keyword can be used to give fallback values in Nunjucks templates. 
Eg: `target: "{{ env_var('DBT_TARGET', default='jaffle') }}"`

Giving no keywords is also supported.
Eg: `target: "{{ env_var('DBT_TARGET', 'jaffle') }}"`

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
