### PR TITLE
feat: semantic layer sorting backend

### DIFF
--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -1,21 +1,26 @@
 import {
     Cube,
     Query as CubeQuery,
+    QueryOrder,
     ResultSet,
     SqlQuery,
     TCubeDimension,
     TCubeMeasure,
     TCubeMemberType,
     TimeDimensionGranularity,
+    TQueryOrderArray,
 } from '@cubejs-client/core';
 import {
     assertUnreachable,
     FieldType as FieldKind,
     SemanticLayerField,
     SemanticLayerFieldType,
+    SemanticLayerSortBy,
+    SemanticLayerSortByDirection,
     SemanticLayerTimeGranularity,
     SemanticLayerTransformer,
 } from '@lightdash/common';
+import { Query } from '@tsoa/runtime';
 
 function getSemanticLayerTypeFromCubeType(
     cubeType: TCubeMemberType,
@@ -98,6 +103,22 @@ const getCubeTimeDimensionGranularity = (
             );
     }
 };
+
+function getCubeQueryOrder(
+    direction: SemanticLayerSortByDirection,
+): QueryOrder {
+    switch (direction) {
+        case SemanticLayerSortByDirection.ASC:
+            return 'asc';
+        case SemanticLayerSortByDirection.DESC:
+            return 'desc';
+        default:
+            return assertUnreachable(
+                direction,
+                `Unknown order direction: ${direction}`,
+            );
+    }
+}
 
 const allAvailableGranularities = [
     'second',
@@ -189,6 +210,10 @@ export const cubeTransfomers: SemanticLayerTransformer<
                 td.granularity &&
                 getCubeTimeDimensionGranularity(td.granularity),
         })),
+        order: query.sortBy.map((sort): TQueryOrderArray[number] => [
+            sort.name,
+            getCubeQueryOrder(sort.direction),
+        ]),
         filters: [],
         offset: query.offset,
         limit: query.limit || 100,

--- a/packages/backend/src/clients/dbtCloud/transformer.ts
+++ b/packages/backend/src/clients/dbtCloud/transformer.ts
@@ -11,6 +11,7 @@ import {
     FieldType as FieldKind,
     SemanticLayerField,
     SemanticLayerFieldType,
+    SemanticLayerSortByDirection,
     SemanticLayerTimeGranularity,
     SemanticLayerTransformer,
     SemanticLayerView,
@@ -114,7 +115,33 @@ export const dbtCloudTransfomers: SemanticLayerTransformer<
                 ...timeDimensions,
             ],
             where: [],
