### PR TITLE
fix: pass limit to saved chart & tile

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -182,6 +182,7 @@ export const DashboardSqlChartTile: FC<Props> = ({
                         sql={data.chart.sql}
                         projectUuid={projectUuid}
                         uuid={savedSqlUuid}
+                        limit={data.chart.limit}
                     />
                 )}
         </TileBase>

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -177,6 +177,7 @@ const ViewSqlChart = () => {
                                                     sql={sql}
                                                     projectUuid={projectUuid}
                                                     slug={params.slug}
+                                                    limit={sqlChart?.limit}
                                                 />
                                             )}
                                     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Before

<img width="783" alt="Screenshot 2024-09-04 at 09 44 12" src="https://github.com/user-attachments/assets/f5f1e0f0-bf70-4da3-b297-9b7583860da4">

After



<img width="804" alt="Screenshot 2024-09-04 at 09 44 17" src="https://github.com/user-attachments/assets/6ca2f947-2536-4ea6-88ba-9dc97219f23e">

Before

<img width="860" alt="Screenshot 2024-09-04 at 09 43 37" src="https://github.com/user-attachments/assets/3c19ab3e-4a6b-4419-8f68-a634a4f7237b">

After
<img width="880" alt="Screenshot 2024-09-04 at 09 43 42" src="https://github.com/user-attachments/assets/c7ba242d-73a5-4db5-85e2-03dcd127386c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
