### PR TITLE
chore: sql runner - dont unmount charts

### DIFF
--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -1,8 +1,8 @@
 import {
     type CartesianChartDisplay,
     type PieChartDisplay,
+    type SqlCartesianChartLayout,
     type SqlColumn,
-    type SqlTransformCartesianChartConfig,
     type SqlTransformPieChartConfig,
 } from '../visualizations/SqlRunnerResultsTransformer';
 import { type Dashboard } from './dashboard';
@@ -86,19 +86,19 @@ export type TableChartSqlConfig = SqlRunnerChartConfig &
 
 export type CartesianChartSqlConfig = SqlRunnerChartConfig & {
     type: ChartKind.VERTICAL_BAR | ChartKind.LINE;
-    fieldConfig: SqlTransformCartesianChartConfig | undefined;
+    fieldConfig: SqlCartesianChartLayout | undefined;
     display: CartesianChartDisplay | undefined;
 };
 
 export type BarChartSqlConfig = SqlRunnerChartConfig & {
     type: ChartKind.VERTICAL_BAR;
-    fieldConfig: SqlTransformCartesianChartConfig | undefined;
+    fieldConfig: SqlCartesianChartLayout | undefined;
     display: CartesianChartDisplay | undefined;
 };
 
 export type LineChartSqlConfig = SqlRunnerChartConfig & {
     type: ChartKind.LINE;
-    fieldConfig: SqlTransformCartesianChartConfig | undefined;
+    fieldConfig: SqlCartesianChartLayout | undefined;
     display: CartesianChartDisplay | undefined;
 };
 

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -3,7 +3,7 @@ import {
     type PieChartDisplay,
     type SqlCartesianChartLayout,
     type SqlColumn,
-    type SqlTransformPieChartConfig,
+    type SqlPieChartConfig,
 } from '../visualizations/SqlRunnerResultsTransformer';
 import { type Dashboard } from './dashboard';
 import { type Organization } from './organization';
@@ -104,7 +104,7 @@ export type LineChartSqlConfig = SqlRunnerChartConfig & {
 
 export type PieChartSqlConfig = SqlRunnerChartConfig & {
     type: ChartKind.PIE;
-    fieldConfig: SqlTransformPieChartConfig | undefined;
+    fieldConfig: SqlPieChartConfig | undefined;
     display: PieChartDisplay | undefined;
 };
 

--- a/packages/common/src/visualizations/PieChartDataTransformer.ts
+++ b/packages/common/src/visualizations/PieChartDataTransformer.ts
@@ -1,5 +1,7 @@
+import { ChartKind } from '../types/savedCharts';
 import {
     isPieChartSQLConfig,
+    type PieChartSqlConfig,
     type SqlRunnerChartConfig,
 } from '../types/sqlRunner';
 import { type ResultsTransformerBase } from './ResultsTransformerBase';
@@ -14,6 +16,34 @@ export class PieChartDataTransformer<TBarChartLayout, TPieChartConfig> {
         transformer: ResultsTransformerBase<TBarChartLayout, TPieChartConfig>;
     }) {
         this.transformer = args.transformer;
+    }
+
+    getChartConfig({ currentConfig }: { currentConfig?: PieChartSqlConfig }) {
+        const newDefaultConfig = this.transformer.defaultPieChartFieldConfig();
+
+        let newConfig = currentConfig;
+
+        if (!currentConfig) {
+            newConfig = {
+                metadata: {
+                    version: 1,
+                },
+                type: ChartKind.PIE,
+                fieldConfig: newDefaultConfig,
+                display: {
+                    isDonut: false,
+                },
+            };
+        } else {
+            newConfig = {
+                ...currentConfig,
+                fieldConfig: newDefaultConfig,
+            };
+        }
+
+        return {
+            newConfig,
+        };
     }
 
     async getEchartsSpec(config: SqlRunnerChartConfig) {

--- a/packages/common/src/visualizations/ResultsTransformerBase.ts
+++ b/packages/common/src/visualizations/ResultsTransformerBase.ts
@@ -1,4 +1,7 @@
-import { type SqlCartesianChartLayout } from './SqlRunnerResultsTransformer';
+import {
+    type SqlCartesianChartLayout,
+    type SqlPieChartConfig,
+} from './SqlRunnerResultsTransformer';
 
 export type RowData = Record<string, unknown>;
 
@@ -21,6 +24,7 @@ export interface ResultsTransformerBase<
     ): Promise<CartesianChartData>;
 
     defaultCartesianChartLayout(): SqlCartesianChartLayout | undefined;
