### PR TITLE
feat: hide results table when viewing table chart

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -62,6 +62,7 @@ export const ContentPanel: FC = () => {
         [resultsHeight, maxResultsHeight],
     );
 
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const {
         sql,
         limit,
@@ -161,7 +162,6 @@ export const ContentPanel: FC = () => {
             tableConfig,
         };
     });
-    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
 
     const showTable = useMemo(
         () => isTableChartSQLConfig(currentVisConfig),
@@ -299,13 +299,7 @@ export const ContentPanel: FC = () => {
                                         timingFunction="ease"
                                     >
                                         {(styles) => (
-                                            <Box
-                                                px="sm"
-                                                pb="sm"
-                                                style={{
-                                                    ...styles,
-                                                }}
-                                            >
+                                            <Box px="sm" pb="sm" style={styles}>
                                                 {activeConfigs.chartConfigs.map(
                                                     (c) => (
                                                         <ConditionalVisibility
@@ -315,33 +309,27 @@ export const ContentPanel: FC = () => {
                                                                 c.type
                                                             }
                                                         >
-                                                            {activeChartTypes.has(
-                                                                c.type,
-                                                            ) && (
-                                                                <ChartView
-                                                                    data={
-                                                                        queryResults
-                                                                    }
-                                                                    transformer={
-                                                                        transformer
-                                                                    }
-                                                                    config={c}
-                                                                    isLoading={
-                                                                        isLoading
-                                                                    }
-                                                                    sql={sql}
-                                                                    projectUuid={
-                                                                        projectUuid
-                                                                    }
-                                                                    limit={
-                                                                        limit
-                                                                    }
-                                                                    style={{
-                                                                        height: inputSectionHeight,
-                                                                        width: '100%',
-                                                                    }}
-                                                                />
-                                                            )}
+                                                            <ChartView
+                                                                data={
+                                                                    queryResults
+                                                                }
+                                                                transformer={
+                                                                    transformer
+                                                                }
+                                                                config={c}
+                                                                isLoading={
+                                                                    isLoading
+                                                                }
+                                                                sql={sql}
+                                                                projectUuid={
+                                                                    projectUuid
+                                                                }
+                                                                limit={limit}
+                                                                style={{
+                                                                    height: inputSectionHeight,
+                                                                    width: '100%',
+                                                                }}
+                                                            />
                                                         </ConditionalVisibility>
                                                     ),
                                                 )}

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -428,10 +428,7 @@ export const ContentPanel: FC = () => {
                     <Paper
                         shadow="none"
                         radius={0}
-                        // p="sm"
-                        // mt="sm"
                         sx={(theme) => ({
-                            // flex: 1,
                             overflow: 'auto',
                             borderWidth: '0 0 1px 1px',
                             borderStyle: 'solid',

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -77,6 +77,13 @@ export const ContentPanel: FC = () => {
         selectChartConfigByKind(state, selectedChartType),
     );
 
+    const hideResultsPanel = useMemo(
+        () =>
+            activeEditorTab === EditorTabs.VISUALIZATION &&
+            isTableChartSQLConfig(currentVisConfig),
+        [activeEditorTab, currentVisConfig],
+    );
+
     const {
         mutate: runSqlQuery,
         data: queryResults,
@@ -331,71 +338,73 @@ export const ContentPanel: FC = () => {
                     </Box>
                 </Paper>
 
-                <ResizableBox
-                    height={deferredResultsHeight}
-                    minConstraints={[50, 50]}
-                    maxConstraints={[Infinity, maxResultsHeight]}
-                    resizeHandles={['n']}
-                    axis="y"
-                    handle={
+                {!hideResultsPanel && (
+                    <ResizableBox
+                        height={deferredResultsHeight}
+                        minConstraints={[50, 50]}
+                        maxConstraints={[Infinity, maxResultsHeight]}
+                        resizeHandles={['n']}
+                        axis="y"
+                        handle={
+                            <Paper
+                                pos="absolute"
+                                top={0}
+                                left={0}
+                                right={0}
+                                shadow="none"
+                                radius={0}
+                                px="md"
+                                py={6}
+                                withBorder
+                                bg="gray.1"
+                                sx={(theme) => ({
+                                    zIndex: getDefaultZIndex('modal') - 1,
+                                    borderWidth: isResultsPanelFullHeight
+                                        ? '0 0 0 1px'
+                                        : '0 0 1px 1px',
+                                    borderStyle: 'solid',
+                                    borderColor: theme.colors.gray[3],
+                                    cursor: 'ns-resize',
+                                })}
+                            />
+                        }
+                        style={{
+                            position: 'relative',
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                        onResizeStop={(e, data) =>
+                            setResultsHeight(data.size.height)
+                        }
+                    >
                         <Paper
-                            pos="absolute"
-                            top={0}
-                            left={0}
-                            right={0}
                             shadow="none"
                             radius={0}
-                            px="md"
-                            py={6}
-                            withBorder
-                            bg="gray.1"
+                            p="sm"
+                            mt="sm"
                             sx={(theme) => ({
-                                zIndex: getDefaultZIndex('modal') - 1,
-                                borderWidth: isResultsPanelFullHeight
-                                    ? '0 0 0 1px'
-                                    : '0 0 1px 1px',
+                                flex: 1,
+                                overflow: 'auto',
+                                borderWidth: '0 0 1px 1px',
                                 borderStyle: 'solid',
                                 borderColor: theme.colors.gray[3],
-                                cursor: 'ns-resize',
                             })}
-                        />
-                    }
-                    style={{
-                        position: 'relative',
-                        display: 'flex',
-                        flexDirection: 'column',
-                    }}
-                    onResizeStop={(e, data) =>
-                        setResultsHeight(data.size.height)
-                    }
-                >
-                    <Paper
-                        shadow="none"
-                        radius={0}
-                        p="sm"
-                        mt="sm"
-                        sx={(theme) => ({
-                            flex: 1,
-                            overflow: 'auto',
-                            borderWidth: '0 0 1px 1px',
-                            borderStyle: 'solid',
-                            borderColor: theme.colors.gray[3],
-                        })}
-                    >
-                        <LoadingOverlay
-                            loaderProps={{
-                                size: 'xs',
-                            }}
-                            visible={isLoading}
-                        />
-                        {queryResults?.results && (
-                            <Table
-                                data={queryResults.results}
-                                config={resultsTableConfig}
+                        >
+                            <LoadingOverlay
+                                loaderProps={{
+                                    size: 'xs',
+                                }}
+                                visible={isLoading}
                             />
-                        )}
-                    </Paper>
-                </ResizableBox>
+                            {queryResults?.results && (
+                                <Table
+                                    data={queryResults.results}
+                                    config={resultsTableConfig}
+                                />
+                            )}
+                        </Paper>
+                    </ResizableBox>
+                )}
             </Tooltip.Group>
         </Stack>
     );

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -346,9 +346,7 @@ export const ContentPanel: FC = () => {
                                     >
                                         {(styles) => (
                                             <Box
-                                                pt="xs"
-                                                px="sm"
-                                                pb="sm"
+                                                p="xs"
                                                 style={{
                                                     flex: 1,
                                                     ...styles,
@@ -416,6 +414,7 @@ export const ContentPanel: FC = () => {
                     <Paper
                         shadow="none"
                         radius={0}
+                        pt="md"
                         sx={(theme) => ({
                             overflow: 'auto',
                             borderWidth: '0 0 1px 1px',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11064 

### Description:

Adds a `Transition` to move from `table` view and `other charts` view
Keeps charts mounted


> [!NOTE]
> There's a table layout shift when selecting its config view. I'm aware of this but don't think it's pressing for now.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
