### PR TITLE
fix: allow to update a dashboard whith SQL chart tiles where the uuid…

### DIFF
--- a/packages/backend/src/database/migrations/20240801113622_update_dashboard_tile_sql_chart_to_be_nullable.ts
+++ b/packages/backend/src/database/migrations/20240801113622_update_dashboard_tile_sql_chart_to_be_nullable.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('dashboard_tile_sql_charts', (table) => {
+        table.uuid('saved_sql_uuid').nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('dashboard_tile_sql_charts', (table) => {
+        table.uuid('saved_sql_uuid').notNullable().alter();
+    });
+}


### PR DESCRIPTION
… is null

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We allow a user to update a dashboard with tiles where the chart was deleted.

Reproduction steps:

- create dashboard
- add tile with SQL chart
- save
- delete SQL chart
- update dashboard

Before: SQL error because table doesn't allow `null` value
After: Dashboard is updated with success

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
