### PR TITLE
fix: show SQL chart page error

### DIFF
--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
+import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import { Sidebar } from '../features/sqlRunner';
@@ -43,7 +44,7 @@ const SqlRunnerNew = () => {
         }
     }, [dispatch, params.projectUuid, projectUuid]);
 
-    const { data } = useSavedSqlChart({
+    const { data, error: chartError } = useSavedSqlChart({
         projectUuid,
         slug: params.slug,
     });
@@ -64,8 +65,8 @@ const SqlRunnerNew = () => {
         }
     }, [dispatch, project?.warehouseConnection?.type]);
 
-    if (!projectUuid) {
-        return null;
+    if (chartError) {
+        return <ErrorState error={chartError.error} />;
     }
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10990](https://github.com/lightdash/lightdash/issues/10990)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We now show a page error, as we have for other pages, in case it can't load the saved SQL chart

<img width="1184" alt="Screenshot 2024-08-02 at 13 29 56" src="https://github.com/user-attachments/assets/2139fcd3-a55e-4aeb-84f3-7859aac1256c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
