### PR TITLE
fix: update x y labels if undefined

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -1,12 +1,16 @@
 import { IndexType, type ChartKind } from '@lightdash/common';
 import { Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
-import { type CartesianChartActionsType, useVizDispatch, useVizSelector } from '../store';
-import { selectCurrentCartesianChartState } from '../store/selectors';
-import { CartesianChartFormatConfig } from './CartesianChartFormatConfig';
 import { useMemo } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { Config } from '../../VisualizationConfigs/common/Config';
+import {
+    useVizDispatch,
+    useVizSelector,
+    type CartesianChartActionsType,
+} from '../store';
+import { selectCurrentCartesianChartState } from '../store/selectors';
+import { CartesianChartFormatConfig } from './CartesianChartFormatConfig';
 
 export const CartesianChartStyling = ({
     selectedChartType,

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -1,18 +1,12 @@
 import { IndexType, type ChartKind } from '@lightdash/common';
 import { Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
-import debounce from 'lodash/debounce';
-import MantineIcon from '../../common/MantineIcon';
-import { Config } from '../../VisualizationConfigs/common/Config';
-import {
-    useVizDispatch,
-    useVizSelector,
-    type CartesianChartActionsType,
-} from '../store';
+import { type CartesianChartActionsType, useVizDispatch, useVizSelector } from '../store';
 import { selectCurrentCartesianChartState } from '../store/selectors';
 import { CartesianChartFormatConfig } from './CartesianChartFormatConfig';
-
-const DEBOUNCE_TIME = 500;
+import { useMemo } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import { Config } from '../../VisualizationConfigs/common/Config';
 
 export const CartesianChartStyling = ({
     selectedChartType,
@@ -45,29 +39,19 @@ export const CartesianChartStyling = ({
         });
     });
 
-    const xAxisLabel =
-        currentConfig?.config?.display?.xAxis?.label ??
-        currentConfig?.config?.fieldConfig?.x?.reference;
-    const yAxisLabel =
-        currentConfig?.config?.display?.yAxis?.[0]?.label ??
-        currentConfig?.config?.fieldConfig?.y?.[0]?.reference;
+    const xAxisLabel = useMemo(() => {
+        return (
+            currentConfig?.config?.display?.xAxis?.label ??
+            currentConfig?.config?.fieldConfig?.x?.reference
+        );
+    }, [currentConfig]);
+    const yAxisLabel = useMemo(() => {
+        return (
+            currentConfig?.config?.display?.yAxis?.[0]?.label ??
+            currentConfig?.config?.fieldConfig?.y?.[0]?.reference
+        );
+    }, [currentConfig]);
     const yAxisPosition = currentConfig?.config?.display?.yAxis?.[0]?.position;
-
-    const onXAxisLabelChange = debounce((label: string) => {
-        dispatch(actions.setXAxisLabel({ label, type: IndexType.CATEGORY }));
-    }, DEBOUNCE_TIME);
-
-    const onYAxisLabelChange = debounce((label: string) => {
-        dispatch(actions.setYAxisLabel({ index: 0, label }));
-    }, DEBOUNCE_TIME);
-
-    const onYAxisPositionChange = debounce((position: string | undefined) => {
-        dispatch(actions.setYAxisPosition({ index: 0, position }));
-    }, DEBOUNCE_TIME);
-
-    const onStackedChange = debounce((isStacked: boolean) => {
-        dispatch(actions.setStacked(isStacked));
-    }, DEBOUNCE_TIME);
 
     return (
         <Stack spacing="xs">
@@ -93,7 +77,7 @@ export const CartesianChartStyling = ({
                                 : 'None'
                         }
                         onChange={(value) =>
-                            onStackedChange(value === 'Stacked')
+                            dispatch(actions.setStacked(value === 'Stacked'))
                         }
                     />
                 </Config.Group>
@@ -103,9 +87,16 @@ export const CartesianChartStyling = ({
                     <Config.Heading>{`X-axis label`}</Config.Heading>
 
                     <TextInput
-                        defaultValue={xAxisLabel}
+                        value={xAxisLabel}
                         radius="md"
-                        onChange={(e) => onXAxisLabelChange(e.target.value)}
+                        onChange={(e) =>
+                            dispatch(
+                                actions.setXAxisLabel({
+                                    label: e.target.value,
+                                    type: IndexType.CATEGORY,
+                                }),
+                            )
+                        }
                     />
                 </Config.Section>
             </Config>
@@ -115,9 +106,16 @@ export const CartesianChartStyling = ({
                     <Config.Group>
                         <Config.Label>{`Label`}</Config.Label>
                         <TextInput
-                            defaultValue={yAxisLabel}
+                            value={yAxisLabel}
                             radius="md"
-                            onChange={(e) => onYAxisLabelChange(e.target.value)}
+                            onChange={(e) =>
+                                dispatch(
+                                    actions.setYAxisLabel({
+                                        index: 0,
+                                        label: e.target.value,
+                                    }),
+                                )
+                            }
                         />
                     </Config.Group>
                     {series.length < 1 && (
@@ -185,9 +183,14 @@ export const CartesianChartStyling = ({
                                     ),
                                 },
                             ]}
-                            defaultValue={yAxisPosition}
+                            value={yAxisPosition}
                             onChange={(value) =>
-                                onYAxisPositionChange(value || undefined)
+                                dispatch(
+                                    actions.setYAxisPosition({
+                                        index: 0,
+                                        position: value || undefined,
+                                    }),
+                                )
                             }
                         />
                     </Config.Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- removed `defaultValue` usage now that `display` changes don't trigger a new query
- if the label is `undefined` then we swap its value with the reference of the field used.

Demo: 


https://github.com/user-attachments/assets/2b73845c-19d1-4bd8-90ae-b852563dcd8f



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
