### PR TITLE
fix: slack auth model throwing an error

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -61,7 +61,9 @@ export class SlackClient {
         return new WebClient(installation.token);
     }
 
-    async getChannels(organizationUuid: string): Promise<SlackChannel[]> {
+    async getChannels(
+        organizationUuid: string,
+    ): Promise<SlackChannel[] | undefined> {
         if (
             cachedChannels[organizationUuid] &&
             new Date().getTime() -
@@ -75,6 +77,13 @@ export class SlackClient {
 
         let nextCursor: string | undefined;
         let allChannels: ConversationsListResponse['channels'] = [];
+
+        const installation =
+            await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+                organizationUuid,
+            );
+
+        if (!installation) return undefined;
 
         const webClient = await this.getWebClient(organizationUuid);
 

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -1,6 +1,7 @@
 import {
     SlackAppCustomSettings,
     SlackChannel,
+    SlackInstallationNotFoundError,
     SlackSettings,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -55,7 +56,7 @@ export class SlackClient {
             );
 
         if (!installation) {
-            throw new Error('Could not find slack installation');
+            throw new SlackInstallationNotFoundError();
         }
 
         return new WebClient(installation.token);
@@ -193,7 +194,7 @@ export class SlackClient {
             );
 
         if (!installation) {
-            throw new Error('Could not find slack installation');
+            throw new SlackInstallationNotFoundError();
         }
 
         const { appProfilePhotoUrl } = installation;

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -54,7 +54,11 @@ export class SlackClient {
                 organizationUuid,
             );
 
-        return new WebClient(installation?.token);
+        if (!installation) {
+            throw new Error('Could not find slack installation');
+        }
+
+        return new WebClient(installation.token);
     }
 
     async getChannels(organizationUuid: string): Promise<SlackChannel[]> {
@@ -173,10 +177,17 @@ export class SlackClient {
     ) {
         const { organizationUuid, ...slackMessageArgs } = message;
         const webClient = await this.getWebClient(organizationUuid);
-        const { appProfilePhotoUrl } =
-            (await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+
+        const installation =
+            await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                 organizationUuid,
-            )) || {};
+            );
+
+        if (!installation) {
+            throw new Error('Could not find slack installation');
+        }
+
+        const { appProfilePhotoUrl } = installation;
 
         return webClient.chat
             .postMessage({

--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -1,4 +1,7 @@
-import { LightdashMode } from '@lightdash/common';
+import {
+    LightdashMode,
+    SlackInstallationNotFoundError,
+} from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { App, ExpressReceiver, LogLevel } from '@slack/bolt';
 import { Express } from 'express';
@@ -190,7 +193,7 @@ export class SlackBot {
                         );
 
                     if (!installation) {
-                        throw new Error('Could not find slack installation');
+                        throw new SlackInstallationNotFoundError();
                     }
 
                     appProfilePhotoUrl = installation.appProfilePhotoUrl;

--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -189,7 +189,11 @@ export class SlackBot {
                             details?.organizationUuid,
                         );
 
-                    appProfilePhotoUrl = installation?.appProfilePhotoUrl;
+                    if (!installation) {
+                        throw new Error('Could not find slack installation');
+                    }
+
+                    appProfilePhotoUrl = installation.appProfilePhotoUrl;
 
                     const { imageUrl } = await this.unfurlService.unfurlImage({
                         url: details.minimalUrl,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2769,6 +2769,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        uncompiledSqlWhere: { dataType: 'string' },
                         source: {
                             dataType: 'union',
                             subSchemas: [
@@ -6189,8 +6190,17 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SlackChannel' },
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'SlackChannel',
+                            },
+                        },
+                        { dataType: 'undefined' },
+                    ],
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3002,6 +3002,9 @@
                     },
                     {
                         "properties": {
+                            "uncompiledSqlWhere": {
+                                "type": "string"
+                            },
                             "source": {
                                 "$ref": "#/components/schemas/Source"
                             },
@@ -6921,7 +6924,7 @@
                         "nullable": false
                     }
                 },
-                "required": ["results", "status"],
+                "required": ["status"],
                 "type": "object"
             },
             "ApiSlackCustomSettingsResponse": {
@@ -8817,7 +8820,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1202.11",
+        "version": "0.1202.16",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -115,12 +115,11 @@ export class SlackAuthenticationModel {
                 'slack_auth_tokens.organization_id',
                 'organizations.organization_id',
             )
-            .select<(DbSlackAuthTokens & DbOrganization)[]>('*')
+            .select('*')
             .where('organization_uuid', organizationUuid);
-        if (row === undefined) {
-            return undefined;
-            // throw new Error(`Could not find slack installation`);
-        }
+
+        if (row === undefined) return undefined;
+
         return {
             createdAt: row.created_at,
             slackTeamName: row.installation?.team?.name || 'Slack',
@@ -129,7 +128,7 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
-            isSlackInstalled: true
+            isSlackInstalled: true,
         };
     }
 

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -118,7 +118,8 @@ export class SlackAuthenticationModel {
             .select<(DbSlackAuthTokens & DbOrganization)[]>('*')
             .where('organization_uuid', organizationUuid);
         if (row === undefined) {
-            throw new Error(`Could not find slack installation`);
+            return row;
+            // throw new Error(`Could not find slack installation`);
         }
         return {
             createdAt: row.created_at,
@@ -128,6 +129,7 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
+            slackEnabled: true
         };
     }
 

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -118,7 +118,7 @@ export class SlackAuthenticationModel {
             .select<(DbSlackAuthTokens & DbOrganization)[]>('*')
             .where('organization_uuid', organizationUuid);
         if (row === undefined) {
-            return row;
+            return undefined;
             // throw new Error(`Could not find slack installation`);
         }
         return {
@@ -129,7 +129,7 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
-            slackEnabled: true
+            isSlackInstalled: true
         };
     }
 

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -128,7 +128,6 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
-            isSlackInstalled: true,
         };
     }
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -37,6 +37,7 @@ import {
     SchedulerJobStatus,
     SchedulerLog,
     SessionUser,
+    SlackInstallationNotFoundError,
     SlackNotificationPayload,
     SqlColumn,
     sqlRunnerJob,
@@ -597,7 +598,7 @@ export default class SchedulerTask {
                 details: { error: e.message },
             });
 
-            if (`${e}`.includes('Could not find slack installation')) {
+            if (e instanceof SlackInstallationNotFoundError) {
                 console.warn(
                     `Disabling scheduler with non-retryable error: ${e}`,
                 );

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -37,11 +37,8 @@ export class SlackIntegrationService<
             );
         if (slackAuth === undefined) {
             return {
-                slackEnabled: false
+                isSlackInstalled: false
             };
-            // throw new NotFoundError(
-            //     `Could not find an installation for organizationUuid ${organizationUuid}`,
-            // );
         }
         const response: SlackSettings = {
             organizationUuid,
@@ -50,7 +47,7 @@ export class SlackIntegrationService<
             scopes: slackAuth.scopes,
             notificationChannel: slackAuth.notificationChannel,
             appProfilePhotoUrl: slackAuth.appProfilePhotoUrl,
-            slackEnabled: true
+            isSlackInstalled: true
         };
         return response;
     }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -31,23 +31,26 @@ export class SlackIntegrationService<
     async getInstallationFromOrganizationUuid(user: SessionUser) {
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
-        const slackAuth =
+
+        const installation =
             await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                 organizationUuid,
             );
-        if (slackAuth === undefined) {
+
+        if (installation === undefined) {
             return {
-                isSlackInstalled: false
+                isSlackInstalled: false,
             };
         }
+
         const response: SlackSettings = {
             organizationUuid,
-            slackTeamName: slackAuth.slackTeamName,
-            createdAt: slackAuth.createdAt,
-            scopes: slackAuth.scopes,
-            notificationChannel: slackAuth.notificationChannel,
-            appProfilePhotoUrl: slackAuth.appProfilePhotoUrl,
-            isSlackInstalled: true
+            slackTeamName: installation.slackTeamName,
+            createdAt: installation.createdAt,
+            scopes: installation.scopes,
+            notificationChannel: installation.notificationChannel,
+            appProfilePhotoUrl: installation.appProfilePhotoUrl,
+            isSlackInstalled: true,
         };
         return response;
     }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -37,11 +37,7 @@ export class SlackIntegrationService<
                 organizationUuid,
             );
 
-        if (installation === undefined) {
-            return {
-                isSlackInstalled: false,
-            };
-        }
+        if (installation === undefined) return undefined;
 
         const response: SlackSettings = {
             organizationUuid,
@@ -50,7 +46,6 @@ export class SlackIntegrationService<
             scopes: installation.scopes,
             notificationChannel: installation.notificationChannel,
             appProfilePhotoUrl: installation.appProfilePhotoUrl,
-            isSlackInstalled: true,
         };
         return response;
     }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -36,9 +36,12 @@ export class SlackIntegrationService<
                 organizationUuid,
             );
         if (slackAuth === undefined) {
-            throw new NotFoundError(
-                `Could not find an installation for organizationUuid ${organizationUuid}`,
-            );
+            return {
+                slackEnabled: false
+            };
+            // throw new NotFoundError(
+            //     `Could not find an installation for organizationUuid ${organizationUuid}`,
+            // );
         }
         const response: SlackSettings = {
             organizationUuid,
@@ -47,6 +50,7 @@ export class SlackIntegrationService<
             scopes: slackAuth.scopes,
             notificationChannel: slackAuth.notificationChannel,
             appProfilePhotoUrl: slackAuth.appProfilePhotoUrl,
+            slackEnabled: true
         };
         return response;
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -99,7 +99,7 @@ import {
     type SchedulerJobStatus,
     type SchedulerWithLogs,
 } from './types/scheduler';
