### PR TITLE
feat: remove limit and display chart results in chart viz

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6896,6 +6896,9 @@ const models: TsoaRoute.Models = {
                             additionalProperties: {
                                 dataType: 'nestedObjectLiteral',
                                 nestedProperties: {
+                                    aggregation: {
+                                        ref: 'VizAggregationOptions',
+                                    },
                                     order: { dataType: 'double' },
                                     frozen: {
                                         dataType: 'boolean',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7563,6 +7563,9 @@
                                 "properties": {},
                                 "additionalProperties": {
                                     "properties": {
+                                        "aggregation": {
+                                            "$ref": "#/components/schemas/VizAggregationOptions"
+                                        },
                                         "order": {
                                             "type": "number",
                                             "format": "double"
@@ -9474,7 +9477,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1231.0",
+        "version": "0.1232.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2065,16 +2065,20 @@ export class ProjectService extends BaseService {
             ),
         ];
         const groupByQuery = `SELECT ${[
-            ...groupBySelectDimensions,
+            ...new Set(groupBySelectDimensions), // Remove duplicate columns
             ...groupBySelectMetrics,
-        ].join(
-            ', ',
-        )} FROM original_query group by ${groupBySelectDimensions.join(', ')}`;
+        ].join(', ')} FROM original_query group by ${Array.from(
+            new Set(groupBySelectDimensions),
+        ).join(', ')}`;
 
         const selectReferences = [
             indexColumn.reference,
             ...(groupByColumns || []).map((col) => col.reference),
-            ...(valuesColumns || []).map((col) => col.reference),
+            ...(valuesColumns || []).map((col) =>
+                groupByColumns && groupByColumns.length > 0
+                    ? `${col.reference}_${col.aggregation}`
+                    : `${col.reference}_${col.aggregation} as ${col.reference}`,
+            ),
         ];
 
         const pivotQuery = `SELECT ${selectReferences.join(
@@ -2204,7 +2208,7 @@ export class ProjectService extends BaseService {
                                 currentTransformedRow =
                                     currentTransformedRow ?? {};
                                 currentTransformedRow[valueColumnReference] =
-                                    row[col.reference];
+                                    row[`${col.reference}_${col.aggregation}`];
                             });
                         });
                     },

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2061,7 +2061,7 @@ export class ProjectService extends BaseService {
         const groupBySelectMetrics = [
             ...(valuesColumns ?? []).map(
                 (col) =>
-                    `${col.aggregation}(${col.reference}) as ${col.reference}`,
+                    `${col.aggregation}(${col.reference}) as ${col.reference}_${col.aggregation}`,
             ),
         ];
         const groupByQuery = `SELECT ${[
@@ -2222,7 +2222,9 @@ export class ProjectService extends BaseService {
             fileUrl,
             valuesColumns: groupByColumns
                 ? Array.from(valuesColumnReferences)
-                : valuesColumns.map((col) => col.reference),
+                : valuesColumns.map(
+                      (col) => `${col.reference}_${col.aggregation}`,
+                  ),
             indexColumn,
         };
     }

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -15,15 +15,6 @@ type CartesianChartKind = Extract<
     ChartKind.LINE | ChartKind.VERTICAL_BAR
 >;
 
-// type CartesianChartConfig<TPivotChartLayout> = {
-//     metadata: {
-//         version: number;
-//     };
-//     type: CartesianChartKind;
-//     fieldConfig: TPivotChartLayout | undefined;
-//     display: CartesianChartDisplay | undefined;
-// };
-
 export class CartesianChartDataModel
     implements
         IChartDataModel<

--- a/packages/common/src/visualizations/TableDataModel.ts
+++ b/packages/common/src/visualizations/TableDataModel.ts
@@ -50,11 +50,11 @@ export class TableDataModel
             (acc, key) => ({
                 ...acc,
                 [key]: {
-                    visible: true, // FIXME: should this be true all the time?
+                    visible: this.config?.columns[key].visible ?? true,
                     reference: key,
-                    label: key,
-                    frozen: true,
-                    order: undefined,
+                    label: this.config?.columns[key].label ?? key,
+                    frozen: this.config?.columns[key].frozen ?? false,
+                    order: this.config?.columns[key].order,
                 },
             }),
             {},

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -23,7 +23,7 @@ export const VIZ_DEFAULT_AGGREGATION = VizAggregationOptions.COUNT;
 
 export type VizSqlColumn = {
     reference: string;
-    type: DimensionType;
+    type?: DimensionType;
 };
 
 export enum VizIndexType {
@@ -93,6 +93,7 @@ export type VizTableColumnsConfig = {
             label: string;
             frozen: boolean;
             order?: number;
+            aggregation?: VizAggregationOptions;
         };
     };
 };

--- a/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
+++ b/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
@@ -131,20 +131,18 @@ export class ResultsRunner implements IResultsRunner<VizChartLayout> {
                 reference: fieldConfig.x.reference,
                 label: fieldConfig.x.reference,
                 frozen: true,
-                order: 1,
             },
         };
         const columnYs = fieldConfig.y.reduce<
             Record<string, VizTableConfig['columns'][string]>
         >(
-            (acc, y, index) => ({
+            (acc, y) => ({
                 ...acc,
                 [`${y.reference}_${y.aggregation}`]: {
                     visible: true,
                     reference: `${y.reference}_${y.aggregation}`,
                     label: y.reference,
                     frozen: true,
-                    order: index + 2,
                     aggregation: y.aggregation,
                 },
             }),

--- a/packages/frontend/src/components/DataViz/transformers/useChart.ts
+++ b/packages/frontend/src/components/DataViz/transformers/useChart.ts
@@ -4,6 +4,7 @@ import {
     isVizCartesianChartConfig,
     isVizPieChartConfig,
     PieChartDataModel,
+    type PivotChartData,
     type VizCartesianChartConfig,
     type VizPieChartConfig,
 } from '@lightdash/common';
@@ -17,12 +18,14 @@ export const useChart = <T extends ResultsRunner>({
     sql,
     projectUuid,
     limit,
+    onPivot,
 }: {
     config?: VizCartesianChartConfig | VizPieChartConfig;
     resultsRunner: T;
     sql?: string;
     projectUuid?: string;
     limit?: number;
+    onPivot?: (pivotData: PivotChartData) => void;
 }) => {
     const chartTransformer = useMemo(() => {
         if (config?.type === ChartKind.PIE) {
@@ -52,7 +55,13 @@ export const useChart = <T extends ResultsRunner>({
         [chartTransformer, config?.fieldConfig, projectUuid, limit],
     );
 
-    const transformedData = useAsync(getTransformedData, [getTransformedData]);
+    const transformedData = useAsync(async () => {
+        const data = await getTransformedData();
+        if (onPivot && data) {
+            onPivot(data);
+        }
+        return data;
+    }, [getTransformedData]);
 
     const chartSpec = useMemo(() => {
         if (!transformedData.value) return undefined;

--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -1,4 +1,5 @@
 import {
+    type PivotChartData,
     type VizCartesianChartConfig,
     type VizPieChartConfig,
 } from '@lightdash/common';
@@ -20,6 +21,7 @@ type ChartViewProps<T extends ResultsRunner> = {
     sql?: string;
     projectUuid?: string;
     limit?: number;
+    onPivot?: (pivotData: PivotChartData | undefined) => void;
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 
 const ChartView = memo(
@@ -32,12 +34,20 @@ const ChartView = memo(
         isLoading: isLoadingProp,
         resultsRunner,
         style,
+        onPivot,
     }: ChartViewProps<T>) => {
         const {
             loading: transformLoading,
             error,
             value: spec,
-        } = useChart({ config, resultsRunner, sql, projectUuid, limit });
+        } = useChart({
+            config,
+            resultsRunner,
+            sql,
+            projectUuid,
+            limit,
+            onPivot,
+        });
 
         if (!config?.fieldConfig?.x || config?.fieldConfig.y.length === 0) {
             return (

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -2,7 +2,7 @@ import {
     type RawResultRow,
     type VizTableColumnsConfig,
 } from '@lightdash/common';
-import { Flex } from '@mantine/core';
+import { Badge, Flex, Group } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import { SMALL_TEXT_LENGTH } from '../../common/LightTable';
 import BodyCell from '../../common/Table/ScrollableTable/BodyCell';
@@ -58,12 +58,28 @@ export const Table = <T extends ResultsRunner>({
                                             backgroundColor: TABLE_HEADER_BG,
                                         }}
                                     >
-                                        {/* TODO: do we need to check if it's a
-                                        placeholder? */}
-                                        {flexRender(
-                                            header.column.columnDef.header,
-                                            header.getContext(),
-                                        )}
+                                        <Group spacing="two">
+                                            {config?.columns[header.id]
+                                                ?.aggregation && (
+                                                <Badge
+                                                    size="sm"
+                                                    color="indigo"
+                                                    radius="xs"
+                                                >
+                                                    {
+                                                        config?.columns[
+                                                            header.id
+                                                        ]?.aggregation
+                                                    }
+                                                </Badge>
+                                            )}
+                                            {/* TODO: do we need to check if it's a
+                                            placeholder? */}
+                                            {flexRender(
+                                                header.column.columnDef.header,
+                                                header.getContext(),
+                                            )}
+                                        </Group>
                                     </th>
                                 )),
                             )}

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -225,15 +225,34 @@ export const ContentPanel: FC = () => {
     }, [queryResults, activeEditorTab]);
 
     const showSqlResultsTable = useMemo(() => {
-        return !!(queryResults?.results && activeEditorTab === EditorTabs.SQL);
-    }, [queryResults, activeEditorTab]);
+        return !!(
+            (queryResults?.results && activeEditorTab === EditorTabs.SQL) ||
+            // if the chart is pivoted, show the sql results table
+            activeConfigs.chartConfigs.find((c) => c.type === selectedChartType)
+                ?.fieldConfig?.groupBy
+        );
+    }, [
+        queryResults,
+        activeEditorTab,
+        activeConfigs.chartConfigs,
+        selectedChartType,
+    ]);
 
     const showChartResultsTable = useMemo(() => {
         return !!(
             queryResults?.results &&
-            activeEditorTab === EditorTabs.VISUALIZATION
+            activeEditorTab === EditorTabs.VISUALIZATION &&
+            // if the chart is not pivoted, show the chart results table
+            !activeConfigs.chartConfigs.find(
+                (c) => c.type === selectedChartType,
+            )?.fieldConfig?.groupBy
         );
-    }, [queryResults, activeEditorTab]);
+    }, [
+        queryResults,
+        activeEditorTab,
+        activeConfigs.chartConfigs,
+        selectedChartType,
+    ]);
 
     return (
         <Stack

--- a/packages/frontend/src/features/sqlRunner/hooks/useChartResultsTableConfig.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useChartResultsTableConfig.tsx
@@ -1,0 +1,96 @@
+import {
+    ChartKind,
+    isVizTableConfig,
+    type PivotChartData,
+    type VizTableConfig,
+} from '@lightdash/common';
+import { useCallback, useState } from 'react';
+import { type selectChartConfigByKind } from '../../../components/DataViz/store/selectors';
+import { SqlRunnerResultsRunner } from '../runners/SqlRunnerResultsRunner';
+import { useAppSelector } from '../store/hooks';
+
+export const useChartResultsTableConfig = (
+    resultsRunner: SqlRunnerResultsRunner | undefined,
+    activeConfigs: {
+        chartConfigs: Exclude<
+            NonNullable<ReturnType<typeof selectChartConfigByKind>>,
+            VizTableConfig
+        >[];
+        tableConfig: VizTableConfig | undefined;
+    },
+) => {
+    const [tableConfigByChartType, setTableConfigByChartType] = useState<
+        | Record<ChartKind, Pick<VizTableConfig, 'columns'> | undefined>
+        | undefined
+    >();
+    const [resultsTableRunnerByChartType, setResultsTableRunnerByChartType] =
+        useState<
+            Record<ChartKind, SqlRunnerResultsRunner | undefined> | undefined
+        >();
+
+    const currentVisualizationType = useAppSelector((state) =>
+        state.sqlRunner.selectedChartType === ChartKind.TABLE
+            ? activeConfigs.tableConfig
+            : activeConfigs.chartConfigs.find(
+                  (c) => c.type === state.sqlRunner.selectedChartType,
+              ),
+    );
+
+    const handlePivotData = useCallback(
+        (chartType: ChartKind, pivotData: PivotChartData | undefined) => {
+            if (!pivotData) return;
+
+            setTableConfigByChartType((prev) => {
+                const config = currentVisualizationType;
+                if (config && !isVizTableConfig(config) && config.fieldConfig) {
+                    const newTableConfig = resultsRunner?.getResultsColumns(
+                        config.fieldConfig,
+                    );
+                    return {
+                        ...prev,
+                        [chartType]: newTableConfig,
+                    } as Record<
+                        ChartKind,
+                        Pick<VizTableConfig, 'columns'> | undefined
+                    >;
+                }
+                return prev;
+            });
+
+            setResultsTableRunnerByChartType((prev) => {
+                const config = currentVisualizationType;
+                if (config && !isVizTableConfig(config) && config.fieldConfig) {
+                    const newTableConfig = resultsRunner?.getResultsColumns(
+                        config.fieldConfig,
+                    );
+                    if (newTableConfig && pivotData.results) {
+                        const newResultsTableRunner =
+                            new SqlRunnerResultsRunner({
+                                rows: pivotData.results,
+                                columns: Object.values(
+                                    newTableConfig.columns,
+                                ).map((c) => ({
+                                    reference: c.reference,
+                                })),
+                            });
+                        return {
+                            ...prev,
+                            [chartType]: newResultsTableRunner,
+                        } as Record<
+                            ChartKind,
+                            SqlRunnerResultsRunner | undefined
+                        >;
+                    }
+                }
+                return prev;
+            });
+        },
+        [currentVisualizationType, resultsRunner],
+    );
+
+    return {
+        tableConfigByChartType,
+        resultsTableRunnerByChartType,
+        handlePivotData,
+    };
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useChartResultsTableConfig.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useChartResultsTableConfig.tsx
@@ -9,6 +9,13 @@ import { type selectChartConfigByKind } from '../../../components/DataViz/store/
 import { SqlRunnerResultsRunner } from '../runners/SqlRunnerResultsRunner';
 import { useAppSelector } from '../store/hooks';
 
+/**
+ * This hook is used to get the table config for the chart results table.
+ * When the pivot data is received, it is used to update the table config so that it matches what is configured/displayed in the chart.
+ * @param resultsRunner - The results runner for the chart.
+ * @param activeConfigs - The active configs in the SQL Runner.
+ * @returns {Object} { tableConfigByChartType, resultsTableRunnerByChartType, handlePivotData } - The table config for the chart results table + the results table runner for the chart results table + the function to handle the pivot data.
+ */
 export const useChartResultsTableConfig = (
     resultsRunner: SqlRunnerResultsRunner | undefined,
     activeConfigs: {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -124,9 +124,6 @@ export const sqlRunnerSlice = createSlice({
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
         },
-        setSqlLimit: (state, action: PayloadAction<number>) => {
-            state.limit = action.payload;
-        },
         setActiveEditorTab: (state, action: PayloadAction<EditorTabs>) => {
             state.activeEditorTab = action.payload;
             if (action.payload === EditorTabs.VISUALIZATION) {
@@ -179,7 +176,6 @@ export const {
     setSqlRunnerResults,
     updateName,
     setSql,
-    setSqlLimit,
     setActiveEditorTab,
     setSavedChartData,
     setSelectedChartType,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#11233](https://github.com/lightdash/lightdash/issues/11233)

### Description:

- Removed `limit` override in button
- Allows for charts to have their own `results` table 

> [!NOTE]
> Don't have the `Allow fine-tuning the limit on the visualization` - this will be in a separate PR

Demo: 


https://github.com/user-attachments/assets/4d11f70a-11ba-40e0-9698-0935a58213e9



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
