### PR TITLE
fix: allow clearing the groupby if no options

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -154,12 +154,15 @@ const GroupByFieldAxisConfig = ({
     sqlColumns,
 }: {
     sqlColumns: VizSqlColumn[];
-
     field: undefined | { reference: string };
     groupByOptions?: VizPivotLayoutOptions[];
     actions: CartesianChartActionsType;
 }) => {
     const dispatch = useVizDispatch();
+    const error =
+        field !== undefined &&
+        !groupByOptions.find((x) => x.reference === field.reference) &&
+        `Column "${field.reference}" does not exist. Choose another`;
     return (
         <FieldReferenceSelect
             clearable
@@ -169,11 +172,13 @@ const GroupByFieldAxisConfig = ({
             }))}
             value={field?.reference ?? null}
             placeholder="Select group by"
-            error={
-                field !== undefined &&
-                !groupByOptions.find((x) => x.reference === field.reference) &&
-                `Column "${field.reference}" does not exist. Choose another`
-            }
+            onClick={() => {
+                // If the user had a grouped by field, but then deleted it, and there are no more group by options, unset the group by reference, since the clear button doesn't get rendered
+                if (groupByOptions.length === 0 && !!error) {
+                    dispatch(actions.unsetGroupByReference());
+                }
+            }}
+            error={error}
             onChange={(value) => {
                 if (!value) {
                     dispatch(actions.unsetGroupByReference());

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -7,8 +7,10 @@ import {
     type VizSqlColumn,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box } from '@mantine/core';
+import { ActionIcon, Box } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
 import { AddButton } from '../../VisualizationConfigs/common/AddButton';
 import { Config } from '../../VisualizationConfigs/common/Config';
 import { FieldReferenceSelect } from '../FieldReferenceSelect';
@@ -161,10 +163,23 @@ const GroupByFieldAxisConfig = ({
     const dispatch = useVizDispatch();
     const error =
         field !== undefined &&
-        !groupByOptions.find((x) => x.reference === field.reference) &&
-        `Column "${field.reference}" does not exist. Choose another`;
+        !groupByOptions.find((x) => x.reference === field.reference)
+            ? `Column "${field.reference}" does not exist. Choose another`
+            : undefined;
     return (
         <FieldReferenceSelect
+            rightSection={
+                // When the field is deleted, the error state prevents the clear button from showing
+                error && (
+                    <ActionIcon
+                        onClick={() =>
+                            dispatch(actions.unsetGroupByReference())
+                        }
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                )
+            }
             clearable
             data={groupByOptions.map((groupBy) => ({
                 value: groupBy.reference,
@@ -172,12 +187,6 @@ const GroupByFieldAxisConfig = ({
             }))}
             value={field?.reference ?? null}
             placeholder="Select group by"
-            onClick={() => {
-                // If the user had a grouped by field, but then deleted it, and there are no more group by options, unset the group by reference, since the clear button doesn't get rendered
-                if (groupByOptions.length === 0 && !!error) {
-                    dispatch(actions.unsetGroupByReference());
-                }
-            }}
             error={error}
             onChange={(value) => {
                 if (!value) {
@@ -230,6 +239,7 @@ export const CartesianChartFieldConfiguration = ({
     const groupByLayoutOptions = useVizSelector((state) =>
         cartesianChartSelectors.getPivotLayoutOptions(state, selectedChartType),
     );
+
     return (
         <>
             <Config>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11326

### Description:

Allow clearing the `groupBy` select when there's an error + no options to group by

The `clearable` prop only works if there's data, so if the user clicks, it will clear. 

> [!IMPORTANT]
> there should be a better way to merge configs. Currently, `mergeConfig` doesn't influence the RTK state when we edit the query/config. Therefore, the result of this should change the state `onResults`. Look into `ResultsRunner`, where it should have clear steps on how to handle this - for example, if the `groupBy`'s references aren't valid, then unset this property (to `undefined`). Since it required a wider change + `useEffect` dependencies considerations, it would mean a bigger PR. that can be handled later.

demo: 


https://github.com/user-attachments/assets/e77f84ff-94b7-4658-a5b0-c263948f3c06



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