-import { type SlackChannel } from './types/slack';
+import { type ApiSlackChannelsResponse } from './types/slack';
 import { type Space } from './types/space';
 import { type ApiSshKeyPairResponse } from './types/SshKeyPair';
 import { type TableBase } from './types/table';
@@ -625,8 +625,8 @@ type ApiResults =
     | DbtCloudIntegration
     | ShareUrl
     | SlackSettings
+    | ApiSlackChannelsResponse['results']
     | UserActivity
-    | SlackChannel[]
     | SchedulerAndTargets
     | SchedulerAndTargets[]
     | FieldValueSearchResult

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -313,3 +313,14 @@ export class KnexPaginationError extends LightdashError {
         });
     }
 }
+
+export class SlackInstallationNotFoundError extends LightdashError {
+    constructor(message: string = 'Could not find slack installation') {
+        super({
+            message,
+            name: 'SlackInstallationNotFoundError',
+            statusCode: 404,
+            data: {},
+        });
+    }
+}

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -5,7 +5,7 @@ export type SlackChannel = {
 
 export type ApiSlackChannelsResponse = {
     status: 'ok';
-    results: SlackChannel[];
+    results: SlackChannel[] | undefined;
 };
 
 export type ApiSlackCustomSettingsResponse = {

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -9,7 +9,7 @@ export type SlackSettings = {
     notificationChannel: string | undefined;
     appProfilePhotoUrl: string | undefined;
     slackChannelProjectMappings?: SlackChannelProjectMapping[];
-    slackEnabled: boolean;
+    isSlackInstalled: boolean;
 };
 
 export const slackRequiredScopes = [

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -9,6 +9,7 @@ export type SlackSettings = {
     notificationChannel: string | undefined;
     appProfilePhotoUrl: string | undefined;
     slackChannelProjectMappings?: SlackChannelProjectMapping[];
+    slackEnabled: boolean;
 };
 
 export const slackRequiredScopes = [

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -9,7 +9,6 @@ export type SlackSettings = {
     notificationChannel: string | undefined;
     appProfilePhotoUrl: string | undefined;
     slackChannelProjectMappings?: SlackChannelProjectMapping[];
-    isSlackInstalled: boolean;
 };
 
 export const slackRequiredScopes = [

--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -46,9 +46,12 @@ const Schedulers: FC<SchedulersProps> = ({
     dashboards,
 }) => {
     const { classes, theme } = useTableStyles();
-    const { data } = useGetSlack();
+
+    const { data: slackInstallation } = useGetSlack();
+    const organizationHasSlack = !!slackInstallation?.organizationUuid;
+
     const { data: allSlackChannels } = useSlackChannels({
-        enabled: !!data?.isSlackInstalled,
+        enabled: organizationHasSlack,
     });
 
     const getSlackChannelName = useCallback(

--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -8,7 +8,7 @@ import {
 import { Anchor, Box, Group, Stack, Table, Text, Tooltip } from '@mantine/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { Link } from 'react-router-dom';
-import { useSlackChannels } from '../../hooks/slack/useSlack';
+import { useGetSlack, useSlackChannels } from '../../hooks/slack/useSlack';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
 import {
@@ -46,7 +46,8 @@ const Schedulers: FC<SchedulersProps> = ({
     dashboards,
 }) => {
     const { classes, theme } = useTableStyles();
-    const { data: allSlackChannels } = useSlackChannels();
+    const { data } = useGetSlack();
+    const { data: allSlackChannels } = data?.slackEnabled ? useSlackChannels() : { data: [] };
 
     const getSlackChannelName = useCallback(
         (channelId: string) => {

--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -47,7 +47,9 @@ const Schedulers: FC<SchedulersProps> = ({
 }) => {
     const { classes, theme } = useTableStyles();
     const { data } = useGetSlack();
-    const { data: allSlackChannels } = data?.slackEnabled ? useSlackChannels() : { data: [] };
+    const { data: allSlackChannels } = useSlackChannels({
+        enabled: !!data?.isSlackInstalled,
+    });
 
     const getSlackChannelName = useCallback(
         (channelId: string) => {

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -54,9 +54,13 @@ const SlackSettingsPanel: FC = () => {
     const { data, isError, isInitialLoading } = useGetSlack();
     const isValidSlack = data?.slackTeamName !== undefined && !isError;
     const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } =
+        data?.slackEnabled ?
         useSlackChannels({
             enabled: isValidSlack,
-        });
+        }) : {
+            data: [],
+            isInitialLoading: false,
+        };
     const { mutate: deleteSlack } = useDeleteSlack();
     const { mutate: updateCustomSettings } =
         useUpdateSlackAppCustomSettingsMutation();

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -53,14 +53,9 @@ const SLACK_INSTALL_URL = `/api/v1/slack/install/`;
 const SlackSettingsPanel: FC = () => {
     const { data, isError, isInitialLoading } = useGetSlack();
     const isValidSlack = data?.slackTeamName !== undefined && !isError;
-    const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } =
-        data?.slackEnabled ?
-        useSlackChannels({
-            enabled: isValidSlack,
-        }) : {
-            data: [],
-            isInitialLoading: false,
-        };
+    const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } = useSlackChannels({
+        enabled: isValidSlack && !!data.isSlackInstalled,
+    });
     const { mutate: deleteSlack } = useDeleteSlack();
     const { mutate: updateCustomSettings } =
         useUpdateSlackAppCustomSettingsMutation();

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -51,11 +51,14 @@ export const hasRequiredScopes = (slackSettings: SlackSettings) => {
 const SLACK_INSTALL_URL = `/api/v1/slack/install/`;
 
 const SlackSettingsPanel: FC = () => {
-    const { data, isError, isInitialLoading } = useGetSlack();
-    const isValidSlack = data?.slackTeamName !== undefined && !isError;
-    const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } = useSlackChannels({
-        enabled: isValidSlack && !!data.isSlackInstalled,
-    });
+    const { data: slackInstallation, isInitialLoading } = useGetSlack();
+    const organizationHasSlack = !!slackInstallation?.organizationUuid;
+
+    const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } =
+        useSlackChannels({
+            enabled: organizationHasSlack,
+        });
+
     const { mutate: deleteSlack } = useDeleteSlack();
     const { mutate: updateCustomSettings } =
         useUpdateSlackAppCustomSettingsMutation();
@@ -70,11 +73,11 @@ const SlackSettingsPanel: FC = () => {
     const { setFieldValue, onSubmit } = form;
 
     useEffect(() => {
-        if (!data) return;
+        if (!slackInstallation) return;
 
         const initialValues = {
-            notificationChannel: data.notificationChannel ?? null,
-            appProfilePhotoUrl: data.appProfilePhotoUrl ?? null,
+            notificationChannel: slackInstallation.notificationChannel ?? null,
+            appProfilePhotoUrl: slackInstallation.appProfilePhotoUrl ?? null,
         };
 
         if (form.initialized) {
@@ -84,7 +87,7 @@ const SlackSettingsPanel: FC = () => {
             form.initialize(initialValues);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data]);
+    }, [slackInstallation]);
 
     const slackChannelOptions = useMemo(() => {
         return (
@@ -100,7 +103,7 @@ const SlackSettingsPanel: FC = () => {
     }
 
     const handleSubmit = onSubmit((args) => {
-        if (isValidSlack) {
+        if (organizationHasSlack) {
             updateCustomSettings(args);
         }
     });
@@ -118,7 +121,7 @@ const SlackSettingsPanel: FC = () => {
 
             <Stack>
                 <Stack spacing="sm">
-                    {isValidSlack && (
+                    {organizationHasSlack && (
                         <Group spacing="xs">
                             <Text fw={500}>Added to the Slack workspace: </Text>{' '}
                             <Badge
@@ -128,7 +131,7 @@ const SlackSettingsPanel: FC = () => {
                                 w="fit-content"
                             >
                                 <Text span fw={500}>
-                                    {data.slackTeamName}
+                                    {slackInstallation.slackTeamName}
                                 </Text>
                             </Badge>
                         </Group>
@@ -144,7 +147,7 @@ const SlackSettingsPanel: FC = () => {
                     </Text>
                 </Stack>
 
-                {isValidSlack ? (
+                {organizationHasSlack ? (
                     <form onSubmit={handleSubmit}>
                         <Stack spacing="sm">
                             <Select
@@ -193,7 +196,7 @@ const SlackSettingsPanel: FC = () => {
                                     size="xs"
                                     placeholder="https://lightdash.cloud/photo.jpg"
                                     type="url"
-                                    disabled={!isValidSlack}
+                                    disabled={!organizationHasSlack}
                                     {...form.getInputProps(
                                         'appProfilePhotoUrl',
                                     )}
@@ -241,18 +244,22 @@ const SlackSettingsPanel: FC = () => {
                                 </Button>
                             </Group>
 
-                            {data && !hasRequiredScopes(data) && (
-                                <Alert
-                                    color="blue"
-                                    icon={
-                                        <MantineIcon icon={IconAlertCircle} />
-                                    }
-                                >
-                                    Your Slack integration is not up to date,
-                                    you should reinstall the Slack integration
-                                    to guarantee the best user experience.
-                                </Alert>
-                            )}
+                            {organizationHasSlack &&
+                                !hasRequiredScopes(slackInstallation) && (
+                                    <Alert
+                                        color="blue"
+                                        icon={
+                                            <MantineIcon
+                                                icon={IconAlertCircle}
+                                            />
+                                        }
+                                    >
+                                        Your Slack integration is not up to
+                                        date, you should reinstall the Slack
+                                        integration to guarantee the best user
+                                        experience.
+                                    </Alert>
+                                )}
                         </Stack>
                     </form>
                 ) : (

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -339,7 +339,7 @@ const SchedulerForm: FC<Props> = ({
     });
 
     const slackQuery = useGetSlack();
-    const isSlackEnabled = slackQuery.data?.slackEnabled ? true : false
+    const isSlackInstalled = slackQuery.data?.isSlackInstalled ? true : false
     const slackState = useMemo(() => {
         if (slackQuery.isInitialLoading) {
             return SlackStates.LOADING;
@@ -356,7 +356,9 @@ const SchedulerForm: FC<Props> = ({
         }
     }, [slackQuery]);
 
-    const slackChannelsQuery = isSlackEnabled ? useSlackChannels() : undefined;
+    const slackChannelsQuery = useSlackChannels({
+        enabled: isSlackInstalled,
+    });
 
     const slackChannels = useMemo(() => {
         return (slackChannelsQuery?.data || [])

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -338,26 +338,19 @@ const SchedulerForm: FC<Props> = ({
         enabled: isDashboard,
     });
 
-    const slackQuery = useGetSlack();
-    const isSlackInstalled = slackQuery.data?.isSlackInstalled ? true : false
+    const { data: slackInstallation, isInitialLoading } = useGetSlack();
+    const organizationHasSlack = !!slackInstallation?.organizationUuid;
+
     const slackState = useMemo(() => {
-        if (slackQuery.isInitialLoading) {
-            return SlackStates.LOADING;
-        } else {
-            if (
-                slackQuery.data?.slackTeamName === undefined ||
-                slackQuery.isError
-            ) {
-                return SlackStates.NO_SLACK;
-            } else if (slackQuery.data && !hasRequiredScopes(slackQuery.data)) {
-                return SlackStates.MISSING_SCOPES;
-            }
-            return SlackStates.SUCCESS;
-        }
-    }, [slackQuery]);
+        if (isInitialLoading) return SlackStates.LOADING;
+        if (!organizationHasSlack) return SlackStates.NO_SLACK;
+        if (!hasRequiredScopes(slackInstallation))
+            return SlackStates.MISSING_SCOPES;
+        return SlackStates.SUCCESS;
+    }, [isInitialLoading, organizationHasSlack, slackInstallation]);
 
     const slackChannelsQuery = useSlackChannels({
-        enabled: isSlackInstalled,
+        enabled: organizationHasSlack,
     });
 
     const slackChannels = useMemo(() => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -339,6 +339,7 @@ const SchedulerForm: FC<Props> = ({
     });
 
     const slackQuery = useGetSlack();
+    const isSlackEnabled = slackQuery.data?.slackEnabled ? true : false
     const slackState = useMemo(() => {
         if (slackQuery.isInitialLoading) {
             return SlackStates.LOADING;
@@ -355,10 +356,10 @@ const SchedulerForm: FC<Props> = ({
         }
     }, [slackQuery]);
 
-    const slackChannelsQuery = useSlackChannels();
+    const slackChannelsQuery = isSlackEnabled ? useSlackChannels() : undefined;
 
     const slackChannels = useMemo(() => {
-        return (slackChannelsQuery.data || [])
+        return (slackChannelsQuery?.data || [])
             .map((channel) => {
                 const channelPrefix = channel.name.charAt(0);
 
@@ -374,7 +375,7 @@ const SchedulerForm: FC<Props> = ({
                 };
             })
             .concat(privateChannels);
-    }, [slackChannelsQuery.data, privateChannels]);
+    }, [slackChannelsQuery?.data, privateChannels]);
 
     const handleSendNow = useCallback(() => {
         if (form.isValid()) {
@@ -880,7 +881,7 @@ const SchedulerForm: FC<Props> = ({
                                                                 .slackTargets
                                                         }
                                                         rightSection={
-                                                            slackChannelsQuery.isInitialLoading ?? (
+                                                            slackChannelsQuery?.isInitialLoading ?? (
                                                                 <Loader size="sm" />
                                                             )
                                                         }

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -55,16 +55,16 @@ export const useDeleteSlack = () => {
 };
 
 const getSlackChannels = async () =>
-    lightdashApi<SlackChannel[]>({
+    lightdashApi<SlackChannel[] | undefined>({
         url: `/slack/channels`,
         method: 'GET',
         body: undefined,
     });
 
 export const useSlackChannels = (
-    useQueryOptions?: UseQueryOptions<SlackChannel[], ApiError>,
+    useQueryOptions?: UseQueryOptions<SlackChannel[] | undefined, ApiError>,
 ) =>
-    useQuery<SlackChannel[], ApiError>({
+    useQuery<SlackChannel[] | undefined, ApiError>({
         queryKey: ['slack_channels'],
         queryFn: getSlackChannels,
         ...useQueryOptions,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/10473
Closes: https://github.com/lightdash/lightdash/pull/10716

### Description:

if organization does not have a slack integration it throws an error when visiting integrations page and returns error 500

two routes were affected by this:

`/api/v1/slack/`
`/api/v1/slack/channels`

you can see whole bunch of sentry events here:

https://lightdash.sentry.io/issues/4521767626/events/?project=5959292&sort=-url

THIS PR IS BASED on contributions from @maxdiplogit -> https://github.com/lightdash/lightdash/pull/10716

> This PR deals with improving developer productivity by not relying on network errors on the Frontend and also not requesting /slack/channels endpoint if slack is not enabled.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
