### PR TITLE
fix: cli compile joined models

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/plan.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/plan.yml
@@ -4,6 +4,9 @@ models:
     meta:
       required_attributes:
         is_admin: 'true'
+      joins:
+        - join: customers
+          sql_on: ${customers.customer_id} = ${plan.id}
     columns:
       - name: id
       - name: plan_name

--- a/examples/full-jaffle-shop-demo/dbt/models/plan.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/plan.yml
@@ -4,9 +4,6 @@ models:
     meta:
       required_attributes:
         is_admin: 'true'
-      joins:
-        - join: customers
-          sql_on: ${customers.customer_id} = ${plan.id}
     columns:
       - name: id
       - name: plan_name

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import globalState from '../globalState';
 import { getDbtVersion } from '../handlers/dbt/getDbtVersion';
 
-type LoadManifestArgs = {
+export type LoadManifestArgs = {
     targetDir: string;
 };
 

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -85,15 +85,6 @@ export function getCompiledModels(
     });
 }
 
-// TODO: Move this to somewhere appropriate
-type UnrenderedConfig =
-    | {
-          meta?: {
-              joins?: Array<{ join: string }>;
-          };
-      }
-    | undefined;
-
 const getJoinedModelsRecursively = (
     modelNode: DbtModelNode,
     allModelNodes: DbtModelNode[],
@@ -107,9 +98,9 @@ const getJoinedModelsRecursively = (
     GlobalState.debug(`Getting joined models for ${modelNode.name}`);
     visited.add(modelNode.name);
 
-    const joinedModelNames = (
-        modelNode.unrendered_config as UnrenderedConfig
-    )?.meta?.joins?.map((j) => j.join);
+    const joinedModelNames = modelNode.unrendered_config?.meta?.joins?.map(
+        (j) => j.join,
+    );
 
     if (!joinedModelNames) {
         return [];

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -1,5 +1,7 @@
-import { ParseError } from '@lightdash/common';
+import { DbtModelNode, ParseError } from '@lightdash/common';
 import execa from 'execa';
+import { loadManifest, LoadManifestArgs } from '../../dbt/manifest';
+import { getModelsFromManifest } from '../../dbt/models';
 import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
 
@@ -41,7 +43,7 @@ const dbtCompileArgs = [
 const camelToSnakeCase = (str: string) =>
     str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
 
-const optionsToArgs = (options: DbtCompileOptions): string[] =>
+const optionsToArgs = (options: Partial<DbtCompileOptions>): string[] =>
     Object.entries(options).reduce<string[]>((acc, [key, value]) => {
         if (value !== undefined && dbtCompileArgs.includes(key)) {
             const argKey = `--${camelToSnakeCase(key)}`;
@@ -56,6 +58,7 @@ const optionsToArgs = (options: DbtCompileOptions): string[] =>
         }
         return acc;
     }, []);
+
 export const dbtCompile = async (options: DbtCompileOptions) => {
     try {
         const args = optionsToArgs(options);
@@ -66,6 +69,103 @@ export const dbtCompile = async (options: DbtCompileOptions) => {
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : '-';
         throw new ParseError(`Failed to run dbt compile:\n  ${msg}`);
+    }
+};
+
+// TODO: Move this to somewhere appropriate
+type UnrenderedConfig =
+    | {
+          meta?: {
+              joins?: Array<{ join: string }>;
+          };
+      }
+    | undefined;
+
+const recursivelyGetJoinedModelNames = (
+    modelNode: DbtModelNode,
+    allModelNodes: DbtModelNode[],
+): string[] => {
+    const joinedModelNames = (
+        modelNode.unrendered_config as UnrenderedConfig
+    )?.meta?.joins?.map((j) => j.join);
+
+    if (!joinedModelNames) {
+        return [];
+    }
+
+    const joinedModelNodes = allModelNodes.filter((model) =>
+        joinedModelNames.includes(model.name),
+    );
+
+    return joinedModelNodes.reduce<string[]>(
+        (acc, model) => [
+            ...acc,
+            model.name,
+            ...recursivelyGetJoinedModelNames(model, allModelNodes),
+        ],
+        [],
+    );
+};
+
+export const dbtCompileNecessaryModels = async (
+    loadManifestOpts: LoadManifestArgs,
+    options: DbtCompileOptions,
+) => {
+    // If no models are explicitly selected or excluded, compile all models
+    if (!options.select && !options.exclude) {
+        await dbtCompile(options);
+        return;
+    }
+
+    const manifest = await loadManifest(loadManifestOpts);
+    const manifestModels = getModelsFromManifest(manifest);
+
+    const selectedModelNames = (
+        options.select ?? manifestModels.map((model) => model.name)
+    ).filter((modelName) => !options.exclude?.includes(modelName));
+
+    const selectedModelNodes = manifestModels.filter((model) =>
+        selectedModelNames.includes(model.name),
+    );
+
+    // Selected models and their joined models
+    const modelNamesToCompile = new Set(
+        selectedModelNodes.reduce<string[]>((acc, model) => {
+            const joinedModelNames = recursivelyGetJoinedModelNames(
+                model,
+                manifestModels,
+            );
+            return [...acc, model.name, ...(joinedModelNames ?? [])];
+        }, []),
+    );
+
+    await dbtCompile({
+        ...options,
+        select: Array.from(modelNamesToCompile),
+    });
+};
+
+export const dbtParse = async (
+    dbtVersion: string,
+    opts: Pick<
+        DbtCompileOptions,
+        'profilesDir' | 'projectDir' | 'profile' | 'target'
+    >,
+) => {
+    try {
+        const args = optionsToArgs(opts);
+
+        if (dbtVersion.startsWith('1.3.') || dbtVersion.startsWith('1.4.')) {
+            args.push('--write-manifest');
+        }
+
+        GlobalState.debug(`> Running: dbt parse ${args.join(' ')}`);
+        const { stdout, stderr } = await execa('dbt', ['parse', ...args]);
+        console.error(stdout);
+        console.error(stderr);
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
+        throw new ParseError(`Failed to run dbt parse:\n  ${msg}`);
     }
 };
 

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -94,7 +94,7 @@ type UnrenderedConfig =
       }
     | undefined;
 
-const recursivelyGetJoinedModelNames = (
+const getJoinedModelsRecursively = (
     modelNode: DbtModelNode,
     allModelNodes: DbtModelNode[],
     visited: Set<string> = new Set(),
@@ -123,7 +123,7 @@ const recursivelyGetJoinedModelNames = (
         (acc, model) => [
             ...acc,
             model.name,
-            ...recursivelyGetJoinedModelNames(model, allModelNodes, visited),
+            ...getJoinedModelsRecursively(model, allModelNodes, visited),
         ],
         [],
     );
@@ -149,7 +149,7 @@ export const compileModelsAndJoins = async (
     // Selected models and their joined models
     const modelsToCompile = new Set(
         currCompiledModels.reduce<string[]>((acc, model) => {
-            const joinedModelNames = recursivelyGetJoinedModelNames(
+            const joinedModelNames = getJoinedModelsRecursively(
                 model,
                 allManifestModels,
                 new Set(acc), // minimize recursion by passing already visited models in the current list

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -80,7 +80,7 @@ export function getCompiledModels(
         if (compiledModelIds) {
             return compiledModelIds.includes(model.unique_id);
         }
-        // in case they skipped the compile step, we check if the models are compiled
+
         return model.compiled;
     });
 }

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -47,6 +47,11 @@ export type DbtRawModelNode = CompiledModelNode & {
 };
 export type DbtModelNode = DbtRawModelNode & {
     database: string;
+    unrendered_config?: {
+        meta?: {
+            joins?: Array<{ join: string }>;
+        };
+    };
 };
 export type DbtModelColumn = ColumnInfo & {
     meta: DbtColumnMetadata;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4748

### Description:

- Previous implementation didn't take into account recursively joined models and also selecting/excluding models via tags instead of names.
This PR fixes that by keeping track of the visited models and by running `compile` with the passed arguments instead of `parse` this way we make sure that we get the initially compiled models at the expense of having to compile twice.

The following diff creates recursively joined models `customer -> plan -> customer` and can be used for testing

```diff
diff --git a/examples/full-jaffle-shop-demo/dbt/models/plan.yml b/examples/full-jaffle-shop-demo/dbt/models/plan.yml
index 14ae531a0..871a6cc42 100755
--- a/examples/full-jaffle-shop-demo/dbt/models/plan.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/plan.yml
@@ -4,6 +4,9 @@ models:
     meta:
       required_attributes:
         is_admin: 'true'
+      joins:
+        - join: customers
+          sql_on: ${customers.customer_id} = ${plan.id}
     columns:
       - name: id
       - name: plan_name
```

**Before**

https://github.com/user-attachments/assets/4500e14b-0d09-4039-910b-37dfadcc13e9

**After**

https://github.com/user-attachments/assets/ff17f046-fac9-4b65-baf5-b3d24cc5c944



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-cli