### PR TITLE
feat: add semantic layer time granularities backend

### DIFF
--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -8,10 +8,7 @@ import {
     SemanticLayerSelectedFields,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
-import {
-    cubeTransfomers,
-    getCubeTimeDimensionGranularity,
-} from './transformer';
+import { cubeTransfomers } from './transformer';
 
 type CubeArgs = {
     lightdashConfig: LightdashConfig;

--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -5,6 +5,7 @@ import {
     SemanticLayerClient,
     SemanticLayerQuery,
     SemanticLayerResultRow,
+    SemanticLayerSelectedFields,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -54,10 +55,7 @@ export default class CubeClient implements SemanticLayerClient {
             dimensions: selectedDimensions,
             timeDimensions: selectedTimeDimensions,
             metrics: selectedMetrics,
-        }: Pick<
-            SemanticLayerQuery,
-            'dimensions' | 'timeDimensions' | 'metrics'
-        >,
+        }: SemanticLayerSelectedFields,
     ) {
         if (this.cubeApi === undefined)
             throw new MissingConfigError('Cube has not been initialized');
@@ -89,8 +87,7 @@ export default class CubeClient implements SemanticLayerClient {
             {
                 dimensions: selectedDimensions,
                 timeDimensions: selectedTimeDimensions.map((d) => ({
-                    dimension: d.name,
-                    granularity: getCubeTimeDimensionGranularity(d.granularity),
+                    dimension: d,
                 })),
                 measures: selectedMetrics,
             },
@@ -106,8 +103,7 @@ export default class CubeClient implements SemanticLayerClient {
             {
                 dimensions: selectedDimensions,
                 timeDimensions: selectedTimeDimensions.map((d) => ({
-                    dimension: d.name,
-                    granularity: getCubeTimeDimensionGranularity(d.granularity),
+                    dimension: d,
                 })),
                 measures: selectedMetrics,
             },

--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -7,7 +7,10 @@ import {
     SemanticLayerResultRow,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
-import { cubeTransfomers } from './transformer';
+import {
+    cubeTransfomers,
+    getCubeTimeDimensionGranularity,
+} from './transformer';
 
 type CubeArgs = {
     lightdashConfig: LightdashConfig;
@@ -86,7 +89,8 @@ export default class CubeClient implements SemanticLayerClient {
             {
                 dimensions: selectedDimensions,
                 timeDimensions: selectedTimeDimensions.map((d) => ({
-                    dimension: d,
+                    dimension: d.name,
+                    granularity: getCubeTimeDimensionGranularity(d.granularity),
                 })),
                 measures: selectedMetrics,
             },
@@ -102,7 +106,8 @@ export default class CubeClient implements SemanticLayerClient {
             {
                 dimensions: selectedDimensions,
                 timeDimensions: selectedTimeDimensions.map((d) => ({
-                    dimension: d,
+                    dimension: d.name,
+                    granularity: getCubeTimeDimensionGranularity(d.granularity),
                 })),
                 measures: selectedMetrics,
             },

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -38,8 +38,12 @@ function getSemanticLayerTypeFromCubeType(
 }
 
 export function getCubeTimeDimensionGranularity(
-    granularity: SemanticLayerTimeGranularity,
-): TimeDimensionGranularity {
+    granularity: SemanticLayerTimeGranularity | undefined,
+): TimeDimensionGranularity | undefined {
+    if (!granularity) {
+        return undefined;
+    }
+
     switch (granularity) {
         case SemanticLayerTimeGranularity.NANOSECOND:
         case SemanticLayerTimeGranularity.MICROSECOND:

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -38,27 +38,26 @@ function getSemanticLayerTypeFromCubeType(
 }
 
 const granularityMap: Record<
-    SemanticLayerTimeGranularity,
-    TimeDimensionGranularity | undefined
+    TimeDimensionGranularity,
+    SemanticLayerTimeGranularity
 > = {
-    // ! This is a partial mapping, not all supported granularities are supported by Cube
-    [SemanticLayerTimeGranularity.NANOSECOND]: undefined,
-    [SemanticLayerTimeGranularity.MICROSECOND]: undefined,
-    [SemanticLayerTimeGranularity.MILLISECOND]: undefined,
-    [SemanticLayerTimeGranularity.SECOND]: 'second',
-    [SemanticLayerTimeGranularity.MINUTE]: 'minute',
-    [SemanticLayerTimeGranularity.HOUR]: 'hour',
-    [SemanticLayerTimeGranularity.DAY]: 'day',
-    [SemanticLayerTimeGranularity.WEEK]: 'week',
-    [SemanticLayerTimeGranularity.MONTH]: 'month',
-    [SemanticLayerTimeGranularity.QUARTER]: 'quarter',
-    [SemanticLayerTimeGranularity.YEAR]: 'year',
+    second: SemanticLayerTimeGranularity.SECOND,
+    minute: SemanticLayerTimeGranularity.MINUTE,
+    hour: SemanticLayerTimeGranularity.HOUR,
+    day: SemanticLayerTimeGranularity.DAY,
+    week: SemanticLayerTimeGranularity.WEEK,
+    month: SemanticLayerTimeGranularity.MONTH,
+    quarter: SemanticLayerTimeGranularity.QUARTER,
+    year: SemanticLayerTimeGranularity.YEAR,
 };
 
+// TODO: should we just have a reverse map here to avoid the need for looping?
 export function getCubeTimeDimensionGranularity(
     granularity?: SemanticLayerTimeGranularity,
 ) {
-    return granularity ? granularityMap[granularity] : undefined;
+    return Object.entries(granularityMap).find(
+        ([_, value]) => value === granularity,
+    )?.[0] as TimeDimensionGranularity | undefined;
 }
 
 type DimensionsWithVisibility = (TCubeDimension &
@@ -81,9 +80,7 @@ export const cubeTransfomers: SemanticLayerTransformer<
             // TODO: check if cube has a function to get available granularities
             const availableGranularities =
                 type === SemanticLayerFieldType.TIME
-                    ? Object.entries(granularityMap)
-                          .filter(([_, v]) => !!v)
-                          .map(([k, _]) => k as SemanticLayerTimeGranularity)
+                    ? Object.values(granularityMap)
                     : [];
 
             return {

--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -110,16 +110,16 @@ const allAvailableGranularities = [
     'year',
 ] as const;
 
+// The following lines ensure that all available granularities from the cube
+// are covered by an exhaustiveness check
 type AllAvailableGranularities = typeof allAvailableGranularities[number];
-
 type EnsureExhaustive = Exclude<
     TimeDimensionGranularity,
     AllAvailableGranularities
 > extends never
     ? true
     : false;
-
-// The next line checks that all available granularities are covered in the switch statement
+// DO NOT REMOVE
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ensureExhaustiveCheck: EnsureExhaustive = true;
 

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -325,7 +325,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
                 await this.getMetricsForDimensions({
                     dimensions: [
                         ...selectedDimensions.map((d) => ({ name: d })),
-                        ...selectedTimeDimensions.map((d) => ({ name: d })),
+                        ...selectedTimeDimensions,
                     ],
                 });
 

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -16,6 +16,7 @@ import {
     SemanticLayerClient,
     SemanticLayerQuery,
     SemanticLayerResultRow,
+    SemanticLayerSelectedFields,
     SemanticLayerView,
 } from '@lightdash/common';
 import { GraphQLClient } from 'graphql-request';
@@ -303,10 +304,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
             dimensions: selectedDimensions,
             timeDimensions: selectedTimeDimensions,
             metrics: selectedMetrics,
-        }: Pick<
-            SemanticLayerQuery,
-            'dimensions' | 'timeDimensions' | 'metrics'
-        >,
+        }: SemanticLayerSelectedFields,
     ) {
         // Get all metrics and check which ones are available for the selected dimensions
         const { metrics: allMetrics } = await this.getMetrics();
@@ -325,7 +323,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
                 await this.getMetricsForDimensions({
                     dimensions: [
                         ...selectedDimensions.map((d) => ({ name: d })),
-                        ...selectedTimeDimensions,
+                        ...selectedTimeDimensions.map((d) => ({ name: d })),
                     ],
                 });
 

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -35,6 +35,24 @@ function getSemanticLayerTypeFromDbtType(
     }
 }
 
+const granularityMap: Record<DbtTimeGranularity, SemanticLayerTimeGranularity> =
+    {
+        [DbtTimeGranularity.NANOSECOND]:
+            SemanticLayerTimeGranularity.NANOSECOND,
+        [DbtTimeGranularity.MICROSECOND]:
+            SemanticLayerTimeGranularity.MICROSECOND,
+        [DbtTimeGranularity.MILLISECOND]:
+            SemanticLayerTimeGranularity.MILLISECOND,
+        [DbtTimeGranularity.SECOND]: SemanticLayerTimeGranularity.SECOND,
+        [DbtTimeGranularity.MINUTE]: SemanticLayerTimeGranularity.MINUTE,
+        [DbtTimeGranularity.HOUR]: SemanticLayerTimeGranularity.HOUR,
+        [DbtTimeGranularity.DAY]: SemanticLayerTimeGranularity.DAY,
+        [DbtTimeGranularity.WEEK]: SemanticLayerTimeGranularity.WEEK,
+        [DbtTimeGranularity.MONTH]: SemanticLayerTimeGranularity.MONTH,
+        [DbtTimeGranularity.QUARTER]: SemanticLayerTimeGranularity.QUARTER,
+        [DbtTimeGranularity.YEAR]: SemanticLayerTimeGranularity.YEAR,
+    };
+
 export const dbtCloudTransfomers: SemanticLayerTransformer<
     SemanticLayerView,
     DbtGraphQLCreateQueryArgs | DbtGraphQLCompileSqlArgs,
@@ -52,6 +70,9 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
                 type: getSemanticLayerTypeFromDbtType(dimension.type),
                 visible: dimension.visible,
                 kind: FieldKind.DIMENSION,
+                availableGranularities: dimension.queryableGranularities.map(
+                    (g) => granularityMap[g],
+                ),
             }),
         );
 
@@ -62,6 +83,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
             visible: metric.visible,
             type: getSemanticLayerTypeFromDbtType(metric.type),
             kind: FieldKind.METRIC,
+            availableGranularities: [],
         }));
 
         return [...semanticDimensions, ...semanticMetrics];

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -35,23 +35,39 @@ function getSemanticLayerTypeFromDbtType(
     }
 }
 
-const granularityMap: Record<DbtTimeGranularity, SemanticLayerTimeGranularity> =
-    {
-        [DbtTimeGranularity.NANOSECOND]:
-            SemanticLayerTimeGranularity.NANOSECOND,
-        [DbtTimeGranularity.MICROSECOND]:
-            SemanticLayerTimeGranularity.MICROSECOND,
-        [DbtTimeGranularity.MILLISECOND]:
-            SemanticLayerTimeGranularity.MILLISECOND,
-        [DbtTimeGranularity.SECOND]: SemanticLayerTimeGranularity.SECOND,
-        [DbtTimeGranularity.MINUTE]: SemanticLayerTimeGranularity.MINUTE,
-        [DbtTimeGranularity.HOUR]: SemanticLayerTimeGranularity.HOUR,
-        [DbtTimeGranularity.DAY]: SemanticLayerTimeGranularity.DAY,
-        [DbtTimeGranularity.WEEK]: SemanticLayerTimeGranularity.WEEK,
-        [DbtTimeGranularity.MONTH]: SemanticLayerTimeGranularity.MONTH,
-        [DbtTimeGranularity.QUARTER]: SemanticLayerTimeGranularity.QUARTER,
-        [DbtTimeGranularity.YEAR]: SemanticLayerTimeGranularity.YEAR,
-    };
+const getSemanticLayerTimeGranularityFromDbtTimeGranularity = (
+    granularity: DbtTimeGranularity,
+): SemanticLayerTimeGranularity => {
+    switch (granularity) {
+        case DbtTimeGranularity.NANOSECOND:
+            return SemanticLayerTimeGranularity.NANOSECOND;
+        case DbtTimeGranularity.MICROSECOND:
+            return SemanticLayerTimeGranularity.MICROSECOND;
+        case DbtTimeGranularity.MILLISECOND:
+            return SemanticLayerTimeGranularity.MILLISECOND;
+        case DbtTimeGranularity.SECOND:
+            return SemanticLayerTimeGranularity.SECOND;
+        case DbtTimeGranularity.MINUTE:
+            return SemanticLayerTimeGranularity.MINUTE;
+        case DbtTimeGranularity.HOUR:
+            return SemanticLayerTimeGranularity.HOUR;
+        case DbtTimeGranularity.DAY:
+            return SemanticLayerTimeGranularity.DAY;
+        case DbtTimeGranularity.WEEK:
+            return SemanticLayerTimeGranularity.WEEK;
+        case DbtTimeGranularity.MONTH:
+            return SemanticLayerTimeGranularity.MONTH;
+        case DbtTimeGranularity.QUARTER:
+            return SemanticLayerTimeGranularity.QUARTER;
+        case DbtTimeGranularity.YEAR:
+            return SemanticLayerTimeGranularity.YEAR;
+        default:
+            return assertUnreachable(
+                granularity,
+                `Unknown dbt time granularity: ${granularity}`,
+            );
+    }
+};
 
 export const dbtCloudTransfomers: SemanticLayerTransformer<
     SemanticLayerView,
@@ -71,7 +87,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
                 visible: dimension.visible,
                 kind: FieldKind.DIMENSION,
                 availableGranularities: dimension.queryableGranularities.map(
-                    (g) => granularityMap[g],
+                    getSemanticLayerTimeGranularityFromDbtTimeGranularity,
                 ),
             }),
         );

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -7,9 +7,11 @@ import {
     DbtGraphQLJsonResult,
     DbtGraphQLMetric,
     DbtMetricType,
+    DbtTimeGranularity,
     FieldType as FieldKind,
     SemanticLayerField,
     SemanticLayerFieldType,
+    SemanticLayerTimeGranularity,
     SemanticLayerTransformer,
     SemanticLayerView,
 } from '@lightdash/common';
