### PR TITLE
fix: clarify threshold alerts errors when it doesn't have enough results

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -18,6 +18,14 @@ describe('isPositiveThresholdAlert', () => {
             SchedulerTask.isPositiveThresholdAlert([], resultsWithOneRow),
         ).toBe(false);
     });
+    it('should throw error if there are no results', () => {
+        expect(() =>
+            SchedulerTask.isPositiveThresholdAlert(
+                [thresholdIncreasedByMock],
+                [],
+            ),
+        ).toThrowError(NotEnoughResults);
+    });
     it('should throw error if operation requires second row but there isnt one', () => {
         expect(() =>
             SchedulerTask.isPositiveThresholdAlert(

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -18,14 +18,6 @@ describe('isPositiveThresholdAlert', () => {
             SchedulerTask.isPositiveThresholdAlert([], resultsWithOneRow),
         ).toBe(false);
     });
-    it('should throw error if there are no results', () => {
-        expect(() =>
-            SchedulerTask.isPositiveThresholdAlert(
-                [thresholdIncreasedByMock],
-                [],
-            ),
-        ).toThrowError(NotEnoughResults);
-    });
     it('should throw error if operation requires second row but there isnt one', () => {
         expect(() =>
             SchedulerTask.isPositiveThresholdAlert(

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1297,9 +1297,15 @@ export default class SchedulerTask {
 
         const getValue = (resultIdx: number) => {
             if (resultIdx >= results.length) {
-                throw new NotEnoughResults(
-                    `Threshold alert error: Can't find enough results`,
-                );
+                if (results.length === 1) {
+                    throw new NotEnoughResults(
+                        `Threshold alert error: Query returned only 1 row, but more rows are required to evaluate the threshold.`,
+                    );
+                } else {
+                    throw new NotEnoughResults(
+                        `Threshold alert error: Insufficient results returned by query. Expected more than ${resultIdx + 1} rows.`,
+                    );
+                }
             }
             const result = results[resultIdx];
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1297,24 +1297,16 @@ export default class SchedulerTask {
         const { fieldId, operator, value: thresholdValue } = thresholds[0];
 
         const getValue = (resultIdx: number) => {
-            // Case 1: No rows available (resultIdx === 0)
-            if (resultIdx === 0 && results.length === 0) {
+            if (results.length === 0) {
                 throw new NotEnoughResults(
-                    `Threshold alert error: Query returned no rows, but at least one row is required.`,
-                );
-            }
-
-            // Case 2: One row available but increase/decrease comparison needs two rows
-            if (resultIdx === 1 && results.length === 1) {
-                throw new NotEnoughResults(
-                    `Threshold alert error: Query returned only 1 row, but 2 rows are needed for increase/decrease comparison.`,
+                    `Threshold alert error: Query returned no rows.`,
                 );
             }
 
             // If we are trying to access beyond available rows, throw a general error
             if (resultIdx >= results.length) {
                 throw new NotEnoughResults(
-                    `Threshold alert error: Can't find enough results for threshold evaluation.`,
+                    `Threshold alert error: Expected at least ${resultIdx} rows, but only ${results.length} row(s) were returned.`,
                 );
             }
 


### PR DESCRIPTION
Closes: #11229 

### Description:
This PR improves error messaging for threshold alerts when queries return insufficient results. It explicitly distinguishes between cases where the query returns zero rows or just one row (when more are required). This helps users understand why an alert failed and guides them to adjust their queries accordingly.

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
