### PR TITLE
fix: day of week does not work with desc sorts

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -1420,6 +1420,24 @@ export const MONTH_NAME_SORT_SQL = `(
     END
     )`;
 
+export const MONTH_NAME_SORT_DESCENDING_SQL = `(
+        CASE
+            WHEN "table1_dim1" = 'January' THEN 1
+            WHEN "table1_dim1" = 'February' THEN 2
+            WHEN "table1_dim1" = 'March' THEN 3
+            WHEN "table1_dim1" = 'April' THEN 4
+            WHEN "table1_dim1" = 'May' THEN 5
+            WHEN "table1_dim1" = 'June' THEN 6
+            WHEN "table1_dim1" = 'July' THEN 7
+            WHEN "table1_dim1" = 'August' THEN 8
+            WHEN "table1_dim1" = 'September' THEN 9
+            WHEN "table1_dim1" = 'October' THEN 10
+            WHEN "table1_dim1" = 'November' THEN 11
+            WHEN "table1_dim1" = 'December' THEN 12
+            ELSE 0
+        END
+        ) DESC`;
+
 export const COMPILED_WEEK_NAME_DIMENSION: CompiledDimension = {
     type: DimensionType.STRING,
     name: 'dim1',
@@ -1446,6 +1464,19 @@ export const WEEK_NAME_SORT_SQL = `(
         ELSE 0
     END
 )`;
+
+export const WEEK_NAME_SORT_DESCENDING_SQL = `(
+    CASE
+        WHEN "table1_dim1" = 'Sunday' THEN 1
+        WHEN "table1_dim1" = 'Monday' THEN 2
+        WHEN "table1_dim1" = 'Tuesday' THEN 3
+        WHEN "table1_dim1" = 'Wednesday' THEN 4
+        WHEN "table1_dim1" = 'Thursday' THEN 5
+        WHEN "table1_dim1" = 'Friday' THEN 6
+        WHEN "table1_dim1" = 'Saturday' THEN 7
+        ELSE 0
+    END
+) DESC`;
 
 export const CUSTOM_SQL_DIMENSION: CompiledCustomSqlDimension = {
     id: 'is_adult',

--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -64,9 +64,11 @@ import {
     METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER_SQL,
     METRIC_QUERY_WITH_TABLE_REFERENCE,
     METRIC_QUERY_WITH_TABLE_REFERENCE_SQL,
+    MONTH_NAME_SORT_DESCENDING_SQL,
     MONTH_NAME_SORT_SQL,
     QUERY_BUILDER_UTC_TIMEZONE,
     warehouseClientMock,
+    WEEK_NAME_SORT_DESCENDING_SQL,
     WEEK_NAME_SORT_SQL,
 } from './queryBuilder.mock';
 
@@ -927,16 +929,28 @@ describe('Time frame sorting', () => {
     it('sortMonthName SQL', () => {
         expect(
             ignoreIndentation(
-                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"'),
+                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"', false),
             ),
         ).toStrictEqual(ignoreIndentation(MONTH_NAME_SORT_SQL));
     });
-    it('sortDayOfWeekName SQL for undefined startOfWeek', () => {
+    it('sortMonthName Descending SQL', () => {
         expect(
             ignoreIndentation(
-                sortDayOfWeekName(COMPILED_WEEK_NAME_DIMENSION, undefined, `"`),
+                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"', true),
             ),
-        ).toStrictEqual(ignoreIndentation(WEEK_NAME_SORT_SQL));
+        ).toStrictEqual(ignoreIndentation(MONTH_NAME_SORT_DESCENDING_SQL));
+    });
+    it('sortDayOfWeekName SQL for Saturday startOfWeek', () => {
+        expect(
+            ignoreIndentation(
+                sortDayOfWeekName(
+                    COMPILED_WEEK_NAME_DIMENSION,
+                    undefined,
+                    `"`,
+                    true,
+                ),
+            ),
+        ).toStrictEqual(ignoreIndentation(WEEK_NAME_SORT_DESCENDING_SQL));
     });
     it('sortDayOfWeekName SQL for Sunday startOfWeek', () => {
         expect(
@@ -945,6 +959,7 @@ describe('Time frame sorting', () => {
                     COMPILED_WEEK_NAME_DIMENSION,
                     WeekDay.SUNDAY,
                     `"`,
+                    false,
                 ),
             ),
         ).toStrictEqual(ignoreIndentation(WEEK_NAME_SORT_SQL)); // same as undefined
@@ -957,6 +972,7 @@ describe('Time frame sorting', () => {
                     COMPILED_WEEK_NAME_DIMENSION,
                     WeekDay.WEDNESDAY,
                     `"`,
+                    false,
                 ),
             ),
         ).toStrictEqual(

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -252,6 +252,7 @@ const getJoinType = (type: DbtModelJoinType = 'left') => {
 export const sortMonthName = (
     dimension: CompiledDimension,
     fieldQuoteChar: string,
+    descending: Boolean,
 ) => {
     const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
 
@@ -271,12 +272,13 @@ export const sortMonthName = (
             WHEN ${fieldId} = 'December' THEN 12
             ELSE 0
         END
-        )`;
+        )${descending ? ' DESC' : ''}`;
 };
 export const sortDayOfWeekName = (
     dimension: CompiledDimension,
     startOfWeek: WeekDay | null | undefined,
     fieldQuoteChar: string,
+    descending: Boolean,
 ) => {
     const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
     const calculateDayIndex = (dayNumber: number) => {
@@ -294,7 +296,7 @@ export const sortDayOfWeekName = (
             WHEN ${fieldId} = 'Saturday' THEN ${calculateDayIndex(7)}
             ELSE 0
         END
-    )`;
+    )${descending ? ' DESC' : ''}`;
 };
 
 export const applyLimitToSqlQuery = ({
@@ -949,6 +951,7 @@ export const buildQuery = ({
             return sortMonthName(
                 sortedDimension,
                 getFieldQuoteChar(warehouseClient.credentials.type),
+                sort.descending,
             );
         }
         if (
@@ -963,6 +966,7 @@ export const buildQuery = ({
                 sortedDimension,
                 startOfWeek,
                 getFieldQuoteChar(warehouseClient.credentials.type),
+                sort.descending,
             );
         }
         return `${fieldQuoteChar}${sort.fieldId}${fieldQuoteChar}${


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11070

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Here in `backend/src/queryBuilder.ts`, sorting in descending order (DESC) is not implemented for `sortMonthName` and `sortDayOfWeekName`. So, I implemented DESC by checking if `sort.descending` is `true` and adding 'DESC' to the query. I also wrote test cases to verify this DESC functionality.
<!-- Even better add a screenshot / gif / loom -->
https://www.loom.com/share/3addfb9d5997498fb33f4fbc25b03b73?sid=8ad9bc20-2f54-4116-92f6-5f72f15e2edb

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
