### PR TITLE
fix: show popover on paste

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -5,6 +5,7 @@ import uniq from 'lodash/uniq';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../MantineIcon';
 import { useFiltersContext } from '../FiltersProvider';
+import MultiValuePastePopover from './MultiValuePastePopover';
 
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     field: FilterableItem;
@@ -26,6 +27,10 @@ const FilterMultiStringInput: FC<Props> = ({
     }
 
     const [search, setSearch] = useState('');
+    const [pastePopUpOpened, setPastePopUpOpened] = useState(false);
+    const [tempPasteValues, setTempPasteValues] = useState<
+        string | undefined
+    >();
 
     const [resultsSets] = useState([]);
 
@@ -61,20 +66,12 @@ const FilterMultiStringInput: FC<Props> = ({
     const handlePaste = useCallback(
         (event: React.ClipboardEvent<HTMLInputElement>) => {
             const clipboardData = event.clipboardData.getData('Text');
-            const clipboardDataArray = clipboardData
-                .split(/\,|\n/)
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0);
-
-            // if clipboard data is comma separated or new line separated and has more than 1 value
-            // we add all of them to the values list and reset search
-            // when there's only 1 value in the clipboard, we let the default behavior of the input handle it
-            if (clipboardDataArray.length > 1) {
-                handleAddMultiple(clipboardDataArray);
-                handleResetSearch();
+            if (clipboardData.includes(',') || clipboardData.includes('\n')) {
+                setTempPasteValues(clipboardData);
+                setPastePopUpOpened(true);
             }
         },
-        [handleAddMultiple, handleResetSearch],
+        [],
     );
 
     const data = useMemo(() => {
@@ -88,48 +85,75 @@ const FilterMultiStringInput: FC<Props> = ({
     }, [results, values]);
 
     return (
-        <MultiSelect
-            size="xs"
-            w="100%"
-            placeholder={
-                values.length > 0 || disabled ? undefined : placeholder
-            }
-            disabled={disabled}
-            creatable
-            getCreateLabel={(query) => (
-                <Group spacing="xxs">
-                    <MantineIcon icon={IconPlus} color="blue" size="sm" />
-                    <Text color="blue">Add "{query}"</Text>
-                </Group>
-            )}
-            styles={{
-                item: {
-                    // makes add new item button sticky to bottom
-                    '&:last-child:not([value])': {
-                        position: 'sticky',
-                        bottom: 4,
-                        // casts shadow on the bottom of the list to avoid transparency
-                        boxShadow: '0 4px 0 0 white',
-                    },
-                    '&:last-child:not([value]):not(:hover)': {
-                        background: 'white',
-                    },
-                },
+        <MultiValuePastePopover
+            opened={pastePopUpOpened}
+            onClose={() => {
+                setPastePopUpOpened(false);
+                setTempPasteValues(undefined);
+                handleResetSearch();
             }}
-            disableSelectedItemFiltering={false}
-            searchable
-            clearSearchOnChange
-            {...rest}
-            searchValue={search}
-            onSearchChange={setSearch}
-            onPaste={handlePaste}
-            nothingFound={'Please type to add the filter value'}
-            data={data}
-            value={values}
-            onDropdownClose={handleResetSearch}
-            onChange={handleChange}
-            onCreate={handleAdd}
-        />
+            onMultiValue={() => {
+                if (!tempPasteValues) {
+                    setPastePopUpOpened(false);
+                    return;
+                }
+                const clipboardDataArray = tempPasteValues
+                    .split(/\,|\n/)
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                handleAddMultiple(clipboardDataArray);
+            }}
+            onSingleValue={() => {
+                if (!tempPasteValues) {
+                    setPastePopUpOpened(false);
+                    return;
+                }
+                handleAdd(tempPasteValues);
+            }}
+        >
+            <MultiSelect
+                size="xs"
+                w="100%"
+                placeholder={
+                    values.length > 0 || disabled ? undefined : placeholder
+                }
+                disabled={disabled}
+                creatable
+                getCreateLabel={(query) => (
+                    <Group spacing="xxs">
+                        <MantineIcon icon={IconPlus} color="blue" size="sm" />
+                        <Text color="blue">Add "{query}"</Text>
+                    </Group>
+                )}
+                styles={{
+                    item: {
+                        // makes add new item button sticky to bottom
+                        '&:last-child:not([value])': {
+                            position: 'sticky',
+                            bottom: 4,
+                            // casts shadow on the bottom of the list to avoid transparency
+                            boxShadow: '0 4px 0 0 white',
+                        },
+                        '&:last-child:not([value]):not(:hover)': {
+                            background: 'white',
+                        },
+                    },
+                }}
+                disableSelectedItemFiltering={false}
+                searchable
+                clearSearchOnChange
+                {...rest}
+                searchValue={search}
+                onSearchChange={setSearch}
+                onPaste={handlePaste}
+                nothingFound={'Please type to add the filter value'}
+                data={data}
+                value={values}
+                onDropdownClose={handleResetSearch}
+                onChange={handleChange}
+                onCreate={handleAdd}
+            />
+        </MultiValuePastePopover>
     );
 };
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../hooks/useFieldValues';
 import MantineIcon from '../../MantineIcon';
 import { useFiltersContext } from '../FiltersProvider';
+import MultiValuePastePopover from './MultiValuePastePopover';
 
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     filterId: string;
@@ -44,6 +45,10 @@ const FilterStringAutoComplete: FC<Props> = ({
     }
 
     const [search, setSearch] = useState('');
+    const [pastePopUpOpened, setPastePopUpOpened] = useState(false);
+    const [tempPasteValues, setTempPasteValues] = useState<
+        string | undefined
+    >();
 
     const autocompleteFilterGroup = useMemo(
         () => getAutocompleteFilterGroup(filterId, field),
@@ -92,20 +97,13 @@ const FilterStringAutoComplete: FC<Props> = ({
     const handlePaste = useCallback(
         (event: React.ClipboardEvent<HTMLInputElement>) => {
             const clipboardData = event.clipboardData.getData('Text');
-            const clipboardDataArray = clipboardData
-                .split(/\,|\n/)
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0);
-
-            // if clipboard data is comma separated or new line separated and has more than 1 value
-            // we add all of them to the values list and reset search
-            // when there's only 1 value in the clipboard, we let the default behavior of the input handle it
-            if (clipboardDataArray.length > 1) {
-                handleAddMultiple(clipboardDataArray);
-                handleResetSearch();
+            console.log('onPaste2', clipboardData);
+            if (clipboardData.includes(',') || clipboardData.includes('\n')) {
+                setTempPasteValues(clipboardData);
+                setPastePopUpOpened(true);
             }
         },
-        [handleAddMultiple, handleResetSearch],
+        [],
     );
 
     const handleKeyDown = useCallback(
@@ -154,76 +152,105 @@ const FilterStringAutoComplete: FC<Props> = ({
     );
 
     return (
-        <MultiSelect
-            size="xs"
-            w="100%"
-            placeholder={
-                values.length > 0 || disabled ? undefined : placeholder
-            }
-            disabled={disabled}
-            creatable
-            /**
-             * Opts out of Mantine's default condition and always allows adding, as long as not
-             * an empty query.
-             */
-            shouldCreate={(query) =>
-                query.trim().length > 0 && !values.includes(query)
-            }
-            getCreateLabel={(query) => (
-                <Group spacing="xxs">
-                    <MantineIcon icon={IconPlus} color="blue" size="sm" />
-                    <Text color="blue">Add "{query}"</Text>
-                </Group>
-            )}
-            styles={{
-                item: {
-                    // makes add new item button sticky to bottom
-                    '&:last-child:not([value])': {
-                        position: 'sticky',
-                        bottom: 4,
-                        // casts shadow on the bottom of the list to avoid transparency
-                        boxShadow: '0 4px 0 0 white',
-                    },
-                    '&:last-child:not([value]):not(:hover)': {
-                        background: 'white',
-                    },
-                },
-            }}
-            disableSelectedItemFiltering
-            searchable
-            clearSearchOnChange
-            {...rest}
-            searchValue={search}
-            onSearchChange={setSearch}
-            limit={MAX_AUTOCOMPLETE_RESULTS}
-            onPaste={handlePaste}
-            nothingFound={isInitialLoading ? 'Loading...' : 'No results found'}
-            rightSection={
-                isInitialLoading ? <Loader size="xs" color="gray" /> : null
-            }
-            dropdownComponent={DropdownComponentOverride}
-            itemComponent={({ label, ...others }) =>
-                others.disabled ? (
-                    <Text color="dimmed" {...others}>
-                        {label}
-                    </Text>
-                ) : (
-                    <Highlight highlight={search} {...others}>
-                        {label}
-                    </Highlight>
-                )
-            }
-            data={data}
-            value={values}
-            onDropdownOpen={onDropdownOpen}
-            onDropdownClose={() => {
+        <MultiValuePastePopover
+            opened={pastePopUpOpened}
+            onClose={() => {
+                setPastePopUpOpened(false);
+                setTempPasteValues(undefined);
                 handleResetSearch();
-                onDropdownClose?.();
             }}
-            onChange={handleChange}
-            onCreate={handleAdd}
-            onKeyDown={handleKeyDown}
-        />
+            onMultiValue={() => {
+                if (!tempPasteValues) {
+                    setPastePopUpOpened(false);
+                    return;
+                }
+                const clipboardDataArray = tempPasteValues
+                    .split(/\,|\n/)
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                handleAddMultiple(clipboardDataArray);
+            }}
+            onSingleValue={() => {
+                if (!tempPasteValues) {
+                    setPastePopUpOpened(false);
+                    return;
+                }
+                handleAdd(tempPasteValues);
+            }}
+        >
+            <MultiSelect
+                size="xs"
+                w="100%"
+                placeholder={
+                    values.length > 0 || disabled ? undefined : placeholder
+                }
+                disabled={disabled}
+                creatable
+                /**
+                 * Opts out of Mantine's default condition and always allows adding, as long as not
+                 * an empty query.
+                 */
+                shouldCreate={(query) =>
+                    query.trim().length > 0 && !values.includes(query)
+                }
+                getCreateLabel={(query) => (
+                    <Group spacing="xxs">
+                        <MantineIcon icon={IconPlus} color="blue" size="sm" />
+                        <Text color="blue">Add "{query}"</Text>
+                    </Group>
+                )}
+                styles={{
+                    item: {
+                        // makes add new item button sticky to bottom
+                        '&:last-child:not([value])': {
+                            position: 'sticky',
+                            bottom: 4,
+                            // casts shadow on the bottom of the list to avoid transparency
+                            boxShadow: '0 4px 0 0 white',
+                        },
+                        '&:last-child:not([value]):not(:hover)': {
+                            background: 'white',
+                        },
+                    },
+                }}
+                disableSelectedItemFiltering
+                searchable
+                clearSearchOnChange
+                {...rest}
+                searchValue={search}
+                onSearchChange={setSearch}
+                limit={MAX_AUTOCOMPLETE_RESULTS}
+                onPaste={handlePaste}
+                nothingFound={
+                    isInitialLoading ? 'Loading...' : 'No results found'
+                }
+                rightSection={
+                    isInitialLoading ? <Loader size="xs" color="gray" /> : null
+                }
+                dropdownComponent={DropdownComponentOverride}
+                itemComponent={({ label, ...others }) =>
+                    others.disabled ? (
+                        <Text color="dimmed" {...others}>
+                            {label}
+                        </Text>
+                    ) : (
+                        <Highlight highlight={search} {...others}>
+                            {label}
+                        </Highlight>
+                    )
+                }
+                data={data}
+                value={values}
+                onDropdownOpen={onDropdownOpen}
+                onDropdownClose={() => {
+                    handleResetSearch();
+                    onDropdownClose?.();
+                }}
+                onChange={handleChange}
+                onCreate={handleAdd}
+                onKeyDown={handleKeyDown}
+            />
+        </MultiValuePastePopover>
     );
 };
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -97,7 +97,6 @@ const FilterStringAutoComplete: FC<Props> = ({
     const handlePaste = useCallback(
         (event: React.ClipboardEvent<HTMLInputElement>) => {
             const clipboardData = event.clipboardData.getData('Text');
-            console.log('onPaste2', clipboardData);
             if (clipboardData.includes(',') || clipboardData.includes('\n')) {
                 setTempPasteValues(clipboardData);
                 setPastePopUpOpened(true);

--- a/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
@@ -1,0 +1,66 @@
+import { Button, Flex, Popover, Text } from '@mantine/core';
+import { useCallback, type FC, type PropsWithChildren } from 'react';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    onMultiValue: () => void;
+    onSingleValue: () => void;
+};
+
+const MultiValuePastePopUp: FC<PropsWithChildren<Props>> = ({
+    opened,
+    onClose,
+    onMultiValue,
+    onSingleValue,
+    children,
+}) => {
+    const onSingleValueClick = useCallback(() => {
+        onSingleValue();
+        onClose();
+    }, [onClose, onSingleValue]);
+
+    const onMultiValueClick = useCallback(() => {
+        onMultiValue();
+        onClose();
+    }, [onClose, onMultiValue]);
+
+    return (
+        <Popover
+            opened={opened}
+            onClose={onClose}
+            position="top-start"
+            withArrow
+            arrowPosition="side"
+            closeOnEscape
+        >
+            <Popover.Target>{children}</Popover.Target>
+            <Popover.Dropdown>
+                <Text weight={500}>
+                    Multiple comma-separated values detected:
+                </Text>
+                <Text>
+                    Would you like to add them as single or multiple values?
+                </Text>
+                <Flex mt="xl" align={'center'} gap={'sm'} justify={'flex-end'}>
+                    <Button
+                        variant="light"
+                        size="sm"
+                        onClick={onSingleValueClick}
+                    >
+                        Single value
+                    </Button>
+                    <Button
+                        variant="light"
+                        size="sm"
+                        onClick={onMultiValueClick}
+                    >
+                        Multiple values
+                    </Button>
+                </Flex>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default MultiValuePastePopUp;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
@@ -32,7 +32,6 @@ const MultiValuePastePopUp: FC<PropsWithChildren<Props>> = ({
             position="top-start"
             withArrow
             arrowPosition="side"
-            closeOnEscape
         >
             <Popover.Target>{children}</Popover.Target>
             <Popover.Dropdown>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

When pasting a value into a filter our default behavior was to always add it as multiple values when the clipboard contents had commas.
This PR makes it so that when pasting a comma separated value we ask for user input on how the value should be treated

- Shows a popover when pasting to filters if the clipboard values has comma separated values

**chart filters**

https://github.com/user-attachments/assets/245d04d9-6a15-462a-99c7-dfb192a23d41

**dashboard filters**
![Screenshot 2024-08-02 at 09 41 50](https://github.com/user-attachments/assets/e0da89b9-3287-4b18-b580-bbde1b0e6e04)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
