### PR TITLE
fix: move groups property to valid structure

### DIFF
--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -273,16 +273,16 @@
                                                         },
                                                         "percentile": {
                                                             "type": "number"
-                                                        }
-                                                    },
-                                                    "groups": {
-                                                        "type": "array",
-                                                        "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 2 levels",
-                                                        "items": {
-                                                            "type": "string",
-                                                            "minLength": 1
                                                         },
-                                                        "maxItems": 2
+                                                        "groups": {
+                                                            "type": "array",
+                                                            "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 2 levels",
+                                                            "items": {
+                                                                "type": "string",
+                                                                "minLength": 1
+                                                            },
+                                                            "maxItems": 2
+                                                        }
                                                     },
                                                     "required": ["type"]
                                                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11146<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Related to PR: https://github.com/lightdash/lightdash/pull/11090

"groups" was defined in the wrong place in the schema causing AVJ to throw an error.

How to reproduce: 

- add groups to a dimension in orders model
```
        meta:
          dimension:
            groups:
              - product_details
```
- compile that model ```node ./packages/cli/dist/index.js generate --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles -s orders```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
