### PR TITLE
chore: Correct operation IDs in controllers

### DIFF
--- a/packages/backend/src/controllers/gitIntegrationController.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.ts
@@ -78,7 +78,7 @@ export class GitIntegrationController extends BaseController {
     ])
     @SuccessResponse('200', 'Success')
     @Post('/pull-requests/custom-metrics')
-    @OperationId('CreatePullRequestForChartFields')
+    @OperationId('CreatePullRequestForCustomMetrics')
     async CreatePullRequestForCustomMetrics(
         @Path() projectUuid: string,
         @Body()

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -48,7 +48,7 @@ export class SavedChartController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Post('/results')
-    @OperationId('postChartResults')
+    @OperationId('PostChartResults')
     async postChartResults(
         @Body()
         body: {
@@ -73,7 +73,7 @@ export class SavedChartController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Post('/chart-and-results')
-    @OperationId('postChartResults')
+    @OperationId('PostDashboardTile')
     async postDashboardTile(
         @Body()
         body: {
@@ -114,7 +114,7 @@ export class SavedChartController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/history')
-    @OperationId('get')
+    @OperationId('GetChartHistory')
     async getChartHistory(
         @Path() chartUuid: string,
         @Request() req: express.Request,
@@ -137,7 +137,7 @@ export class SavedChartController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/version/{versionUuid}')
-    @OperationId('get')
+    @OperationId('GetChartVersion')
     async getChartVersion(
         @Path() chartUuid: string,
         @Path() versionUuid: string,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8811,7 +8811,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1201.0",
+        "version": "0.1202.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -10100,7 +10100,7 @@
         },
         "/api/v1/projects/{projectUuid}/git-integration/pull-requests/custom-metrics": {
             "post": {
-                "operationId": "CreatePullRequestForChartFields",
+                "operationId": "CreatePullRequestForCustomMetrics",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -12469,7 +12469,7 @@
         },
         "/api/v1/saved/{chartUuid}/results": {
             "post": {
-                "operationId": "postChartResults",
+                "operationId": "PostChartResults",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -12525,7 +12525,7 @@
         },
         "/api/v1/saved/{chartUuid}/chart-and-results": {
             "post": {
-                "operationId": "postChartResults",
+                "operationId": "PostDashboardTile",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -12600,7 +12600,7 @@
         },
         "/api/v1/saved/{chartUuid}/history": {
             "get": {
-                "operationId": "get",
+                "operationId": "GetChartHistory",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -12641,7 +12641,7 @@
         },
         "/api/v1/saved/{chartUuid}/version/{versionUuid}": {
             "get": {
-                "operationId": "get",
+                "operationId": "GetChartVersion",
                 "responses": {
                     "200": {
                         "description": "Success",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: xxx

I didn't open an issue for the pull request due to the minor changes. Please let me know, if I should open one.

### Description:

It seems that there are few duplicated operation IDs in controllers. So, I encountered the errors on a OpenAPI schema validator with `swagger.json`.

https://editor.swagger.io/

```
Semantic error at paths./api/v1/projects/{projectUuid}/git-integration/pull-requests/custom-metrics.post.operationId
Operations must have unique operationIds.
Jump to line 10103
Semantic error at paths./api/v1/saved/{chartUuid}/chart-and-results.post.operationId
Operations must have unique operationIds.
Jump to line 12528
Semantic error at paths./api/v1/saved/{chartUuid}/version/{versionUuid}.get.operationId
Operations must have unique operationIds.
Jump to line 12644
```

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
