### PR TITLE
perf: only trigger query when config.type/config.fieldConfig changes

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -20,6 +20,7 @@ export class CartesianChartDataModel
         IChartDataModel<
             VizCartesianChartOptions,
             VizCartesianChartConfig,
+            CartesianChartDisplay,
             CartesianChartKind
         >
 {

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -25,16 +25,16 @@ export class CartesianChartDataModel
 {
     private readonly resultsRunner: IResultsRunner<VizChartLayout>;
 
-    private readonly config: VizCartesianChartConfig | undefined;
+    private readonly fieldConfig: VizCartesianChartConfig['fieldConfig'];
 
     private colorMap: Map<string, string>;
 
     constructor(args: {
         resultsRunner: IResultsRunner<VizChartLayout>;
-        config: VizCartesianChartConfig | undefined;
+        fieldConfig: VizCartesianChartConfig['fieldConfig'];
     }) {
         this.resultsRunner = args.resultsRunner;
-        this.config = args.config;
+        this.fieldConfig = args.fieldConfig;
 
         this.colorMap = new Map();
     }
@@ -80,16 +80,19 @@ export class CartesianChartDataModel
         return undefined;
     }
 
-    mergeConfig(chartKind: CartesianChartKind): VizCartesianChartConfig {
+    mergeConfig(
+        chartKind: CartesianChartKind,
+        display: CartesianChartDisplay | undefined,
+    ): VizCartesianChartConfig {
         return {
             metadata: {
                 version: 1,
             },
             type: chartKind,
             fieldConfig: this.resultsRunner.mergePivotChartLayout(
-                this.config?.fieldConfig,
+                this.fieldConfig,
             ),
-            display: this.config?.display,
+            display,
         };
     }
 

--- a/packages/common/src/visualizations/PieChartDataModel.ts
+++ b/packages/common/src/visualizations/PieChartDataModel.ts
@@ -11,30 +11,38 @@ import { type IResultsRunner } from './types/IResultsRunner';
 
 export class PieChartDataModel
     implements
-        IChartDataModel<VizPieChartOptions, VizPieChartConfig, ChartKind.PIE>
+        IChartDataModel<
+            VizPieChartOptions,
+            VizPieChartConfig,
+            VizPieChartDisplay,
+            ChartKind.PIE
+        >
 {
     private readonly resultsRunner: IResultsRunner<VizChartLayout>;
 
-    private readonly config: VizPieChartConfig | undefined;
+    private readonly fieldConfig: VizPieChartConfig['fieldConfig'];
 
     constructor(args: {
         resultsRunner: IResultsRunner<VizChartLayout>;
-        config: VizPieChartConfig | undefined;
+        fieldConfig: VizPieChartConfig['fieldConfig'] | undefined;
     }) {
         this.resultsRunner = args.resultsRunner;
-        this.config = args.config;
+        this.fieldConfig = args.fieldConfig;
     }
 
-    mergeConfig(chartKind: ChartKind.PIE): VizPieChartConfig {
+    mergeConfig(
+        chartKind: ChartKind.PIE,
+        display: VizPieChartDisplay | undefined,
+    ): VizPieChartConfig {
         return {
             metadata: {
                 version: 1,
             },
             type: chartKind,
             fieldConfig: this.resultsRunner.mergePivotChartLayout(
-                this.config?.fieldConfig,
+                this.fieldConfig,
             ),
-            display: this.config?.display,
+            display,
         };
     }
 

--- a/packages/common/src/visualizations/TableDataModel.ts
+++ b/packages/common/src/visualizations/TableDataModel.ts
@@ -9,7 +9,12 @@ import type { IResultsRunner } from './types/IResultsRunner';
 
 export class TableDataModel
     implements
-        IChartDataModel<VizTableOptions, VizTableConfig, ChartKind.TABLE>
+        IChartDataModel<
+            VizTableOptions,
+            VizTableConfig,
+            undefined,
+            ChartKind.TABLE
+        >
 {
     private readonly resultsRunner: IResultsRunner<VizChartLayout>;
 

--- a/packages/common/src/visualizations/types/IChartDataModel.ts
+++ b/packages/common/src/visualizations/types/IChartDataModel.ts
@@ -3,9 +3,10 @@ import { type ChartKind } from '../../types/savedCharts';
 export interface IChartDataModel<
     TVizChartOptions,
     TVizChartConfig,
+    TVizChartDisplay,
     T extends ChartKind,
 > {
     getResultOptions(): TVizChartOptions;
 
-    mergeConfig(chartKind: T, currentConfig?: TVizChartConfig): TVizChartConfig;
+    mergeConfig(chartKind: T, display?: TVizChartDisplay): TVizChartConfig;
 }

--- a/packages/frontend/src/components/DataViz/transformers/getChartConfigAndOptions.ts
+++ b/packages/frontend/src/components/DataViz/transformers/getChartConfigAndOptions.ts
@@ -24,13 +24,16 @@ const getChartConfigAndOptions = (
 
             const pieChartDataModel = new PieChartDataModel({
                 resultsRunner,
-                config: currentVizConfig,
+                fieldConfig: currentVizConfig?.fieldConfig,
             });
 
             return {
                 type: chartType,
                 options: pieChartDataModel.getResultOptions(),
-                config: pieChartDataModel.mergeConfig(chartType),
+                config: pieChartDataModel.mergeConfig(
+                    chartType,
+                    currentVizConfig?.display,
+                ),
             } as const;
         case ChartKind.TABLE:
             if (currentVizConfig && !isVizTableConfig(currentVizConfig)) {
@@ -53,13 +56,16 @@ const getChartConfigAndOptions = (
 
             const barChartModel = new CartesianChartDataModel({
                 resultsRunner,
-                config: currentVizConfig,
+                fieldConfig: currentVizConfig?.fieldConfig,
             });
 
             return {
                 type: chartType,
                 options: barChartModel.getResultOptions(),
-                config: barChartModel.mergeConfig(chartType),
+                config: barChartModel.mergeConfig(
+                    chartType,
+                    currentVizConfig?.display,
+                ),
             } as const;
 
         case ChartKind.LINE:
@@ -69,13 +75,16 @@ const getChartConfigAndOptions = (
 
             const lineChartModel = new CartesianChartDataModel({
                 resultsRunner,
-                config: currentVizConfig,
+                fieldConfig: currentVizConfig?.fieldConfig,
             });
 
             return {
                 type: chartType,
                 options: lineChartModel.getResultOptions(),
-                config: lineChartModel.mergeConfig(chartType),
+                config: lineChartModel.mergeConfig(
+                    chartType,
+                    currentVizConfig?.display,
+                ),
             } as const;
         default:
             throw new Error(`Not implemented for chart type: ${chartType}`);

--- a/packages/frontend/src/components/DataViz/transformers/useChart.ts
+++ b/packages/frontend/src/components/DataViz/transformers/useChart.ts
@@ -31,7 +31,10 @@ export const useChart = <T extends ResultsRunner>({
 }) => {
     const chartTransformer = useMemo(() => {
         if (config?.type === ChartKind.PIE) {
-            return new PieChartDataModel({ resultsRunner, config });
+            return new PieChartDataModel({
+                resultsRunner,
+                fieldConfig: config?.fieldConfig,
+            });
         }
         if (
             config?.type === ChartKind.VERTICAL_BAR ||
@@ -39,10 +42,10 @@ export const useChart = <T extends ResultsRunner>({
         ) {
             return new CartesianChartDataModel({
                 resultsRunner,
-                config,
+                fieldConfig: config.fieldConfig,
             });
         }
-    }, [resultsRunner, config]);
+    }, [resultsRunner, config?.fieldConfig, config?.type]);
 
     const getTransformedData = useCallback(
         async () =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

`...DataModel`s should have a `fieldConfig` in the constructor but no `display`. the `display` should be passed to the `mergeConfig` so that we don't trigger a new query every time it changes.



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
