### PR TITLE
feat: fetch results on load of edit chart

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -247,7 +247,7 @@ const Routes: FC = () => {
                                     >
                                         <NavBar />
 
-                                        <SqlRunnerNew />
+                                        <SqlRunnerNew isEditMode />
                                     </Route>
 
                                     <Route

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -75,14 +75,21 @@ export const ContentPanel: FC = () => {
         [resultsHeight, maxResultsHeight],
     );
 
-    const {
-        projectUuid,
-        sql,
-        limit,
-        activeEditorTab,
-        selectedChartType,
-        resultsTableConfig,
-    } = useAppSelector((state) => state.sqlRunner);
+    const fetchResultsOnLoad = useAppSelector(
+        (state) => state.sqlRunner.fetchResultsOnLoad,
+    );
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const sql = useAppSelector((state) => state.sqlRunner.sql);
+    const selectedChartType = useAppSelector(
+        (state) => state.sqlRunner.selectedChartType,
+    );
+    const activeEditorTab = useAppSelector(
+        (state) => state.sqlRunner.activeEditorTab,
+    );
+    const limit = useAppSelector((state) => state.sqlRunner.limit);
+    const resultsTableConfig = useAppSelector(
+        (state) => state.sqlRunner.resultsTableConfig,
+    );
 
     // currently editing chart config
     const currentVizConfig = useAppSelector((state) =>
@@ -144,6 +151,14 @@ export const ContentPanel: FC = () => {
     useHotkeys([
         ['mod + enter', () => handleRunQuery, { preventDefault: true }],
     ]);
+
+    useEffect(() => {
+        if (fetchResultsOnLoad && !queryResults) {
+            void handleRunQuery();
+        } else if (fetchResultsOnLoad && queryResults) {
+            dispatch(setActiveEditorTab(EditorTabs.VISUALIZATION));
+        }
+    }, [fetchResultsOnLoad, handleRunQuery, queryResults, dispatch]);
 
     const resultsRunner = useMemo(() => {
         if (!queryResults) return;
@@ -287,18 +302,18 @@ export const ContentPanel: FC = () => {
                                 radius="sm"
                                 data={[
                                     {
-                                        value: 'sql',
+                                        value: EditorTabs.SQL,
                                         label: (
                                             <Group spacing="xs" noWrap>
                                                 <MantineIcon
                                                     icon={IconCodeCircle}
                                                 />
-                                                <Text>Query</Text>
+                                                <Text>SQL</Text>
                                             </Group>
                                         ),
                                     },
                                     {
-                                        value: 'chart',
+                                        value: EditorTabs.VISUALIZATION,
                                         label: (
                                             <Group spacing="xs" noWrap>
                                                 <MantineIcon
@@ -310,22 +325,13 @@ export const ContentPanel: FC = () => {
                                         disabled: !queryResults?.results,
                                     },
                                 ]}
-                                defaultValue={'sql'}
-                                onChange={(value) => {
+                                value={activeEditorTab}
+                                onChange={(value: EditorTabs) => {
                                     if (isLoading) {
                                         return;
                                     }
-                                    if (value === 'sql') {
-                                        dispatch(
-                                            setActiveEditorTab(EditorTabs.SQL),
-                                        );
-                                    } else {
-                                        dispatch(
-                                            setActiveEditorTab(
-                                                EditorTabs.VISUALIZATION,
-                                            ),
-                                        );
-                                    }
+
+                                    dispatch(setActiveEditorTab(value));
                                 }}
                             />
                         </Group>

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -10,8 +10,8 @@ import { createSlice } from '@reduxjs/toolkit';
 import { type ResultsAndColumns } from '../hooks/useSqlQueryRun';
 
 export enum EditorTabs {
-    SQL = 'sql',
-    VISUALIZATION = 'visualization',
+    SQL = 'SQL',
+    VISUALIZATION = 'Chart',
 }
 
 export enum SidebarTabs {
@@ -48,6 +48,7 @@ export interface SqlRunnerState {
     quoteChar: string;
     sqlColumns: VizSqlColumn[] | undefined;
     activeConfigs: ChartKind[];
+    fetchResultsOnLoad: boolean;
 }
 
 const initialState: SqlRunnerState = {
@@ -77,6 +78,7 @@ const initialState: SqlRunnerState = {
     quoteChar: '"',
     sqlColumns: undefined,
     activeConfigs: [ChartKind.VERTICAL_BAR],
+    fetchResultsOnLoad: false,
 };
 
 export const sqlRunnerSlice = createSlice({
@@ -88,6 +90,9 @@ export const sqlRunnerSlice = createSlice({
         },
         setProjectUuid: (state, action: PayloadAction<string>) => {
             state.projectUuid = action.payload;
+        },
+        setFetchResultsOnLoad: (state, action: PayloadAction<boolean>) => {
+            state.fetchResultsOnLoad = action.payload;
         },
         setSqlRunnerResults: (
             state,
@@ -134,6 +139,12 @@ export const sqlRunnerSlice = createSlice({
         },
         setActiveEditorTab: (state, action: PayloadAction<EditorTabs>) => {
             state.activeEditorTab = action.payload;
+            if (
+                state.fetchResultsOnLoad &&
+                state.activeEditorTab === EditorTabs.SQL
+            ) {
+                state.fetchResultsOnLoad = false;
+            }
             if (action.payload === EditorTabs.VISUALIZATION) {
                 state.activeSidebarTab = SidebarTabs.VISUALIZATION;
                 if (state.selectedChartType === undefined) {
@@ -187,6 +198,7 @@ export const sqlRunnerSlice = createSlice({
 export const {
     toggleActiveTable,
     setProjectUuid,
+    setFetchResultsOnLoad,
     setSqlRunnerResults,
     updateName,
     setSql,

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -20,13 +20,14 @@ import {
 } from '../features/sqlRunner/store/hooks';
 import {
     resetState,
+    setFetchResultsOnLoad,
     setProjectUuid,
     setQuoteChar,
     setSavedChartData,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
 import { useProject } from '../hooks/useProject';
 
-const SqlRunnerNew = () => {
+const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
 
@@ -42,8 +43,9 @@ const SqlRunnerNew = () => {
     useEffect(() => {
         if (!projectUuid && params.projectUuid) {
             dispatch(setProjectUuid(params.projectUuid));
+            dispatch(setFetchResultsOnLoad(!!isEditMode));
         }
-    }, [dispatch, params.projectUuid, projectUuid]);
+    }, [dispatch, params.projectUuid, projectUuid, isEditMode]);
 
     const { data, error: chartError } = useSavedSqlChart({
         projectUuid,
@@ -118,10 +120,10 @@ const SqlRunnerNew = () => {
     );
 };
 
-const SqlRunnerNewPage = () => {
+const SqlRunnerNewPage = ({ isEditMode }: { isEditMode?: boolean }) => {
     return (
         <Provider store={store}>
-            <SqlRunnerNew />
+            <SqlRunnerNew isEditMode={isEditMode} />
         </Provider>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/10977

### Description:

When on `/edit` pass `isEditMode` 
Then that means that it should fetch results on load. If that is `true`, then select the tab to be `Chart` so that the user can view the chart on load

Screen recording:


https://github.com/user-attachments/assets/7b5a3ff7-fbcf-4fb2-8489-093027211d8f



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
