### PR TITLE
feat: add dbt semantic layer to service

### DIFF
--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -116,7 +116,10 @@ export class ClientRepository
     public getDbtCloudGraphqlClient(): DbtCloudGraphqlClient {
         return this.getClient(
             'dbtCloudGraphqlClient',
-            () => new DbtCloudGraphqlClient(),
+            () =>
+                new DbtCloudGraphqlClient({
+                    lightdashConfig: this.context.lightdashConfig,
+                }),
         );
     }
 

--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -60,7 +60,7 @@ export default class CubeClient {
         if (this.cubeApi === undefined)
             throw new MissingConfigError('Cube has not been initialized');
         const cubeQuery = this.transformers.semanticLayerQueryToQuery(query);
-        const resultSet: any = await this.cubeApi.load(cubeQuery);
+        const resultSet = await this.cubeApi.load(cubeQuery);
         return this.transformers.resultsToResultRows(resultSet);
     }
 

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -1,17 +1,13 @@
 import {
     Cube,
     Query as CubeQuery,
-    ResultSet,
-    SqlQuery,
     TCubeDimension,
     TCubeMeasure,
 } from '@cubejs-client/core';
 import {
-    FieldType,
+    FieldType as FieldKind,
     SemanticLayerField,
-    SemanticLayerQuery,
     SemanticLayerTransformer,
-    SemanticLayerView,
 } from '@lightdash/common';
 
 export const cubeTransfomers: SemanticLayerTransformer<
@@ -30,7 +26,7 @@ export const cubeTransfomers: SemanticLayerTransformer<
                 type: d.type,
                 description: d.shortTitle,
                 visible: d.public,
-                fieldType: FieldType.DIMENSION,
+                kind: FieldKind.DIMENSION,
             }),
         );
         const semanticMetrics: SemanticLayerField[] = metrics.map((d) => ({
@@ -39,7 +35,7 @@ export const cubeTransfomers: SemanticLayerTransformer<
             description: d.shortTitle,
             visible: d.public,
             type: d.type,
-            fieldType: FieldType.METRIC,
+            kind: FieldKind.METRIC,
         }));
 
         return [...semanticDimensions, ...semanticMetrics];

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -74,8 +74,10 @@ export const cubeTransfomers: SemanticLayerTransformer<
     semanticLayerQueryToQuery: (query) => ({
         measures: query.metrics,
         dimensions: query.dimensions,
+        timeDimensions: query.timeDimensions.map((td) => ({
+            dimension: td,
+        })),
         filters: [],
-        timeDimensions: [],
         limit: 100,
     }),
     resultsToResultRows: (cubeResultSet) => cubeResultSet.tablePivot(),

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -3,12 +3,31 @@ import {
     Query as CubeQuery,
     TCubeDimension,
     TCubeMeasure,
+    TCubeMemberType,
 } from '@cubejs-client/core';
 import {
     FieldType as FieldKind,
     SemanticLayerField,
+    SemanticLayerFieldType,
     SemanticLayerTransformer,
 } from '@lightdash/common';
+
+function getSemanticLayerTypeFromCubeType(
+    cubeType: TCubeMemberType,
+): SemanticLayerFieldType {
+    switch (cubeType) {
+        case 'string':
+            return SemanticLayerFieldType.STRING;
+        case 'number':
+            return SemanticLayerFieldType.NUMBER;
+        case 'boolean':
+            return SemanticLayerFieldType.BOOLEAN;
+        case 'time':
+            return SemanticLayerFieldType.TIME;
+        default:
+            throw new Error(`Unknown cube type: ${cubeType}`);
+    }
+}
 
 export const cubeTransfomers: SemanticLayerTransformer<
     Cube,
