### PR TITLE
fix: display error toast on no sql runner results

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -105,7 +105,7 @@ export const useSqlQueryRun = ({
 
     const { data: sqlQueryResults, isFetching: isResultsLoading } = useQuery<
         ResultRow[] | undefined,
-        ApiError,
+        ApiError | unknown, // Error could be unknown when trying to parse the JSON
         ResultsAndColumns | undefined
     >(
         ['sqlQueryResults', sqlQueryJob?.jobId],

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -165,10 +165,9 @@ export const useSqlQueryRun = ({
             return jsonObjects;
         },
         {
-            onError: (data) => {
+            onError: () => {
                 showToastError({
                     title: 'Could not fetch SQL query results',
-                    subtitle: data.error.message,
                 });
             },
             enabled: Boolean(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11109](https://github.com/lightdash/lightdash/issues/11109)

### Description:

Display error toast message by removing the invalid error message reference. 

<img width="1526" alt="Screenshot 2024-08-12 at 14 15 05" src="https://github.com/user-attachments/assets/85c1d3bd-b88f-45bb-894b-97b90705fb31">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