+    defaultPieChartFieldConfig(): SqlPieChartConfig | undefined;
 
     transformPieChartData(config: PieChartConfigType): Promise<PieChartData>;
 }

--- a/packages/common/src/visualizations/ResultsTransformerBase.ts
+++ b/packages/common/src/visualizations/ResultsTransformerBase.ts
@@ -1,3 +1,5 @@
+import { type SqlCartesianChartLayout } from './SqlRunnerResultsTransformer';
+
 export type RowData = Record<string, unknown>;
 
 export type CartesianChartData = {
@@ -17,6 +19,8 @@ export interface ResultsTransformerBase<
     transformCartesianChartData(
         config: CartesianChartConfigType,
     ): Promise<CartesianChartData>;
+
+    defaultCartesianChartLayout(): SqlCartesianChartLayout | undefined;
 
     transformPieChartData(config: PieChartConfigType): Promise<PieChartData>;
 }

--- a/packages/common/src/visualizations/SqlRunnerResultsTransformer.ts
+++ b/packages/common/src/visualizations/SqlRunnerResultsTransformer.ts
@@ -59,7 +59,7 @@ export type CartesianChartDisplay = {
     };
 };
 
-export type SqlTransformCartesianChartConfig = {
+export type SqlCartesianChartLayout = {
     x: {
         reference: string;
         type: XLayoutType;
@@ -155,7 +155,7 @@ type SqlRunnerResultsTransformerDeps = {
 export class SqlRunnerResultsTransformer
     implements
         ResultsTransformerBase<
-            SqlTransformCartesianChartConfig,
+            SqlCartesianChartLayout,
             SqlTransformPieChartConfig
         >
 {
@@ -250,9 +250,19 @@ export class SqlRunnerResultsTransformer
         return options;
     }
 
-    defaultCartesianChartLayout():
-        | SqlTransformCartesianChartConfig
-        | undefined {
+    getCartesianLayoutOptions(): {
+        xLayoutOptions: XLayoutOptions[];
+        yLayoutOptions: YLayoutOptions[];
+        groupByOptions: GroupByLayoutOptions[];
+    } {
+        return {
+            xLayoutOptions: this.cartesianChartXLayoutOptions(),
+            yLayoutOptions: this.cartesianChartYLayoutOptions(),
+            groupByOptions: this.cartesianChartGroupByLayoutOptions(),
+        };
+    }
+
+    defaultCartesianChartLayout(): SqlCartesianChartLayout | undefined {
         const firstCategoricalColumn = this.columns.find(
             (column) => column.type === DimensionType.STRING,
         );
@@ -274,7 +284,7 @@ export class SqlRunnerResultsTransformer
         if (xColumn === undefined) {
             return undefined;
         }
-        const x: SqlTransformCartesianChartConfig['x'] = {
+        const x: SqlCartesianChartLayout['x'] = {
             reference: xColumn.reference,
             type: [DimensionType.DATE, DimensionType.TIMESTAMP].includes(
                 xColumn.type,
@@ -306,7 +316,7 @@ export class SqlRunnerResultsTransformer
     }
 
     public async transformCartesianChartData(
-        config: SqlTransformCartesianChartConfig,
+        config: SqlCartesianChartLayout,
     ): Promise<CartesianChartData> {
         const groupByColumns = [config.x.reference];
         const pivotsSql =

--- a/packages/common/src/visualizations/SqlRunnerResultsTransformer.ts
+++ b/packages/common/src/visualizations/SqlRunnerResultsTransformer.ts
@@ -82,7 +82,7 @@ export type PieChartDisplay = {
     isDonut?: boolean;
 };
 
-export type SqlTransformPieChartConfig = {
+export type SqlPieChartConfig = {
     groupFieldIds?: string[];
     metricId?: string;
 };
@@ -154,10 +154,7 @@ type SqlRunnerResultsTransformerDeps = {
 };
 export class SqlRunnerResultsTransformer
     implements
-        ResultsTransformerBase<
-            SqlCartesianChartLayout,
-            SqlTransformPieChartConfig
-        >
+        ResultsTransformerBase<SqlCartesianChartLayout, SqlPieChartConfig>
 {
     private readonly duckDBSqlFunction: DuckDBSqlFunction;
 
@@ -357,7 +354,7 @@ export class SqlRunnerResultsTransformer
         return this.cartesianChartYLayoutOptions();
     }
 
-    defaultPieChartFieldConfig(): SqlTransformPieChartConfig | undefined {
+    defaultPieChartFieldConfig(): SqlPieChartConfig | undefined {
         const firstCategoricalColumn = this.columns.find(
             (column) => column.type === DimensionType.STRING,
         );

--- a/packages/frontend/src/features/sqlRunner/components/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/CartesianChartFieldConfiguration.tsx
@@ -1,7 +1,7 @@
 import {
     DimensionType,
     type GroupByLayoutOptions,
-    type SqlTransformCartesianChartConfig,
+    type SqlCartesianChartLayout,
     type XLayoutOptions,
     type YLayoutOptions,
 } from '@lightdash/common';
@@ -23,7 +23,7 @@ import { CartesianChartAggregationConfig } from './CartesianChartAggregationConf
 import { FieldReferenceSelect } from './FieldReferenceSelect';
 
 const YFieldsAxisConfig: FC<{
-    field: SqlTransformCartesianChartConfig['y'][number];
+    field: SqlCartesianChartLayout['y'][number];
     yLayoutOptions: YLayoutOptions[];
     isSingle: boolean;
     index: number;
@@ -143,7 +143,7 @@ const XFieldAxisConfig = ({
     xLayoutOptions,
     actions,
 }: {
-    field: SqlTransformCartesianChartConfig['x'];
+    field: SqlCartesianChartLayout['x'];
     xLayoutOptions: XLayoutOptions[];
     actions: CartesianChartActionsType;
 }) => {

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -1,9 +1,4 @@
-import {
-    ChartKind,
-    isCartesianChartSQLConfig,
-    isPieChartSQLConfig,
-    isTableChartSQLConfig,
-} from '@lightdash/common';
+import { isTableChartSQLConfig } from '@lightdash/common';
 import {
     Box,
     getDefaultZIndex,
@@ -68,9 +63,20 @@ export const ContentPanel: FC = () => {
         (state) => state.sqlRunner.resultsTableConfig,
     );
 
-    // configurable table
+    // currently editing chart config
     const currentVisConfig = useAppSelector((state) =>
         selectCurrentChartConfig(state),
+    );
+
+    // Select these configs so we can keep the charts mounted
+    const barChartConfig = useAppSelector(
+        (state) => state.barChartConfig.config,
+    );
+    const lineChartConfig = useAppSelector(
+        (state) => state.lineChartConfig.config,
+    );
+    const pieChartConfig = useAppSelector(
+        (state) => state.pieChartConfig.config,
     );
 
     const {
@@ -226,24 +232,33 @@ export const ContentPanel: FC = () => {
                         >
                             {queryResults?.results &&
                                 currentVisConfig &&
-                                (isCartesianChartSQLConfig(currentVisConfig) ||
-                                    isPieChartSQLConfig(currentVisConfig)) && (
-                                    <SqlRunnerChart
-                                        data={queryResults}
-                                        config={currentVisConfig}
-                                        isLoading={isLoading}
-                                        style={{
-                                            // NOTE: Ensures the chart is always full height
-                                            display:
-                                                selectedChartType !==
-                                                ChartKind.TABLE
-                                                    ? 'block'
-                                                    : 'none',
-                                            height: deferredInputSectionHeight,
-                                            width: '100%',
-                                            flex: 1,
-                                        }}
-                                    />
+                                [
+                                    barChartConfig,
+                                    lineChartConfig,
+                                    pieChartConfig,
+                                ].map(
+                                    (config, idx) =>
+                                        config && (
+                                            <ConditionalVisibility
+                                                key={idx}
+                                                isVisible={
+                                                    selectedChartType ===
+                                                    config?.type
+                                                }
+                                            >
+                                                <SqlRunnerChart
+                                                    data={queryResults}
+                                                    config={config}
+                                                    isLoading={isLoading}
+                                                    style={{
+                                                        // NOTE: Ensures the chart is always full height
+                                                        height: deferredInputSectionHeight,
+                                                        width: '100%',
+                                                        flex: 1,
+                                                    }}
+                                                />
+                                            </ConditionalVisibility>
+                                        ),
                                 )}
 
                             {queryResults?.results &&

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/SqlRunnerChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/SqlRunnerChart.tsx
@@ -22,11 +22,16 @@ const SqlRunnerChart: FC<SqlRunnerChartProps> = memo(
         } = useSqlChart(data.results, data.columns, config);
         const loading = isLoadingProp || transformLoading;
 
+        // TODO: this could be more robust
+        const errorMessage = error?.message.includes('Binder Error')
+            ? 'Some specified columns do not exist in the data'
+            : error?.message;
+
         if (error) {
             return (
                 <SuboptimalState
-                    title="Error"
-                    description={error.message}
+                    title="Error generating chart"
+                    description={errorMessage}
                     icon={IconAlertCircle}
                 />
             );

--- a/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/barChartSlice.ts
@@ -1,4 +1,8 @@
-import { ChartKind, deepEqual, isBarChartSQLConfig } from '@lightdash/common';
+import {
+    CartesianChartDataTransformer,
+    ChartKind,
+    isBarChartSQLConfig,
+} from '@lightdash/common';
 import { createSlice } from '@reduxjs/toolkit';
 import { SqlRunnerResultsTransformerFE } from '../transformers/SqlRunnerResultsTransformerFE';
 import { cartesianChartConfigSlice } from './cartesianChartBaseSlice';
@@ -13,45 +17,27 @@ export const barChartConfigSlice = createSlice({
     extraReducers: (builder) => {
         builder.addCase(setSqlRunnerResults, (state, action) => {
             if (action.payload.results && action.payload.columns) {
-                // Transform results into options
                 const sqlRunnerResultsTransformer =
                     new SqlRunnerResultsTransformerFE({
                         rows: action.payload.results,
                         columns: action.payload.columns,
                     });
-                if (action.payload.columns) {
-                    state.options = {
-                        xLayoutOptions:
-                            sqlRunnerResultsTransformer.cartesianChartXLayoutOptions(),
-                        yLayoutOptions:
-                            sqlRunnerResultsTransformer.cartesianChartYLayoutOptions(),
-                        groupByOptions:
-                            sqlRunnerResultsTransformer.cartesianChartGroupByLayoutOptions(),
-                    };
-                }
 
-                // Update layout
-                const oldDefaultLayout = state.defaultLayout;
-                const newDefaultLayout =
-                    sqlRunnerResultsTransformer.defaultCartesianChartLayout();
+                state.options =
+                    sqlRunnerResultsTransformer.getCartesianLayoutOptions();
+
+                const chartDataTransformer = new CartesianChartDataTransformer({
+                    transformer: sqlRunnerResultsTransformer,
+                });
+
+                const { newConfig, newDefaultLayout } =
+                    chartDataTransformer.getChartConfig({
+                        chartType: ChartKind.VERTICAL_BAR,
+                        currentConfig: state.config,
+                    });
+
+                state.config = newConfig;
                 state.defaultLayout = newDefaultLayout;
-
-                if (
-                    !state.config ||
-                    deepEqual(
-                        oldDefaultLayout || {},
-                        state.config?.fieldConfig || {},
-                    )
-                ) {
-                    state.config = {
-                        metadata: {
-                            version: 1,
-                        },
-                        type: ChartKind.VERTICAL_BAR,
-                        fieldConfig: newDefaultLayout,
-                        display: state.config?.display,
-                    };
-                }
             }
         });
         builder.addCase(setSavedChartData, (state, action) => {

--- a/packages/frontend/src/features/sqlRunner/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/cartesianChartBaseSlice.ts
@@ -6,7 +6,7 @@ import {
     type CartesianChartDisplay,
     type GroupByLayoutOptions,
     type LineChartSqlConfig,
-    type SqlTransformCartesianChartConfig,
+    type SqlCartesianChartLayout,
     type XLayoutOptions,
     type YLayoutOptions,
 } from '@lightdash/common';
@@ -14,7 +14,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
 type InitialState = {
-    defaultLayout: SqlTransformCartesianChartConfig | undefined;
+    defaultLayout: SqlCartesianChartLayout | undefined;
     config: BarChartSqlConfig | LineChartSqlConfig | undefined;
     options: {
         xLayoutOptions: XLayoutOptions[];
@@ -39,9 +39,7 @@ export const cartesianChartConfigSlice = createSlice({
     reducers: {
         setXAxisReference: (
             state,
-            action: PayloadAction<
-                SqlTransformCartesianChartConfig['x']['reference']
-            >,
+            action: PayloadAction<SqlCartesianChartLayout['x']['reference']>,
         ) => {
             if (state.config?.fieldConfig?.x) {
                 state.config.fieldConfig.x.reference = action.payload;

--- a/packages/frontend/src/features/sqlRunner/store/lineChartSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/lineChartSlice.ts
@@ -1,4 +1,8 @@
-import { ChartKind, deepEqual, isLineChartSQLConfig } from '@lightdash/common';
+import {
+    CartesianChartDataTransformer,
+    ChartKind,
+    isLineChartSQLConfig,
+} from '@lightdash/common';
 import { createSlice } from '@reduxjs/toolkit';
 import { SqlRunnerResultsTransformerFE } from '../transformers/SqlRunnerResultsTransformerFE';
 import { cartesianChartConfigSlice } from './cartesianChartBaseSlice';
@@ -18,39 +22,22 @@ export const lineChartConfigSlice = createSlice({
                         rows: action.payload.results,
                         columns: action.payload.columns,
                     });
-                if (action.payload.columns) {
-                    state.options = {
-                        xLayoutOptions:
-                            sqlRunnerResultsTransformer.cartesianChartXLayoutOptions(),
-                        yLayoutOptions:
-                            sqlRunnerResultsTransformer.cartesianChartYLayoutOptions(),
-                        groupByOptions:
-                            sqlRunnerResultsTransformer.cartesianChartGroupByLayoutOptions(),
-                    };
-                }
 
-                // Update layout
-                const oldDefaultLayout = state.defaultLayout;
-                const newDefaultLayout =
-                    sqlRunnerResultsTransformer.defaultCartesianChartLayout();
+                state.options =
+                    sqlRunnerResultsTransformer.getCartesianLayoutOptions();
+
+                const chartDataTransformer = new CartesianChartDataTransformer({
+                    transformer: sqlRunnerResultsTransformer,
+                });
+
+                const { newConfig, newDefaultLayout } =
+                    chartDataTransformer.getChartConfig({
+                        chartType: ChartKind.LINE,
+                        currentConfig: state.config,
+                    });
+
+                state.config = newConfig;
                 state.defaultLayout = newDefaultLayout;
-
-                if (
-                    !state.config ||
-                    deepEqual(
-                        oldDefaultLayout || {},
-                        state.config?.fieldConfig || {},
-                    )
-                ) {
-                    state.config = {
-                        metadata: {
-                            version: 1,
-                        },
-                        type: ChartKind.LINE,
-                        fieldConfig: newDefaultLayout,
-                        display: state.config?.display,
-                    };
-                }
             }
         });
         builder.addCase(setSavedChartData, (state, action) => {

--- a/packages/frontend/src/features/sqlRunner/store/pieChartSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/pieChartSlice.ts
@@ -1,11 +1,10 @@
 import {
-    ChartKind,
-    deepEqual,
     isPieChartSQLConfig,
+    PieChartDataTransformer,
     type PieChartDimensionOptions,
     type PieChartMetricOptions,
     type PieChartSqlConfig,
-    type SqlTransformPieChartConfig,
+    type SqlPieChartConfig,
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
@@ -13,7 +12,7 @@ import { SqlRunnerResultsTransformerFE } from '../transformers/SqlRunnerResultsT
 import { setSavedChartData, setSqlRunnerResults } from './sqlRunnerSlice';
 
 type InitialState = {
-    defaultFieldConfig: SqlTransformPieChartConfig | undefined;
+    defaultFieldConfig: SqlPieChartConfig | undefined;
     config: PieChartSqlConfig | undefined;
     options: {
         groupFieldOptions: PieChartDimensionOptions[];
@@ -61,29 +60,15 @@ export const pieChartConfigSlice = createSlice({
                     };
                 }
 
-                const oldDefaultConfig = state.defaultFieldConfig;
-                const newDefaultConfig =
-                    sqlRunnerResultsTransformer.defaultPieChartFieldConfig();
-                state.defaultFieldConfig = newDefaultConfig;
+                const dataTransformer = new PieChartDataTransformer({
+                    transformer: sqlRunnerResultsTransformer,
+                });
 
-                if (
-                    !state.config ||
-                    deepEqual(
-                        oldDefaultConfig || {},
-                        state.config?.fieldConfig || {},
-                    )
-                ) {
-                    state.config = {
-                        metadata: {
-                            version: 1,
-                        },
-                        type: ChartKind.PIE,
-                        fieldConfig: newDefaultConfig,
-                        display: {
-                            isDonut: false,
-                        },
-                    };
-                }
+                const { newConfig } = dataTransformer.getChartConfig({
+                    currentConfig: state.config,
+                });
+
+                state.config = newConfig;
             }
         });
         builder.addCase(setSavedChartData, (state, action) => {

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -17,32 +17,41 @@ export const selectTableVisConfigState = (
     state: RootState,
 ): RootState['tableVisConfig'] => state.tableVisConfig;
 
-export const selectCurrentChartConfig = createSelector(
+const selectChartConfigByKind = createSelector(
     [
-        selectSqlRunnerState,
+        (state, chartKind) => chartKind,
         selectBarChartConfigState,
         selectLineChartConfigState,
         selectPieChartConfigState,
         selectTableVisConfigState,
     ],
     (
-        sqlRunnerState,
+        chartKind,
         barChartConfigState,
         lineChartConfigState,
         pieChartConfigState,
         tableVisConfigState,
     ) => {
-        const { selectedChartType } = sqlRunnerState;
-        if (selectedChartType === ChartKind.VERTICAL_BAR) {
-            return barChartConfigState.config;
-        } else if (selectedChartType === ChartKind.LINE) {
-            return lineChartConfigState.config;
-        } else if (selectedChartType === ChartKind.PIE) {
-            return pieChartConfigState.config;
-        } else if (selectedChartType === ChartKind.TABLE) {
-            return tableVisConfigState.config;
+        switch (chartKind) {
+            case ChartKind.VERTICAL_BAR:
+                return barChartConfigState.config;
+            case ChartKind.LINE:
+                return lineChartConfigState.config;
+            case ChartKind.PIE:
+                return pieChartConfigState.config;
+            case ChartKind.TABLE:
+                return tableVisConfigState.config;
+            default:
+                return undefined;
         }
-        return undefined;
+    },
+);
+
+export const selectCurrentChartConfig = createSelector(
+    [selectSqlRunnerState, (state) => state],
+    (sqlRunnerState, state) => {
+        const { selectedChartType } = sqlRunnerState;
+        return selectChartConfigByKind(state, selectedChartType);
     },
 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10983

### Description:

Keeps charts mounted so it is instant switching between them. 

I can't tell, but there might be a bit of a perf problem on initial load. Is it ok? What should we do about it?

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