@@ -23,7 +42,7 @@ export const cubeTransfomers: SemanticLayerTransformer<
             (d) => ({
                 name: d.name,
                 label: d.title,
-                type: d.type,
+                type: getSemanticLayerTypeFromCubeType(d.type),
                 description: d.shortTitle,
                 visible: d.public,
                 kind: FieldKind.DIMENSION,
@@ -34,7 +53,7 @@ export const cubeTransfomers: SemanticLayerTransformer<
             label: d.title,
             description: d.shortTitle,
             visible: d.public,
-            type: d.type,
+            type: getSemanticLayerTypeFromCubeType(d.type),
             kind: FieldKind.METRIC,
         }));
 

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -6,6 +6,7 @@ import {
     TCubeMemberType,
 } from '@cubejs-client/core';
 import {
+    assertUnreachable,
     FieldType as FieldKind,
     SemanticLayerField,
     SemanticLayerFieldType,
@@ -25,7 +26,10 @@ function getSemanticLayerTypeFromCubeType(
         case 'time':
             return SemanticLayerFieldType.TIME;
         default:
-            throw new Error(`Unknown cube type: ${cubeType}`);
+            return assertUnreachable(
+                cubeType,
+                `Unknown cube type: ${cubeType}`,
+            );
     }
 }
 

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -1,6 +1,8 @@
 import {
     Cube,
     Query as CubeQuery,
+    ResultSet,
+    SqlQuery,
     TCubeDimension,
     TCubeMeasure,
     TCubeMemberType,
@@ -38,8 +40,8 @@ export const cubeTransfomers: SemanticLayerTransformer<
     CubeQuery,
     TCubeDimension[] | TCubeMeasure[],
     TCubeDimension[] | TCubeMeasure[],
-    any,
-    any
+    ResultSet,
+    SqlQuery
 > = {
     fieldsToSemanticLayerFields: (dimensions, metrics) => {
         const semanticDimensions: SemanticLayerField[] = dimensions.map(
@@ -76,8 +78,6 @@ export const cubeTransfomers: SemanticLayerTransformer<
         timeDimensions: [],
         limit: 100,
     }),
-    resultsToResultRows: (cubeResultSet) =>
-        cubeResultSet.loadResponse.results[0]?.data || [],
-
-    sqlToString: (cubeSql) => cubeSql.sqlQuery.sql.sql[0],
+    resultsToResultRows: (cubeResultSet) => cubeResultSet.tablePivot(),
+    sqlToString: (cubeSql) => cubeSql.sql(),
 };

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -10,23 +10,30 @@ import {
     FieldType,
     SemanticLayerField,
     SemanticLayerQuery,
+    SemanticLayerTransformer,
     SemanticLayerView,
 } from '@lightdash/common';
 
-export const cubeTransfomers = {
-    cubeFieldsToSemanticLayerFields: (
-        cubeDimensions: TCubeDimension[] | TCubeMeasure[],
-        cubeMetrics: TCubeDimension[] | TCubeMeasure[],
-    ): SemanticLayerField[] => {
-        const dimensions: SemanticLayerField[] = cubeDimensions.map((d) => ({
-            name: d.name,
-            label: d.title,
-            type: d.type,
-            description: d.shortTitle,
-            visible: d.public,
-            fieldType: FieldType.DIMENSION,
-        }));
-        const metrics: SemanticLayerField[] = cubeMetrics.map((d) => ({
+export const cubeTransfomers: SemanticLayerTransformer<
+    Cube,
+    CubeQuery,
+    TCubeDimension[] | TCubeMeasure[],
+    TCubeDimension[] | TCubeMeasure[],
+    any,
+    any
+> = {
+    fieldsToSemanticLayerFields: (dimensions, metrics) => {
+        const semanticDimensions: SemanticLayerField[] = dimensions.map(
+            (d) => ({
+                name: d.name,
+                label: d.title,
+                type: d.type,
+                description: d.shortTitle,
+                visible: d.public,
+                fieldType: FieldType.DIMENSION,
+            }),
+        );
+        const semanticMetrics: SemanticLayerField[] = metrics.map((d) => ({
             name: d.name,
             label: d.title,
             description: d.shortTitle,
@@ -35,23 +42,23 @@ export const cubeTransfomers = {
             fieldType: FieldType.METRIC,
         }));
 
-        return [...dimensions, ...metrics];
+        return [...semanticDimensions, ...semanticMetrics];
     },
-    cubesToSemanticLayerViews: (cubeViews: Cube[]): SemanticLayerView[] =>
+    viewsToSemanticLayerViews: (cubeViews) =>
         cubeViews.map((view) => ({
             name: view.name,
             label: view.title,
             visible: view.public,
         })),
-    semanticLayerQueryToCubeQuery: (query: SemanticLayerQuery): CubeQuery => ({
+    semanticLayerQueryToQuery: (query) => ({
         measures: query.metrics,
         dimensions: query.dimensions,
         filters: [],
         timeDimensions: [],
         limit: 100,
     }),
-    cubeResultSetToResultRows: (cubeResultSet: any): Record<string, any>[] =>
+    resultsToResultRows: (cubeResultSet) =>
         cubeResultSet.loadResponse.results[0]?.data || [],
 
-    cubeSqlToString: (cubeSql: any): string => cubeSql.sqlQuery.sql.sql[0],
+    sqlToString: (cubeSql) => cubeSql.sqlQuery.sql.sql[0],
 };

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -10,7 +10,6 @@ import {
     DbtGraphQLGetMetricsResponse,
     DbtGraphQLJsonResult,
     DbtGraphQLRunQueryRawResponse,
-    DbtGraphQLRunQueryResponse,
     SemanticLayerQuery,
     SemanticLayerView,
 } from '@lightdash/common';

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -23,7 +23,6 @@ type DbtCloudGraphqlClientArgs = {
     lightdashConfig: LightdashConfig;
 };
 
-type RunQueryFnArgs = DbtGraphQLCreateQueryArgs;
 type GetDimensionsFnArgs = DbtGraphQLGetDimensionsArgs;
 type GetMetricsForDimensionsFnArgs = DbtGraphQLGetMetricsForDimensionsArgs;
 

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -196,11 +196,13 @@ export default class DbtCloudGraphqlClient {
                 metrics(environmentId: $environmentId) {
                     name
                     description
+                    label
                     type
                     queryableGranularities
                     dimensions {
                         name
                         description
+                        label
                         type
                         queryableGranularities
                     }
@@ -228,11 +230,13 @@ export default class DbtCloudGraphqlClient {
                 )}]) {
                     name
                     description
+                    label
                     type
                     queryableGranularities
                     dimensions {
                         name
                         description
+                        label
                         type
                         queryableGranularities
                     }
@@ -260,6 +264,7 @@ export default class DbtCloudGraphqlClient {
                 )}]) {
                     name
                     description
+                    label
                     type
                     queryableGranularities
                 }

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -67,10 +67,15 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
     },
     viewsToSemanticLayerViews: (views) => views, // dbt doesn't have the concept of views so we return a placeholder
     semanticLayerQueryToQuery: (query) => {
-        const { metrics, dimensions } = query;
+        const { metrics, dimensions, timeDimensions } = query;
         return {
             metrics: metrics.map((metric) => ({ name: metric })),
-            groupBy: dimensions.map((dimension) => ({ name: dimension })),
+            groupBy: [
+                ...dimensions.map((dimension) => ({ name: dimension })),
+                ...timeDimensions.map((timeDimension) => ({
+                    name: timeDimension,
+                })),
+            ],
             where: [],
             orderBy: [],
             limit: 100, // Let this be 100 for now

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -8,9 +8,9 @@ import {
     DbtGraphQLMetric,
     DbtMetricType,
     FieldType as FieldKind,
-    ResultRow,
     SemanticLayerField,
     SemanticLayerFieldType,
+    SemanticLayerResultRow,
     SemanticLayerTransformer,
     SemanticLayerView,
 } from '@lightdash/common';
@@ -77,17 +77,9 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
     },
     resultsToResultRows: (results) => {
         const { data } = results;
-        return data.map((row): ResultRow => {
-            const newRow: ResultRow = {};
-            Object.entries(row).forEach(([key, value]) => {
-                newRow[key] = {
-                    value: {
-                        formatted: value ? value.toString() : '∅', // For now formatting the value to go into the ResultRow is just stringifying it or showing '∅' if it's null
-                        raw: value,
-                    },
-                };
-            });
-            return newRow;
+        return data.map((row) => {
+            const { index, ...rowValues } = row;
+            return rowValues;
         });
     },
     sqlToString: (sql) => sql,

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -1,0 +1,65 @@
+import {
+    DbtGraphQLCompileSqlArgs,
+    DbtGraphQLCreateQueryArgs,
+    DbtGraphQLDimension,
+    DbtGraphQLJsonResult,
+    DbtGraphQLMetric,
+    FieldType as FieldKind,
+    SemanticLayerField,
+    SemanticLayerTransformer,
+} from '@lightdash/common';
+
+export const dbtCloudTransfomers: SemanticLayerTransformer<
+    unknown, // dbt doesn't have the concept of views
+    DbtGraphQLCreateQueryArgs | DbtGraphQLCompileSqlArgs,
+    DbtGraphQLDimension[],
+    DbtGraphQLMetric[],
+    DbtGraphQLJsonResult,
+    string
+> = {
+    fieldsToSemanticLayerFields: (dimensions, metrics) => {
+        const semanticDimensions: SemanticLayerField[] = dimensions.map(
+            (dimension) => ({
+                name: dimension.name,
+                label: dimension.label ?? '',
+                description: dimension.description ?? '',
+                type: dimension.type,
+                visible: true,
+                kind: FieldKind.DIMENSION,
+            }),
+        );
+
+        const semanticMetrics: SemanticLayerField[] = metrics.map((metric) => ({
+            name: metric.name,
+            label: metric.label ?? '',
+            description: metric.description ?? '',
+            visible: true,
+            type: metric.type,
+            kind: FieldKind.METRIC,
+        }));
+
+        return [...semanticDimensions, ...semanticMetrics];
+    },
+    viewsToSemanticLayerViews: (_ = []) => [
+        // return a placeholder view
+        {
+            label: 'DBT Semantic View',
+            name: 'dbtSemanticView',
+            visible: true,
+        },
+    ],
+    semanticLayerQueryToQuery: (query) => {
+        const { metrics, dimensions } = query;
+        return {
+            metrics: metrics.map((metric) => ({ name: metric })),
+            groupBy: dimensions.map((dimension) => ({ name: dimension })),
+            where: [],
+            orderBy: [],
+        };
+    },
+    resultsToResultRows: (results) => {
+        const { data } = results;
+        return data;
+    },
+    sqlToString: (sql) => sql,
+};

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -22,7 +22,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
         const semanticDimensions: SemanticLayerField[] = dimensions.map(
             (dimension) => ({
                 name: dimension.name,
-                label: dimension.label ?? '',
+                label: dimension.label ?? dimension.name,
                 description: dimension.description ?? '',
                 type: dimension.type,
                 visible: true,
@@ -32,7 +32,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
 
         const semanticMetrics: SemanticLayerField[] = metrics.map((metric) => ({
             name: metric.name,
-            label: metric.label ?? '',
+            label: metric.label ?? metric.name,
             description: metric.description ?? '',
             visible: true,
             type: metric.type,

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -8,6 +8,7 @@ import {
     DbtGraphQLMetric,
     DbtMetricType,
     FieldType as FieldKind,
+    ResultRow,
     SemanticLayerField,
     SemanticLayerFieldType,
     SemanticLayerTransformer,
@@ -76,7 +77,18 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
     },
     resultsToResultRows: (results) => {
         const { data } = results;
-        return data;
+        return data.map((row): ResultRow => {
+            const newRow: ResultRow = {};
+            Object.entries(row).forEach(([key, value]) => {
+                newRow[key] = {
+                    value: {
+                        formatted: value ? value.toString() : '∅', // For now formatting the value to go into the ResultRow is just stringifying it or showing '∅' if it's null
+                        raw: value,
+                    },
+                };
+            });
+            return newRow;
+        });
     },
     sqlToString: (sql) => sql,
 };

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -73,6 +73,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
             groupBy: dimensions.map((dimension) => ({ name: dimension })),
             where: [],
             orderBy: [],
+            limit: 100, // Let this be 100 for now
         };
     },
     resultsToResultRows: (results) => {

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -7,10 +7,11 @@ import {
     FieldType as FieldKind,
     SemanticLayerField,
     SemanticLayerTransformer,
+    SemanticLayerView,
 } from '@lightdash/common';
 
 export const dbtCloudTransfomers: SemanticLayerTransformer<
-    unknown, // dbt doesn't have the concept of views
+    SemanticLayerView,
     DbtGraphQLCreateQueryArgs | DbtGraphQLCompileSqlArgs,
     DbtGraphQLDimension[],
     DbtGraphQLMetric[],
@@ -40,14 +41,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
 
         return [...semanticDimensions, ...semanticMetrics];
     },
-    viewsToSemanticLayerViews: (_ = []) => [
-        // return a placeholder view
-        {
-            label: 'DBT Semantic View',
-            name: 'dbtSemanticView',
-            visible: true,
-        },
-    ],
+    viewsToSemanticLayerViews: (views) => views, // dbt doesn't have the concept of views so we return a placeholder
     semanticLayerQueryToQuery: (query) => {
         const { metrics, dimensions } = query;
         return {

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -1,14 +1,37 @@
 import {
+    assertUnreachable,
+    DbtDimensionType,
     DbtGraphQLCompileSqlArgs,
     DbtGraphQLCreateQueryArgs,
     DbtGraphQLDimension,
     DbtGraphQLJsonResult,
     DbtGraphQLMetric,
+    DbtMetricType,
     FieldType as FieldKind,
     SemanticLayerField,
+    SemanticLayerFieldType,
     SemanticLayerTransformer,
     SemanticLayerView,
 } from '@lightdash/common';
+
+function getSemanticLayerTypeFromDbtType(
+    dbtType: DbtDimensionType | DbtMetricType,
+): SemanticLayerFieldType {
+    switch (dbtType) {
+        case DbtDimensionType.CATEGORICAL:
+            return SemanticLayerFieldType.STRING;
+        case DbtDimensionType.TIME:
+            return SemanticLayerFieldType.TIME;
+        case DbtMetricType.CONVERSION:
+        case DbtMetricType.CUMULATIVE:
+        case DbtMetricType.RATIO:
+        case DbtMetricType.DERIVED:
+        case DbtMetricType.SIMPLE:
+            return SemanticLayerFieldType.NUMBER;
+        default:
+            return assertUnreachable(dbtType, `Unknown dbt type: ${dbtType}`);
+    }
+}
 
 export const dbtCloudTransfomers: SemanticLayerTransformer<
     SemanticLayerView,
@@ -24,7 +47,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
                 name: dimension.name,
                 label: dimension.label ?? dimension.name,
                 description: dimension.description ?? '',
-                type: dimension.type,
+                type: getSemanticLayerTypeFromDbtType(dimension.type),
                 visible: true,
                 kind: FieldKind.DIMENSION,
             }),
@@ -35,7 +58,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
             label: metric.label ?? metric.name,
             description: metric.description ?? '',
             visible: true,
-            type: metric.type,
+            type: getSemanticLayerTypeFromDbtType(metric.type),
             kind: FieldKind.METRIC,
         }));
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -151,4 +151,9 @@ export const lightdashConfigMock: LightdashConfig = {
     cube: {
         token: '',
     },
+    dbtCloud: {
+        domain: '',
+        bearerToken: '',
+        environmentId: '',
+    },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -273,6 +273,11 @@ export type LightdashConfig = {
         token: string;
         domain?: string;
     };
+    dbtCloud: {
+        bearerToken?: string;
+        environmentId?: string;
+        domain: string;
+    };
 };
 
 export type SlackConfig = {
@@ -767,6 +772,13 @@ export const parseConfig = (): LightdashConfig => {
         cube: {
             token: process.env.CUBE_TOKEN || '',
             domain: process.env.CUBE_DOMAIN,
+        },
+        dbtCloud: {
+            bearerToken: process.env.DBT_CLOUD_BEARER_TOKEN,
+            environmentId: process.env.DBT_CLOUD_ENVIRONMENT_ID,
+            domain:
+                process.env.DBT_CLOUD_DOMAIN ||
+                `https://semantic-layer.cloud.getdbt.com`,
         },
     };
 };

--- a/packages/backend/src/controllers/metricFlowController.ts
+++ b/packages/backend/src/controllers/metricFlowController.ts
@@ -82,12 +82,7 @@ export class MetricFlowController extends BaseController {
             status: 'ok',
             results: await req.clients
                 .getDbtCloudGraphqlClient()
-                .runGraphQlQuery({
-                    domain,
-                    bearerToken,
-                    environmentId,
-                    query: body.query,
-                }),
+                .runGraphQlQuery(body.query),
         };
     }
 }

--- a/packages/backend/src/controllers/metricFlowController.ts
+++ b/packages/backend/src/controllers/metricFlowController.ts
@@ -42,17 +42,6 @@ export class MetricFlowController extends BaseController {
     ): Promise<any> {
         this.setStatus(200);
 
-        // TODO: soon available via UI - https://github.com/lightdash/lightdash/issues/6767
-        const bearerToken = process.env.DBT_CLOUD_BEARER_TOKEN || undefined;
-        const environmentId = process.env.DBT_CLOUD_ENVIRONMENT_ID || undefined;
-        const domain =
-            process.env.DBT_CLOUD_DOMAIN ||
-            `https://semantic-layer.cloud.getdbt.com`;
-
-        if (!bearerToken || !environmentId) {
-            throw new Error('Dbt Cloud is not enabled');
-        }
-
         // TODO: soon to be moved to a service
         if (body.operationName === 'GetQueryResults') {
             // TODO: to be removed once this is refactored. https://github.com/lightdash/lightdash/issues/9099

--- a/packages/backend/src/controllers/v2/SemanticLayerController.ts
+++ b/packages/backend/src/controllers/v2/SemanticLayerController.ts
@@ -1,11 +1,8 @@
 import {
     ApiErrorPayload,
-    CatalogField,
-    CatalogTable,
-    MetricQueryRequest,
-    ResultRow,
     SemanticLayerField,
     SemanticLayerQuery,
+    SemanticLayerResultRow,
     SemanticLayerView,
 } from '@lightdash/common';
 import {
@@ -84,7 +81,7 @@ export class SemanticLayerController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
         @Body() body: SemanticLayerQuery,
-    ): Promise<{ status: 'ok'; results: ResultRow[] }> {
+    ): Promise<{ status: 'ok'; results: SemanticLayerResultRow[] }> {
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7711,6 +7711,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerFieldType: {
+        dataType: 'refEnum',
+        enums: ['time', 'number', 'string', 'boolean'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerField: {
         dataType: 'refAlias',
         type: {
@@ -7719,8 +7724,8 @@ const models: TsoaRoute.Models = {
                 aggType: { dataType: 'string' },
                 visible: { dataType: 'boolean' },
                 description: { dataType: 'string' },
-                fieldType: { ref: 'FieldType', required: true },
-                type: { dataType: 'string', required: true },
+                kind: { ref: 'FieldType', required: true },
+                type: { ref: 'SemanticLayerFieldType', required: true },
                 label: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
             },
@@ -7728,7 +7733,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string._value-ResultValue--__': {
+    'Record_string.string-or-number-or-boolean-or-null_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -7737,9 +7742,12 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResultRow: {
+    SemanticLayerResultRow: {
         dataType: 'refAlias',
-        type: { ref: 'Record_string._value-ResultValue--__', validators: {} },
+        type: {
+            ref: 'Record_string.string-or-number-or-boolean-or-null_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerQuery: {
@@ -7748,6 +7756,11 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                timeDimensions: {
                     dataType: 'array',
                     array: { dataType: 'string' },
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8597,6 +8597,10 @@
                 "required": ["label", "name"],
                 "type": "object"
             },
+            "SemanticLayerFieldType": {
+                "enum": ["time", "number", "string", "boolean"],
+                "type": "string"
+            },
             "SemanticLayerField": {
                 "properties": {
                     "aggType": {
@@ -8608,11 +8612,11 @@
                     "description": {
                         "type": "string"
                     },
-                    "fieldType": {
+                    "kind": {
                         "$ref": "#/components/schemas/FieldType"
                     },
                     "type": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/SemanticLayerFieldType"
                     },
                     "label": {
                         "type": "string"
@@ -8621,20 +8625,26 @@
                         "type": "string"
                     }
                 },
-                "required": ["fieldType", "type", "label", "name"],
+                "required": ["kind", "type", "label", "name"],
                 "type": "object"
             },
-            "Record_string._value-ResultValue--__": {
+            "Record_string.string-or-number-or-boolean-or-null_": {
                 "properties": {},
                 "type": "object",
                 "description": "Construct a type with a set of properties K of type T"
             },
-            "ResultRow": {
-                "$ref": "#/components/schemas/Record_string._value-ResultValue--__"
+            "SemanticLayerResultRow": {
+                "$ref": "#/components/schemas/Record_string.string-or-number-or-boolean-or-null_"
             },
             "SemanticLayerQuery": {
                 "properties": {
                     "metrics": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "timeDimensions": {
                         "items": {
                             "type": "string"
                         },
@@ -8647,7 +8657,7 @@
                         "type": "array"
                     }
                 },
-                "required": ["metrics", "dimensions"],
+                "required": ["metrics", "timeDimensions", "dimensions"],
                 "type": "object"
             },
             "ValidationTarget": {
@@ -8891,7 +8901,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1203.4",
+        "version": "0.1205.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -140,8 +140,8 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.headlessBrowser?.host !== undefined,
             // TODO: soon to be deleted as we move feature to UI - https://github.com/lightdash/lightdash/issues/6767
             hasDbtSemanticLayer:
-                !!process.env.DBT_CLOUD_ENVIRONMENT_ID &&
-                !!process.env.DBT_CLOUD_BEARER_TOKEN,
+                !!this.lightdashConfig.dbtCloud.environmentId &&
+                !!this.lightdashConfig.dbtCloud.bearerToken,
             hasGroups: await this.hasGroups(user),
             hasExtendedUsageAnalytics:
                 this.lightdashConfig.extendedUsageAnalytics.enabled,

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -1,14 +1,7 @@
 import { subject } from '@casl/ability';
-import { Cube } from '@cubejs-client/core';
 import {
-    CatalogField,
-    CatalogTable,
-    CatalogType,
-    FieldType,
     ForbiddenError,
-    MetricQuery,
     MissingConfigError,
-    NotFoundError,
     ResultRow,
     SemanticLayerField,
     SemanticLayerQuery,
@@ -114,7 +107,7 @@ export class SemanticLayerService extends BaseService {
                 const { client, transformer } =
                     await this.getSemanticLayerClient(projectUuid);
                 const views = await client.getViews();
-                return transformer.cubesToSemanticLayerViews(views);
+                return transformer.viewsToSemanticLayerViews(views);
             },
             // Extra properties for analytic event after the function is executed
             (result) => ({
@@ -133,7 +126,7 @@ export class SemanticLayerService extends BaseService {
             projectUuid,
         );
         const [dimensions, metrics] = await client.getFields(table);
-        return transformer.cubeFieldsToSemanticLayerFields(dimensions, metrics);
+        return transformer.fieldsToSemanticLayerFields(dimensions, metrics);
     }
 
     async getResults(
@@ -146,9 +139,9 @@ export class SemanticLayerService extends BaseService {
             projectUuid,
         );
 
-        const semanticQuery = transformer.semanticLayerQueryToCubeQuery(query);
+        const semanticQuery = transformer.semanticLayerQueryToQuery(query);
         const results = await client.getResults(semanticQuery);
-        const resultRows = transformer.cubeResultSetToResultRows(results);
+        const resultRows = transformer.resultsToResultRows(results);
 
         return resultRows;
     }
@@ -163,9 +156,9 @@ export class SemanticLayerService extends BaseService {
             projectUuid,
         );
 
-        const semanticQuery = transformer.semanticLayerQueryToCubeQuery(query);
+        const semanticQuery = transformer.semanticLayerQueryToQuery(query);
         const sqlQuery = await client.getSql(semanticQuery);
-        const sql = transformer.cubeSqlToString(sqlQuery);
+        const sql = transformer.sqlToString(sqlQuery);
 
         return sql;
     }

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -66,16 +66,21 @@ export class SemanticLayerService extends BaseService {
     async getSemanticLayerClient(
         projectUuid: string,
     ): Promise<CubeClient | DbtCloudGraphqlClient> {
-        // TODO return same types from dbtcloud
-        // TODO get different client based on project
-        // For now, we get the client based on the available lightdash config
-        // TODO move dbt to lightdashConfig
-        /* const bearerToken = process.env.DBT_CLOUD_BEARER_TOKEN || undefined;
-        if (bearerToken) {
+        // TODO: get different client based on project, right now we're only doing this based on config
+
+        if (
+            !!this.lightdashConfig.dbtCloud.bearerToken &&
+            !!this.lightdashConfig.dbtCloud.environmentId
+        ) {
             return this.dbtCloudClient;
-        } */
-        // TODO check if cube is available
-        return this.cubeClient;
+        }
+
+        if (
+            !!this.lightdashConfig.cube.token &&
+            !!this.lightdashConfig.cube.domain
+        ) {
+            return this.cubeClient;
+        }
 
         throw new MissingConfigError('No semantic layer available');
     }

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -2,9 +2,9 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     MissingConfigError,
-    ResultRow,
     SemanticLayerField,
     SemanticLayerQuery,
+    SemanticLayerResultRow,
     SemanticLayerView,
     SessionUser,
 } from '@lightdash/common';
@@ -128,7 +128,7 @@ export class SemanticLayerService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         query: SemanticLayerQuery,
-    ): Promise<ResultRow[]> {
+    ): Promise<SemanticLayerResultRow[]> {
         await this.checkCanViewProject(user, projectUuid);
         const client = await this.getSemanticLayerClient(projectUuid);
 

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -115,16 +115,18 @@ export type DbtGraphQLRunQueryResponse =
         jsonResult: DbtGraphQLJsonResult | null;
     };
 
-type DbtGraphQLDimension = {
+export type DbtGraphQLDimension = {
     name: string;
-    description: string;
+    description: string | null;
+    label: string | null;
     type: DbtDimensionType;
     queryableGranularities: DbtTimeGranularity[];
 };
 
-type DbtGraphQLMetric = {
+export type DbtGraphQLMetric = {
     name: string;
-    description: string;
+    description: string | null;
+    label: string | null;
     type: DbtMetricType;
     dimensions: DbtGraphQLDimension[];
     queryableGranularities: DbtTimeGranularity[];

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -1,5 +1,4 @@
 import { type FieldType as FieldKind } from './field';
-import { type ResultRow } from './results';
 
 export type SemanticLayerView = {
     name: string;
@@ -30,6 +29,11 @@ export type SemanticLayerQuery = {
     metrics: string[];
 };
 
+export type SemanticLayerResultRow = Record<
+    string,
+    string | number | boolean | null
+>;
+
 export interface SemanticLayerTransformer<
     ViewType,
     QueryType,
@@ -44,6 +48,6 @@ export interface SemanticLayerTransformer<
     ) => SemanticLayerField[];
     viewsToSemanticLayerViews: (views: ViewType[]) => SemanticLayerView[];
     semanticLayerQueryToQuery: (query: SemanticLayerQuery) => QueryType;
-    resultsToResultRows: (results: ResultsType) => ResultRow[];
+    resultsToResultRows: (results: ResultsType) => SemanticLayerResultRow[];
     sqlToString: (sql: SqlType) => string;
 }

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -1,4 +1,5 @@
 import { type FieldType as FieldKind } from './field';
+import { type ResultRow } from './results';
 
 export type SemanticLayerView = {
     name: string;
@@ -43,6 +44,6 @@ export interface SemanticLayerTransformer<
     ) => SemanticLayerField[];
     viewsToSemanticLayerViews: (views: ViewType[]) => SemanticLayerView[];
     semanticLayerQueryToQuery: (query: SemanticLayerQuery) => QueryType;
-    resultsToResultRows: (results: ResultsType) => Record<string, any>[];
+    resultsToResultRows: (results: ResultsType) => ResultRow[];
     sqlToString: (sql: SqlType) => string;
 }

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -6,10 +6,18 @@ export type SemanticLayerView = {
     description?: string;
     visible?: boolean;
 };
+
+export enum SemanticLayerFieldType {
+    TIME = 'time',
+    NUMBER = 'number',
+    STRING = 'string',
+    BOOLEAN = 'boolean',
+}
+
 export type SemanticLayerField = {
     name: string;
     label: string;
-    type: string;
+    type: SemanticLayerFieldType;
     kind: FieldKind;
     description?: string;
     visible?: boolean;

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -1,4 +1,4 @@
-import { type FieldType } from './field';
+import { type FieldType as FieldKind } from './field';
 
 export type SemanticLayerView = {
     name: string;
@@ -10,7 +10,7 @@ export type SemanticLayerField = {
     name: string;
     label: string;
     type: string;
-    fieldType: FieldType;
+    kind: FieldKind;
     description?: string;
     visible?: boolean;
     aggType?: string; // eg: count, sum

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -20,3 +20,21 @@ export type SemanticLayerQuery = {
     dimensions: string[];
     metrics: string[];
 };
+
+export interface SemanticLayerTransformer<
+    ViewType,
+    QueryType,
+    DimensionsType,
+    MetricsType,
+    ResultsType,
+    SqlType,
+> {
+    fieldsToSemanticLayerFields: (
+        dimensions: DimensionsType,
+        metrics: MetricsType,
+    ) => SemanticLayerField[];
+    viewsToSemanticLayerViews: (views: ViewType[]) => SemanticLayerView[];
+    semanticLayerQueryToQuery: (query: SemanticLayerQuery) => QueryType;
+    resultsToResultRows: (results: ResultsType) => Record<string, any>[];
+    sqlToString: (sql: SqlType) => string;
+}

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -1,4 +1,4 @@
-import { type FieldType as FieldKind } from './field';
+import { type FieldType } from './field';
 
 export type SemanticLayerView = {
     name: string;
@@ -18,7 +18,7 @@ export type SemanticLayerField = {
     name: string;
     label: string;
     type: SemanticLayerFieldType;
-    kind: FieldKind;
+    kind: FieldType;
     description?: string;
     visible?: boolean;
     aggType?: string; // eg: count, sum
@@ -26,6 +26,7 @@ export type SemanticLayerField = {
 
 export type SemanticLayerQuery = {
     dimensions: string[];
+    timeDimensions: string[];
     metrics: string[];
 };
 

--- a/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
@@ -1,6 +1,6 @@
 import {
     assertUnreachable,
-    FieldType,
+    FieldType as FieldKind,
     type SemanticLayerField,
 } from '@lightdash/common';
 import {
@@ -15,14 +15,14 @@ import MantineIcon, {
     type MantineIconProps,
 } from '../../../components/common/MantineIcon';
 
-const getFieldColor = (type: SemanticLayerField['fieldType']) => {
-    switch (type) {
-        case FieldType.DIMENSION:
+const getFieldColor = (kind: SemanticLayerField['kind']) => {
+    switch (kind) {
+        case FieldKind.DIMENSION:
             return 'blue';
-        case FieldType.METRIC:
+        case FieldKind.METRIC:
             return 'orange';
         default:
-            return assertUnreachable(type, `Unknown field type: ${type}`);
+            return assertUnreachable(kind, `Unknown field kind: ${kind}`);
     }
 };
 
@@ -54,7 +54,7 @@ const FieldIcon = forwardRef<SVGSVGElement, Props>(
     ({ field, size = 'lg', selected, ...iconProps }, ref) => {
         const iconColor = selected
             ? 'white'
-            : iconProps.color ?? getFieldColor(field.fieldType);
+            : iconProps.color ?? getFieldColor(field.kind);
 
         const props = {
             ...iconProps,

--- a/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
@@ -1,5 +1,7 @@
 import {
     assertUnreachable,
+    DbtDimensionType,
+    DbtMetricType,
     FieldType as FieldKind,
     type SemanticLayerField,
 } from '@lightdash/common';
@@ -28,14 +30,21 @@ const getFieldColor = (kind: SemanticLayerField['kind']) => {
 
 const getFieldIconName = (type: SemanticLayerField['type']) => {
     switch (type) {
+        case DbtMetricType.CONVERSION:
+        case DbtDimensionType.CATEGORICAL:
         case 'string':
             return 'citation';
+        case DbtMetricType.DERIVED:
+        case DbtMetricType.CUMULATIVE:
+        case DbtMetricType.RATIO:
+        case DbtMetricType.SIMPLE:
         case 'number':
             return 'numerical';
         case 'date':
             return 'calendar';
         case 'boolean':
             return 'segmented-control';
+        case DbtDimensionType.TIME:
         case 'time':
             return 'time';
         default:

--- a/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/FieldIcon.tsx
@@ -1,14 +1,12 @@
 import {
     assertUnreachable,
-    DbtDimensionType,
-    DbtMetricType,
     FieldType as FieldKind,
+    SemanticLayerFieldType,
     type SemanticLayerField,
 } from '@lightdash/common';
 import {
     Icon123,
     IconAbc,
-    IconCalendar,
     IconClockHour4,
     IconToggleLeft,
 } from '@tabler/icons-react';
@@ -28,25 +26,16 @@ const getFieldColor = (kind: SemanticLayerField['kind']) => {
     }
 };
 
-const getFieldIconName = (type: SemanticLayerField['type']) => {
+const getFieldIconName = (type: SemanticLayerFieldType) => {
     switch (type) {
-        case DbtMetricType.CONVERSION:
-        case DbtDimensionType.CATEGORICAL:
-        case 'string':
+        case SemanticLayerFieldType.STRING:
             return 'citation';
-        case DbtMetricType.DERIVED:
-        case DbtMetricType.CUMULATIVE:
-        case DbtMetricType.RATIO:
-        case DbtMetricType.SIMPLE:
-        case 'number':
+        case SemanticLayerFieldType.NUMBER:
             return 'numerical';
-        case 'date':
-            return 'calendar';
-        case 'boolean':
-            return 'segmented-control';
-        case DbtDimensionType.TIME:
-        case 'time':
+        case SemanticLayerFieldType.TIME:
             return 'time';
+        case SemanticLayerFieldType.BOOLEAN:
+            return 'segmented-control';
         default:
             // FIXME: type should be FieldType
             // return assertUnreachable(type, `Unknown field type: ${type}`);
@@ -79,8 +68,6 @@ const FieldIcon = forwardRef<SVGSVGElement, Props>(
                 return <MantineIcon icon={IconAbc} {...props} />;
             case 'numerical':
                 return <MantineIcon icon={Icon123} {...props} />;
-            case 'calendar':
-                return <MantineIcon icon={IconCalendar} {...props} />;
             case 'time':
                 return <MantineIcon icon={IconClockHour4} {...props} />;
             case 'segmented-control':

--- a/packages/frontend/src/features/semanticViewer/components/SidebarViewFields.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SidebarViewFields.tsx
@@ -1,6 +1,6 @@
 import {
     assertUnreachable,
-    FieldType,
+    FieldType as FieldKind,
     type SemanticLayerField,
 } from '@lightdash/common';
 import {
@@ -23,19 +23,14 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { toggleField } from '../store/semanticViewerSlice';
 import FieldIcon from './FieldIcon';
 
-const getNavbarColorByFieldType = (
-    fieldType: SemanticLayerField['fieldType'],
-) => {
-    switch (fieldType) {
-        case FieldType.DIMENSION:
+const getNavbarColorByFieldKind = (kind: SemanticLayerField['kind']) => {
+    switch (kind) {
+        case FieldKind.DIMENSION:
             return 'blue';
-        case FieldType.METRIC:
+        case FieldKind.METRIC:
             return 'orange';
         default:
-            return assertUnreachable(
-                fieldType,
-                `Unknown field type ${fieldType}`,
-            );
+            return assertUnreachable(kind, `Unknown field kind ${kind}`);
     }
 };
 
@@ -85,8 +80,8 @@ const SidebarViewFields = () => {
         );
     }
 
-    const handleFieldToggle = (field: string, fieldType: FieldType) => {
-        dispatch(toggleField({ field, fieldType }));
+    const handleFieldToggle = (field: string, kind: FieldKind) => {
+        dispatch(toggleField({ field, kind }));
     };
 
     const searchedOrAllFields = searchedFields ?? fields.data;
@@ -130,7 +125,7 @@ const SidebarViewFields = () => {
                         <NavLink
                             key={field.name}
                             h="xxl"
-                            color={getNavbarColorByFieldType(field.fieldType)}
+                            color={getNavbarColorByFieldKind(field.kind)}
                             label={
                                 <Highlight
                                     highlight={searchQuery.split(' ')}
@@ -147,7 +142,7 @@ const SidebarViewFields = () => {
                                 selectedMetrics.includes(field.name)
                             }
                             onClick={() =>
-                                handleFieldToggle(field.name, field.fieldType)
+                                handleFieldToggle(field.name, field.kind)
                             }
                         />
                     ))}

--- a/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
@@ -15,6 +15,7 @@ const SqlViewer: FC = () => {
             payload: {
                 dimensions: selectedDimensions,
                 metrics: selectedMetrics,
+                timeDimensions: [],
             },
         },
         {

--- a/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
+++ b/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
@@ -1,4 +1,4 @@
-import { FieldType } from '@lightdash/common';
+import { FieldType as FieldKind } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
@@ -42,7 +42,7 @@ export const semanticViewerSlice = createSlice({
             state,
             action: PayloadAction<{
                 field: string;
-                fieldType: FieldType;
+                kind: FieldKind;
             }>,
         ) => {
             if (!state.view) {
@@ -51,8 +51,8 @@ export const semanticViewerSlice = createSlice({
 
             console.log(action.payload);
 
-            switch (action.payload.fieldType) {
-                case FieldType.DIMENSION:
+            switch (action.payload.kind) {
+                case FieldKind.DIMENSION:
                     if (
                         state.selectedDimensions.includes(action.payload.field)
                     ) {
@@ -64,7 +64,7 @@ export const semanticViewerSlice = createSlice({
                         state.selectedDimensions.push(action.payload.field);
                     }
                     break;
-                case FieldType.METRIC:
+                case FieldKind.METRIC:
                     if (state.selectedMetrics.includes(action.payload.field)) {
                         state.selectedMetrics = state.selectedMetrics.filter(
                             (field) => field !== action.payload.field,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11027 

### Description:

- Instantiates the `DbtCloudGraphqlClient` with `lightdashConfig` and makes necessary changes so that current `dbt semantic layer` works
- Moves transformer usage into `semantic layer clients` so that we don't have to deal with returned types right now - see: [Move transformer usage out of the clients and into the service layer](https://github.com/lightdash/lightdash/issues/11082)
- Select client type depending on config
- Make adjustments to `DbtCloudGraphqlClient` so that it can be used in the service

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