@@ -71,9 +73,7 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
             metrics: metrics.map((metric) => ({ name: metric })),
             groupBy: [
                 ...dimensions.map((dimension) => ({ name: dimension })),
-                ...timeDimensions.map((timeDimension) => ({
-                    name: timeDimension,
-                })),
+                ...timeDimensions,
             ],
             where: [],
             orderBy: [],

--- a/packages/backend/src/controllers/v2/SemanticLayerController.ts
+++ b/packages/backend/src/controllers/v2/SemanticLayerController.ts
@@ -1,9 +1,11 @@
 import {
     ApiErrorPayload,
     ApiJobScheduledResponse,
+    ParameterError,
     SemanticLayerField,
     SemanticLayerQuery,
-    SemanticLayerResultRow,
+    SemanticLayerTimeDimension,
+    SemanticLayerTimeGranularity,
     SemanticLayerView,
 } from '@lightdash/common';
 import {
@@ -63,10 +65,26 @@ export class SemanticLayerController extends BaseController {
         @Path() projectUuid: string,
         @Path() view: string,
         @Query() dimensions: string[] = [],
-        @Query() timeDimensions: string[] = [],
+        @Query() timeDimensionNames: string[] = [],
+        @Query()
+        timeDimensionGranularities: SemanticLayerTimeGranularity[] = [],
         @Query() metrics: string[] = [],
     ): Promise<{ status: 'ok'; results: SemanticLayerField[] }> {
         this.setStatus(200);
+
+        if (timeDimensionNames.length !== timeDimensionGranularities.length) {
+            throw new ParameterError(
+                'timeDimensionNames and timeDimensionGranularities must be the same length',
+            );
+        }
+
+        // Time dimensions are a special case where we need to pair the name with the granularity
+        const timeDimensions: SemanticLayerTimeDimension[] =
+            timeDimensionNames.map((name, index) => ({
+                name,
+                granularity: timeDimensionGranularities[index],
+            }));
+
         return {
             status: 'ok',
             results: await this.services

--- a/packages/backend/src/controllers/v2/SemanticLayerController.ts
+++ b/packages/backend/src/controllers/v2/SemanticLayerController.ts
@@ -1,11 +1,8 @@
 import {
     ApiErrorPayload,
     ApiJobScheduledResponse,
-    ParameterError,
     SemanticLayerField,
     SemanticLayerQuery,
-    SemanticLayerTimeDimension,
-    SemanticLayerTimeGranularity,
     SemanticLayerView,
 } from '@lightdash/common';
 import {

--- a/packages/backend/src/controllers/v2/SemanticLayerController.ts
+++ b/packages/backend/src/controllers/v2/SemanticLayerController.ts
@@ -65,25 +65,10 @@ export class SemanticLayerController extends BaseController {
         @Path() projectUuid: string,
         @Path() view: string,
         @Query() dimensions: string[] = [],
-        @Query() timeDimensionNames: string[] = [],
-        @Query()
-        timeDimensionGranularities: SemanticLayerTimeGranularity[] = [],
+        @Query() timeDimensions: string[] = [],
         @Query() metrics: string[] = [],
     ): Promise<{ status: 'ok'; results: SemanticLayerField[] }> {
         this.setStatus(200);
-
-        if (timeDimensionNames.length !== timeDimensionGranularities.length) {
-            throw new ParameterError(
-                'timeDimensionNames and timeDimensionGranularities must be the same length',
-            );
-        }
-
-        // Time dimensions are a special case where we need to pair the name with the granularity
-        const timeDimensions: SemanticLayerTimeDimension[] =
-            timeDimensionNames.map((name, index) => ({
-                name,
-                granularity: timeDimensionGranularities[index],
-            }));
 
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7740,6 +7740,38 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerTimeGranularity: {
+        dataType: 'refEnum',
+        enums: [
+            'NANOSECOND',
+            'MICROSECOND',
+            'MILLISECOND',
+            'SECOND',
+            'MINUTE',
+            'HOUR',
+            'DAY',
+            'WEEK',
+            'MONTH',
+            'QUARTER',
+            'YEAR',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerTimeDimension: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                granularity: {
+                    ref: 'SemanticLayerTimeGranularity',
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerQuery: {
         dataType: 'refAlias',
         type: {
@@ -7754,7 +7786,10 @@ const models: TsoaRoute.Models = {
                 },
                 timeDimensions: {
                     dataType: 'array',
-                    array: { dataType: 'string' },
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'SemanticLayerTimeDimension',
+                    },
                     required: true,
                 },
                 dimensions: {
@@ -16006,12 +16041,22 @@ export function RegisterRoutes(app: express.Router) {
                     dataType: 'array',
                     array: { dataType: 'string' },
                 },
-                timeDimensions: {
+                timeDimensionNames: {
                     default: [],
                     in: 'query',
-                    name: 'timeDimensions',
+                    name: 'timeDimensionNames',
                     dataType: 'array',
                     array: { dataType: 'string' },
+                },
+                timeDimensionGranularities: {
+                    default: [],
+                    in: 'query',
+                    name: 'timeDimensionGranularities',
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refEnum',
+                        ref: 'SemanticLayerTimeGranularity',
+                    },
                 },
                 metrics: {
                     default: [],

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7723,23 +7723,6 @@ const models: TsoaRoute.Models = {
         enums: ['time', 'number', 'string', 'boolean'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SemanticLayerField: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                aggType: { dataType: 'string' },
-                visible: { dataType: 'boolean', required: true },
-                description: { dataType: 'string' },
-                kind: { ref: 'FieldType', required: true },
-                type: { ref: 'SemanticLayerFieldType', required: true },
-                label: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerTimeGranularity: {
         dataType: 'refEnum',
         enums: [
@@ -7757,19 +7740,37 @@ const models: TsoaRoute.Models = {
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerField: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                availableGranularities: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refEnum',
+                        ref: 'SemanticLayerTimeGranularity',
+                    },
+                    required: true,
+                },
+                aggType: { dataType: 'string' },
+                visible: { dataType: 'boolean', required: true },
+                description: { dataType: 'string' },
+                kind: { ref: 'FieldType', required: true },
+                type: { ref: 'SemanticLayerFieldType', required: true },
+                label: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerTimeDimension: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                granularity: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'SemanticLayerTimeGranularity' },
-                        { dataType: 'undefined' },
-                    ],
-                    required: true,
-                },
+                granularity: { ref: 'SemanticLayerTimeGranularity' },
                 name: { dataType: 'string', required: true },
             },
             validators: {},

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16046,22 +16046,12 @@ export function RegisterRoutes(app: express.Router) {
                     dataType: 'array',
                     array: { dataType: 'string' },
                 },
-                timeDimensionNames: {
+                timeDimensions: {
                     default: [],
                     in: 'query',
-                    name: 'timeDimensionNames',
+                    name: 'timeDimensions',
                     dataType: 'array',
                     array: { dataType: 'string' },
-                },
-                timeDimensionGranularities: {
-                    default: [],
-                    in: 'query',
-                    name: 'timeDimensionGranularities',
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refEnum',
-                        ref: 'SemanticLayerTimeGranularity',
-                    },
                 },
                 metrics: {
                     default: [],

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7763,7 +7763,11 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 granularity: {
-                    ref: 'SemanticLayerTimeGranularity',
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'SemanticLayerTimeGranularity' },
+                        { dataType: 'undefined' },
+                    ],
                     required: true,
                 },
                 name: { dataType: 'string', required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8647,6 +8647,34 @@
                 "required": ["visible", "kind", "type", "label", "name"],
                 "type": "object"
             },
+            "SemanticLayerTimeGranularity": {
+                "enum": [
+                    "NANOSECOND",
+                    "MICROSECOND",
+                    "MILLISECOND",
+                    "SECOND",
+                    "MINUTE",
+                    "HOUR",
+                    "DAY",
+                    "WEEK",
+                    "MONTH",
+                    "QUARTER",
+                    "YEAR"
+                ],
+                "type": "string"
+            },
+            "SemanticLayerTimeDimension": {
+                "properties": {
+                    "granularity": {
+                        "$ref": "#/components/schemas/SemanticLayerTimeGranularity"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["granularity", "name"],
+                "type": "object"
+            },
             "SemanticLayerQuery": {
                 "properties": {
                     "limit": {
@@ -8665,7 +8693,7 @@
                     },
                     "timeDimensions": {
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/SemanticLayerTimeDimension"
                         },
                         "type": "array"
                     },
@@ -8920,7 +8948,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1211.1",
+        "version": "0.1212.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8672,7 +8672,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["granularity", "name"],
+                "required": ["name"],
                 "type": "object"
             },
             "SemanticLayerQuery": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8620,8 +8620,30 @@
                 "enum": ["time", "number", "string", "boolean"],
                 "type": "string"
             },
+            "SemanticLayerTimeGranularity": {
+                "enum": [
+                    "NANOSECOND",
+                    "MICROSECOND",
+                    "MILLISECOND",
+                    "SECOND",
+                    "MINUTE",
+                    "HOUR",
+                    "DAY",
+                    "WEEK",
+                    "MONTH",
+                    "QUARTER",
+                    "YEAR"
+                ],
+                "type": "string"
+            },
             "SemanticLayerField": {
                 "properties": {
+                    "availableGranularities": {
+                        "items": {
+                            "$ref": "#/components/schemas/SemanticLayerTimeGranularity"
+                        },
+                        "type": "array"
+                    },
                     "aggType": {
                         "type": "string"
                     },
@@ -8644,24 +8666,15 @@
                         "type": "string"
                     }
                 },
-                "required": ["visible", "kind", "type", "label", "name"],
-                "type": "object"
-            },
-            "SemanticLayerTimeGranularity": {
-                "enum": [
-                    "NANOSECOND",
-                    "MICROSECOND",
-                    "MILLISECOND",
-                    "SECOND",
-                    "MINUTE",
-                    "HOUR",
-                    "DAY",
-                    "WEEK",
-                    "MONTH",
-                    "QUARTER",
-                    "YEAR"
+                "required": [
+                    "availableGranularities",
+                    "visible",
+                    "kind",
+                    "type",
+                    "label",
+                    "name"
                 ],
-                "type": "string"
+                "type": "object"
             },
             "SemanticLayerTimeDimension": {
                 "properties": {

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -5,6 +5,7 @@ import {
     SemanticLayerField,
     SemanticLayerQuery,
     SemanticLayerQueryPayload,
+    SemanticLayerSelectedFields,
     SemanticLayerView,
     SessionUser,
 } from '@lightdash/common';
@@ -133,10 +134,7 @@ export class SemanticLayerService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         view: string,
-        selectedFields: Pick<
-            SemanticLayerQuery,
-            'dimensions' | 'timeDimensions' | 'metrics'
-        >,
+        selectedFields: SemanticLayerSelectedFields,
     ): Promise<SemanticLayerField[]> {
         await this.checkCanViewProject(user, projectUuid);
         const client = await this.getSemanticLayerClient(projectUuid);

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -75,14 +75,17 @@ export interface SemanticLayerTransformer<
     sqlToString: (sql: SqlType) => string;
 }
 
+export type SemanticLayerSelectedFields = {
+    dimensions: string[];
+    timeDimensions: string[];
+    metrics: string[];
+};
+
 export interface SemanticLayerClient {
     getViews: () => Promise<SemanticLayerView[]>;
     getFields: (
         viewName: string,
-        selectedFields: Pick<
-            SemanticLayerQuery,
-            'dimensions' | 'timeDimensions' | 'metrics'
-        >,
+        selectedFields: SemanticLayerSelectedFields,
     ) => Promise<SemanticLayerField[]>;
     streamResults: (
         projectUuid: string,

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -14,6 +14,20 @@ export enum SemanticLayerFieldType {
     BOOLEAN = 'boolean',
 }
 
+export enum SemanticLayerTimeGranularity {
+    NANOSECOND = 'NANOSECOND',
+    MICROSECOND = 'MICROSECOND',
+    MILLISECOND = 'MILLISECOND',
+    SECOND = 'SECOND',
+    MINUTE = 'MINUTE',
+    HOUR = 'HOUR',
+    DAY = 'DAY',
+    WEEK = 'WEEK',
+    MONTH = 'MONTH',
+    QUARTER = 'QUARTER',
+    YEAR = 'YEAR',
+}
+
 export type SemanticLayerField = {
     name: string;
     label: string;
@@ -24,9 +38,14 @@ export type SemanticLayerField = {
     aggType?: string; // eg: count, sum
 };
 
+export type SemanticLayerTimeDimension = {
+    name: string;
+    granularity: SemanticLayerTimeGranularity;
+};
+
 export type SemanticLayerQuery = {
     dimensions: string[];
-    timeDimensions: string[];
+    timeDimensions: SemanticLayerTimeDimension[];
     metrics: string[];
     offset?: number;
     limit?: number;

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -36,11 +36,12 @@ export type SemanticLayerField = {
     description?: string;
     visible: boolean;
     aggType?: string; // eg: count, sum
+    availableGranularities: SemanticLayerTimeGranularity[];
 };
 
 export type SemanticLayerTimeDimension = {
     name: string;
-    granularity: SemanticLayerTimeGranularity | undefined;
+    granularity?: SemanticLayerTimeGranularity;
 };
 
 export type SemanticLayerQuery = {

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -40,7 +40,7 @@ export type SemanticLayerField = {
 
 export type SemanticLayerTimeDimension = {
     name: string;
-    granularity: SemanticLayerTimeGranularity;
+    granularity: SemanticLayerTimeGranularity | undefined;
 };
 
 export type SemanticLayerQuery = {

--- a/packages/frontend/src/features/semanticViewer/api/hooks.ts
+++ b/packages/frontend/src/features/semanticViewer/api/hooks.ts
@@ -36,22 +36,30 @@ export const useSemanticLayerViewFields = ({
     projectUuid,
     view,
     selectedFields,
-}: SemanticLayerViewFieldsParams) =>
-    useQuery<SemanticLayerField[], ApiError>({
+}: SemanticLayerViewFieldsParams) => {
+    const selectedFieldsWithTimeDimensionNames = {
+        ...selectedFields,
+        timeDimensions: selectedFields.timeDimensions.map(
+            (timeDimension) => timeDimension.name,
+        ),
+    };
+
+    return useQuery<SemanticLayerField[], ApiError>({
         queryKey: [
             projectUuid,
             'semanticLayer',
             view,
             'fields',
-            selectedFields,
+            selectedFieldsWithTimeDimensionNames,
         ],
         queryFn: () =>
             apiGetSemanticLayerViewFields({
                 projectUuid,
                 view,
-                selectedFields,
+                selectedFields: selectedFieldsWithTimeDimensionNames,
             }),
     });
+};
 
 type SemanticLayerSqlParams = {
     projectUuid: string;

--- a/packages/frontend/src/features/semanticViewer/api/requests.ts
+++ b/packages/frontend/src/features/semanticViewer/api/requests.ts
@@ -1,6 +1,7 @@
 import {
     type SemanticLayerField,
     type SemanticLayerQuery,
+    type SemanticLayerSelectedFields,
     type SemanticLayerView,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
@@ -22,10 +23,7 @@ export const apiGetSemanticLayerViews = ({
 type GetSemanticLayerViewFieldsRequestParams = {
     projectUuid: string;
     view: string;
-    selectedFields: Pick<
-        SemanticLayerQuery,
-        'dimensions' | 'timeDimensions' | 'metrics'
-    >;
+    selectedFields: SemanticLayerSelectedFields;
 };
 
 // Makes sure the selectedFields object is in the correct format for the Query Params

--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -5,15 +5,22 @@ import ResultsViewer from './ResultsViewer';
 import SqlViewer from './SqlViewer';
 
 const Content: FC = () => {
-    const { view, selectedDimensions, selectedMetrics } = useAppSelector(
-        (state) => state.semanticViewer,
-    );
+    const {
+        view,
+        selectedDimensions,
+        selectedTimeDimensions,
+        selectedMetrics,
+    } = useAppSelector((state) => state.semanticViewer);
 
     if (!view) {
         return null;
     }
 
-    if (selectedDimensions.length === 0 && selectedMetrics.length === 0) {
+    if (
+        selectedDimensions.length === 0 &&
+        selectedTimeDimensions.length === 0 &&
+        selectedMetrics.length === 0
+    ) {
         return null;
     }
 

--- a/packages/frontend/src/features/semanticViewer/components/ResultsViewer.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ResultsViewer.tsx
@@ -47,24 +47,23 @@ const ResultsViewer: FC = () => {
         });
 
     const config: SqlTableConfig = useMemo(() => {
-        const columns = [
-            ...selectedTimeDimensions,
-            ...selectedDimensions,
-            ...selectedMetrics,
-        ].reduce((acc, dimension) => {
+        const firstRow = results?.[0];
+        const columns = Object.keys(firstRow || {}).reduce((acc, key) => {
             return {
                 ...acc,
-                [sanitizeFieldId(dimension)]: {
+                [sanitizeFieldId(key)]: {
                     visible: true,
-                    reference: sanitizeFieldId(dimension),
-                    label: dimension,
+                    reference: sanitizeFieldId(key),
+                    label: key,
                     frozen: false,
                     order: undefined,
                 },
             };
         }, {});
+
         return { columns };
-    }, [selectedDimensions, selectedTimeDimensions, selectedMetrics]);
+    }, [results]);
+
     return (
         <Box pos="relative">
             <LoadingOverlay

--- a/packages/frontend/src/features/semanticViewer/components/SidebarViewFields.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SidebarViewFields.tsx
@@ -154,7 +154,11 @@ const SidebarViewFields = () => {
                             active={
                                 // FIXME: not the best way to check if a field is selected
                                 selectedDimensions.includes(field.name) ||
-                                selectedTimeDimensions.includes(field.name) ||
+                                Boolean(
+                                    selectedTimeDimensions.find(
+                                        (td) => td.name === field.name,
+                                    ),
+                                ) ||
                                 selectedMetrics.includes(field.name)
                             }
                             onClick={() => handleFieldToggle(field)}

--- a/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
+++ b/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
@@ -3,6 +3,7 @@ import {
     SemanticLayerFieldType,
     type ResultRow,
     type SemanticLayerField,
+    type SemanticLayerTimeDimension,
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
@@ -14,7 +15,7 @@ export interface SemanticViewerState {
 
     selectedDimensions: Array<string>;
     selectedMetrics: Array<string>;
-    selectedTimeDimensions: Array<string>;
+    selectedTimeDimensions: Array<SemanticLayerTimeDimension>;
 
     results: ResultRow[] | undefined;
 }
@@ -67,23 +68,35 @@ export const semanticViewerSlice = createSlice({
 
             switch (action.payload.kind) {
                 case FieldKind.DIMENSION:
-                    const stateSelectedDimensionsArrayName: keyof typeof state =
-                        action.payload.type === SemanticLayerFieldType.TIME
-                            ? 'selectedTimeDimensions'
-                            : 'selectedDimensions';
+                    if (action.payload.type === SemanticLayerFieldType.TIME) {
+                        if (
+                            state.selectedTimeDimensions.find(
+                                (field) => field.name === action.payload.name,
+                            )
+                        ) {
+                            state.selectedTimeDimensions =
+                                state.selectedTimeDimensions.filter(
+                                    (field) =>
+                                        field.name !== action.payload.name,
+                                );
+                        } else {
+                            state.selectedTimeDimensions.push({
+                                name: action.payload.name,
+                                granularity: undefined, // TODO: pass the selected granularity here
+                            });
+                        }
+                        break;
+                    }
 
                     if (
-                        state[stateSelectedDimensionsArrayName].includes(
-                            action.payload.name,
-                        )
+                        state.selectedDimensions.includes(action.payload.name)
                     ) {
-                        state[stateSelectedDimensionsArrayName] = state[
-                            stateSelectedDimensionsArrayName
-                        ].filter((field) => field !== action.payload.name);
+                        state.selectedDimensions =
+                            state.selectedDimensions.filter(
+                                (field) => field !== action.payload.name,
+                            );
                     } else {
-                        state[stateSelectedDimensionsArrayName].push(
-                            action.payload.name,
-                        );
+                        state.selectedDimensions.push(action.payload.name);
                     }
                     break;
                 case FieldKind.METRIC:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #11125 

### Description:

- Adds `availableGranularities` to fields
- Uses the selected granularity when fetching results

![image](https://github.com/user-attachments/assets/03ae9a3b-bcb8-4044-880a-7b761cc9b9cb)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
