### PR TITLE
feat: allow fine tuning query limits for non-table visualizations

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -49,7 +49,7 @@ import {
 import { SqlEditor, type MonacoHighlightChar } from './SqlEditor';
 
 const MIN_RESULTS_HEIGHT = 10;
-const DEFAULT_LIMIT = 500;
+const DEFAULT_SQL_LIMIT = 500;
 
 export const ContentPanel: FC = () => {
     const dispatch = useAppDispatch();
@@ -133,7 +133,7 @@ export const ContentPanel: FC = () => {
         if (!sql) return;
         const newQueryResults = await runSqlQuery({
             sql,
-            limit: DEFAULT_LIMIT,
+            limit: DEFAULT_SQL_LIMIT,
         });
 
         setQueryResults(newQueryResults);
@@ -219,7 +219,7 @@ export const ContentPanel: FC = () => {
         return (
             queryResults?.results &&
             activeEditorTab === EditorTabs.SQL &&
-            queryResults.results.length >= DEFAULT_LIMIT
+            queryResults.results.length >= DEFAULT_SQL_LIMIT
         );
     }, [queryResults, activeEditorTab]);
 
@@ -529,7 +529,7 @@ export const ContentPanel: FC = () => {
                             {showLimitText && (
                                 <Group position="center">
                                     <Text fz="sm" fw={500}>
-                                        Showing first {DEFAULT_LIMIT} rows
+                                        Showing first {DEFAULT_SQL_LIMIT} rows
                                     </Text>
                                 </Group>
                             )}

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -220,7 +220,7 @@ export const ContentPanel: FC = () => {
         return (
             queryResults?.results &&
             activeEditorTab === EditorTabs.SQL &&
-            queryResults.results.length > 500
+            queryResults.results.length >= 500
         );
     }, [queryResults, activeEditorTab]);
 

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -126,6 +126,9 @@ export const sqlRunnerSlice = createSlice({
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
         },
+        setSqlLimit: (state, action: PayloadAction<number>) => {
+            state.limit = action.payload;
+        },
         setActiveEditorTab: (state, action: PayloadAction<EditorTabs>) => {
             state.activeEditorTab = action.payload;
             if (action.payload === EditorTabs.VISUALIZATION) {
@@ -182,6 +185,7 @@ export const {
     setSqlRunnerResults,
     updateName,
     setSql,
+    setSqlLimit,
     setActiveEditorTab,
     setSavedChartData,
     setSelectedChartType,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11305](https://github.com/lightdash/lightdash/issues/11305)

### Description:

Allows setting sql limit for visualizations. This will be shared across all visualizations **except tables** because the main sql query results will remain the same. 

demo:

https://github.com/user-attachments/assets/9be3b34a-5914-4681-b3b6-818246dd86f8



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
