### PR TITLE
chore: add a selector for the current chart config

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,4 +1,3 @@
-import { ChartKind } from '@lightdash/common';
 import { ActionIcon, Group, Paper, Stack, Title, Tooltip } from '@mantine/core';
 import {
     IconArrowBackUp,
@@ -17,6 +16,7 @@ import { toggleModal } from '../../store/sqlRunnerSlice';
 import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { UpdateSqlChartModal } from '../UpdateSqlChartModal';
+import {selectCurrentChartConfig} from "../../store/selectors";
 
 export const HeaderEdit: FC = () => {
     const history = useHistory();
@@ -25,11 +25,7 @@ export const HeaderEdit: FC = () => {
         (state) => state.sqlRunner.savedSqlChart,
     );
     const sql = useAppSelector((state) => state.sqlRunner.sql);
-    const config = useAppSelector((state) =>
-        state.sqlRunner.selectedChartType === ChartKind.TABLE
-            ? state.tableVisConfig.config
-            : state.barChartConfig.config,
-    );
+    const config = useAppSelector((state) => selectCurrentChartConfig(state));
     const { mutate } = useUpdateSqlChartMutation(
         savedSqlChart?.project.projectUuid || '',
         savedSqlChart?.savedSqlUuid || '',

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -1,4 +1,3 @@
-import { ChartKind } from '@lightdash/common';
 import {
     Button,
     Group,
@@ -25,6 +24,7 @@ import {
 } from '../../../hooks/useSpaces';
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { selectCurrentChartConfig } from '../store/selectors';
 import { updateName } from '../store/sqlRunnerSlice';
 
 type FormValues = z.infer<typeof validationSchema>;
@@ -64,12 +64,7 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     }, [name, form, description, spaces]);
 
     const sql = useAppSelector((state) => state.sqlRunner.sql);
-    const config = useAppSelector((state) =>
-        state.sqlRunner.selectedChartType === undefined ||
-        state.sqlRunner.selectedChartType === ChartKind.TABLE
-            ? state.tableVisConfig.config
-            : state.barChartConfig.config,
-    );
+    const config = useAppSelector((state) => selectCurrentChartConfig(state));
 
     const {
         mutateAsync: createSavedSqlChart,

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -1,0 +1,40 @@
+import { ChartKind } from '@lightdash/common';
+import { createSelector } from 'reselect';
+import { type RootState } from '.';
+
+const selectSqlRunnerState = (state: RootState): RootState['sqlRunner'] =>
+    state.sqlRunner;
+const selectBarChartConfigState = (
+    state: RootState,
+): RootState['barChartConfig'] => state.barChartConfig;
+const selectPieChartConfigState = (
+    state: RootState,
+): RootState['pieChartConfig'] => state.pieChartConfig;
+const selectTableVisConfigState = (
+    state: RootState,
+): RootState['tableVisConfig'] => state.tableVisConfig;
+
+export const selectCurrentChartConfig = createSelector(
+    [
+        selectSqlRunnerState,
+        selectBarChartConfigState,
+        selectPieChartConfigState,
+        selectTableVisConfigState,
+    ],
+    (
+        sqlRunnerState,
+        barChartConfigState,
+        pieChartConfigState,
+        tableVisConfigState,
+    ) => {
+        const { selectedChartType } = sqlRunnerState;
+        if (selectedChartType === ChartKind.VERTICAL_BAR) {
+            return barChartConfigState.config;
+        } else if (selectedChartType === ChartKind.PIE) {
+            return pieChartConfigState.config;
+        } else if (selectedChartType === ChartKind.TABLE) {
+            return tableVisConfigState.config;
+        }
+        return null;
+    },
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Add a selectors file with a compound selector. This makes it so you can get the current chart config without know which it is like 

`const config = useAppSelector((state) => selectCurrentChartConfig(state));`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
