### PR TITLE
chore: fix semantic viewer zIndex and empty sort

### DIFF
--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -40,6 +40,11 @@ const Content: FC = () => {
         dispatch(updateSortBy({ name: fieldName, kind }));
     };
 
+    const selectedFieldsCount =
+        allSelectedFieldsByKind.dimensions.length +
+        allSelectedFieldsByKind.metrics.length +
+        allSelectedFieldsByKind.timeDimensions.length;
+
     return (
         <>
             <Group
@@ -93,7 +98,7 @@ const Content: FC = () => {
 
                 <RunSemanticQueryButton />
             </Group>
-            {sortBy.length > 0 && (
+            {selectedFieldsCount > 0 && (
                 <Group
                     px="md"
                     pt="sm"

--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -93,63 +93,76 @@ const Content: FC = () => {
 
                 <RunSemanticQueryButton />
             </Group>
-            <Group
-                px="md"
-                pt="sm"
-                bg="gray.1"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${theme.colors.gray[3]}`,
-                })}
-                spacing="xxs"
-                align="baseline"
-            >
-                <Text fw={600} h="100%" mr="xs">
-                    Sort by:
-                </Text>
-                {Object.entries(allSelectedFieldsByKind).map(([kind, fields]) =>
-                    fields.map((field) => {
-                        // TODO: this is annoying
-                        const normalKind =
-                            kind === 'metrics'
-                                ? FieldType.METRIC
-                                : FieldType.DIMENSION;
+            {sortBy.length > 0 && (
+                <Group
+                    px="md"
+                    pt="sm"
+                    bg="gray.1"
+                    sx={(theme) => ({
+                        borderBottom: `1px solid ${theme.colors.gray[3]}`,
+                    })}
+                    spacing="xxs"
+                    align="baseline"
+                >
+                    <Text fw={600} h="100%" mr="xs">
+                        Sort by:
+                    </Text>
+                    {Object.entries(allSelectedFieldsByKind).map(
+                        ([kind, fields]) =>
+                            fields.map((field) => {
+                                // TODO: this is annoying
+                                const normalKind =
+                                    kind === 'metrics'
+                                        ? FieldType.METRIC
+                                        : FieldType.DIMENSION;
 
-                        const sortDirection = sortBy.find(
-                            (s) =>
-                                s.name === field.name && s.kind === normalKind,
-                        )?.direction;
+                                const sortDirection = sortBy.find(
+                                    (s) =>
+                                        s.name === field.name &&
+                                        s.kind === normalKind,
+                                )?.direction;
 
-                        return (
-                            <Button
-                                key={`${kind}-${field.name}`}
-                                variant={sortDirection ? 'filled' : 'outline'}
-                                size="sm"
-                                mr="xs"
-                                mb="xs"
-                                color={kind === 'metrics' ? 'orange' : 'blue'}
-                                compact
-                                onClick={() =>
-                                    handleAddSortBy(field.name, normalKind)
-                                }
-                                rightIcon={
-                                    sortDirection && (
-                                        <MantineIcon
-                                            icon={
-                                                sortDirection ===
-                                                SemanticLayerSortByDirection.ASC
-                                                    ? IconArrowUp
-                                                    : IconArrowDown
-                                            }
-                                        ></MantineIcon>
-                                    )
-                                }
-                            >
-                                {field.name}
-                            </Button>
-                        );
-                    }),
-                )}
-            </Group>
+                                return (
+                                    <Button
+                                        key={`${kind}-${field.name}`}
+                                        variant={
+                                            sortDirection ? 'filled' : 'outline'
+                                        }
+                                        size="sm"
+                                        mr="xs"
+                                        mb="xs"
+                                        color={
+                                            kind === 'metrics'
+                                                ? 'orange'
+                                                : 'blue'
+                                        }
+                                        compact
+                                        onClick={() =>
+                                            handleAddSortBy(
+                                                field.name,
+                                                normalKind,
+                                            )
+                                        }
+                                        rightIcon={
+                                            sortDirection && (
+                                                <MantineIcon
+                                                    icon={
+                                                        sortDirection ===
+                                                        SemanticLayerSortByDirection.ASC
+                                                            ? IconArrowUp
+                                                            : IconArrowDown
+                                                    }
+                                                ></MantineIcon>
+                                            )
+                                        }
+                                    >
+                                        {field.name}
+                                    </Button>
+                                );
+                            }),
+                    )}
+                </Group>
+            )}
 
             {!view ? (
                 <Center sx={{ flexGrow: 1 }}>

--- a/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SqlViewer.tsx
@@ -1,4 +1,4 @@
-import { Box, LoadingOverlay } from '@mantine/core';
+import { Box, getDefaultZIndex, LoadingOverlay } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import { type FC } from 'react';
 import { useSemanticLayerSql } from '../api/hooks';
@@ -27,6 +27,7 @@ const SqlViewer: FC = () => {
             <LoadingOverlay
                 visible={sql.isFetching}
                 opacity={1}
+                zIndex={getDefaultZIndex('modal') - 1}
                 loaderProps={{ color: 'gray', size: 'sm' }}
             />
 


### PR DESCRIPTION
### Description:

Fix some visual bugs in semantic viewer:
1. Don't show 'sort by' when there is nothing to sort by
2. Change loader zIndex to avoid this:
<img width="1551" alt="Screenshot 2024-09-04 at 15 49 08" src="https://github.com/user-attachments/assets/8ebd7b82-c1ba-41f7-b835-acf6a5185309">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
