### PR TITLE
fix: result cols mapping and query when fetching pivoted results

### DIFF
--- a/packages/backend/src/services/SemanticLayerService/Pivoting.ts
+++ b/packages/backend/src/services/SemanticLayerService/Pivoting.ts
@@ -1,9 +1,24 @@
-import { SemanticLayerPivot, SemanticLayerResultRow } from '@lightdash/common';
+import {
+    convertToResultsColumns,
+    SemanticLayerPivot,
+    SemanticLayerResultRow,
+} from '@lightdash/common';
 import pl from 'nodejs-polars';
 
 export function pivotResults(
     results: SemanticLayerResultRow[],
     { values, ...options }: SemanticLayerPivot,
 ): SemanticLayerResultRow[] {
-    return pl.DataFrame(results).pivot(values, options).toRecords();
+    // These might have different casing from the config, so we need to find the correct column name
+    const resultsColumns = Object.keys(results[0] ?? {});
+    const valuesColumns = convertToResultsColumns(values, resultsColumns);
+    const resultsColOptions = {
+        on: convertToResultsColumns(options.on, resultsColumns),
+        index: convertToResultsColumns(options.index, resultsColumns),
+    };
+
+    return pl
+        .DataFrame(results)
+        .pivot(valuesColumns, resultsColOptions)
+        .toRecords();
 }

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -240,5 +240,5 @@ export function convertToResultsColumns(
 ) {
     return columns
         .map((value) => convertColumnToResultsColumn(value, resultsColumns))
-        .filter(Boolean) as string[];
+        .filter((value): value is string => !!value);
 }

--- a/packages/common/src/types/semanticLayer.ts
+++ b/packages/common/src/types/semanticLayer.ts
@@ -222,3 +222,23 @@ export function getFilterFieldNamesRecursively(filter: SemanticLayerFilter): {
         ...orFiltersFieldNames,
     ];
 }
+
+// Helper functions to convert between the column names in the query and the column names in the results
+
+export function convertColumnToResultsColumn(
+    column: string,
+    resultsColumns: string[],
+) {
+    return resultsColumns.find(
+        (resultCol) => resultCol.toLowerCase() === column.toLowerCase(),
+    );
+}
+
+export function convertToResultsColumns(
+    columns: string[],
+    resultsColumns: string[],
+) {
+    return columns
+        .map((value) => convertColumnToResultsColumn(value, resultsColumns))
+        .filter(Boolean) as string[];
+}

--- a/packages/common/src/visualizations/TableDataModel.ts
+++ b/packages/common/src/visualizations/TableDataModel.ts
@@ -55,11 +55,11 @@ export class TableDataModel
             (acc, key) => ({
                 ...acc,
                 [key]: {
-                    visible: this.config?.columns[key].visible ?? true,
+                    visible: this.config?.columns[key]?.visible ?? true,
                     reference: key,
-                    label: this.config?.columns[key].label ?? key,
-                    frozen: this.config?.columns[key].frozen ?? false,
-                    order: this.config?.columns[key].order,
+                    label: this.config?.columns[key]?.label ?? key,
+                    frozen: this.config?.columns[key]?.frozen ?? false,
+                    order: this.config?.columns[key]?.order,
                 },
             }),
             {},

--- a/packages/common/src/visualizations/types/IResultsRunner.ts
+++ b/packages/common/src/visualizations/types/IResultsRunner.ts
@@ -22,6 +22,10 @@ export interface IResultsRunner<TPivotChartLayout> {
 
     getColumns(): string[];
 
+    getColumnsAccessorFn(
+        column: string,
+    ): (row: RawResultRow) => RawResultRow[string];
+
     getRows(): RawResultRow[];
 
     // TODO: other runner types

--- a/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
+++ b/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
@@ -259,6 +259,10 @@ export class ResultsRunner implements IResultsRunner<VizChartLayout> {
         return this.columns.map((column) => column.reference);
     }
 
+    getColumnsAccessorFn(column: string) {
+        return (row: RawResultRow) => row[column];
+    }
+
     getRows() {
         return this.rows;
     }

--- a/packages/frontend/src/components/DataViz/transformers/useTableDataModel.ts
+++ b/packages/frontend/src/components/DataViz/transformers/useTableDataModel.ts
@@ -50,11 +50,11 @@ export const useTableDataModel = <T extends ResultsRunner>({
             // react table has a bug with accessors that has dots in them
             // we found the fix here -> https://github.com/TanStack/table/issues/1671
             // do not remove the line below
-            accessorFn: (row) => row[column],
+            accessorFn: resultsRunner.getColumnsAccessorFn(column),
             header: config?.columns[column].label || column,
             cell: getValueCell,
         }));
