### PR TITLE
fix: chart queries to get last version

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1211,13 +1211,6 @@ export class SavedChartModel {
             Pick<Project, 'projectUuid'> &
             Pick<Organization, 'organizationUuid'>)[]
     > {
-        const getLatestQueryVersionSubQuery = this.database(
-            'saved_queries_versions',
-        )
-            .select('saved_query_id', 'explore_name')
-            .max('created_at as latest')
-            .groupBy('saved_query_id', 'explore_name');
-
         const charts = await this.database('saved_queries')
             .whereIn(
                 `${SavedChartsTableName}.saved_query_uuid`,
@@ -1227,7 +1220,7 @@ export class SavedChartModel {
                 uuid: 'saved_queries.saved_query_uuid',
                 name: 'saved_queries.name',
                 spaceUuid: 'spaces.space_uuid',
-                tableName: 'latest_saved_query.explore_name',
+                tableName: `${SavedChartVersionsTableName}.explore_name`,
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
             })
@@ -1248,20 +1241,24 @@ export class SavedChartModel {
                 );
             })
             .innerJoin(
-                getLatestQueryVersionSubQuery.as('latest_saved_query'),
-                function latestSavedQueryJoin() {
-                    this.on(
-                        `${SavedChartsTableName}.saved_query_id`,
-                        '=',
-                        'latest_saved_query.saved_query_id',
-                    );
-                },
+                SavedChartVersionsTableName,
+                'saved_queries.saved_query_id',
+                'saved_queries_versions.saved_query_id',
             )
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
             .leftJoin(
                 OrganizationTableName,
                 'organizations.organization_id',
                 'projects.organization_id',
+            )
+            .where(
+                // filter by last version
+                `saved_queries_version_id`,
+                this.database.raw(`(select saved_queries_version_id
+                                           from ${SavedChartVersionsTableName}
+                                           where saved_queries.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
+                                           order by ${SavedChartVersionsTableName}.created_at desc
+                                           limit 1)`),
             );
 
         if (charts.length === 0) {
@@ -1278,31 +1275,19 @@ export class SavedChartModel {
                 Pick<LightdashUser, 'firstName' | 'lastName'>
         >
     > {
-        const getLatestQueryVersionSubQuery = this.database(
-            'saved_queries_versions',
-        )
-            .select('saved_query_id', 'explore_name', 'updated_by_user_uuid')
-            .max('created_at as latest')
-            .groupBy('saved_query_id', 'explore_name', 'updated_by_user_uuid');
-
         return this.database('saved_queries')
             .select({
                 uuid: 'saved_queries.saved_query_uuid',
                 name: 'saved_queries.name',
                 description: 'saved_queries.description',
-                tableName: 'latest_saved_query.explore_name',
+                tableName: `${SavedChartVersionsTableName}.explore_name`,
                 firstName: `${UserTableName}.first_name`,
                 lastName: `${UserTableName}.last_name`,
             })
             .innerJoin(
-                getLatestQueryVersionSubQuery.as('latest_saved_query'),
-                function latestSavedQueryJoin() {
-                    this.on(
-                        `${SavedChartsTableName}.saved_query_id`,
-                        '=',
-                        'latest_saved_query.saved_query_id',
-                    );
-                },
+                SavedChartVersionsTableName,
+                'saved_queries.saved_query_id',
+                'saved_queries_versions.saved_query_id',
             )
             .leftJoin(
                 DashboardsTableName,
@@ -1323,9 +1308,18 @@ export class SavedChartModel {
             .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
             .leftJoin(
                 UserTableName,
-                `latest_saved_query.updated_by_user_uuid`,
+                `${SavedChartVersionsTableName}.updated_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
-            .where('projects.project_uuid', projectUuid);
+            .where('projects.project_uuid', projectUuid)
+            .where(
+                // filter by last version
+                `saved_queries_version_id`,
+                this.database.raw(`(select saved_queries_version_id
+                                           from ${SavedChartVersionsTableName}
+                                           where saved_queries.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
+                                           order by ${SavedChartVersionsTableName}.created_at desc
+                                           limit 1)`),
+            );
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#1978](https://github.com/lightdash/lightdash-internal-work/issues/1978) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem occurs when a chart is updated to use a different explore has each version can have a distinct explore value. This can happen when promoting or via the API.

How to replicate:
- edit chart
- go to database and edit the first version to have the explore "banana"
- load embed dashboard / run `lightdash generate-exposures` 

You can see that this query returns 2 rows because we are grouping by explore name in the join CTE.
<img width="1180" alt="Screenshot 2024-08-14 at 14 23 32" src="https://github.com/user-attachments/assets/6a6ba228-ef8e-482b-b533-fb0670a1fefe">
Fix when filtering by last version instead of a CTE in the join logic.
<img width="1100" alt="Screenshot 2024-08-14 at 14 36 57" src="https://github.com/user-attachments/assets/d135ae5d-f3b5-48e2-9eb8-a0c0302c2c51">


Problem in embed filters:
<img width="1477" alt="Screenshot 2024-08-14 at 14 38 54" src="https://github.com/user-attachments/assets/ceaaff39-eb98-46cc-bdd1-d573a447ded8">

After:
<img width="1477" alt="Screenshot 2024-08-14 at 14 38 20" src="https://github.com/user-attachments/assets/6b5e89b6-41d1-4db7-a6fa-b9af47bb9852">


Problem when generating exposures, `depends_on` is empty:
```
cd examples/full-jaffle-shop-demo/dbt
node ../../../packages/cli/dist/index.js generate-exposures
```
<img width="1093" alt="Screenshot 2024-08-14 at 15 09 38" src="https://github.com/user-attachments/assets/bf2eb315-5aca-42e3-b002-1822dd0f2883">

After:
<img width="1081" alt="Screenshot 2024-08-14 at 15 13 38" src="https://github.com/user-attachments/assets/2281d43f-e4f3-460b-a201-5a9821d409a4">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
