### PR TITLE
fix: remove semantic viewer aggregation functions

### DIFF
--- a/packages/backend/src/clients/cube/transformer.ts
+++ b/packages/backend/src/clients/cube/transformer.ts
@@ -20,7 +20,6 @@ import {
     SemanticLayerTimeGranularity,
     SemanticLayerTransformer,
 } from '@lightdash/common';
-import { Query } from '@tsoa/runtime';
 
 function getSemanticLayerTypeFromCubeType(
     cubeType: TCubeMemberType,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8345,24 +8345,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SemanticLayerAggFunc: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { dataType: 'enum', enums: ['sum'] },
-                { dataType: 'enum', enums: ['max'] },
-                { dataType: 'enum', enums: ['min'] },
-                { dataType: 'enum', enums: ['mean'] },
-                { dataType: 'enum', enums: ['median'] },
-                { dataType: 'enum', enums: ['first'] },
-                { dataType: 'enum', enums: ['last'] },
-                { dataType: 'enum', enums: ['count'] },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerPivot: {
         dataType: 'refAlias',
         type: {
@@ -8370,16 +8352,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 values: {
                     dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            aggFunction: {
-                                ref: 'SemanticLayerAggFunc',
-                                required: true,
-                            },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
+                    array: { dataType: 'string' },
                     required: true,
                 },
                 index: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9206,33 +9206,11 @@
                     }
                 ]
             },
-            "SemanticLayerAggFunc": {
-                "type": "string",
-                "enum": [
-                    "sum",
-                    "max",
-                    "min",
-                    "mean",
-                    "median",
-                    "first",
-                    "last",
-                    "count"
-                ]
-            },
             "SemanticLayerPivot": {
                 "properties": {
                     "values": {
                         "items": {
-                            "properties": {
-                                "aggFunction": {
-                                    "$ref": "#/components/schemas/SemanticLayerAggFunc"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["aggFunction", "name"],
-                            "type": "object"
+                            "type": "string"
                         },
                         "type": "array"
                     },
@@ -9538,7 +9516,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1236.2",
+        "version": "0.1237.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SemanticLayerService/Pivoting.ts
+++ b/packages/backend/src/services/SemanticLayerService/Pivoting.ts
@@ -1,66 +1,9 @@
-import {
-    SemanticLayerGroupBy,
-    SemanticLayerPivot,
-    SemanticLayerResultRow,
-} from '@lightdash/common';
-import uniq from 'lodash/uniq';
+import { SemanticLayerPivot, SemanticLayerResultRow } from '@lightdash/common';
 import pl from 'nodejs-polars';
 
 export function pivotResults(
     results: SemanticLayerResultRow[],
-    allDimensions: string[],
     { values, ...options }: SemanticLayerPivot,
 ): SemanticLayerResultRow[] {
-    const df = pl.DataFrame(results);
-
-    // Group by all dimensions that are not in the values
-    const dimensionsToGroupBy = uniq([
-        ...options.on,
-        ...options.index,
-        ...allDimensions,
-    ]).filter((dim) => !values.map((v) => v.name).includes(dim));
-
-    // This can happen when we group by and aggregate on the same dimension
-    if (dimensionsToGroupBy.length === 0) {
-        return results;
-    }
-
-    const aggs: pl.Expr[] = values.map((v) => {
-        if (v.aggFunction === 'avg') {
-            return pl.col(v.name).mean();
-        }
-        return pl.col(v.name)[v.aggFunction]();
-    });
-
-    return df
-        .groupBy(dimensionsToGroupBy)
-        .agg(...aggs)
-        .withColumns(pl.col(dimensionsToGroupBy).fillNull('zero'))
-        .pivot(
-            values.map((v) => v.name),
-            options,
-        )
-        .toRecords();
+    return pl.DataFrame(results).pivot(values, options).toRecords();
 }
-
-export const groupResults = (
-    results: SemanticLayerResultRow[],
-    { values, groupBy }: SemanticLayerGroupBy,
-): SemanticLayerResultRow[] => {
-    const df = pl.DataFrame(results);
-
-    const aliasedAggs: pl.Expr[] = values.map((v) => {
-        if (v.aggFunction === 'avg') {
-            return pl.col(v.name).mean().alias(`avg(${v.name})`);
-        }
-        return pl
-            .col(v.name)
-            [v.aggFunction]()
-            .alias(`${v.aggFunction}(${v.name})`);
-    });
-
-    return df
-        .groupBy(groupBy)
-        .agg(...aliasedAggs)
-        .toRecords();
-};

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -21,7 +21,7 @@ import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
-import { groupResults, pivotResults } from './Pivoting';
+import { pivotResults } from './Pivoting';
 
 type SearchServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -211,18 +211,8 @@ export class SemanticLayerService extends BaseService {
             // Pivot results
             const pivotedResults =
                 query.pivot.index.length === 0
-                    ? groupResults(results, {
-                          values: query.pivot.values,
-                          groupBy: query.pivot.on,
-                      })
-                    : pivotResults(
-                          results,
-                          [
-                              ...query.dimensions.map((d) => d.name),
-                              ...query.timeDimensions.map((d) => d.name),
-                          ],
-                          query.pivot,
-                      );
+                    ? results
+                    : pivotResults(results, query.pivot);
 
             streamFunctionCallback = async (writer) => {
                 pivotedResults.forEach(writer);

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -57,27 +57,10 @@ export type SemanticLayerSortBy = Pick<SemanticLayerField, 'name' | 'kind'> & {
     direction: SemanticLayerSortByDirection;
 };
 
-// These agg functions match 1:1 to polars' agg functions, they're not typed
-export type SemanticLayerAggFunc =
-    | 'sum'
-    | 'max'
-    | 'min'
-    | 'mean'
-    | 'avg'
-    | 'median'
-    | 'first'
-    | 'last'
-    | 'count';
-
 export type SemanticLayerPivot = {
     on: string[];
     index: string[];
-    values: { name: string; aggFunction: SemanticLayerAggFunc }[];
-};
-
-export type SemanticLayerGroupBy = {
-    groupBy: string[];
-    values: { name: string; aggFunction: SemanticLayerAggFunc }[];
+    values: string[];
 };
 
 export type SemanticLayerQuery = {

--- a/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
+++ b/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
@@ -15,10 +15,7 @@ const transformChartLayoutToSemanticPivot = (
     return {
         on: config.x ? [config.x.reference] : [],
         index: config.groupBy?.map((groupBy) => groupBy.reference) ?? [],
-        values: config.y.map((y) => ({
-            name: y.reference,
-            aggFunction: y.aggregation,
-        })),
+        values: config.y.map((y) => y.reference),
     };
 };
 


### PR DESCRIPTION
Closes: 
### Description:

removes unnecessary group by and pivot with aggregations from semantic viewer pivoting functionality

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
