### PR TITLE
fix: non-bar charts not showing on edit

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -147,6 +147,7 @@ export const sqlRunnerSlice = createSlice({
             state.limit = action.payload.limit || 500;
             state.selectedChartType =
                 action.payload.config.type || ChartKind.VERTICAL_BAR;
+            state.activeConfigs.push(action.payload.config.type);
         },
         setSelectedChartType: (state, action: PayloadAction<ChartKind>) => {
             state.selectedChartType = action.payload;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11294 

### Description:

Non-bar charts were not showing during editing. This adds the save chart type to the active chart types. 

Before:
![piebefore](https://github.com/user-attachments/assets/e9210e06-2df5-4466-a33d-7dabd0778e83)

After:
![Kapture 2024-08-29 at 16 09 39](https://github.com/user-attachments/assets/72bf88ff-d35d-410b-8383-e266994a4232)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
