### PR TITLE
fix: change y axis aggregation based on index instead of reference

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/BarChartFieldConfiguration.tsx
@@ -145,7 +145,7 @@ const YFieldsAxisConfig: FC<{
                                 onChangeAggregation={(value) =>
                                     dispatch(
                                         setYAxisAggregation({
-                                            reference: field.reference,
+                                            index,
                                             aggregation: value,
                                         }),
                                     )

--- a/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
@@ -84,16 +84,14 @@ export const barChartConfigSlice = createSlice({
         setYAxisAggregation: (
             { config },
             action: PayloadAction<{
-                reference: string;
+                index: number;
                 aggregation: AggregationOptions;
             }>,
         ) => {
             if (!config) return;
             if (!config?.fieldConfig?.y) return;
 
-            const yAxis = config.fieldConfig.y.find(
-                (axis) => axis.reference === action.payload.reference,
-            );
+            const yAxis = config.fieldConfig.y[action.payload.index];
             if (yAxis) {
                 yAxis.aggregation = action.payload.aggregation;
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A


### Description:

Before we were relying on `reference` but a 2 series can have the same reference. This won't work as expected when changing a series' aggregation. So this relies on the `index` as the other actions for y axis fields.


Demo:


https://github.com/user-attachments/assets/36d540ef-ea98-45a1-aee8-2edb275f19da



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
