### PR TITLE
feat: allow for lightdash dbt run --assume-yes flag

### DIFF
--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -54,7 +54,6 @@ export const dbtRunHandler = async (
     }
     await generateHandler({
         ...options,
-        assumeYes: options.assumeYes,
         excludeMeta: options.excludeMeta,
     });
 };

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -9,13 +9,12 @@ import { DbtCompileOptions } from './compile';
 type DbtRunHandlerOptions = DbtCompileOptions & {
     excludeMeta: boolean;
     verbose: boolean;
+    assumeYes: boolean;
 };
 
 export const dbtRunHandler = async (
     options: DbtRunHandlerOptions,
-    command: Command & {
-        assumeYes?: boolean;
-    },
+    command: Command,
 ) => {
     GlobalState.setVerbose(options.verbose);
 
@@ -55,7 +54,7 @@ export const dbtRunHandler = async (
     }
     await generateHandler({
         ...options,
-        assumeYes: !!command.assumeYes,
+        assumeYes: options.assumeYes,
         excludeMeta: options.excludeMeta,
     });
 };

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -13,7 +13,9 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
 
 export const dbtRunHandler = async (
     options: DbtRunHandlerOptions,
-    command: Command,
+    command: Command & {
+        assumeYes?: boolean;
+    },
 ) => {
     GlobalState.setVerbose(options.verbose);
 
@@ -29,7 +31,7 @@ export const dbtRunHandler = async (
     });
 
     const commands = command.parent.args.reduce<string[]>((acc, arg) => {
-        if (arg === '--verbose') return acc;
+        if (arg === '--verbose' || arg === '--assume-yes') return acc;
         return [...acc, arg];
     }, []);
 
@@ -53,7 +55,7 @@ export const dbtRunHandler = async (
     }
     await generateHandler({
         ...options,
-        assumeYes: true,
+        assumeYes: !!command.assumeYes,
         excludeMeta: options.excludeMeta,
     });
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -244,10 +244,7 @@ ${styles.bold('Examples:')}
     )
     .option('--verbose', undefined, false)
     .option('-y, --assume-yes', 'assume yes to prompts', false)
-    .action(async (options, command) => {
-        const { assumeYes, ...dbtOptions } = options;
-        await dbtRunHandler(dbtOptions, { assumeYes, ...command });
-    });
+    .action(dbtRunHandler);
 
 program
     .command('compile')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -243,8 +243,11 @@ ${styles.bold('Examples:')}
         false,
     )
     .option('--verbose', undefined, false)
-
-    .action(dbtRunHandler);
+    .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .action(async (options, command) => {
+        const { assumeYes, ...dbtOptions } = options;
+        await dbtRunHandler(dbtOptions, { assumeYes, ...command });
+    });
 
 program
     .command('compile')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10831

### Description:

- When users run `lightdash dbt run`, `assumeYes` is currently turned on by default. So all doc finds will overwrite the existing description for a dimension/metric.
- This adds the ability to pass `--assume-yes` and if not passed, it asks the user through a prompt if they want to replace the description field with a doc block. 

Demo:


https://github.com/user-attachments/assets/e10031b5-9f5f-4d0b-a338-0c1407e33829



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
