### PR TITLE
fix: pass granularity as null to graphql query

### DIFF
--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -16,7 +16,6 @@ import {
     SemanticLayerClient,
     SemanticLayerQuery,
     SemanticLayerResultRow,
-    SemanticLayerSelectedFields,
     SemanticLayerView,
 } from '@lightdash/common';
 import { GraphQLClient } from 'graphql-request';
@@ -74,7 +73,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
         const groupByString =
             groupBy?.map((g) => {
                 if ('grain' in g) {
-                    return `{ name: "${g.name}", grain: ${g.grain} }`;
+                    return `{ name: "${g.name}", grain: ${g.grain ?? null} }`;
                 }
 
                 return `{ name: "${g.name}" }`;

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -5,7 +5,6 @@ import {
     SemanticLayerField,
     SemanticLayerQuery,
     SemanticLayerQueryPayload,
-    SemanticLayerSelectedFields,
     SemanticLayerView,
     SessionUser,
 } from '@lightdash/common';

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -85,12 +85,6 @@ export interface SemanticLayerTransformer<
     sqlToString: (sql: SqlType) => string;
 }
 
-export type SemanticLayerSelectedFields = {
-    dimensions: string[];
-    timeDimensions: string[];
-    metrics: string[];
-};
-
 export interface SemanticLayerClient {
     getViews: () => Promise<SemanticLayerView[]>;
     getFields: (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #11125 

### Description:

- Pass `grain` as `null` to `GraphQL` query
- Transform `granularity` into `grain` in query

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
