### PR TITLE
perf: track active configs and render on selection

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -46,6 +46,7 @@ export interface SqlRunnerState {
     };
     quoteChar: string;
     sqlColumns: SqlColumn[] | undefined;
+    activeConfigs: ChartKind[];
 }
 
 const initialState: SqlRunnerState = {
@@ -73,6 +74,7 @@ const initialState: SqlRunnerState = {
     },
     quoteChar: '"',
     sqlColumns: undefined,
+    activeConfigs: [ChartKind.VERTICAL_BAR],
 };
 
 export const sqlRunnerSlice = createSlice({
@@ -148,6 +150,9 @@ export const sqlRunnerSlice = createSlice({
         },
         setSelectedChartType: (state, action: PayloadAction<ChartKind>) => {
             state.selectedChartType = action.payload;
+            if (!state.activeConfigs.includes(action.payload)) {
+                state.activeConfigs.push(action.payload);
+            }
         },
         toggleActiveTable: (
             state,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#11047](https://github.com/lightdash/lightdash/issues/11047)

### Description:

We currently generate the data for all configs when the user hits run query. 

This gives a better experience between selecting different chart types, but slows down the initial load. 

This PR tracks the active chart config and _marks it as active_ so next time the user selects that same type, it won't re-mount.

Demo


https://github.com/user-attachments/assets/293aa5f8-5837-45ec-af4d-9736e9aec1d5



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
