### PR TITLE
fix: orphaned chart deletion

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1033,23 +1033,20 @@ export class DashboardModel {
     async getOrphanedCharts(
         dashboardUuid: string,
     ): Promise<Pick<SavedChart, 'uuid'>[]> {
-        const getLastVersionIdQuery = this.database(DashboardsTableName)
+        const getChartsInTilesQuery = this.database(DashboardTileChartTableName)
+            .distinct('saved_chart_id')
             .leftJoin(
                 DashboardVersionsTableName,
+                `${DashboardVersionsTableName}.dashboard_version_id`,
+                `${DashboardTileChartTableName}.dashboard_version_id`,
+            )
+            .leftJoin(
+                DashboardsTableName,
                 `${DashboardsTableName}.dashboard_id`,
                 `${DashboardVersionsTableName}.dashboard_id`,
             )
-            .select([`${DashboardVersionsTableName}.dashboard_version_id`])
-            .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
-            .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
-            .limit(1);
+            .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid);
 
-        const getChartsInTilesQuery = this.database(DashboardTileChartTableName)
-            .select(`saved_chart_id`)
-            .where(
-                `${DashboardTileChartTableName}.dashboard_version_id`,
-                getLastVersionIdQuery,
-            );
         const orphanedCharts = await this.database(SavedChartsTableName)
             .select(`saved_query_uuid`)
             .where(`${SavedChartsTableName}.dashboard_uuid`, dashboardUuid)

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -132,6 +132,7 @@ export class DashboardService extends BaseService {
         const orphanedCharts = await this.dashboardModel.getOrphanedCharts(
             dashboardUuid,
         );
+
         await Promise.all(
             orphanedCharts.map(async (chart) => {
                 const deletedChart = await this.savedChartModel.delete(

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -51,7 +51,7 @@ const duplicateSavedQuery = async (
         body: JSON.stringify(data),
     });
 
-export const deleteSavedQuery = async (id: string) =>
+const deleteSavedQuery = async (id: string) =>
     lightdashApi<null>({
         url: `/saved/${id}`,
         method: 'DELETE',

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import {
     DashboardTileTypes,
-    isDashboardChartTileType,
     ResourceViewItemType,
     type Dashboard as IDashboard,
     type DashboardTab,
@@ -35,7 +34,6 @@ import { useOrganization } from '../hooks/organization/useOrganization';
 import { useDashboardPinningMutation } from '../hooks/pinning/useDashboardPinningMutation';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
 import useToaster from '../hooks/toaster/useToaster';
-import { deleteSavedQuery } from '../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useApp } from '../providers/AppProvider';
 import {
@@ -435,39 +433,17 @@ const Dashboard: FC = () => {
     );
 
     const handleCancel = useCallback(() => {
+        if (!dashboard) return;
+
         sessionStorage.clear();
 
-        // Delete charts that were created in edit mode
-        dashboardTiles?.forEach((tile) => {
-            if (
-                isDashboardChartTileType(tile) &&
-                tile.properties.belongsToDashboard &&
-                tile.properties.savedChartUuid
-            ) {
-                const isChartNew =
-                    (dashboard?.tiles || []).find(
-                        (t) =>
-                            isDashboardChartTileType(t) &&
-                            t.properties.savedChartUuid ===
-                                tile.properties.savedChartUuid,
-                    ) === undefined;
-
-                if (isChartNew) {
-                    deleteSavedQuery(tile.properties.savedChartUuid).catch(
-                        () => {
-                            //ignore error
-                        },
-                    );
-                }
-            }
-        });
-
-        setDashboardTiles(dashboard?.tiles || []);
+        setDashboardTiles(dashboard.tiles);
         setHaveTilesChanged(false);
-        if (dashboard) setDashboardFilters(dashboard.filters);
+        setDashboardFilters(dashboard.filters);
         setHaveFiltersChanged(false);
         setHaveTabsChanged(false);
-        setDashboardTabs(dashboard?.tabs || []);
+        setDashboardTabs(dashboard.tabs);
+
         if (dashboardTabs.length > 0) {
             history.replace(
                 `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${activeTab?.uuid}`,
@@ -482,7 +458,6 @@ const Dashboard: FC = () => {
         dashboardUuid,
         history,
         projectUuid,
-        dashboardTiles,
         setDashboardTiles,
         setHaveFiltersChanged,
         setDashboardFilters,


### PR DESCRIPTION
Closes: #11007 

### Description:

this PR fixes two things:
- exiting dashboard edit mode in the **frontend** is never going to delete orphan charts (or any charts)
- **backend** will only delete orphans if, and only if, they do not belong to any tile. This means that version reverting will now work for charts created within the dashboard, even if they get removed from the tile in the next dashboard version save.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
