### PR TITLE
fix: Unable to find application named 'Docker'

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,7 +278,11 @@ install_docker_compose() {
 start_docker() {
     echo "Starting Docker ..."
     if [ $os = "Mac" ]; then
+      if open -Ra Docker; then
         open --background -a Docker && while ! docker system info > /dev/null 2>&1; do sleep 1; done
+      else
+        open --background -a OrbStack && while ! docker system info > /dev/null 2>&1; do sleep 1; done
+      fi
     elif [ $os = "Windows" ]; then
       echo "+++++++++++ IMPORTANT READ ++++++++++++++++++++++"
       echo "Make sure Docker Desktop is running."


### PR DESCRIPTION
### Description:

Hello! When I executed `./scripts/install.sh`, the following error occurred.
There are two ways to run Docker on Mac: 'Docker Desktop' and 'OrbStack'.

In my environment, I use 'OrbStack'.
I think that's why the following error occurred.

> Starting Docker ...
> Unable to find application named 'Docker'
> 🔴 The containers didn't seem to start correctly. Please run the following command to check containers that may have errored out:

Modified the `scripts/install.sh` script so that it can be used by 'OrbStack' users.


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
