### PR TITLE
fix: allow cmd+enter when focusing sql editor

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -132,7 +132,7 @@ export const ContentPanel: FC = () => {
         [
             'mod + enter',
             () => {
-                if (sql) runSqlQuery({ sql, limit: 7 });
+                if (sql) runSqlQuery({ sql, limit });
             },
             { preventDefault: true },
         ],

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -257,20 +257,18 @@ export const SqlEditor: FC<{
     const decorationsCollectionRef =
         useRef<editor.IEditorDecorationsCollection | null>(null); // Ref to store the decorations collection
 
-    const onMount: OnMount = useCallback(
-        (editorObj, monacoObj) => {
-            editorRef.current = editorObj;
-            decorationsCollectionRef.current =
-                editorObj.createDecorationsCollection(); // Initialize the decorations collection
-            editorObj.addCommand(
-                monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
-                () => {
-                    onSubmit?.();
-                },
-            );
-        },
-        [onSubmit],
-    );
+    const onMount: OnMount = useCallback((editorObj, monacoObj) => {
+        editorRef.current = editorObj;
+        decorationsCollectionRef.current =
+            editorObj.createDecorationsCollection(); // Initialize the decorations collection
+        editorObj.addCommand(
+            monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
+            () => {
+                // When the editor is mounted, the onSubmit callback should be set to the latest value, otherwise it will be set to the initial value on the first render
+                onSubmitRef.current?.();
+            },
+        );
+    }, []);
 
     useEffect(() => {
         // remove any existing decorations


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Bring back logic in `onMount` from here: https://github.com/lightdash/lightdash/pull/10740/files

To test: 

Click on Sql Editor 
use `Cmd`+`Enter` shortcut
See query run 

THis also works when the sql editor isn't focused.

demo:


https://github.com/user-attachments/assets/1dd89540-08c0-43ae-98ed-2b7616f4037c


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
