### PR TITLE
feat: preview commands fail if there are compile errors

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -25,6 +25,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     name?: string;
     verbose: boolean;
     startOfWeek?: number;
+    raiseErrors: boolean;
 };
 
 type StopPreviewHandlerOptions = {
@@ -314,7 +315,7 @@ export const startPreviewHandler = async (
         await deploy(explores, {
             ...options,
             projectUuid: previewProject.projectUuid,
-            ignoreErrors: true,
+            ignoreErrors: !options.raiseErrors,
         });
         const url = await projectUrl(previewProject);
         console.error(`Project updated on ${url}`);

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -25,7 +25,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     name?: string;
     verbose: boolean;
     startOfWeek?: number;
-    raiseErrors: boolean;
+    ignoreErrors: boolean;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -188,7 +188,6 @@ export const previewHandler = async (
         await deploy(explores, {
             ...options,
             projectUuid: project.projectUuid,
-            ignoreErrors: true,
         });
 
         await setPreviewProject(project.projectUuid, name);
@@ -246,7 +245,6 @@ export const previewHandler = async (
                     await deploy(await compile(options), {
                         ...options,
                         projectUuid: project.projectUuid,
-                        ignoreErrors: true,
                     });
                 }
 
@@ -315,7 +313,6 @@ export const startPreviewHandler = async (
         await deploy(explores, {
             ...options,
             projectUuid: previewProject.projectUuid,
-            ignoreErrors: options.ignoreErrors,
         });
         const url = await projectUrl(previewProject);
         console.error(`Project updated on ${url}`);
@@ -375,7 +372,6 @@ export const startPreviewHandler = async (
         await deploy(explores, {
             ...options,
             projectUuid: project.projectUuid,
-            ignoreErrors: true,
         });
         const url = await projectUrl(project);
 

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -315,7 +315,7 @@ export const startPreviewHandler = async (
         await deploy(explores, {
             ...options,
             projectUuid: previewProject.projectUuid,
-            ignoreErrors: !options.raiseErrors,
+            ignoreErrors: options.ignoreErrors,
         });
         const url = await projectUrl(previewProject);
         console.error(`Project updated on ${url}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -344,6 +344,7 @@ program
         parseUseDbtListOption,
         true,
     )
+    .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .action(previewHandler);
 
 program
@@ -406,7 +407,7 @@ program
         parseUseDbtListOption,
         true,
     )
-    .option('--raise-errors', 'Raise errors if deploy fails', false)
+    .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .action(startPreviewHandler);
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -406,6 +406,7 @@ program
         parseUseDbtListOption,
         true,
     )
+    .option('--raise-errors', 'Raise errors if deploy fails', false)
     .action(startPreviewHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11044

### Description:

Similar to `deploy` command, the preview commands will now fail if there are compile errors. 
To keep the existing behaviour, you can use the option `--ignore-errors`

Example:

```lightdash preview --ignore-errors```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
