### PR TITLE
chore: add loading state when saving  chart changes

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -40,7 +40,7 @@ export const HeaderEdit: FC = () => {
     const config = useAppSelector((state) =>
         selectChartConfigByKind(state, selectedChartType),
     );
-    const { mutate } = useUpdateSqlChartMutation(
+    const { mutate, isLoading } = useUpdateSqlChartMutation(
         savedSqlChart?.project.projectUuid || '',
         savedSqlChart?.savedSqlUuid || '',
     );
@@ -107,6 +107,7 @@ export const HeaderEdit: FC = () => {
                             variant="default"
                             size="xs"
                             disabled={!config || !sql}
+                            loading={isLoading}
                             onClick={() => {
                                 if (config && sql) {
                                     mutate({
@@ -127,27 +128,25 @@ export const HeaderEdit: FC = () => {
                             label="Back to view page"
                             position="bottom"
                         >
-                            <ActionIcon size="xs">
-                                <MantineIcon
-                                    icon={IconArrowBackUp}
-                                    onClick={() =>
-                                        history.push(
-                                            `/projects/${savedSqlChart.project.projectUuid}/sql-runner/${savedSqlChart.slug}`,
-                                        )
-                                    }
-                                />
+                            <ActionIcon
+                                size="xs"
+                                onClick={() =>
+                                    history.push(
+                                        `/projects/${savedSqlChart.project.projectUuid}/sql-runner/${savedSqlChart.slug}`,
+                                    )
+                                }
+                            >
+                                <MantineIcon icon={IconArrowBackUp} />
                             </ActionIcon>
                         </Tooltip>
                         <Tooltip variant="xs" label="Delete" position="bottom">
-                            <ActionIcon size="xs">
-                                <MantineIcon
-                                    icon={IconTrash}
-                                    onClick={() =>
-                                        dispatch(
-                                            toggleModal('deleteChartModal'),
-                                        )
-                                    }
-                                />
+                            <ActionIcon
+                                size="xs"
+                                onClick={() =>
+                                    dispatch(toggleModal('deleteChartModal'))
+                                }
+                            >
+                                <MantineIcon icon={IconTrash} />
                             </ActionIcon>
                         </Tooltip>
                     </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Adds loading state to this save button:

<img width="115" alt="image" src="https://github.com/user-attachments/assets/334a7a20-62d4-4d62-a0bd-6af7760a506b">

Moves `onClick` to the ActionIcon instead of the icons 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
