### PR TITLE
fix: If a chart is deleted, It should be redirected to the dashboard

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -976,7 +976,13 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                             }
                         });
 
-                        history.push('/');
+                        if (search) {
+                            history.push(
+                                `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                            );
+                        } else {
+                            history.push(`/`);
+                        }
 
                         deleteModalHandlers.close();
                     }}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -976,7 +976,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                             }
                         });
 
-                        if (search) {
+                        if (dashboardUuid) {
                             history.push(
                                 `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
                             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: (https://github.com/lightdash/lightdash/issues/10819)

### Description:
If we are editing chats from any dashboard, the history will include parameters like fromDashboard={dashboardId}. If we are editing chats from space, it will be null. I check if the search parameter is not null; 
If it isn’t, I redirect to the dashboard, Otherwise I redirect to the home page.



https://www.loom.com/share/2c58db6dba4647deaf8bb95685f40b1e?sid=a5f8d6a7-6f18-4caa-8c97-f16d4a82391d

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
