### PR TITLE
perf: improve sql chart display changes

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6570,6 +6570,283 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.VERTICAL_BAR': {
+        dataType: 'refEnum',
+        enums: ['vertical_bar'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.LINE': {
+        dataType: 'refEnum',
+        enums: ['line'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    IndexType: {
+        dataType: 'refEnum',
+        enums: ['time', 'category'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AggregationOptions: {
+        dataType: 'refAlias',
+        type: { dataType: 'string', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SqlCartesianChartLayout: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                groupBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    reference: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                },
+                            },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                y: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            aggregation: {
+                                ref: 'AggregationOptions',
+                                required: true,
+                            },
+                            reference: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                x: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: { ref: 'IndexType', required: true },
+                        reference: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string._label%3F%3Astring--format%3F%3AFormat--yAxisIndex%3F%3Anumber--__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {},
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CartesianChartDisplay: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                stack: { dataType: 'boolean' },
+                legend: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        align: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'enum', enums: ['start'] },
+                                { dataType: 'enum', enums: ['center'] },
+                                { dataType: 'enum', enums: ['end'] },
+                            ],
+                            required: true,
+                        },
+                        position: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'enum', enums: ['top'] },
+                                { dataType: 'enum', enums: ['bottom'] },
+                                { dataType: 'enum', enums: ['left'] },
+                                { dataType: 'enum', enums: ['right'] },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+                series: {
+                    ref: 'Record_string._label%3F%3Astring--format%3F%3AFormat--yAxisIndex%3F%3Anumber--__',
+                },
+                yAxis: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            format: { ref: 'Format' },
+                            position: { dataType: 'string' },
+                            label: { dataType: 'string' },
+                        },
+                    },
+                },
+                xAxis: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: { ref: 'IndexType', required: true },
+                        label: { dataType: 'string' },
+                    },
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CartesianChartSqlConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SqlRunnerChartConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartDisplay' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'SqlCartesianChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartKind.VERTICAL_BAR' },
+                                { ref: 'ChartKind.LINE' },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.PIE': {
+        dataType: 'refEnum',
+        enums: ['pie'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SqlPivotChartLayout: {
+        dataType: 'refAlias',
+        type: { ref: 'SqlCartesianChartLayout', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PieChartDisplay: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { isDonut: { dataType: 'boolean' } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PieChartSqlConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SqlRunnerChartConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PieChartDisplay' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'SqlPivotChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: { ref: 'ChartKind.PIE', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SqlTableConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                columns: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {},
+                    additionalProperties: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            order: { dataType: 'double' },
+                            frozen: { dataType: 'boolean', required: true },
+                            label: { dataType: 'string', required: true },
+                            reference: { dataType: 'string', required: true },
+                            visible: { dataType: 'boolean', required: true },
+                        },
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.TABLE': {
+        dataType: 'refEnum',
+        enums: ['table'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableChartSqlConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SqlRunnerChartConfig' },
+                { ref: 'SqlTableConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: { ref: 'ChartKind.TABLE', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_': {
         dataType: 'refAlias',
         type: {
@@ -6670,7 +6947,21 @@ const models: TsoaRoute.Models = {
                 },
                 createdAt: { dataType: 'datetime', required: true },
                 chartKind: { ref: 'ChartKind', required: true },
-                config: { ref: 'SqlRunnerChartConfig', required: true },
+                config: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'SqlRunnerChartConfig' },
+                        {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartSqlConfig' },
+                                { ref: 'PieChartSqlConfig' },
+                                { ref: 'TableChartSqlConfig' },
+                            ],
+                        },
+                    ],
+                    required: true,
+                },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
                 slug: { dataType: 'string', required: true },
@@ -6745,7 +7036,21 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 spaceUuid: { dataType: 'string', required: true },
-                config: { ref: 'SqlRunnerChartConfig', required: true },
+                config: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'SqlRunnerChartConfig' },
+                        {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartSqlConfig' },
+                                { ref: 'PieChartSqlConfig' },
+                                { ref: 'TableChartSqlConfig' },
+                            ],
+                        },
+                    ],
+                    required: true,
+                },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
                 description: {
@@ -6813,7 +7118,21 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                config: { ref: 'SqlRunnerChartConfig', required: true },
+                config: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'SqlRunnerChartConfig' },
+                        {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartSqlConfig' },
+                                { ref: 'PieChartSqlConfig' },
+                                { ref: 'TableChartSqlConfig' },
+                            ],
+                        },
+                    ],
+                    required: true,
+                },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7309,6 +7309,251 @@
                 "required": ["type", "metadata"],
                 "type": "object"
             },
