### PR TITLE
fix: display error message if failed

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -692,6 +692,12 @@ export type ApiError = {
     error: ApiErrorDetail;
 };
 
+export const isApiError = (error: unknown): error is ApiError =>
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    error.status === 'error';
+
 export enum LightdashMode {
     DEFAULT = 'default',
     DEMO = 'demo',

--- a/packages/frontend/src/components/DataViz/transformers/useChart.ts
+++ b/packages/frontend/src/components/DataViz/transformers/useChart.ts
@@ -1,6 +1,7 @@
 import {
     CartesianChartDataModel,
     ChartKind,
+    isApiError,
     isVizCartesianChartConfig,
     isVizPieChartConfig,
     PieChartDataModel,
@@ -66,12 +67,19 @@ export const useChart = <T extends ResultsRunner>({
         [chartTransformer, config?.fieldConfig, projectUuid, limit],
     );
 
-    const transformedData = useAsync(async () => {
-        const data = await getTransformedData();
-        if (onPivot && data) {
-            onPivot(data);
+    const transformedData = useAsync<typeof getTransformedData>(async () => {
+        try {
+            const data = await getTransformedData();
+            if (onPivot && data) {
+                onPivot(data);
+            }
+            return data;
+        } catch (error) {
+            if (isApiError(error)) {
+                throw error.error;
+            }
+            throw error;
         }
-        return data;
     }, [getTransformedData]);
 
     const chartSpec = useMemo(() => {

--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -60,8 +60,6 @@ const ChartView = memo(
             uuid,
         });
 
-        console.log({ error });
-
         if (!config?.fieldConfig?.x || config?.fieldConfig.y.length === 0) {
             return (
                 <SuboptimalState

--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -1,4 +1,5 @@
 import {
+    isApiError,
     type PivotChartData,
     type VizCartesianChartConfig,
     type VizPieChartConfig,
@@ -59,6 +60,8 @@ const ChartView = memo(
             uuid,
         });
 
+        console.log({ error });
+
         if (!config?.fieldConfig?.x || config?.fieldConfig.y.length === 0) {
             return (
                 <SuboptimalState
@@ -75,11 +78,9 @@ const ChartView = memo(
         }
         const loading = isLoadingProp || transformLoading;
 
-        // TODO: this could be more robust
-        const errorMessage = error?.message?.includes('Binder Error')
-            ? 'Some specified columns do not exist in the data'
+        const errorMessage = isApiError(error)
+            ? error.error.message
             : error?.message;
-
         if (error && !loading) {
             return (
                 <SuboptimalState

--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -1,5 +1,4 @@
 import {
-    isApiError,
     type PivotChartData,
     type VizCartesianChartConfig,
     type VizPieChartConfig,
@@ -76,14 +75,11 @@ const ChartView = memo(
         }
         const loading = isLoadingProp || transformLoading;
 
-        const errorMessage = isApiError(error)
-            ? error.error.message
-            : error?.message;
         if (error && !loading) {
             return (
                 <SuboptimalState
                     title="Error generating chart"
-                    description={errorMessage}
+                    description={error.message}
                     icon={IconAlertCircle}
                     mt="xl"
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Now that we get the pivot results through an API endpoint, we should get the error's `message` correctly to display under the `ChartView` `SuboptimalState`

How to test: 

- Select * any table
- Run query
- Select * another table
- See error states in chart configuration + `error generating chart` with a description from the Api error.

Similar screenshot:

<img width="872" alt="Screenshot 2024-09-02 at 10 13 19" src="https://github.com/user-attachments/assets/844073e5-a77a-4a9b-90c4-b4ce3311b478">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
