### PR TITLE
fix: SQL chart access in private spaces

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6554,13 +6554,22 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.uuid-or-name_': {
+    'Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 name: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
+                isPrivate: { dataType: 'boolean', required: true },
+                userAccess: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'SpaceShare' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
             },
             validators: {},
         },
@@ -6618,7 +6627,10 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                space: { ref: 'Pick_Space.uuid-or-name_', required: true },
+                space: {
+                    ref: 'Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_',
+                    required: true,
+                },
                 lastUpdatedBy: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7301,16 +7301,22 @@
                 "required": ["type", "metadata"],
                 "type": "object"
             },
-            "Pick_Space.uuid-or-name_": {
+            "Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
                     },
                     "uuid": {
                         "type": "string"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
+                    },
+                    "userAccess": {
+                        "$ref": "#/components/schemas/SpaceShare"
                     }
                 },
-                "required": ["name", "uuid"],
+                "required": ["name", "uuid", "isPrivate"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -7366,7 +7372,7 @@
                         "nullable": true
                     },
                     "space": {
-                        "$ref": "#/components/schemas/Pick_Space.uuid-or-name_"
+                        "$ref": "#/components/schemas/Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_"
                     },
                     "lastUpdatedBy": {
                         "allOf": [
@@ -8811,7 +8817,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1202.1",
+        "version": "0.1202.11",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -2,6 +2,7 @@ import {
     CreateSqlChart,
     generateSlug,
     NotFoundError,
+    SpaceSummary,
     SqlChart,
     UpdateSqlChart,
 } from '@lightdash/common';
@@ -38,6 +39,7 @@ type SelectSavedSql = Pick<
     Pick<DbOrganization, 'organization_uuid'> & {
         updated_at: Date;
         spaceName: string;
+        space_is_private: boolean;
         dashboardName: string | null;
         created_by_user_uuid: string | null;
         created_by_user_first_name: string | null;
@@ -54,7 +56,12 @@ export class SavedSqlModel {
         this.database = args.database;
     }
 
-    static convertSelectSavedSql(row: SelectSavedSql): SqlChart {
+    static convertSelectSavedSql(row: SelectSavedSql): Omit<
+        SqlChart,
+        'space'
+    > & {
+        space: Pick<SpaceSummary, 'uuid' | 'name' | 'isPrivate'>;
+    } {
         return {
             savedSqlUuid: row.saved_sql_uuid,
             name: row.name,
@@ -84,6 +91,7 @@ export class SavedSqlModel {
             space: {
                 uuid: row.space_uuid,
                 name: row.spaceName,
+                isPrivate: row.space_is_private,
             },
             project: {
                 projectUuid: row.project_uuid,
@@ -170,6 +178,7 @@ export class SavedSqlModel {
                 `updatedByUser.last_name as last_version_updated_by_user_last_name`,
                 `${SpaceTableName}.space_uuid`,
                 `${SpaceTableName}.name as spaceName`,
+                `${SpaceTableName}.is_private as space_is_private`,
             ])
             .where((builder) => {
                 if (options.uuid) {

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -14,7 +14,7 @@ import {
     type ApiJobScheduledResponse,
     type SchedulerJobStatus,
 } from './scheduler';
-import { type Space } from './space';
+import { type SpaceSummary } from './space';
 import { type LightdashUser } from './user';
 
 export type SqlRunnerPayload = {
@@ -149,7 +149,7 @@ export type SqlChart = {
         LightdashUser,
         'userUuid' | 'firstName' | 'lastName'
     > | null;
-    space: Pick<Space, 'uuid' | 'name'>;
+    space: Pick<SpaceSummary, 'uuid' | 'name' | 'isPrivate' | 'userAccess'>;
     dashboard: Pick<Dashboard, 'uuid' | 'name'> | null;
     project: Pick<Project, 'projectUuid'>;
     organization: Pick<Organization, 'organizationUuid'>;

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -43,7 +43,10 @@ export const HeaderView: FC = () => {
         subject('SavedChart', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
-            access: [], // todo: update endpoint to return space "isPrivate" and "access"
+            isPrivate: savedSqlChart?.space.isPrivate,
+            access: savedSqlChart?.space.userAccess
+                ? [savedSqlChart.space.userAccess]
+                : [],
         }),
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10937](https://github.com/lightdash/lightdash/issues/10937)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- SQL chart type now contains more properties from SpaceSummary: isPrivate, userAccess
- update FE to use space properties to check access


Before: non-admin users could not see the edit and delete button for SQL charts in private spaces
(right side: page from developer user)
<img width="2228" alt="Screenshot 2024-08-05 at 10 29 12" src="https://github.com/user-attachments/assets/00968ca6-3e46-4e58-b997-94f6a3bfe62b">


After: user can see the edit and delete button for SQL charts in private spaces
Note: non-developers, independently of their space access, cannot see the edit button as they lack access to SQL runner.
(right side: page from developer user)
<img width="2226" alt="Screenshot 2024-08-05 at 10 25 11" src="https://github.com/user-attachments/assets/e602c6d4-6ce3-4872-879c-94cc839747fa">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