-            orderBy: [],
+            orderBy: query.sortBy.map((sort) => {
+                const { name, kind, direction } = sort;
+                const descending =
+                    direction === SemanticLayerSortByDirection.DESC;
+
+                switch (kind) {
+                    case FieldKind.DIMENSION:
+                        return {
+                            descending,
+                            groupBy: {
+                                name,
+                            },
+                        };
+                    case FieldKind.METRIC:
+                        return {
+                            descending,
+                            metric: {
+                                name,
+                            },
+                        };
+                    default:
+                        return assertUnreachable(
+                            kind,
+                            `Unknown field kind: ${kind}`,
+                        );
+                }
+            }),
             limit: 100, // Let this be 100 for now
         };
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7777,6 +7777,43 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SemanticLayerField.name-or-kind_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                kind: { ref: 'FieldType', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerSortByDirection: {
+        dataType: 'refEnum',
+        enums: ['ASC', 'DESC'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SemanticLayerSortBy: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_SemanticLayerField.name-or-kind_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        direction: {
+                            ref: 'SemanticLayerSortByDirection',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerQuery: {
         dataType: 'refAlias',
         type: {
@@ -7784,6 +7821,11 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 limit: { dataType: 'double' },
                 offset: { dataType: 'double' },
+                sortBy: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SemanticLayerSortBy' },
+                    required: true,
+                },
                 metrics: {
                     dataType: 'array',
                     array: { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8688,6 +8688,39 @@
                 "required": ["name"],
                 "type": "object"
             },
+            "Pick_SemanticLayerField.name-or-kind_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "$ref": "#/components/schemas/FieldType"
+                    }
+                },
+                "required": ["name", "kind"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "SemanticLayerSortByDirection": {
+                "enum": ["ASC", "DESC"],
+                "type": "string"
+            },
+            "SemanticLayerSortBy": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_SemanticLayerField.name-or-kind_"
+                    },
+                    {
+                        "properties": {
+                            "direction": {
+                                "$ref": "#/components/schemas/SemanticLayerSortByDirection"
+                            }
+                        },
+                        "required": ["direction"],
+                        "type": "object"
+                    }
+                ]
+            },
             "SemanticLayerQuery": {
                 "properties": {
                     "limit": {
@@ -8697,6 +8730,12 @@
                     "offset": {
                         "type": "number",
                         "format": "double"
+                    },
+                    "sortBy": {
+                        "items": {
+                            "$ref": "#/components/schemas/SemanticLayerSortBy"
+                        },
+                        "type": "array"
                     },
                     "metrics": {
                         "items": {
@@ -8717,7 +8756,12 @@
                         "type": "array"
                     }
                 },
-                "required": ["metrics", "timeDimensions", "dimensions"],
+                "required": [
+                    "sortBy",
+                    "metrics",
+                    "timeDimensions",
+                    "dimensions"
+                ],
                 "type": "object"
             },
             "ValidationTarget": {
@@ -8961,7 +9005,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1212.1",
+        "version": "0.1213.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -28,6 +28,11 @@ export enum SemanticLayerTimeGranularity {
     YEAR = 'YEAR',
 }
 
+export enum SemanticLayerSortByDirection {
+    ASC = 'ASC',
+    DESC = 'DESC',
+}
+
 export type SemanticLayerField = {
     name: string;
     label: string;
@@ -44,10 +49,15 @@ export type SemanticLayerTimeDimension = {
     granularity?: SemanticLayerTimeGranularity;
 };
 
+export type SemanticLayerSortBy = Pick<SemanticLayerField, 'name' | 'kind'> & {
+    direction: SemanticLayerSortByDirection;
+};
+
 export type SemanticLayerQuery = {
     dimensions: string[];
     timeDimensions: SemanticLayerTimeDimension[];
     metrics: string[];
+    sortBy: SemanticLayerSortBy[];
     offset?: number;
     limit?: number;
 };

--- a/packages/frontend/src/features/semanticViewer/components/ResultsViewer.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ResultsViewer.tsx
@@ -13,6 +13,7 @@ const ResultsViewer: FC = () => {
         selectedDimensions,
         selectedTimeDimensions,
         selectedMetrics,
+        sortBy,
         results,
     } = useAppSelector((state) => state.semanticViewer);
     const dispatch = useAppDispatch();
@@ -79,6 +80,7 @@ const ResultsViewer: FC = () => {
                             dimensions: selectedDimensions,
                             metrics: selectedMetrics,
                             timeDimensions: selectedTimeDimensions,
+                            sortBy,
                         },
                     })
                 }

--- a/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
@@ -10,6 +10,7 @@ const SqlViewer: FC = () => {
         selectedDimensions,
         selectedTimeDimensions,
         selectedMetrics,
+        sortBy,
     } = useAppSelector((state) => state.semanticViewer);
 
     const sql = useSemanticLayerSql(
@@ -19,6 +20,7 @@ const SqlViewer: FC = () => {
                 dimensions: selectedDimensions,
                 metrics: selectedMetrics,
                 timeDimensions: selectedTimeDimensions,
+                sortBy,
             },
         },
         {

--- a/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
+++ b/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
@@ -3,6 +3,7 @@ import {
     SemanticLayerFieldType,
     type ResultRow,
     type SemanticLayerField,
+    type SemanticLayerSortBy,
     type SemanticLayerTimeDimension,
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
@@ -16,6 +17,7 @@ export interface SemanticViewerState {
     selectedDimensions: Array<string>;
     selectedMetrics: Array<string>;
     selectedTimeDimensions: Array<SemanticLayerTimeDimension>;
+    sortBy: SemanticLayerSortBy[];
 
     results: ResultRow[] | undefined;
 }
@@ -28,6 +30,7 @@ const initialState: SemanticViewerState = {
     selectedDimensions: [],
     selectedMetrics: [],
     selectedTimeDimensions: [],
+    sortBy: [],
 
     results: undefined,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #11033 
### Description:

- Creates `SemanticLayerSortBy` type and handles it in the transformers for each semantic layer

![image](https://github.com/user-attachments/assets/f345f92e-297b-4591-8de3-3777fbf9b3ac)
![image](https://github.com/user-attachments/assets/ff8c7497-812c-4901-88b5-76dfab0e5c5c)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
