### PR TITLE
fix: group by clear bar chart sql

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
@@ -155,7 +155,7 @@ const GroupByFieldAxisConfig = ({
                 value: groupBy.reference,
                 label: groupBy.reference,
             }))}
-            value={field?.reference}
+            value={field?.reference ?? null}
             placeholder="Select group by"
             error={
                 field !== undefined &&

--- a/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
@@ -174,13 +174,15 @@ const GroupByFieldAxisConfig = ({
                 }
             }}
             icon={
-                <TableFieldIcon
-                    fieldType={
-                        sqlColumns?.find(
-                            (x) => x.reference === field?.reference,
-                        )?.type ?? DimensionType.STRING
-                    }
-                />
+                field?.reference ? (
+                    <TableFieldIcon
+                        fieldType={
+                            sqlColumns?.find(
+                                (x) => x.reference === field?.reference,
+                            )?.type ?? DimensionType.STRING
+                        }
+                    />
+                ) : null
             }
             clearable
         />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

When the `group by` is cleared, return `null` on `value` so that it disappears. Mantine takes `undefined` as a "show me previous" 

Demo


https://github.com/user-attachments/assets/b8b60efa-8160-410b-95be-fb19f1b91b52



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
