### PR TITLE
fix: dont use conditional visibility for table overflows

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mantine/core';
 import { IconLayoutSidebarLeftCollapse } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
-import { ConditionalVisibility } from '../../../components/common/ConditionalVisibility';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useAppSelector } from '../store/hooks';
 import { SidebarTabs } from '../store/sqlRunnerSlice';
@@ -42,13 +41,14 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                 </Tooltip>
             </Group>
 
-            <ConditionalVisibility
-                isVisible={activeSidebarTab === SidebarTabs.TABLES}
+            <Stack
+                display={
+                    activeSidebarTab === SidebarTabs.TABLES ? 'inherit' : 'none'
+                }
+                sx={{ flex: 1, overflow: 'hidden' }}
             >
-                <Stack sx={{ flex: 1, overflow: 'hidden' }}>
-                    <TablesPanel />
-                </Stack>
-            </ConditionalVisibility>
+                <TablesPanel />
+            </Stack>
 
             <ScrollArea
                 offsetScrollbars
@@ -56,15 +56,15 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                 className="only-vertical"
                 sx={{
                     flex: 1,
+                    display:
+                        activeSidebarTab === SidebarTabs.VISUALIZATION
+                            ? 'inherit'
+                            : 'none',
                 }}
             >
-                <ConditionalVisibility
-                    isVisible={activeSidebarTab === SidebarTabs.VISUALIZATION}
-                >
-                    <Stack sx={{ flex: 1, overflow: 'hidden' }}>
-                        <VisualizationConfigPanel />
-                    </Stack>
-                </ConditionalVisibility>
+                <Stack sx={{ flex: 1, overflow: 'hidden' }}>
+                    <VisualizationConfigPanel />
+                </Stack>
             </ScrollArea>
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->



### Description:

avoids using `ConditionalVisibility` (because it messes up with the hierarchy + react resizable) It should be a ConditionalDisplay instead - I wanted to add a new component but this should be a quick fix

Before

https://github.com/user-attachments/assets/fd9449f0-9386-4e90-a807-b6f0decaf356

After


https://github.com/user-attachments/assets/af02c5ca-1ecd-4433-a863-e5d5731190ed



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
