### PR TITLE
style: add scrollarea to spaces menu items

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Loader, Menu } from '@mantine/core';
+import { Box, Button, Center, Loader, Menu, ScrollArea } from '@mantine/core';
 import {
     IconCategory,
     IconChartAreaLine,
@@ -80,18 +80,27 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                     </>
                 ) : null}
 
-                {spaces
-                    ?.sort((a, b) => a.name.localeCompare(b.name))
-                    .map((space) => (
-                        <Menu.Item
-                            key={space.uuid}
-                            component={Link}
-                            to={`/projects/${projectUuid}/spaces/${space.uuid}`}
-                            icon={<MantineIcon icon={IconFolder} />}
-                        >
-                            {space.name}
-                        </Menu.Item>
-                    ))}
+                <ScrollArea
+                    offsetScrollbars
+                    variant="primary"
+                    className="only-vertical"
+                    type="auto"
+                >
+                    <Box mah={300}>
+                        {spaces
+                            ?.sort((a, b) => a.name.localeCompare(b.name))
+                            .map((space) => (
+                                <Menu.Item
+                                    key={space.uuid}
+                                    component={Link}
+                                    to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+                                    icon={<MantineIcon icon={IconFolder} />}
+                                >
+                                    {space.name}
+                                </Menu.Item>
+                            ))}
+                    </Box>
+                </ScrollArea>
             </Menu.Dropdown>
         </Menu>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10607

### Description:

adds scrolling area to spaces' menu items

used this to create a mock number of spaces: 

` const mockSpaces = Array.from({ length: 40 }, () => spaces?.[0]);`

before

https://github.com/user-attachments/assets/20949a84-f128-4ae0-9f59-2769f0c52edc

after


https://github.com/user-attachments/assets/55aaf53f-f12d-4d7d-b4d1-0377fd4627f3



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
