### PR TITLE
refactor: select fieldType in selectors

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/CartesianChartFieldConfiguration.tsx
@@ -1,8 +1,6 @@
 import {
-    DimensionType,
     type IndexLayoutOptions,
     type PivotLayoutOptions,
-    type SqlCartesianChartLayout,
     type ValuesLayoutOptions,
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, UnstyledButton } from '@mantine/core';
@@ -23,7 +21,9 @@ import { CartesianChartAggregationConfig } from './CartesianChartAggregationConf
 import { FieldReferenceSelect } from './FieldReferenceSelect';
 
 const YFieldsAxisConfig: FC<{
-    field: SqlCartesianChartLayout['y'][number];
+    field: NonNullable<
+        ReturnType<typeof cartesianChartSelectors.getYAxisFields>
+    >[number];
     yLayoutOptions: ValuesLayoutOptions[];
     isSingle: boolean;
     index: number;
@@ -31,7 +31,6 @@ const YFieldsAxisConfig: FC<{
 }> = ({ field, yLayoutOptions, isSingle, index, actions }) => {
     const { hovered, ref } = useHover();
     const dispatch = useAppDispatch();
-    const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
     const [isOpen, setIsOpen] = useState(true);
 
     return (
@@ -102,11 +101,7 @@ const YFieldsAxisConfig: FC<{
                                     }),
                                 );
                             }}
-                            fieldType={
-                                sqlColumns?.find(
-                                    (x) => x.reference === field.reference,
-                                )?.type ?? DimensionType.STRING
-                            }
+                            fieldType={field.fieldType}
                         />
 
                         <Config.Group>
