### PR TITLE
fix: dashboard SQL chart tile error state

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -1,7 +1,6 @@
 import {
     ChartKind,
     isTableChartSQLConfig,
-    type Dashboard,
     type DashboardSqlChartTile as DashboardSqlChartTileType,
 } from '@lightdash/common';
 import { IconAlertCircle } from '@tabler/icons-react';
@@ -19,21 +18,19 @@ interface Props
         'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
     > {
     tile: DashboardSqlChartTileType;
-    onAddTiles?: (tiles: Dashboard['tiles'][number][]) => void;
+    minimal?: boolean;
 }
 
 /**
  * TODO
  * Handle minimal mode
- * Handle edit
- * Add support for description and title
+ * handle tabs
  */
 
 export const DashboardSqlChartTile: FC<Props> = ({
     tile,
     isEditMode,
-    onEdit,
-    onDelete,
+    ...rest
 }) => {
     const { projectUuid } = useParams<{
         projectUuid: string;
@@ -49,76 +46,60 @@ export const DashboardSqlChartTile: FC<Props> = ({
             <TileBase
                 isEditMode={isEditMode}
                 chartName={tile.properties.chartName ?? ''}
-                // TODO: complete this
-                belongsToDashboard={false}
                 tile={tile}
                 isLoading
-                title={tile.properties.chartName || ''}
-                // TODO: see if we can remove these
-                onDelete={() => {}}
-                onEdit={() => {}}
+                title={tile.properties.title || tile.properties.chartName || ''}
+                {...rest}
             />
         );
     }
 
-    if (error !== null || !data)
+    if (error !== null || !data) {
         return (
             <TileBase
-                title=""
                 isEditMode={isEditMode}
+                chartName={tile.properties.chartName ?? ''}
                 tile={tile}
-                onDelete={() => {}}
-                onEdit={() => {}}
+                title={tile.properties.title || tile.properties.chartName || ''}
+                {...rest}
             >
                 <SuboptimalState
                     icon={IconAlertCircle}
-                    // TODO: handle error
-                    title="No data available"
+                    title={error?.error?.message || 'No data available'}
                 />
             </TileBase>
         );
+    }
 
     return (
-        <>
-            {data.chart && data.results ? (
-                <TileBase
-                    isEditMode={isEditMode}
-                    chartName={tile.properties.chartName ?? ''}
-                    titleHref={`/projects/${projectUuid}/sql-runner-new/saved/${data.chart.slug}`}
-                    tile={tile}
-                    title={
-                        tile.properties.title || tile.properties.chartName || ''
-                    }
-                    onDelete={onDelete}
-                    onEdit={onEdit}
-                >
-                    {data.chart.config.type === ChartKind.TABLE &&
-                        isTableChartSQLConfig(data.chart.config) && (
-                            <Table
-                                data={data.results}
-                                config={data.chart.config}
-                            />
-                        )}
-                    {(data.chart.config.type === ChartKind.VERTICAL_BAR ||
-                        data.chart.config.type === ChartKind.PIE) && (
-                        <SqlRunnerChart
-                            data={{
-                                results: data.results,
-                                columns: [],
-                            }}
-                            config={data.chart.config}
-                            style={{
-                                minHeight: 'inherit',
-                                height: '100%',
-                                width: '100%',
-                            }}
-                            isLoading={isLoading}
-                        />
-                    )}
-                </TileBase>
-            ) : (
-                <div>No data</div>
+        <TileBase
+            isEditMode={isEditMode}
+            chartName={tile.properties.chartName ?? ''}
+            titleHref={`/projects/${projectUuid}/sql-runner-new/saved/${data.chart.slug}`}
+            tile={tile}
+            title={tile.properties.title || tile.properties.chartName || ''}
+            {...rest}
+        >
+            {data.chart.config.type === ChartKind.TABLE &&
+                isTableChartSQLConfig(data.chart.config) && (
+                    <Table data={data.results} config={data.chart.config} />
+                )}
+            {(data.chart.config.type === ChartKind.VERTICAL_BAR ||
+                data.chart.config.type === ChartKind.PIE) && (
+                <SqlRunnerChart
+                    data={{
+                        results: data.results,
+                        columns: [],
+                    }}
+                    config={data.chart.config}
+                    style={{
+                        minHeight: 'inherit',
+                        height: '100%',
+                        width: '100%',
+                    }}
+                    isLoading={isLoading}
+                />
             )}
-        </>
+        </TileBase>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10936](https://github.com/lightdash/lightdash/issues/10936) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- check `isFetched` and `isFetching` to catch when query is not enabled ( aka, savedSqlChartUuid is null )
- check if any of the queries returned an error
- update tile props 

Before: we would show the loading state if something was wrong

After: when saved chart no longer exists

<img width="1329" alt="Screenshot 2024-08-01 at 12 06 42" src="https://github.com/user-attachments/assets/8e22804d-3bf4-466e-8b20-f937d6db4aae">

After: when there is an error fetching chart and results

<img width="1299" alt="Screenshot 2024-08-01 at 12 23 02" src="https://github.com/user-attachments/assets/d51cf5cc-c392-4ca0-ab1f-400af89bd038">




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
