### PR TITLE
fix: viewers+ can view sql runner charts 

### DIFF
--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -11,7 +11,6 @@ import {
     CreateSqlChart,
     SqlRunnerBody,
     SqlRunnerPivotQueryBody,
-    SqlRunnerPivotQueryPayload,
     UpdateSqlChart,
 } from '@lightdash/common';
 import {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6546,6 +6546,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                uuid: { dataType: 'string' },
+                slug: { dataType: 'string' },
                 limit: { dataType: 'double' },
                 sql: { dataType: 'string', required: true },
             },
@@ -7114,27 +7116,93 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizBarChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'VizBaseConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartDisplay' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'VizChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: { ref: 'ChartKind.VERTICAL_BAR', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizLineChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'VizBaseConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CartesianChartDisplay' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'VizChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: { ref: 'ChartKind.LINE', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'VizBarChartConfig' },
+                { ref: 'VizLineChartConfig' },
+                { ref: 'VizPieChartConfig' },
+                { ref: 'VizTableConfig' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateSqlChart: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 spaceUuid: { dataType: 'string', required: true },
-                config: {
-                    dataType: 'intersection',
-                    subSchemas: [
-                        { ref: 'VizBaseConfig' },
-                        {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'VizCartesianChartConfig' },
-                                { ref: 'VizPieChartConfig' },
-                                { ref: 'VizTableConfig' },
-                            ],
-                        },
-                    ],
-                    required: true,
-                },
+                config: { ref: 'VizChartConfig', required: true },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
                 description: {
@@ -7202,21 +7270,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                config: {
-                    dataType: 'intersection',
-                    subSchemas: [
-                        { ref: 'VizBaseConfig' },
-                        {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'VizCartesianChartConfig' },
-                                { ref: 'VizPieChartConfig' },
-                                { ref: 'VizTableConfig' },
-                            ],
-                        },
-                    ],
-                    required: true,
-                },
+                config: { ref: 'VizChartConfig', required: true },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7280,6 +7280,12 @@
             },
             "SqlRunnerBody": {
                 "properties": {
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
                     "limit": {
                         "type": "number",
                         "format": "double"
@@ -7852,30 +7858,73 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "VizBarChartConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBaseConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/CartesianChartDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/VizChartLayout"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "VizLineChartConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBaseConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/CartesianChartDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/VizChartLayout"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.LINE"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "VizChartConfig": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBarChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizLineChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizPieChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizTableConfig"
+                    }
+                ]
+            },
             "CreateSqlChart": {
                 "properties": {
                     "spaceUuid": {
                         "type": "string"
                     },
                     "config": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/VizBaseConfig"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/VizCartesianChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizPieChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizTableConfig"
-                                    }
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/VizChartConfig"
                     },
                     "limit": {
                         "type": "number",
@@ -7945,24 +7994,7 @@
             "UpdateVersionedSqlChart": {
                 "properties": {
                     "config": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/VizBaseConfig"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/VizCartesianChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizPieChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizTableConfig"
-                                    }
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/VizChartConfig"
                     },
                     "limit": {
                         "type": "number",
@@ -9506,7 +9538,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1234.0",
+        "version": "0.1236.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -174,6 +174,7 @@ export class SavedSqlService extends BaseService {
         }
         const { hasAccess: hasViewAccess, userAccess } =
             await this.hasSavedChartAccess(user, 'view', savedChart);
+
         if (!hasViewAccess) {
             throw new ForbiddenError("You don't have access to this chart");
         }
@@ -418,7 +419,35 @@ export class SavedSqlService extends BaseService {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
-        if (
+
+        // If it's a saved chart, check if the user has access to it
+        if (body.slug || body.uuid) {
+            let savedChart;
+            if (body.uuid) {
+                savedChart = await this.savedSqlModel.getByUuid(body.uuid, {
+                    projectUuid,
+                });
+            } else if (body.slug) {
+                savedChart = await this.savedSqlModel.getBySlug(
+                    projectUuid,
+                    body.slug,
+                );
+            }
+
+            if (!savedChart) {
+                throw new Error('Chart not found');
+            }
+
+            const { hasAccess: hasViewAccess } = await this.hasSavedChartAccess(
+                user,
+                'view',
+                savedChart,
+            );
+            if (!hasViewAccess) {
+                throw new ForbiddenError("You don't have access to this chart");
+            }
+        } else if (
+            // If it's not a saved chart, check if the user has access to run a pivot query
             user.ability.cannot('create', 'Job') ||
             user.ability.cannot(
                 'manage',

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -45,6 +45,8 @@ export type SqlRunnerPivotQueryPayload = SqlRunnerPayload &
 export type SqlRunnerBody = {
     sql: string;
     limit?: number;
+    slug?: string;
+    uuid?: string;
 };
 
 export type SqlRunnerPivotQueryBody = SqlRunnerBody &

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -102,15 +102,20 @@ export class CartesianChartDataModel
         sql?: string,
         projectUuid?: string,
         limit?: number,
+        slug?: string,
+        uuid?: string,
     ) {
         if (!layout) {
             return undefined;
         }
+
         return this.resultsRunner.getPivotChartData(
             layout,
             sql,
             projectUuid,
             limit,
+            slug,
+            uuid,
         );
     }
 

--- a/packages/common/src/visualizations/types/IResultsRunner.ts
+++ b/packages/common/src/visualizations/types/IResultsRunner.ts
@@ -8,6 +8,8 @@ export interface IResultsRunner<TPivotChartLayout> {
         sql?: string,
         projectUuid?: string,
         limit?: number,
+        slug?: string,
+        uuid?: string,
     ): Promise<PivotChartData>;
 
     defaultPivotChartLayout(): TPivotChartLayout | undefined;

--- a/packages/frontend/src/components/DataViz/transformers/useChart.ts
+++ b/packages/frontend/src/components/DataViz/transformers/useChart.ts
@@ -20,6 +20,8 @@ export const useChart = <T extends ResultsRunner>({
     limit,
     orgColors,
     onPivot,
+    slug,
+    uuid,
 }: {
     config?: VizCartesianChartConfig | VizPieChartConfig;
     resultsRunner: T;
@@ -28,6 +30,8 @@ export const useChart = <T extends ResultsRunner>({
     limit?: number;
     orgColors?: string[];
     onPivot?: (pivotData: PivotChartData) => void;
+    slug?: string;
+    uuid?: string;
 }) => {
     const chartTransformer = useMemo(() => {
         if (config?.type === ChartKind.PIE) {
@@ -51,6 +55,8 @@ export const useChart = <T extends ResultsRunner>({
                 sql,
                 projectUuid,
                 limit,
+                slug,
+                uuid,
             ),
         // TODO: FIX THIS ISSUE - it should include the SQL, but the sql shouldn't change on change, but on run query
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -23,6 +23,8 @@ type ChartViewProps<T extends ResultsRunner> = {
     projectUuid?: string;
     limit?: number;
     onPivot?: (pivotData: PivotChartData | undefined) => void;
+    slug?: string;
+    uuid?: string;
 } & Partial<Pick<EChartsReactProps, 'style'>>;
 
 const ChartView = memo(
@@ -36,6 +38,8 @@ const ChartView = memo(
         resultsRunner,
         style,
         onPivot,
+        slug,
+        uuid,
     }: ChartViewProps<T>) => {
         const { data: org } = useOrganization();
 
@@ -51,6 +55,8 @@ const ChartView = memo(
             limit,
             orgColors: org?.chartColors,
             onPivot,
+            slug,
+            uuid,
         });
 
         if (!config?.fieldConfig?.x || config?.fieldConfig.y.length === 0) {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -96,33 +96,33 @@ export const HeaderView: FC = () => {
                                 label="Edit chart"
                                 position="bottom"
                             >
-                                <ActionIcon size="xs">
-                                    <MantineIcon
-                                        icon={IconPencil}
-                                        onClick={() =>
-                                            history.push(
-                                                `/projects/${projectUuid}/sql-runner/${savedSqlChart.slug}/edit`,
-                                            )
-                                        }
-                                    />
+                                <ActionIcon
+                                    size="xs"
+                                    onClick={() =>
+                                        history.push(
+                                            `/projects/${projectUuid}/sql-runner/${savedSqlChart.slug}/edit`,
+                                        )
+                                    }
+                                >
+                                    <MantineIcon icon={IconPencil} />
                                 </ActionIcon>
                             </Tooltip>
                         )}
-                        {canManageChart && (
+                        {canManageSqlRunner && canManageChart && (
                             <Tooltip
                                 variant="xs"
                                 label="Delete"
                                 position="bottom"
                             >
-                                <ActionIcon size="xs">
-                                    <MantineIcon
-                                        icon={IconTrash}
-                                        onClick={() =>
-                                            dispatch(
-                                                toggleModal('deleteChartModal'),
-                                            )
-                                        }
-                                    />
+                                <ActionIcon
+                                    size="xs"
+                                    onClick={() =>
+                                        dispatch(
+                                            toggleModal('deleteChartModal'),
+                                        )
+                                    }
+                                >
+                                    <MantineIcon icon={IconTrash} />
                                 </ActionIcon>
                             </Tooltip>
                         )}

--- a/packages/frontend/src/features/sqlRunner/runners/SqlRunnerResultsRunner.ts
+++ b/packages/frontend/src/features/sqlRunner/runners/SqlRunnerResultsRunner.ts
@@ -70,6 +70,8 @@ export class SqlRunnerResultsRunner extends ResultsRunner {
         sql: string,
         projectUuid: string,
         limit: number,
+        slug?: string,
+        uuid?: string,
     ): Promise<PivotChartData> {
         if (config.x === undefined || config.y.length === 0) {
             return {
@@ -80,6 +82,8 @@ export class SqlRunnerResultsRunner extends ResultsRunner {
         }
         const pivotResults = await pivotQueryFn({
             projectUuid,
+            slug,
+            uuid,
             sql,
             indexColumn: {
                 reference: config.x.reference,

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -166,7 +166,8 @@ const ViewSqlChart = () => {
                                             />
                                         )}
                                         {!isVizTableConfig(currentVisConfig) &&
-                                            data && (
+                                            data &&
+                                            params.slug && (
                                                 <ChartView
                                                     resultsRunner={
                                                         resultsRunner
@@ -179,6 +180,7 @@ const ViewSqlChart = () => {
                                                     }}
                                                     sql={sql}
                                                     projectUuid={projectUuid}
+                                                    slug={params.slug}
                                                 />
                                             )}
                                     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

### interactive viewer

Can view saved sql charts:
<img width="1915" alt="Screenshot 2024-08-29 at 18 31 08" src="https://github.com/user-attachments/assets/ae2c1be0-d704-4238-8759-37913014d42c">

Cannot edit saved sql chart in dashboard:
<img width="583" alt="Screenshot 2024-08-29 at 18 31 00" src="https://github.com/user-attachments/assets/d01ae073-f400-4b3e-a6aa-ab27ce55a95d">


### sql runner manager

Can view saved sql charts:
<img width="567" alt="Screenshot 2024-08-29 at 18 32 01" src="https://github.com/user-attachments/assets/f4326459-44a8-4729-a3bd-2eb98b6313d7">

Cannot edit saved sql chart in dashboard:
<img width="1250" alt="Screenshot 2024-08-29 at 18 31 50" src="https://github.com/user-attachments/assets/5407c679-eb09-4a25-9770-d85860d46b4b">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
