### PR TITLE
fix: cli compile joined models on select and exclude

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,6 @@
     "scripts": {
         "test": "jest",
         "build": "tsc --build tsconfig.json",
-        "build-watch": "tsc --build tsconfig.json --watch",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "prettier --config .prettierrc.js --ignore-unknown --ignore-path ./../../.gitignore",
         "lint": "yarn run linter ./src",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "scripts": {
         "test": "jest",
         "build": "tsc --build tsconfig.json",
+        "build-watch": "tsc --build tsconfig.json --watch",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "prettier --config .prettierrc.js --ignore-unknown --ignore-path ./../../.gitignore",
         "lint": "yarn run linter ./src",

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import globalState from '../globalState';
 import { getDbtVersion } from '../handlers/dbt/getDbtVersion';
 
-type LoadManifestArgs = {
+export type LoadManifestArgs = {
     targetDir: string;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4748

### Description:
- Runs `dbt parse` to generate a manifest before compiling all the models and their joins (looks recursively and takes into account `--select` and `--exclude` opts)

https://github.com/user-attachments/assets/5f91ca85-161e-497f-98cf-40a49d35877e

test-cli

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
