### PR TITLE
fix: do not include custom dimensions for drill into

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -117,6 +117,18 @@ const drillDownExploreUrl = ({
     extraFilters,
     pivotReference,
 }: DrillDownExploreUrlArgs) => {
+    let metricQueryWithoutCustomDimensions = metricQuery;
+    const customDimensions = metricQuery.customDimensions;
+    if (customDimensions) {
+        const noncustomDimensions = metricQuery.dimensions
+            .filter(dim_id => !customDimensions.find(cd => cd.id === dim_id));
+        metricQueryWithoutCustomDimensions = {
+            ...metricQuery,
+            dimensions: noncustomDimensions,
+            customDimensions: [],
+        };
+    }
+
     const createSavedChartVersion: CreateSavedChartVersion = {
         tableName,
         metricQuery: {
@@ -125,7 +137,7 @@ const drillDownExploreUrl = ({
             dimensions: [drillByDimension],
             metrics: [drillByMetric],
             filters: combineFilters({
-                metricQuery,
+                metricQuery: metricQueryWithoutCustomDimensions,
                 fieldValues,
                 extraFilters,
                 pivotReference,


### PR DESCRIPTION
EDIT: Does not close. See comment below.
~Closes: https://github.com/lightdash/lightdash/issues/10023~


### Description:
Issue description states:
> "Explore from here" and "drill by" buttons should exclude custom SQL dimensions to avoid errors.

I can replicate, and this fixes, "Drill into" errors. However I cannot replicate errors with any of the three "Explore from here" functions:
1. In Dashboard > Chart 3 dot menu > Explore from here menu item
2. In Chart > Explore from here header blue button
3. After clicking a metric value > "View underlying data" menu item > Modal > Explore from here header link

Interestingly, one of the "Explore" implementations has a check for custom dimensions so perhaps this was at least partially fixed. But far as I can tell, it seems no changes needed for "Explore from here". Also, the issue description mentions moving logic from frontend to backend, but that seems unnecessary to fix this.

Finally, please note that I tried checking user permissions with the following, but this was returning `true` yet the error was still happening so I did not include this check:
```
user.data?.ability.can(
    'manage',
    subject('CustomSql', {
        organizationUuid: user?.data?.organizationUuid,
        projectUuid,
    }),
)
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
