### PR TITLE
fix: infinite google login popup

### DIFF
--- a/packages/frontend/src/features/sync/components/SelectGoogleSheetButton.tsx
+++ b/packages/frontend/src/features/sync/components/SelectGoogleSheetButton.tsx
@@ -49,7 +49,7 @@ export const SelectGoogleSheetButton: FC = () => {
         [methods],
     );
 
-    useGdriveAccessToken({
+    const { closePopup } = useGdriveAccessToken({
         enabled: isGoogleAuthQueryEnabled,
         onSuccess: (accessToken) => {
             if (
@@ -130,6 +130,7 @@ export const SelectGoogleSheetButton: FC = () => {
             <Button
                 size="xs"
                 onClick={() => {
+                    closePopup();
                     setIsGoogleAuthQueryEnabled(true);
                 }}
             >

--- a/packages/frontend/src/hooks/gdrive/useGdrive.ts
+++ b/packages/frontend/src/hooks/gdrive/useGdrive.ts
@@ -5,7 +5,7 @@ import {
     type UploadMetricGsheet,
 } from '@lightdash/common';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { lightdashApi } from '../../api';
 import { convertDateFilters } from '../../utils/dateFilter';
 import useHealth from '../health/useHealth';
@@ -29,26 +29,7 @@ export const useGdriveAccessToken = (
         null,
     );
 
-    useEffect(() => {
-        if (googleLoginPopup) {
-            const checkClosed = setInterval(() => {
-                if (googleLoginPopup?.closed) {
-                    setGoogleLoginPopup(
-                        window.open(
-                            gdriveUrl,
-                            'login-popup',
-                            'width=600,height=600',
-                        ),
-                    );
-                }
-            }, 1000);
-            return () => {
-                clearInterval(checkClosed);
-            };
-        }
-    }, [googleLoginPopup, gdriveUrl]);
-
-    return useQuery<ApiGdriveAccessTokenResponse['results'], ApiError>({
+    useQuery<ApiGdriveAccessTokenResponse['results'], ApiError>({
         queryKey: ['gdrive_access_token'],
         queryFn: getGdriveAccessToken,
         retry: false,
@@ -65,17 +46,25 @@ export const useGdriveAccessToken = (
         },
         onError: () => {
             if (googleLoginPopup?.closed) return false;
-            if (!googleLoginPopup) {
-                setGoogleLoginPopup(
-                    window.open(
-                        gdriveUrl,
-                        'login-popup',
-                        'width=600,height=600',
-                    ),
+            if (googleLoginPopup === null) {
+                const popupWindow = window.open(
+                    gdriveUrl,
+                    'login-popup',
+                    'width=600,height=600',
                 );
+                setGoogleLoginPopup(popupWindow);
             }
         },
     });
+
+    return {
+        closePopup: () => {
+            if (googleLoginPopup !== null) {
+                window.close();
+                setGoogleLoginPopup(null);
+            }
+        },
+    };
 };
 
 export const uploadGsheet = async (gsheetMetric: UploadMetricGsheet) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10914

### What the issue is 

At least on Firefox (popup blocker?) , the `window.close` api always returns true, which doesn't correspond what the documentation says (Related issue: https://stackoverflow.com/questions/5972164/window-open-returns-always-closed-in-true) . This was causing firefox to reopen inifnite popups. 

### Why we were checking for close ? 
This was mainly to `reopen` the modal automatically if someone closed the popup. Because once it was closed, it was not possible to reopen the modal again. 

###  How I fixed this instead 
WHen clicking on the `Select Google Sheet via Google drive`, I `force` close the modal, this opens a new modal. 

### Description:

Before:


[Screencast from 05-08-24 12:11:29.webm](https://github.com/user-attachments/assets/f04733f1-6f22-47c3-bdde-4a67bfde0514)

After:

[Screencast from 05-08-24 13:03:10.webm](https://github.com/user-attachments/assets/c887c9fb-0984-49c9-a77a-d8d3948ac81e)



<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
