### PR TITLE
feat: track views sql runner chart

### DIFF
--- a/packages/backend/src/database/entities/analytics.ts
+++ b/packages/backend/src/database/entities/analytics.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 
 export const AnalyticsChartViewsTableName = 'analytics_chart_views';
 export const AnalyticsDashboardViewsTableName = 'analytics_dashboard_views';
+export const AnalyticsSqlChartViewsTableName = 'analytics_sql_chart_views';
 
 export type DbAnalyticsChartViews = {
     chart_uuid: string;

--- a/packages/backend/src/database/entities/savedSql.ts
+++ b/packages/backend/src/database/entities/savedSql.ts
@@ -20,6 +20,7 @@ export type DbSavedSql = {
     slug: string;
     views_count: number;
     first_viewed_at: Date | null;
+    last_viewed_at: Date | null;
 };
 
 type InsertSqlBase = Pick<

--- a/packages/backend/src/database/migrations/20240829112616_add_last_viewed_sql_chart.ts
+++ b/packages/backend/src/database/migrations/20240829112616_add_last_viewed_sql_chart.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const SAVED_SQL_TABLE_NAME = 'saved_sql';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SAVED_SQL_TABLE_NAME, (table) => {
+        table.timestamp('last_viewed_at').defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SAVED_SQL_TABLE_NAME, 'last_viewed_at')) {
+        await knex.schema.alterTable(SAVED_SQL_TABLE_NAME, (table) => {
+            table.dropColumn('last_viewed_at');
+        });
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6985,6 +6985,9 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                lastViewedAt: { dataType: 'datetime', required: true },
+                firstViewedAt: { dataType: 'datetime', required: true },
+                views: { dataType: 'double', required: true },
                 organization: {
                     ref: 'Pick_Organization.organizationUuid_',
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7655,6 +7655,18 @@
             },
             "SqlChart": {
                 "properties": {
+                    "lastViewedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "firstViewedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "organization": {
                         "$ref": "#/components/schemas/Pick_Organization.organizationUuid_"
                     },
@@ -7741,6 +7753,9 @@
                     }
                 },
                 "required": [
+                    "lastViewedAt",
+                    "firstViewedAt",
+                    "views",
                     "organization",
                     "project",
                     "dashboard",
@@ -9474,7 +9489,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1231.0",
+        "version": "0.1232.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -91,6 +91,30 @@ export class AnalyticsModel {
         });
     }
 
