### PR TITLE
chore: update copy on empty state

### DIFF
--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -180,7 +180,7 @@ const Content: FC = () => {
                 <Center sx={{ flexGrow: 1 }}>
                     <SuboptimalState
                         title="No results"
-                        description="Please run the query to see results"
+                        description="Select some fields, then run the query to see results."
                     />
                 </Center>
             ) : activeEditorTab === EditorTabs.RESULTS ? (


### PR DESCRIPTION
Updates the copy on the empty state for the semantic viewer
