### PR TITLE
chore: reuse Bigquery client

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
@@ -5,7 +5,7 @@ import { BigqueryFieldType } from './BigqueryWarehouseClient';
 
 export const credentials: CreateBigqueryCredentials = {
     type: WarehouseTypes.BIGQUERY,
-    project: '',
+    project: 'myDatabase',
     dataset: '',
     timeoutSeconds: 0,
     priority: 'interactive',
@@ -51,12 +51,9 @@ const metadata = {
 };
 
 export const getTableResponse = {
-    getMetadata: jest.fn(() => [metadata]),
-};
-export const getDatasetResponse = {
-    id: 'mySchema',
+    id: 'myTable',
     bigQuery: { projectId: 'myDatabase' },
-    table: jest.fn(() => getTableResponse),
+    getMetadata: jest.fn(() => [metadata]),
 };
 
 export const rows: Record<string, any>[] = [

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,13 +1,9 @@
-import { BigQuery } from '@google-cloud/bigquery';
-
-import { Readable } from 'stream';
+import { Dataset } from '@google-cloud/bigquery';
 import { BigqueryWarehouseClient } from './BigqueryWarehouseClient';
 import {
     createJobResponse,
     credentials,
-    getDatasetResponse,
     getTableResponse,
-    rows,
 } from './BigqueryWarehouseClient.mock';
 import {
     config,
@@ -33,16 +29,15 @@ describe('BigqueryWarehouseClient', () => {
         ).toHaveBeenCalledTimes(1);
     });
     it('expect schema with bigquery types mapped to dimension types', async () => {
-        const getDatasetMock = jest
+        const getTableMock = jest
             .fn()
-            .mockImplementationOnce(() => getDatasetResponse);
-        BigQuery.prototype.dataset = getDatasetMock;
+            .mockImplementationOnce(() => getTableResponse);
+        Dataset.prototype.table = getTableMock;
         const warehouse = new BigqueryWarehouseClient(credentials);
         expect(await warehouse.getCatalog(config)).toEqual(
             expectedWarehouseSchema,
         );
-        expect(getDatasetMock).toHaveBeenCalledTimes(1);
-        expect(getDatasetResponse.table).toHaveBeenCalledTimes(1);
+        expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -223,19 +223,12 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             table: string;
         }[],
     ) {
-        const databaseClients: { [client: string]: BigQuery } = {};
         const tablesMetadataPromises: Promise<
             [string, string, string, TableSchema] | undefined
         >[] = requests.map(({ database, schema, table }) => {
-            databaseClients[database] =
-                databaseClients[database] ||
-                new BigQuery({
-                    projectId: database,
-                    location: this.credentials.location,
-                    maxRetries: this.credentials.retries,
-                    credentials: this.credentials.keyfileContents,
-                });
-            const dataset = databaseClients[database].dataset(schema);
+            const dataset: Dataset = new Dataset(this.client, schema, {
+                projectId: database,
+            });
             return BigqueryWarehouseClient.getTableMetadata(
                 dataset,
                 table,
@@ -297,13 +290,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     }
 
     async getAllTables() {
-        const client = new BigQuery({
-            projectId: this.credentials.project,
-            location: this.credentials.location,
-            maxRetries: this.credentials.retries,
-            credentials: this.credentials.keyfileContents,
-        });
-        const [datasets] = await client.getDatasets();
+        const [datasets] = await this.client.getDatasets();
         const datasetTablesResponses = await Promise.all(
             datasets.map((d) => d.getTables()),
         );
@@ -321,13 +308,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         schema: string,
         database?: string,
     ): Promise<WarehouseCatalog> {
-        const client = new BigQuery({
-            projectId: database || this.credentials.project,
-            location: this.credentials.location,
-            maxRetries: this.credentials.retries,
-            credentials: this.credentials.keyfileContents,
+        const dataset: Dataset = new Dataset(this.client, schema, {
+            projectId: database,
         });
-        const dataset = client.dataset(schema);
         const schemas = await BigqueryWarehouseClient.getTableMetadata(
             dataset,
             tableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: [#11312](https://github.com/lightdash/lightdash/issues/11312)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Use the same Bigquery client with the same credentials and configuration.
Dataset/table references can still be configured to point to a different database(aka project).

This is in preparation for #11312.

SQL runner queries and sidebar working as expected.

<img width="1381" alt="Screenshot 2024-09-03 at 13 56 34" src="https://github.com/user-attachments/assets/c2f76d1e-3976-417a-866e-db13f9462664">
<img width="1618" alt="Screenshot 2024-09-03 at 13 57 21" src="https://github.com/user-attachments/assets/32259812-f9c7-4a73-8e4a-dd7b883e914f">




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
