### PR TITLE
fix: allow setting labels and colours to series

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -162,6 +162,13 @@ export class CartesianChartDataModel
                 const seriesFormat = Object.values(display?.series || {}).find(
                     (s) => s.yAxisIndex === index,
                 )?.format;
+                const seriesLabel = Object.values(display?.series || {}).find(
+                    (s) => s.yAxisIndex === index,
+                )?.label;
+
+                const seriesColor = Object.values(display?.series || {}).find(
+                    (s) => s.yAxisIndex === index,
+                )?.color;
 
                 return {
                     dimensions: [
@@ -170,10 +177,7 @@ export class CartesianChartDataModel
                     ],
                     type: defaultSeriesType,
                     stack: shouldStack ? 'stack-all-series' : undefined, // TODO: we should implement more sophisticated stacking logic once we have multi-pivoted charts
-                    name:
-                        (display?.series &&
-                            display.series[seriesColumn]?.label) ||
-                        friendlyName(seriesColumn),
+                    name: seriesLabel || friendlyName(seriesColumn),
                     encode: {
                         x: transformedData.indexColumn?.reference,
                         y: seriesColumn,
@@ -190,8 +194,7 @@ export class CartesianChartDataModel
                             : undefined,
                     },
                     color:
-                        (display?.series &&
-                            display.series[seriesColumn]?.color) ||
+                        seriesColor ||
                         CartesianChartDataModel.getDefaultColor(
                             index,
                             orgColors,
@@ -243,7 +246,7 @@ export class CartesianChartDataModel
                     nameTextStyle: {
                         fontWeight: 'bold',
                     },
-                    ...(display?.yAxis?.[0].format
+                    ...(display?.yAxis?.[0]?.format
                         ? {
                               axisLabel: {
                                   formatter:

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -47,7 +47,7 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                 noWrap
                                 position="apart"
                             >
-                                <Group>
+                                <Group spacing="two" noWrap>
                                     <ColorSelector
                                         color={color ?? colors[index]}
                                         onColorChange={(c) => {
@@ -74,7 +74,7 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                         }}
                                     />
                                 </Group>
-                                <Group spacing="xs">
+                                <Group spacing="two" noWrap>
                                     <Tooltip
                                         label="Format"
                                         variant="xs"

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -296,18 +296,33 @@ export const cartesianChartConfigSlice = createSlice({
         setSeriesColor: (
             { config },
             action: PayloadAction<{
-                index: number;
-                color: string;
                 reference: string;
+                color: string;
+                index?: number;
             }>,
         ) => {
             if (!config) return;
             config.display = config.display || {};
+            config.display.yAxis = config.display.yAxis || [];
             config.display.series = config.display.series || {};
-            config.display.series[action.payload.reference] = {
-                ...config.display.series[action.payload.reference],
-                color: action.payload.color,
-            };
+
+            if (config.fieldConfig?.y.length === 1) {
+                const yReference = config.fieldConfig?.y[0].reference;
+                if (yReference) {
+                    config.display.series[yReference] = {
+                        ...config.display.series[yReference],
+                        yAxisIndex: 0,
+                        color: action.payload.color,
+                    };
+                }
+            }
+            if (action.payload.index !== undefined) {
+                config.display.series[action.payload.reference] = {
+                    ...config.display.series[action.payload.reference],
+                    yAxisIndex: action.payload.index,
+                    color: action.payload.color,
+                };
+            }
         },
     },
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11345](https://github.com/lightdash/lightdash/issues/11345)

### Description:

Gets `label` and `color` by checking the `yAxisIndex` - more reliable. Since these objects are usually very small, I don't see performance issues with this

Demo: 


https://github.com/user-attachments/assets/4008e3cf-5449-458a-81a6-58046cb60076



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
