### PR TITLE
fix: sql runner fixes - back button, toasts, styles

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/CartesianChartConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/CartesianChartConfiguration.tsx
@@ -12,7 +12,7 @@ import { CartesianChartStyling } from './CartesianChartStyling';
 export const CartesianChartConfig = () => {
     const [isFieldConfigurationOpen, setIsFieldConfigurationOpen] =
         useState(true);
-    const [isStylingOpen, setIsStylingOpen] = useState(false);
+    const [isStylingOpen, setIsStylingOpen] = useState(true);
     const selectedChartType = useAppSelector(
         (state) => state.sqlRunner.selectedChartType,
     );
@@ -54,7 +54,7 @@ export const CartesianChartConfig = () => {
                 <CartesianChartFieldConfiguration actions={actions} />
             )}
 
-            <Divider />
+            <Divider my="sm" />
 
             <Group spacing="xs">
                 <Title order={5} fz="sm" c="gray.9">

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -9,8 +9,10 @@ import {
     Stack,
     Text,
     Tooltip,
+    useMantineTheme,
 } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
 import { IconChartHistogram, IconCodeCircle } from '@tabler/icons-react';
 import { useDeferredValue, useMemo, useState, type FC } from 'react';
 import { ResizableBox } from 'react-resizable';
@@ -43,6 +45,7 @@ export const ContentPanel: FC = () => {
     const { ref: wrapperRef, height: wrapperHeight } = useElementSize();
     const [resultsHeight, setResultsHeight] = useState(MIN_RESULTS_HEIGHT);
     const maxResultsHeight = useMemo(() => wrapperHeight - 56, [wrapperHeight]);
+    const mantineTheme = useMantineTheme();
     const deferredInputSectionHeight = useDeferredValue(inputSectionHeight);
     const isResultsPanelFullHeight = useMemo(
         () => resultsHeight === maxResultsHeight,
@@ -187,6 +190,7 @@ export const ContentPanel: FC = () => {
                                     runSqlQuery({
                                         sql,
                                     });
+                                    notifications.clean();
                                 }}
                             />
                         </Group>
@@ -256,6 +260,9 @@ export const ContentPanel: FC = () => {
                                                         height: deferredInputSectionHeight,
                                                         width: '100%',
                                                         flex: 1,
+                                                        marginTop:
+                                                            mantineTheme.spacing
+                                                                .sm,
                                                     }}
                                                 />
                                             </ConditionalVisibility>

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
@@ -75,7 +75,7 @@ export const useCreateSqlChartMutation = (projectUuid: string) => {
         {
             mutationKey: ['sqlRunner', 'createSqlChart', projectUuid],
             onSuccess: (data) => {
-                history.replace(
+                history.push(
                     `/projects/${projectUuid}/sql-runner/${data.slug}`,
                 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10986, #10963 

### Description:

A few small fixes for SQL runner:
- After saving a chart, the back button goes back to SQL runner
- Clear toasts on Run Query
- Style section open by default
- Margin changes

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
