### PR TITLE
fix: can save sql without viewing chart

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -14,6 +14,7 @@ import { SaveSqlChartModal } from '../SaveSqlChartModal';
 export const HeaderCreate: FC = () => {
     const dispatch = useAppDispatch();
     const name = useAppSelector((state) => state.sqlRunner.name);
+    const loadedColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
     const isSaveModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.saveChartModal.isOpen,
     );
@@ -42,7 +43,7 @@ export const HeaderCreate: FC = () => {
                             label="Save chart"
                             position="bottom"
                         >
-                            <ActionIcon size="xs">
+                            <ActionIcon size="xs" disabled={!loadedColumns}>
                                 <MantineIcon
                                     icon={IconDeviceFloppy}
                                     onClick={() => {

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -72,9 +72,7 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     }, [name, form, description, spaces, isFormPopulated]);
 
     const sql = useAppSelector((state) => state.sqlRunner.sql);
-    const selectedChartConfig = useAppSelector((state) =>
-        selectCurrentChartConfig(state),
-    );
+    const selectedChartConfig = useAppSelector(selectCurrentChartConfig);
     const defaultChartConfig = useAppSelector(selectTableVisConfigState);
 
     const {

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -25,8 +25,8 @@ import {
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
-    selectBarChartConfigState,
     selectCurrentChartConfig,
+    selectTableVisConfigState,
 } from '../store/selectors';
 import { updateName } from '../store/sqlRunnerSlice';
 
@@ -35,8 +35,6 @@ type FormValues = z.infer<typeof validationSchema>;
 type Props = Pick<ModalProps, 'opened' | 'onClose'>;
 
 export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
-    console.log('SaveSqlChartModal: opened', opened);
-
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
 
@@ -77,7 +75,7 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     const selectedChartConfig = useAppSelector((state) =>
         selectCurrentChartConfig(state),
     );
-    const defaultChartConfig = useAppSelector(selectBarChartConfigState);
+    const defaultChartConfig = useAppSelector(selectTableVisConfigState);
 
     const {
         mutateAsync: createSavedSqlChart,

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -4,7 +4,7 @@ import { type RootState } from '.';
 
 const selectSqlRunnerState = (state: RootState): RootState['sqlRunner'] =>
     state.sqlRunner;
-export const selectBarChartConfigState = (
+const selectBarChartConfigState = (
     state: RootState,
 ): RootState['barChartConfig'] => state.barChartConfig;
 const selectLineChartConfigState = (
@@ -13,7 +13,7 @@ const selectLineChartConfigState = (
 const selectPieChartConfigState = (
     state: RootState,
 ): RootState['pieChartConfig'] => state.pieChartConfig;
-const selectTableVisConfigState = (
+export const selectTableVisConfigState = (
     state: RootState,
 ): RootState['tableVisConfig'] => state.tableVisConfig;
 

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -4,7 +4,7 @@ import { type RootState } from '.';
 
 const selectSqlRunnerState = (state: RootState): RootState['sqlRunner'] =>
     state.sqlRunner;
-const selectBarChartConfigState = (
+export const selectBarChartConfigState = (
     state: RootState,
 ): RootState['barChartConfig'] => state.barChartConfig;
 const selectLineChartConfigState = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10974 

### Description:

Makes it possible to save an SQL runner without viewing the chart.  This will choose a table viz by default. This is least likely to break and most likely to match what they see if they haven't looked at the charts. 

![Kapture 2024-08-05 at 17 11 45](https://github.com/user-attachments/assets/600707dd-10e3-4309-9675-c929e7adae53)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
