### PR TITLE
chore: remove first aggregation option

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6557,7 +6557,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VizAggregationOptions: {
         dataType: 'refEnum',
-        enums: ['sum', 'count', 'avg', 'min', 'max', 'first'],
+        enums: ['sum', 'count', 'avg', 'min', 'max'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiSqlRunnerPivotQueryPayload: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7298,7 +7298,7 @@
                 "type": "object"
             },
             "VizAggregationOptions": {
-                "enum": ["sum", "count", "avg", "min", "max", "first"],
+                "enum": ["sum", "count", "avg", "min", "max"],
                 "type": "string"
             },
             "ApiSqlRunnerPivotQueryPayload": {

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -9,7 +9,6 @@ export enum VizAggregationOptions {
     AVERAGE = 'avg',
     MIN = 'min',
     MAX = 'max',
-    FIRST = 'first',
 }
 
 export const vizAggregationOptions = [
@@ -18,7 +17,6 @@ export const vizAggregationOptions = [
     VizAggregationOptions.AVERAGE,
     VizAggregationOptions.MIN,
     VizAggregationOptions.MAX,
-    VizAggregationOptions.FIRST,
 ];
 
 export const VIZ_DEFAULT_AGGREGATION = VizAggregationOptions.COUNT;

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -9,7 +9,6 @@ import {
     IconMathMax,
     IconMathMin,
     IconMathOff,
-    IconNumber1,
     IconSum,
     IconTrendingUp,
 } from '@tabler/icons-react';
@@ -38,9 +37,6 @@ const AggregationIcon: FC<{ aggregation: string | undefined }> = ({
             break;
         case MetricType.MAX:
             icon = IconMathMax;
-            break;
-        case 'first':
-            icon = IconNumber1;
             break;
         default:
             icon = IconMathOff;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#11329](https://github.com/lightdash/lightdash/issues/11329)

### Description:


Removes this option. We should replace it with `ANY_VALUE` in a separate PR
https://docs.snowflake.com/en/sql-reference/functions/any_value
https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#any_value
https://www.postgresql.org/docs/16/release-16.html

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
