### PR TITLE
fix: page sidebar above center main section

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -86,6 +86,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                 pos="relative"
                 h="100%"
                 mah="100%"
+                sx={{ zIndex: 1 }}
                 {...containerProps}
             >
                 <Transition


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10935](https://github.com/lightdash/lightdash/issues/10935)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Make sure the sidebar component has a higher z-index than the main content so the drag and drop is available.

Before:
![sidebar drag bug](https://github.com/user-attachments/assets/cba65148-8d1b-43f2-a7c6-1ed6e0315164)

After:

![zindex fix](https://github.com/user-attachments/assets/fedc92d7-408a-4e8a-becb-c2b589c1eee3)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
