### PR TITLE
fix: clear dashboard storage if uuids dont match

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.tsx
@@ -10,6 +10,10 @@ const useDashboardStorage = () => {
     const [isEditingDashboardChart, setIsEditingDashboardChart] =
         useState(false);
 
+    const getDashboardUuid = useCallback(() => {
+        return sessionStorage.getItem('dashboardUuid');
+    }, []);
+
     const getIsEditingDashboardChart = useCallback(() => {
         return (
             !!sessionStorage.getItem('fromDashboard') ||
@@ -141,6 +145,7 @@ const useDashboardStorage = () => {
         storeDashboard,
         clearDashboardStorage,
         isEditingDashboardChart,
+        getDashboardUuid,
         getIsEditingDashboardChart,
         getEditingDashboardInfo,
         setDashboardChartInfo,

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -725,9 +725,20 @@ const Dashboard: FC = () => {
 };
 
 const DashboardPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid, dashboardUuid } = useParams<{
+        projectUuid: string;
+        dashboardUuid: string;
+    }>();
     const { user } = useApp();
     const dashboardCommentsCheck = useDashboardCommentsCheck(user?.data);
+    const { clearDashboardStorage, getDashboardUuid } = useDashboardStorage();
+
+    useEffect(() => {
+        if (dashboardUuid !== getDashboardUuid()) {
+            // Clear storage if the dashboardUuid in storage doesn't match the current dashboardUuid
+            clearDashboardStorage();
+        }
+    }, [dashboardUuid, clearDashboardStorage, getDashboardUuid]);
 
     useProfiler('Dashboard');
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11018](https://github.com/lightdash/lightdash/issues/11018)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Replication steps:
- go to dashboard A
- click edit chart
- change browser URL to dashboard B in edit mode

Before:


https://github.com/user-attachments/assets/e1c1a859-5388-4146-9bfc-0a28ab44deb9


After:


https://github.com/user-attachments/assets/2f3834eb-5529-4935-a133-24146a0c3dfb



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
