### PR TITLE
fix: wait for sql before viewing sql chart

### DIFF
--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -163,7 +163,8 @@ const ViewSqlChart = () => {
                                         )}
                                         {!isVizTableConfig(currentVisConfig) &&
                                             data &&
-                                            params.slug && (
+                                            params.slug &&
+                                            sql && (
                                                 <ChartView
                                                     resultsRunner={
                                                         resultsRunner


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

wait for `sql` before trying to display `ChartView` on `ViewSqlChart`. 

To replicate the issue **without the fix**
(keep cache, don't disable it)
- Go to chart A
- Click on breadcrumb to Space
- Go back to chart
<img width="565" alt="image" src="https://github.com/user-attachments/assets/87e523d2-69ec-43e9-a02a-e81e72848420">

Because the SQL was empty.
This is in between states and store initialisations. Since `ChartView`'s prop `sql` is intentionally optional, it led to this error.

Now all is well.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
