### PR TITLE
docs: fix broken sql filter link

### DIFF
--- a/docs/docs/guides/limiting-data-using-filters.mdx
+++ b/docs/docs/guides/limiting-data-using-filters.mdx
@@ -38,7 +38,7 @@ You can [add filters to your charts individually in the Explore view](#adding-fi
 
 :::info
 
-If you're a developer, you can add permanent filters to tables using the `sql_filter` yaml option. For more information see [Table configuration](../references/tables#sql-filter)
+If you're a developer, you can add permanent filters to tables using the `sql_filter` yaml option. For more information see [Table configuration](../../references/tables#sql-filter)
 
 :::
 


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

here

https://docs.lightdash.com/guides/limiting-data-using-filters/

linking to table sql filters:

![CleanShot 2024-08-01 at 12 02 30@2x](https://github.com/user-attachments/assets/d1303acb-45c7-4a9e-9e72-4faea5adc732)

was broken.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
