### PR TITLE
fix: okta state mismatch

### DIFF
--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -86,6 +86,9 @@ const Login: FC<{}> = () => {
     // Disable fetch once it has succeeded
     useEffect(() => {
         if (loginOptions && loginOptionsSuccess) {
+            if (loginOptions.forceRedirect && loginOptions.redirectUri) {
+                window.location.href = loginOptions.redirectUri;
+            }
             setFetchOptionsEnabled(false);
         }
     }, [loginOptionsSuccess, loginOptions]);
@@ -165,14 +168,6 @@ const Login: FC<{}> = () => {
     }
     if (health.status === 'success' && health.data?.isAuthenticated) {
         return <Redirect to={redirectUrl} />;
-    }
-
-    if (
-        loginOptionsSuccess &&
-        loginOptions.forceRedirect === true &&
-        loginOptions.redirectUri
-    ) {
-        window.location.href = loginOptions.redirectUri;
     }
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11118](https://github.com/lightdash/lightdash/issues/11118) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We were calling okta login multiple times and creating a different code/state for each call.

To test this locally run in production mode, otherwise react hooks run multiple times.
`NODE_ENV=production yarn dev`

Problem:
![bug](https://github.com/user-attachments/assets/9c76daae-8ab9-4d2e-a6d6-7b7df97ce4d0)

Fix:

![fix](https://github.com/user-attachments/assets/539dc493-3b85-4123-bab9-6528285968ab)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
