### PR TITLE
fix: dont display validation errors originated from CLI

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -363,6 +363,7 @@ export class DashboardModel {
                                     SELECT json_agg(validations.*)
                                     FROM validations
                                     WHERE validations.dashboard_uuid = ${DashboardsTableName}.dashboard_uuid
+                                    AND validations.job_id IS NULL
                                 ), '[]'
                             ) as validation_errors
                         `),

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -167,6 +167,7 @@ export class SearchModel {
 
         const validationErrors = await this.database('validations')
             .where('project_uuid', projectUuid)
+            .whereNull('job_id')
             .whereIn('dashboard_uuid', dashboardUuids)
             .andWhereNot('dashboard_uuid', null)
             .select('validation_id', 'dashboard_uuid')
@@ -265,6 +266,7 @@ export class SearchModel {
 
         const validationErrors = await this.database('validations')
             .where('project_uuid', projectUuid)
+            .whereNull('job_id')
             .whereIn('saved_chart_uuid', chartUuids)
             .andWhereNot('saved_chart_uuid', null)
             .select('validation_id', 'saved_chart_uuid')
@@ -431,6 +433,7 @@ export class SearchModel {
 
         const validationErrors = await this.database('validations')
             .where('project_uuid', projectUuid)
+            .whereNull('job_id')
             .whereNotNull('model_name')
             .select('validation_id', 'model_name')
             .then((rows) =>

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -521,6 +521,7 @@ export class SpaceModel {
                             SELECT json_agg(validations.*)
                             FROM validations
                             WHERE validations.dashboard_uuid = ${DashboardsTableName}.dashboard_uuid
+                            AND validations.job_id IS NULL
                         ), '[]'
                     ) as validation_errors
                 `),
@@ -1004,6 +1005,7 @@ export class SpaceModel {
                             SELECT json_agg(validations.*)
                             FROM validations
                             WHERE validations.saved_chart_uuid = saved_queries.saved_query_uuid
+                            AND validations.job_id IS NULL
                         ), '[]'
                     ) as validation_errors
                 `),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11322](https://github.com/lightdash/lightdash/issues/11322)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

When we run the validation CLI command, we store the errors in the database under a job id. This is because we may have multiple developers running validation on different branches. The CLI will check the job status every X seconds. Once it is ready, it fetches the validation errors via the job id. 

When we run the validation after a project is deployed or via the UI, we store the errors in the database without a job id (null). This is because there should only be 1 validation state for the project inside Lightdash. 

The validation page accurately fetches the validation state by filtering the errors where the job id is null.
The other pages that list chart/dashboard where NOT filtering the errors where the job id is null. This resulted in displaying errors related to in progress work from a developer branch. 

Reproduction steps:

1. rename a field in `schema.yml`. eg: order_id
2. run validate command `node ./packages/cli/dist/index.js validate --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles` 

Actual:
See errors in home page, search, chart/dashboard pages

Expected:
No errors 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
