### PR TITLE
fix: Rename cancel button tooltip for editing and viewing actions

### DIFF
--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -38,9 +38,9 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
     const cancelButtonText = useMemo(() => {
         switch (action) {
             case 'viewing':
+            case 'editing':
                 return 'Return to dashboard';
             case 'creating':
-            case 'editing':
                 return 'Cancel';
             default:
                 return assertUnreachable(
@@ -55,7 +55,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
             case 'creating':
                 return 'Cancel chart creation and return to dashboard';
             case 'editing':
-                return 'Cancel chart editing and return to dashboard';
+                return 'Conclude chart editing and return to dashboard';
             case 'viewing':
                 return '';
             default:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11335 

### Description:
This pull request updates the button text in the dashboard banner when editing charts. Previously, the button displayed "Cancel" which might have been confusing, as it indicated that changes would be canceled, while it actually navigates back to the dashboard.

Before:
![Screenshot 2024-09-02 at 8 36 02 PM](https://github.com/user-attachments/assets/5b394fe2-cc4a-4bcb-b1b7-197b1a3fcaff)


After:
![Screenshot 2024-09-02 at 8 21 31 PM](https://github.com/user-attachments/assets/20a0441b-57db-422f-b493-e66a3cb5b1a0)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