+            "ChartKind.VERTICAL_BAR": {
+                "enum": ["vertical_bar"],
+                "type": "string"
+            },
+            "ChartKind.LINE": {
+                "enum": ["line"],
+                "type": "string"
+            },
+            "IndexType": {
+                "enum": ["time", "category"],
+                "type": "string"
+            },
+            "AggregationOptions": {
+                "type": "string"
+            },
+            "SqlCartesianChartLayout": {
+                "properties": {
+                    "groupBy": {
+                        "items": {
+                            "properties": {
+                                "reference": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["reference"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "y": {
+                        "items": {
+                            "properties": {
+                                "aggregation": {
+                                    "$ref": "#/components/schemas/AggregationOptions"
+                                },
+                                "reference": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["aggregation", "reference"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "x": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/components/schemas/IndexType"
+                            },
+                            "reference": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["type", "reference"],
+                        "type": "object"
+                    }
+                },
+                "required": ["y", "x"],
+                "type": "object"
+            },
+            "Record_string._label%3F%3Astring--format%3F%3AFormat--yAxisIndex%3F%3Anumber--__": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "CartesianChartDisplay": {
+                "properties": {
+                    "stack": {
+                        "type": "boolean"
+                    },
+                    "legend": {
+                        "properties": {
+                            "align": {
+                                "type": "string",
+                                "enum": ["start", "center", "end"]
+                            },
+                            "position": {
+                                "type": "string",
+                                "enum": ["top", "bottom", "left", "right"]
+                            }
+                        },
+                        "required": ["align", "position"],
+                        "type": "object"
+                    },
+                    "series": {
+                        "$ref": "#/components/schemas/Record_string._label%3F%3Astring--format%3F%3AFormat--yAxisIndex%3F%3Anumber--__"
+                    },
+                    "yAxis": {
+                        "items": {
+                            "properties": {
+                                "format": {
+                                    "$ref": "#/components/schemas/Format"
+                                },
+                                "position": {
+                                    "type": "string"
+                                },
+                                "label": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "xAxis": {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/components/schemas/IndexType"
+                            },
+                            "label": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "CartesianChartSqlConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/CartesianChartDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/SqlCartesianChartLayout"
+                            },
+                            "type": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/ChartKind.LINE"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ChartKind.PIE": {
+                "enum": ["pie"],
+                "type": "string"
+            },
+            "SqlPivotChartLayout": {
+                "$ref": "#/components/schemas/SqlCartesianChartLayout"
+            },
+            "PieChartDisplay": {
+                "properties": {
+                    "isDonut": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "PieChartSqlConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/PieChartDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/SqlPivotChartLayout"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.PIE"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "SqlTableConfig": {
+                "properties": {
+                    "columns": {
+                        "properties": {},
+                        "additionalProperties": {
+                            "properties": {
+                                "order": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "frozen": {
+                                    "type": "boolean"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "reference": {
+                                    "type": "string"
+                                },
+                                "visible": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "frozen",
+                                "label",
+                                "reference",
+                                "visible"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "object"
+                    }
+                },
+                "required": ["columns"],
+                "type": "object"
+            },
+            "ChartKind.TABLE": {
+                "enum": ["table"],
+                "type": "string"
+            },
+            "TableChartSqlConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SqlTableConfig"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.TABLE"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
             "Pick_SpaceSummary.uuid-or-name-or-isPrivate-or-userAccess_": {
                 "properties": {
                     "name": {
@@ -7410,7 +7655,24 @@
                         "$ref": "#/components/schemas/ChartKind"
                     },
                     "config": {
-                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/CartesianChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PieChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TableChartSqlConfig"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     "limit": {
                         "type": "number",
@@ -7519,7 +7781,24 @@
                         "type": "string"
                     },
                     "config": {
-                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/CartesianChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PieChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TableChartSqlConfig"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     "limit": {
                         "type": "number",
@@ -7589,7 +7868,24 @@
             "UpdateVersionedSqlChart": {
                 "properties": {
                     "config": {
-                        "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SqlRunnerChartConfig"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/CartesianChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PieChartSqlConfig"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TableChartSqlConfig"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     "limit": {
                         "type": "number",
@@ -9041,7 +9337,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1220.0",
+        "version": "0.1221.2",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -87,7 +87,7 @@ export class SavedSqlModel {
                 : null,
             sql: row.sql,
             limit: row.limit,
-            config: row.config as SqlRunnerChartConfig,
+            config: row.config as SqlChart['config'],
             chartKind: row.chart_kind,
             space: {
                 uuid: row.space_uuid,

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -140,7 +140,8 @@ export type SqlChart = {
     slug: string;
     sql: string;
     limit: number;
-    config: SqlRunnerChartConfig;
+    config: SqlRunnerChartConfig &
+        (CartesianChartSqlConfig | PieChartSqlConfig | TableChartSqlConfig);
     chartKind: ChartKind;
     createdAt: Date;
     createdBy: Pick<
@@ -163,7 +164,8 @@ export type CreateSqlChart = {
     description: string | null;
     sql: string;
     limit: number;
-    config: SqlRunnerChartConfig;
+    config: SqlRunnerChartConfig &
+        (CartesianChartSqlConfig | PieChartSqlConfig | TableChartSqlConfig);
     spaceUuid: string;
 };
 
@@ -176,7 +178,8 @@ export type UpdateUnversionedSqlChart = {
 export type UpdateVersionedSqlChart = {
     sql: string;
     limit: number;
-    config: SqlRunnerChartConfig;
+    config: SqlRunnerChartConfig &
+        (CartesianChartSqlConfig | PieChartSqlConfig | TableChartSqlConfig);
 };
 
 export type UpdateSqlChart = {

--- a/packages/common/src/visualizations/PieChartDataTransformer.ts
+++ b/packages/common/src/visualizations/PieChartDataTransformer.ts
@@ -1,5 +1,8 @@
 import { ChartKind } from '../types/savedCharts';
-import { type ResultsRunnerBase } from './ResultsRunnerBase';
+import {
+    type PivotChartData,
+    type ResultsRunnerBase,
+} from './ResultsRunnerBase';
 import { type PieChartDisplay } from './SqlResultsRunner';
 
 type PieChartConfig<TPivotChartLayout> = {
@@ -33,16 +36,22 @@ export class PieChartDataTransformer<TPivotChartLayout> {
         };
     }
 
-    async getEchartsSpec(
+    async getTransformedData(
         layout: TPivotChartLayout | undefined,
+    ): Promise<PivotChartData | undefined> {
+        if (!layout) {
+            return undefined;
+        }
+        return this.transformer.getPivotChartData(layout);
+    }
+
+    getEchartsSpec(
+        transformedData: Awaited<ReturnType<typeof this.getTransformedData>>,
         display: PieChartDisplay | undefined,
     ) {
-        if (!layout) {
+        if (!transformedData) {
             return {};
         }
-        const transformedData = await this.transformer.getPivotChartData(
-            layout,
-        );
 
         return {
             legend: {
@@ -61,7 +70,7 @@ export class PieChartDataTransformer<TPivotChartLayout> {
                     type: 'pie',
                     radius: display?.isDonut ? ['30%', '70%'] : '50%',
                     center: ['50%', '50%'],
-                    data: transformedData?.results.map((result) => ({
+                    data: transformedData.results.map((result) => ({
                         name: result[transformedData.indexColumn.reference],
                         groupId: transformedData.indexColumn.reference,
                         value: result[transformedData.valuesColumns[0]],

--- a/packages/frontend/src/features/semanticViewer/transformers/useSqlChart.ts
+++ b/packages/frontend/src/features/semanticViewer/transformers/useSqlChart.ts
@@ -1,9 +1,4 @@
 import {
-    CartesianChartDataTransformer,
-    isBarChartSQLConfig,
-    isLineChartSQLConfig,
-    isPieChartSQLConfig,
-    PieChartDataTransformer,
     type ResultRow,
     type SqlColumn,
     type SqlRunnerChartConfig,
@@ -26,22 +21,24 @@ export const useSqlChart = (
         [rows, columns],
     );
     return useAsync(async () => {
-        if (isPieChartSQLConfig(config)) {
-            return new PieChartDataTransformer({ transformer }).getEchartsSpec(
-                config.fieldConfig,
-                config.display,
-            );
-        }
-        if (isLineChartSQLConfig(config)) {
-            return new CartesianChartDataTransformer({
-                transformer,
-            }).getEchartsSpec(config.fieldConfig, config.display, config.type);
-        }
-        if (isBarChartSQLConfig(config)) {
-            return new CartesianChartDataTransformer({
-                transformer,
-            }).getEchartsSpec(config.fieldConfig, config.display, config.type);
-        }
-        throw new Error('Unknown chart type');
+        // TODO: implement this
+        return undefined;
+        // if (isPieChartSQLConfig(config)) {
+        //     return new PieChartDataTransformer({ transformer }).getEchartsSpec(
+        //         config.fieldConfig,
+        //         config.display,
+        //     );
+        // }
+        // if (isLineChartSQLConfig(config)) {
+        //     return new CartesianChartDataTransformer({
+        //         transformer,
+        //     }).getEchartsSpec(config.fieldConfig, config.display, config.type);
+        // }
+        // if (isBarChartSQLConfig(config)) {
+        //     return new CartesianChartDataTransformer({
+        //         transformer,
+        //     }).getEchartsSpec(config.fieldConfig, config.display, config.type);
+        // }
+        // throw new Error('Unknown chart type');
     }, [config, transformer]);
 };

--- a/packages/frontend/src/features/sqlRunner/components/visualizations/SqlRunnerChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/visualizations/SqlRunnerChart.tsx
@@ -1,4 +1,7 @@
-import { type SqlRunnerChartConfig } from '@lightdash/common';
+import {
+    type CartesianChartSqlConfig,
+    type PieChartSqlConfig,
+} from '@lightdash/common';
 import { LoadingOverlay } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import EChartsReact, { type EChartsReactProps } from 'echarts-for-react';
@@ -9,7 +12,7 @@ import { useSqlChart } from '../../transformers/useSqlChart';
 
 type SqlRunnerChartProps = {
     data: ResultsAndColumns;
-    config: SqlRunnerChartConfig;
+    config: CartesianChartSqlConfig | PieChartSqlConfig;
     isLoading: boolean;
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 

--- a/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
@@ -38,9 +38,10 @@ export const useSqlChart = (
         throw new Error('Unknown chart type');
     }, [transformer, config.type]);
 
-    const getTransformedData = useCallback(async () => {
-        return chartTransformer.getTransformedData(config.fieldConfig);
-    }, [chartTransformer, config.fieldConfig]);
+    const getTransformedData = useCallback(
+        async () => chartTransformer.getTransformedData(config.fieldConfig),
+        [chartTransformer, config.fieldConfig],
+    );
 
     const transformedData = useAsync(getTransformedData, [getTransformedData]);
 

--- a/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
@@ -53,18 +53,20 @@ export const useSqlChart = (
     const chartSpec = useMemo(() => {
         if (!transformedData.value) return undefined;
 
-        if (chartType === ChartKind.PIE) {
-            return (
-                chartTransformer as PieChartDataTransformer<any>
-            ).getEchartsSpec(
+        if (
+            chartType === ChartKind.PIE &&
+            chartTransformer instanceof PieChartDataTransformer
+        ) {
+            return chartTransformer.getEchartsSpec(
                 transformedData.value,
                 config.display as PieChartDisplay,
             );
         }
-        if (chartType === ChartKind.VERTICAL_BAR) {
-            return (
-                chartTransformer as CartesianChartDataTransformer<any>
-            ).getEchartsSpec(
+        if (
+            chartType === ChartKind.VERTICAL_BAR &&
+            chartTransformer instanceof CartesianChartDataTransformer
+        ) {
+            return chartTransformer.getEchartsSpec(
                 transformedData.value,
                 config.display as CartesianChartDisplay,
                 config.type,

--- a/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
+++ b/packages/frontend/src/features/sqlRunner/transformers/useSqlChart.ts
@@ -1,10 +1,10 @@
 import {
     CartesianChartDataTransformer,
     ChartKind,
+    isCartesianChartSQLConfig,
+    isPieChartSQLConfig,
     PieChartDataTransformer,
-    type CartesianChartDisplay,
     type CartesianChartSqlConfig,
-    type PieChartDisplay,
     type PieChartSqlConfig,
     type ResultRow,
     type SqlColumn,
@@ -23,23 +23,17 @@ export const useSqlChart = (
         [rows, columns],
     );
 
-    const { chartTransformer, chartType } = useMemo(() => {
+    const chartTransformer = useMemo(() => {
         if (config.type === ChartKind.PIE) {
-            return {
-                chartTransformer: new PieChartDataTransformer({ transformer }),
-                chartType: ChartKind.PIE,
-            };
+            return new PieChartDataTransformer({ transformer });
         }
         if (
             config.type === ChartKind.VERTICAL_BAR ||
             config.type === ChartKind.LINE
         ) {
-            return {
-                chartTransformer: new CartesianChartDataTransformer({
-                    transformer,
-                }),
-                chartType: ChartKind.VERTICAL_BAR,
-            };
+            return new CartesianChartDataTransformer({
+                transformer,
+            });
         }
         throw new Error('Unknown chart type');
     }, [transformer, config.type]);
@@ -54,32 +48,26 @@ export const useSqlChart = (
         if (!transformedData.value) return undefined;
 
         if (
-            chartType === ChartKind.PIE &&
+            isPieChartSQLConfig(config) &&
             chartTransformer instanceof PieChartDataTransformer
         ) {
             return chartTransformer.getEchartsSpec(
                 transformedData.value,
-                config.display as PieChartDisplay,
+                config.display,
             );
         }
         if (
-            chartType === ChartKind.VERTICAL_BAR &&
+            isCartesianChartSQLConfig(config) &&
             chartTransformer instanceof CartesianChartDataTransformer
         ) {
             return chartTransformer.getEchartsSpec(
                 transformedData.value,
-                config.display as CartesianChartDisplay,
+                config.display,
                 config.type,
             );
         }
         throw new Error('Unknown chart type');
-    }, [
-        chartTransformer,
-        chartType,
-        config.display,
-        config.type,
-        transformedData.value,
-    ]);
+    }, [chartTransformer, config, transformedData.value]);
 
     return {
         ...transformedData,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

We were triggering a duck db query on any config/display change. 
We should **only** trigger a new change when the `fieldConfig` changes.
Any stylistic (`display`) changes should just mutate the echarts spec/config. 

This PR improves chart styling changes UX.

Try interacting with any input in `Styling`

<img width="392" alt="image" src="https://github.com/user-attachments/assets/b3acd5bc-0d66-4b7a-bb1e-b99d715e491d">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