@@ -143,12 +138,13 @@ const XFieldAxisConfig = ({
     xLayoutOptions,
     actions,
 }: {
-    field: SqlCartesianChartLayout['x'];
+    field: NonNullable<
+        ReturnType<typeof cartesianChartSelectors.getXAxisField>
+    >;
     xLayoutOptions: IndexLayoutOptions[];
     actions: CartesianChartActionsType;
 }) => {
     const dispatch = useAppDispatch();
-    const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
 
     return (
         <FieldReferenceSelect
@@ -166,10 +162,7 @@ const XFieldAxisConfig = ({
                 xLayoutOptions.find((x) => x.reference === field.reference) ===
                     undefined && `Column "${field.reference}" not in SQL query`
             }
-            fieldType={
-                sqlColumns?.find((x) => x.reference === field.reference)
-                    ?.type ?? DimensionType.STRING
-            }
+            fieldType={field.fieldType}
         />
     );
 };
@@ -179,12 +172,11 @@ const GroupByFieldAxisConfig = ({
     groupByOptions = [],
     actions,
 }: {
-    field: undefined | { reference: string };
+    field: ReturnType<typeof cartesianChartSelectors.getGroupByField>;
     groupByOptions?: PivotLayoutOptions[];
     actions: CartesianChartActionsType;
 }) => {
     const dispatch = useAppDispatch();
-    const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
     return (
         <FieldReferenceSelect
             clearable
@@ -210,10 +202,7 @@ const GroupByFieldAxisConfig = ({
                     );
                 }
             }}
-            fieldType={
-                sqlColumns?.find((x) => x.reference === field?.reference)
-                    ?.type ?? DimensionType.STRING
-            }
+            fieldType={field?.fieldType}
         />
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/FieldReferenceSelect.tsx
@@ -4,7 +4,7 @@ import { type FC } from 'react';
 import { TableFieldIcon } from './TableFields';
 
 type Props = SelectProps & {
-    fieldType: DimensionType;
+    fieldType: DimensionType | undefined;
 };
 
 export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
@@ -12,7 +12,7 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
         <Select
             radius="md"
             {...props}
-            icon={<TableFieldIcon fieldType={fieldType} />}
+            icon={fieldType && <TableFieldIcon fieldType={fieldType} />}
             styles={{
                 input: {
                     fontWeight: 500,

--- a/packages/frontend/src/features/sqlRunner/components/TableVisConfiguration.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableVisConfiguration.tsx
@@ -4,15 +4,18 @@ import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { Config } from '../../../components/VisualizationConfigs/common/Config';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { tableVisSelectors } from '../store/selectors';
 import {
     updateColumnVisibility,
     updateFieldLabel,
 } from '../store/tableVisSlice';
 import { TableFieldIcon } from './TableFields';
 
-const TableVisConfiguration: FC = ({}) => {
+const TableVisConfiguration: FC = () => {
     const dispatch = useAppDispatch();
-    const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
+    const columnFieldTypes = useAppSelector(
+        tableVisSelectors.getColumnFieldTypes,
+    );
 
     const tableVisConfig = useAppSelector(
         (state) => state.tableVisConfig.config,
@@ -36,20 +39,14 @@ const TableVisConfiguration: FC = ({}) => {
                     <Config.Heading>Column labels</Config.Heading>
 
                     {Object.keys(tableVisConfig.columns).map((reference) => {
-                        const fieldType = sqlColumns?.find(
-                            (c) => c.reference === reference,
-                        )?.type;
+                        const fieldType = columnFieldTypes[reference];
 
                         return (
                             <TextInput
                                 key={reference}
                                 radius="md"
                                 value={tableVisConfig.columns[reference].label}
-                                icon={
-                                    fieldType && (
-                                        <TableFieldIcon fieldType={fieldType} />
-                                    )
-                                }
+                                icon={<TableFieldIcon fieldType={fieldType} />}
                                 rightSection={
                                     <ActionIcon
                                         onClick={() =>

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -135,3 +135,22 @@ export const cartesianChartSelectors = {
     getGroupByLayoutOptions,
     getSqlColumns,
 };
+
+export const tableVisSelectors = {
+    getColumnFieldTypes: createSelector(
+        [selectTableVisConfigState, getSqlColumns],
+        (tableVisConfig, sqlColumns) => {
+            if (!tableVisConfig.config || !sqlColumns) return {};
+
+            return Object.keys(tableVisConfig.config.columns).reduce(
+                (acc, reference) => {
+                    acc[reference] =
+                        sqlColumns.find((c) => c.reference === reference)
+                            ?.type ?? DimensionType.STRING;
+                    return acc;
+                },
+                {} as Record<string, DimensionType>,
+            );
+        },
+    ),
+};

--- a/packages/frontend/src/features/sqlRunner/store/selectors.ts
+++ b/packages/frontend/src/features/sqlRunner/store/selectors.ts
@@ -1,4 +1,4 @@
-import { ChartKind } from '@lightdash/common';
+import { ChartKind, DimensionType, type SqlColumn } from '@lightdash/common';
 import { createSelector } from 'reselect';
 import { type RootState } from '.';
 
@@ -82,19 +82,43 @@ const getYLayoutOptions = createSelector(
     (chartConfig) => chartConfig?.options?.yLayoutOptions,
 );
 
+const getSqlColumns = (state: RootState): SqlColumn[] | undefined =>
+    state.sqlRunner.sqlColumns;
+
 const getXAxisField = createSelector(
-    [selectCurrentCartesianChartState],
-    (chartConfig) => chartConfig?.config?.fieldConfig?.x,
+    [selectCurrentCartesianChartState, getSqlColumns],
+    (chartConfig, sqlColumns) => {
+        const field = chartConfig?.config?.fieldConfig?.x;
+        if (!field) return undefined;
+        const fieldType =
+            sqlColumns?.find((x) => x.reference === field.reference)?.type ??
+            DimensionType.STRING;
+        return { ...field, fieldType };
+    },
 );
 
 const getYAxisFields = createSelector(
-    [selectCurrentCartesianChartState],
-    (chartConfig) => chartConfig?.config?.fieldConfig?.y,
+    [selectCurrentCartesianChartState, getSqlColumns],
+    (chartConfig, sqlColumns) => {
+        return chartConfig?.config?.fieldConfig?.y.map((field) => {
+            const fieldType =
+                sqlColumns?.find((x) => x.reference === field.reference)
+                    ?.type ?? DimensionType.STRING;
+            return { ...field, fieldType };
+        });
+    },
 );
 
 const getGroupByField = createSelector(
-    [selectCurrentCartesianChartState],
-    (chartConfig) => chartConfig?.config?.fieldConfig?.groupBy?.[0],
+    [selectCurrentCartesianChartState, getSqlColumns],
+    (chartConfig, sqlColumns) => {
+        const field = chartConfig?.config?.fieldConfig?.groupBy?.[0];
+        if (!field) return undefined;
+        const fieldType =
+            sqlColumns?.find((x) => x.reference === field.reference)?.type ??
+            DimensionType.STRING;
+        return { ...field, fieldType };
+    },
 );
 
 const getGroupByLayoutOptions = createSelector(
@@ -109,4 +133,5 @@ export const cartesianChartSelectors = {
     getYAxisFields,
     getGroupByField,
     getGroupByLayoutOptions,
+    getSqlColumns,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11012](https://github.com/lightdash/lightdash/issues/11012)

### Description:

Adds `fieldType` to necessary selectors so we don't have to do a `find` on the configuration components

> [!NOTE]
> Left pie chart config untouched because I think we're unifying these

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
