### PR TITLE
chore: replace useDebouncedValue with useDeferredValue

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -13,9 +13,9 @@ import {
     Stack,
     Tooltip,
 } from '@mantine/core';
-import { useDebouncedValue, useElementSize, useHotkeys } from '@mantine/hooks';
+import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { IconChartHistogram, IconCodeCircle } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { useDeferredValue, useMemo, useState, type FC } from 'react';
 import { ResizableBox } from 'react-resizable';
 import { ConditionalVisibility } from '../../../components/common/ConditionalVisibility';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -46,11 +46,7 @@ export const ContentPanel: FC = () => {
     const { ref: wrapperRef, height: wrapperHeight } = useElementSize();
     const [resultsHeight, setResultsHeight] = useState(MIN_RESULTS_HEIGHT);
     const maxResultsHeight = useMemo(() => wrapperHeight - 56, [wrapperHeight]);
-    // NOTE: debounce is used to avoid the chart from being resized too often
-    const [debouncedInputSectionHeight] = useDebouncedValue(
-        inputSectionHeight,
-        100,
-    );
+    const deferredInputSectionHeight = useDeferredValue(inputSectionHeight);
     const isResultsPanelFullHeight = useMemo(
         () => resultsHeight === maxResultsHeight,
         [resultsHeight, maxResultsHeight],
@@ -243,7 +239,7 @@ export const ContentPanel: FC = () => {
                                                 ChartKind.TABLE
                                                     ? 'block'
                                                     : 'none',
-                                            height: debouncedInputSectionHeight,
+                                            height: deferredInputSectionHeight,
                                             width: '100%',
                                             flex: 1,
                                         }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Use `useDeferredValue` to deal with this exact issue: when the user scrolls up and down the results panel it should affect the bar chart's height, but it shouldn't block the UI thread

demo: 

https://github.com/user-attachments/assets/04815c97-83b5-4413-891f-185b1bd90b79



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
