### PR TITLE
feat: simplify limit logic and add endpoint to get the client max query limit

### DIFF
--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -224,4 +224,8 @@ export default class CubeClient implements SemanticLayerClient {
 
         return this.transformers.sqlToString(sql);
     }
+
+    getMaxQueryLimit() {
+        return this.maxQueryLimit;
+    }
 }

--- a/packages/backend/src/clients/cube/CubeClient.ts
+++ b/packages/backend/src/clients/cube/CubeClient.ts
@@ -1,5 +1,6 @@
 import cube, { CubeApi, Query } from '@cubejs-client/core';
 import {
+    getDefaultedLimit,
     MissingConfigError,
     NotFoundError,
     SemanticLayerClient,
@@ -139,19 +140,27 @@ export default class CubeClient implements SemanticLayerClient {
     private async *getResultsGenerator(
         query: SemanticLayerQuery,
         {
-            queryLimit,
             offset,
             partialResultsLimit,
         }: {
-            queryLimit: number;
             offset: number;
-            partialResultsLimit: number;
+            partialResultsLimit?: number;
         },
     ): AsyncGenerator<SemanticLayerResultRow[]> {
+        const defaultedLimit = getDefaultedLimit(
+            this.maxQueryLimit,
+            query.limit,
+        );
+
+        // if the query limit is less than the max partial results limit, use the query limit as the partial results limit
+        const generatorPartialResultsLimit =
+            partialResultsLimit ??
+            Math.min(this.maxPartialResultsLimit, defaultedLimit);
+
         const partialResults = await this.getResults(
             {
                 ...query,
-                limit: partialResultsLimit,
+                limit: generatorPartialResultsLimit,
             },
             offset,
         );
@@ -165,15 +174,14 @@ export default class CubeClient implements SemanticLayerClient {
         yield partialResults;
 
         if (
-            partialResults.length >= partialResultsLimit &&
-            totalResultsFetched < queryLimit
+            partialResults.length >= generatorPartialResultsLimit &&
+            totalResultsFetched < defaultedLimit
         ) {
             yield* this.getResultsGenerator(query, {
-                queryLimit,
                 offset: totalResultsFetched,
                 partialResultsLimit: Math.min(
-                    partialResultsLimit,
-                    queryLimit - offset,
+                    generatorPartialResultsLimit,
+                    defaultedLimit - offset,
                 ),
             });
         }
@@ -184,21 +192,10 @@ export default class CubeClient implements SemanticLayerClient {
         query: SemanticLayerQuery,
         callback: (results: SemanticLayerResultRow[]) => void,
     ): Promise<number> {
-        // if the query limit is not set, use the default limit from the config (LIGHTDASH_QUERY_MAX_LIMIT || 5000)
-        const queryLimit = Math.min(query.limit || 500, this.maxQueryLimit);
-
-        // if the query limit is less than the max partial results limit, use the query limit as the partial results limit
-        const partialResultsLimit = Math.min(
-            this.maxPartialResultsLimit,
-            queryLimit,
-        );
-
         let resultsFetched = 0;
 
         const resultsGenerator = this.getResultsGenerator(query, {
-            queryLimit,
             offset: resultsFetched,
-            partialResultsLimit,
         });
 
         for await (const partialResults of resultsGenerator) {
@@ -214,7 +211,17 @@ export default class CubeClient implements SemanticLayerClient {
         if (this.cubeApi === undefined)
             throw new MissingConfigError('Cube has not been initialized');
         const cubeQuery = this.transformers.semanticLayerQueryToQuery(query);
-        const sql = await this.cubeApi.sql(cubeQuery);
+
+        const defaultedLimit = getDefaultedLimit(
+            this.maxQueryLimit,
+            query.limit,
+        );
+
+        const sql = await this.cubeApi.sql({
+            ...cubeQuery,
+            limit: defaultedLimit,
+        });
+
         return this.transformers.sqlToString(sql);
     }
 }

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -399,4 +399,8 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
             metrics,
         );
     }
+
+    getMaxQueryLimit() {
+        return this.maxQueryLimit;
+    }
 }

--- a/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
+++ b/packages/backend/src/clients/dbtCloud/DbtCloudGraphqlClient.ts
@@ -13,6 +13,7 @@ import {
     DbtGraphQLMetric,
     DbtGraphQLRunQueryRawResponse,
     DbtQueryStatus,
+    getDefaultedLimit,
     SemanticLayerClient,
     SemanticLayerQuery,
     SemanticLayerResultRow,
@@ -189,8 +190,10 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
         const graphqlArgs = this.transformers.semanticLayerQueryToQuery(query);
         const { groupByString, metricsString, orderByString, whereString } =
             await DbtCloudGraphqlClient.getPreparedCreateQueryArgs(graphqlArgs);
-        const { limit } = graphqlArgs;
-        const queryLimit = Math.min(limit || 500, this.maxQueryLimit);
+        const defaultedLimit = getDefaultedLimit(
+            this.maxQueryLimit,
+            graphqlArgs.limit,
+        );
 
         const createQuery = `
             mutation CreateQuery($environmentId: BigInt!) {
@@ -198,7 +201,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
                     environmentId: $environmentId
                     metrics: ${metricsString}
                     groupBy: ${groupByString}
-                    limit: ${queryLimit}
+                    limit: ${defaultedLimit}
                     where: ${whereString}
                     orderBy: ${orderByString}
                 ) {
@@ -225,7 +228,10 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
 
     async getSql(query: SemanticLayerQuery) {
         const graphqlArgs = this.transformers.semanticLayerQueryToQuery(query);
-        const { limit } = graphqlArgs;
+        const defaultedLimit = getDefaultedLimit(
+            this.maxQueryLimit,
+            graphqlArgs.limit,
+        );
 
         const { groupByString, metricsString, orderByString, whereString } =
             await DbtCloudGraphqlClient.getPreparedCreateQueryArgs(graphqlArgs);
@@ -236,7 +242,7 @@ export default class DbtCloudGraphqlClient implements SemanticLayerClient {
                     environmentId: $environmentId
                     metrics: ${metricsString}
                     groupBy: ${groupByString}
-                    limit: ${limit ?? this.maxQueryLimit}
+                    limit: ${defaultedLimit}
                     where: ${whereString}
                     orderBy: ${orderByString}
                 ) {

--- a/packages/backend/src/controllers/v2/SemanticLayerController.ts
+++ b/packages/backend/src/controllers/v2/SemanticLayerController.ts
@@ -96,6 +96,24 @@ export class SemanticLayerController extends BaseController {
         };
     }
 
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/max-query-limit')
+    @OperationId('getMaxQueryLimit')
+    async getMaxQueryLimit(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<{ status: 'ok'; results: number }> {
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSemanticLayerService()
+                .getMaxQueryLimit(req.user!, projectUuid),
+        };
+    }
+
     /**
      * Get semantic layer results from a file
      * @param fileId the fileId for the file

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16783,6 +16783,63 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.get(
+        '/api/v2/projects/:projectUuid/semantic-layer/max-query-limit',
+        ...fetchMiddlewares<RequestHandler>(SemanticLayerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SemanticLayerController.prototype.getMaxQueryLimit,
+        ),
+
+        async function SemanticLayerController_getMaxQueryLimit(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<SemanticLayerController>(
+                        SemanticLayerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.getMaxQueryLimit.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
         '/api/v2/projects/:projectUuid/semantic-layer/results/:fileId',
         ...fetchMiddlewares<RequestHandler>(SemanticLayerController),
         ...fetchMiddlewares<RequestHandler>(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9439,7 +9439,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1227.0",
+        "version": "0.1227.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -167,10 +167,7 @@ export class SemanticLayerService extends BaseService {
         const jobId = await this.schedulerClient.semanticLayerStreamingResults({
             projectUuid,
             userUuid: user.userUuid,
-            query: {
-                ...query,
-                limit: query.limit ?? this.lightdashConfig.query.maxLimit,
-            },
+            query,
             context: 'semanticViewer',
         });
 
@@ -195,16 +192,9 @@ export class SemanticLayerService extends BaseService {
         let streamFunctionCallback: (
             writer: (data: SemanticLayerResultRow) => void,
         ) => Promise<void> = async (writer) => {
-            await client.streamResults(
-                projectUuid,
-                {
-                    ...query,
-                    limit: query.limit ?? this.lightdashConfig.query.maxLimit,
-                },
-                async (rows) => {
-                    rows.forEach(writer);
-                },
-            );
+            await client.streamResults(projectUuid, query, async (rows) => {
+                rows.forEach(writer);
+            });
         };
 
         // When pivot is present, we need to pivot the results
@@ -257,9 +247,6 @@ export class SemanticLayerService extends BaseService {
         await this.checkCanViewProject(user, projectUuid);
         const client = await this.getSemanticLayerClient(projectUuid);
         this.validateQueryLimit(query);
-        return client.getSql({
-            ...query,
-            limit: query.limit ?? this.lightdashConfig.query.maxLimit,
-        });
+        return client.getSql(query);
     }
 }

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -249,4 +249,13 @@ export class SemanticLayerService extends BaseService {
         this.validateQueryLimit(query);
         return client.getSql(query);
     }
+
+    async getMaxQueryLimit(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<number> {
+        await this.checkCanViewProject(user, projectUuid);
+        const client = await this.getSemanticLayerClient(projectUuid);
+        return client.getMaxQueryLimit();
+    }
 }

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -112,6 +112,13 @@ export interface SemanticLayerTransformer<
     sqlToString: (sql: SqlType) => string;
 }
 
+export function getDefaultedLimit(
+    maxQueryLimit: number,
+    queryLimit?: number,
+): number {
+    return Math.min(queryLimit || 500, maxQueryLimit);
+}
+
 export interface SemanticLayerClient {
     getViews: () => Promise<SemanticLayerView[]>;
     getFields: (

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -134,6 +134,7 @@ export interface SemanticLayerClient {
         callback: (results: SemanticLayerResultRow[]) => void,
     ) => Promise<number>;
     getSql: (query: SemanticLayerQuery) => Promise<string>;
+    getMaxQueryLimit: () => number;
 }
 
 export const semanticLayerQueryJob = 'semanticLayer';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Simplifies default limit logic by extracting to a function and default it only when needed instead of trying to default in multiple places

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
