### PR TITLE
fix: empty description on slack unfurl

### DIFF
--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -21,13 +21,23 @@ type GetChartAndDashboardBlocksArgs = {
 
 const getSectionFields = (
     fields: [string, string | undefined][],
-): SectionBlock['fields'] =>
-    fields
-        .filter(([, text]) => Boolean(text))
-        .map(([title, text]) => ({
-            type: 'mrkdwn',
-            text: `*${title}*: \n${text}`,
-        }));
+): SectionBlock['fields'] => {
+    const availableFields = fields.filter(([, text]) => Boolean(text));
+
+    if (availableFields.length === 0) {
+        // Return empty field placeholder to avoid `cannot_parse_attachment` error from Slack
+        return [
+            {
+                type: 'mrkdwn',
+                text: ' ',
+            },
+        ];
+    }
+    return availableFields.map(([title, text]) => ({
+        type: 'mrkdwn',
+        text: `*${title}*: \n${text}`,
+    }));
+};
 
 const getBlocks = (blocks: (KnownBlock | undefined)[]): KnownBlock[] =>
     blocks.filter((block): block is KnownBlock => Boolean(block));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11262

### Description:
fields: [] can't be empty or ` ""` , but `" "` works. 
<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2024-08-26 12-21-31](https://github.com/user-attachments/assets/5115aa4b-1911-463f-9e33-bb84b3d77e7a)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