-    }, [columns, config]);
+    }, [columns, config?.columns, resultsRunner]);
 
     const table = useReactTable({
         data: rows,

--- a/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
+++ b/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
@@ -45,16 +45,19 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
 
     getColumnsAccessorFn(column: string) {
         return (row: RawResultRow) => {
-            const rowKeys = Object.keys(row);
+            const resultsColumns = Object.keys(row);
 
             // Result columns casing depends on warehouse, so we need to find the correct column name
-            const rowKey = convertColumnToResultsColumn(column, rowKeys);
+            const mappedColumn = convertColumnToResultsColumn(
+                column,
+                resultsColumns,
+            );
 
-            if (!rowKey) {
+            if (!mappedColumn) {
                 return;
             }
 
-            return row[rowKey];
+            return row[mappedColumn];
         };
     }
 

--- a/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
+++ b/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
@@ -40,6 +40,23 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
         this.projectUuid = projectUuid;
     }
 
+    getColumnsAccessorFn(column: string) {
+        return (row: RawResultRow) => {
+            const rowKeys = Object.keys(row);
+
+            // Result columns casing depends on warehouse, so we need to find the correct column name
+            const rowKey = rowKeys.find(
+                (key) => key.toLowerCase() === column.toLowerCase(),
+            );
+
+            if (!rowKey) {
+                return;
+            }
+
+            return row[rowKey];
+        };
+    }
+
     async getPivotChartData(config: VizChartLayout): Promise<PivotChartData> {
         const pivotConfig = transformChartLayoutToSemanticPivot(config);
         const pivotedResults = await apiGetSemanticLayerQueryResults({
@@ -50,7 +67,6 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
             },
         });
 
-        // TODO: confirm if it is correct
         return {
             indexColumn: config.x,
             results: pivotedResults ?? [],

--- a/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
+++ b/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
@@ -61,8 +61,8 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
     async getPivotChartData(config: VizChartLayout): Promise<PivotChartData> {
         const pivotConfig = transformChartLayoutToSemanticPivot(config);
 
-        // Since we no longer pivot in the backend (e.g. for pie charts), we need to filter out the dimensions, time dimensions and metrics
-        // that are not included in the pivot config, this way the results will be correctly aggregated
+        // Filter dimensions, time dimensions, and metrics to match pivot config
+        // This ensures correct aggregation for non-aggregated backend pivots (e.g., pie charts)
         const pivotedResults = await apiGetSemanticLayerQueryResults({
             projectUuid: this.projectUuid,
             query: {

--- a/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
+++ b/packages/frontend/src/features/semanticViewer/runners/SemanticViewerResultsRunner.ts
@@ -1,4 +1,6 @@
 import {
+    convertColumnToResultsColumn,
+    convertToResultsColumns,
     type PivotChartData,
     type RawResultRow,
     type SemanticLayerPivot,
@@ -6,6 +8,7 @@ import {
     type VizChartLayout,
     type VizSqlColumn,
 } from '@lightdash/common';
+import { difference } from 'lodash';
 import { ResultsRunner } from '../../../components/DataViz/transformers/ResultsRunner';
 import { apiGetSemanticLayerQueryResults } from '../api/requests';
 
@@ -45,9 +48,7 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
             const rowKeys = Object.keys(row);
 
             // Result columns casing depends on warehouse, so we need to find the correct column name
-            const rowKey = rowKeys.find(
-                (key) => key.toLowerCase() === column.toLowerCase(),
-            );
+            const rowKey = convertColumnToResultsColumn(column, rowKeys);
 
             if (!rowKey) {
                 return;
@@ -67,13 +68,32 @@ export class SemanticViewerResultsRunner extends ResultsRunner {
             },
         });
 
+        const allResultsColumns = Object.keys(pivotedResults?.[0] ?? {});
+        let indexColumn: VizChartLayout['x'] | undefined;
+
+        if (config.x) {
+            const xReference = convertColumnToResultsColumn(
+                config.x.reference,
+                allResultsColumns,
+            );
+
+            indexColumn = xReference
+                ? {
+                      ...config.x,
+                      reference: xReference,
+                  }
+                : undefined;
+        }
+
+        const columnsToRemove = convertToResultsColumns(
+            [...pivotConfig.index, ...pivotConfig.on],
+            allResultsColumns,
+        );
+
         return {
-            indexColumn: config.x,
+            indexColumn,
             results: pivotedResults ?? [],
-            valuesColumns: Object.keys(pivotedResults?.[0] ?? {}).filter(
-                (name) =>
-                    ![...pivotConfig.index, ...pivotConfig.on].includes(name),
-            ),
+            valuesColumns: difference(allResultsColumns, columnsToRemove),
         };
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR fixes 2 issues:
- Depending on the warehouse, the column names might not match the field name casing, so we need to match the column names to field names to avoid this
- We removed aggregations, so we cannot use the same query to fetch results for the visualizations, this is because it might contain more columns than the fields selected in the chart config and therefore it would brake the viz.

**Before**
Notice the lack of x-axis label
![image](https://github.com/user-attachments/assets/7c0c9822-c99e-4dd7-8a28-ddbae2210368)
![image](https://github.com/user-attachments/assets/563512d0-f182-4c34-a512-bde0e321763f)

**After**
![image](https://github.com/user-attachments/assets/f1950976-bce1-4624-95ac-b8188cb64768)
![image](https://github.com/user-attachments/assets/29508c33-f4b1-420f-b2c4-9c31b680631f)
![image](https://github.com/user-attachments/assets/f23bb90c-8b80-470b-a4e7-b95e79815a7b)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