+    async addSqlChartViewEvent(
+        sqlChartUuid: string,
+        userUuid: string,
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            // TODO add sql views table for tracking user views
+            /*  await trx(AnalyticsSqlChartViewsTableName).insert({
+                chart_uuid: chartUuid,
+                user_uuid: userUuid,
+            }); */
+            await trx(`saved_sql`)
+                .update({
+                    // @ts-expect-error knex types don't support raw queries
+                    views_count: trx.raw('views_count + 1'),
+                    // @ts-expect-error knex types don't support raw queries
+                    first_viewed_at: trx.raw(
+                        'COALESCE(first_viewed_at, NOW())',
+                    ), // update first_viewed_at if it is null
+                    last_viewed_at: trx.raw('NOW()'),
+                })
+                .where('saved_sql_uuid', sqlChartUuid);
+        });
+    }
+
     async countDashboardViews(dashboardUuid: string): Promise<number> {
         const [{ count }] = await this.database(
             AnalyticsDashboardViewsTableName,

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -32,6 +32,9 @@ type SelectSavedSql = Pick<
     | 'dashboard_uuid'
     | 'created_at'
     | 'last_version_updated_at'
+    | 'views_count'
+    | 'first_viewed_at'
+    | 'last_viewed_at'
 > &
     Pick<DbSavedSqlVersion, 'sql' | 'limit' | 'config' | 'chart_kind'> &
     Pick<DbSpace, 'space_uuid'> &
@@ -106,6 +109,9 @@ export class SavedSqlModel {
             organization: {
                 organizationUuid: row.organization_uuid,
             },
+            views: row.views_count,
+            firstViewedAt: row.first_viewed_at || new Date(),
+            lastViewedAt: row.last_viewed_at || new Date(),
         };
     }
 
@@ -166,6 +172,9 @@ export class SavedSqlModel {
                 `${SavedSqlTableName}.created_at`,
                 `${SavedSqlTableName}.slug`,
                 `${SavedSqlTableName}.last_version_updated_at`,
+                `${SavedSqlTableName}.views_count`,
+                `${SavedSqlTableName}.first_viewed_at`,
+                `${SavedSqlTableName}.last_viewed_at`,
                 `${DashboardsTableName}.name as dashboardName`,
                 `${SavedSqlVersionsTableName}.sql`,
                 `${SavedSqlVersionsTableName}.limit`,

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -23,6 +23,7 @@ import {
     LightdashAnalytics,
     QueryExecutionContext,
 } from '../../analytics/LightdashAnalytics';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -37,6 +38,7 @@ type SavedSqlServiceArguments = {
     spaceModel: SpaceModel;
     savedSqlModel: SavedSqlModel;
     schedulerClient: SchedulerClient;
+    analyticsModel: AnalyticsModel;
 };
 
 // TODO: Rename to SqlRunnerService
@@ -52,6 +54,8 @@ export class SavedSqlService extends BaseService {
 
     private readonly schedulerClient: SchedulerClient;
 
+    private readonly analyticsModel: AnalyticsModel;
+
     constructor(args: SavedSqlServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -59,6 +63,7 @@ export class SavedSqlService extends BaseService {
         this.spaceModel = args.spaceModel;
         this.savedSqlModel = args.savedSqlModel;
         this.schedulerClient = args.schedulerClient;
+        this.analyticsModel = args.analyticsModel;
     }
 
     static getCreateVersionEventProperties(
@@ -465,6 +470,10 @@ export class SavedSqlService extends BaseService {
             context: QueryExecutionContext.SQL_CHART,
         });
 
+        await this.analyticsModel.addSqlChartViewEvent(
+            savedChart.savedSqlUuid,
+            user.userUuid,
+        );
         return {
             jobId,
         };

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -647,6 +647,7 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
                     schedulerClient: this.clients.getSchedulerClient(),
+                    analyticsModel: this.models.getAnalyticsModel(),
                 }),
         );
     }

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -134,6 +134,9 @@ export type SqlChart = {
     dashboard: Pick<Dashboard, 'uuid' | 'name'> | null;
     project: Pick<Project, 'projectUuid'>;
     organization: Pick<Organization, 'organizationUuid'>;
+    views: number;
+    firstViewedAt: Date;
+    lastViewedAt: Date;
 };
 
 export type CreateSqlChart = {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -95,8 +95,8 @@ export const HeaderEdit: FC = () => {
                                 description={
                                     savedSqlChart.description ?? undefined
                                 }
-                                viewStats={1} // todo: update endpoint to return view stats
-                                firstViewedAt={undefined}
+                                viewStats={savedSqlChart.views}
+                                firstViewedAt={savedSqlChart.firstViewedAt}
                                 withChartData={false}
                             />
                         </Group>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -83,8 +83,8 @@ export const HeaderView: FC = () => {
                                 description={
                                     savedSqlChart.description ?? undefined
                                 }
-                                viewStats={1} // todo: update endpoint to return view stats
-                                firstViewedAt={undefined}
+                                viewStats={savedSqlChart.views}
+                                firstViewedAt={savedSqlChart.firstViewedAt}
                                 withChartData={false}
                             />
                         </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/10829
### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Track when a user views an SQL chart and when the first view was.

- [x] update `views_count` column value
- [x] update `first_viewed_at` column value
- [x] show view count and first viewed at info in space page
- [x] add `last_viewed_at` column to saved_sql table
- [x] update SqlChart type to return the views, first_viewed_at, last_viewed_at

![Screenshot from 2024-08-29 14-01-11](https://github.com/user-attachments/assets/90bd9c8e-3f40-4bbb-bfed-a429c9733b59)
![Screenshot from 2024-08-29 13-49-21](https://github.com/user-attachments/assets/e4e40774-e4c6-4bb2-8a63-677b41c3a405)


### Out of scope
Track user views on separatate table for usage analytics 

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
