### PR TITLE
fix: set series labels depending on field config `y`

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -210,7 +210,7 @@ export class CartesianChartDataModel
                 appendToBody: true, // Similar to rendering a tooltip in a Portal
             },
             legend: {
-                show: true,
+                show: !!(this.fieldConfig && this.fieldConfig.y.length > 1),
                 type: 'scroll',
             },
             xAxis: {

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -162,9 +162,18 @@ export class CartesianChartDataModel
                 const seriesFormat = Object.values(display?.series || {}).find(
                     (s) => s.yAxisIndex === index,
                 )?.format;
-                const seriesLabel = Object.values(display?.series || {}).find(
-                    (s) => s.yAxisIndex === index,
-                )?.label;
+
+                const singleYAxisLabel =
+                    // NOTE: When there's only one y-axis left, set the label on the series as well
+                    this.fieldConfig?.y.length === 1 &&
+                    display?.yAxis?.[0]?.label
+                        ? display.yAxis[0].label
+                        : undefined;
+                const seriesLabel =
+                    singleYAxisLabel ??
+                    Object.values(display?.series || {}).find(
+                        (s) => s.yAxisIndex === index,
+                    )?.label;
 
                 const seriesColor = Object.values(display?.series || {}).find(
                     (s) => s.yAxisIndex === index,
@@ -210,7 +219,7 @@ export class CartesianChartDataModel
                 appendToBody: true, // Similar to rendering a tooltip in a Portal
             },
             legend: {
-                show: !!(this.fieldConfig && this.fieldConfig.y.length > 1),
+                show: !!(transformedData.valuesColumns.length > 1),
                 type: 'scroll',
             },
             xAxis: {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -69,6 +69,7 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                                 actions.setSeriesLabel({
                                                     label: e.target.value,
                                                     reference,
+                                                    index,
                                                 }),
                                             );
                                         }}

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -116,16 +116,6 @@ export const cartesianChartConfigSlice = createSlice({
             config.display = config.display || {};
             config.display.yAxis = config.display.yAxis || [];
 
-            // NOTE: If there's only one y-axis, set the label on the series as well
-            if (config.fieldConfig?.y.length === 1) {
-                config.display.series = {
-                    [config.fieldConfig.y[0].reference]: {
-                        yAxisIndex: 0,
-                        label: action.payload.label,
-                    },
-                };
-            }
-
             const { index, label } = action.payload;
             if (config.display.yAxis[index] === undefined) {
                 config.display.yAxis[index] = {
@@ -195,12 +185,6 @@ export const cartesianChartConfigSlice = createSlice({
             }
 
             if (yAxisFields) {
-                // NOTE: When we add a new y axis when there's only one series, then reset the series' label
-                if (yAxisFields.length === 1 && state.config.display?.series) {
-                    state.config.display.series[
-                        yAxisFields[0].reference
-                    ].label = undefined;
-                }
                 state.config.fieldConfig.y.push({
                     reference: defaultYAxisField,
                     aggregation: VIZ_DEFAULT_AGGREGATION,
@@ -233,19 +217,6 @@ export const cartesianChartConfigSlice = createSlice({
                             }
                         },
                     );
-
-                    // NOTE: When there's only one y-axis left, set the label on the series as well
-                    if (
-                        state.config.fieldConfig.y.length === 1 &&
-                        state.config.display.yAxis
-                    ) {
-                        state.config.display.series = {
-                            [state.config.fieldConfig.y[0].reference]: {
-                                yAxisIndex: 0,
-                                label: state.config.display.yAxis[0].label,
-                            },
-                        };
-                    }
                 }
             }
         },

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -116,6 +116,16 @@ export const cartesianChartConfigSlice = createSlice({
             config.display = config.display || {};
             config.display.yAxis = config.display.yAxis || [];
 
+            // NOTE: If there's only one y-axis, set the label on the series as well
+            if (config.fieldConfig?.y.length === 1) {
+                config.display.series = {
+                    [config.fieldConfig.y[0].reference]: {
+                        yAxisIndex: 0,
+                        label: action.payload.label,
+                    },
+                };
+            }
+
             const { index, label } = action.payload;
             if (config.display.yAxis[index] === undefined) {
                 config.display.yAxis[index] = {
@@ -130,6 +140,7 @@ export const cartesianChartConfigSlice = createSlice({
             action: PayloadAction<{
                 reference: string;
                 label: string;
+                index: number;
             }>,
         ) => {
             if (!config) return;
@@ -137,6 +148,7 @@ export const cartesianChartConfigSlice = createSlice({
             config.display.series = config.display.series || {};
             config.display.series[action.payload.reference] = {
                 ...config.display.series[action.payload.reference],
+                yAxisIndex: action.payload.index,
                 label: action.payload.label,
             };
         },
@@ -183,6 +195,12 @@ export const cartesianChartConfigSlice = createSlice({
             }
 
             if (yAxisFields) {
+                // NOTE: When we add a new y axis when there's only one series, then reset the series' label
+                if (yAxisFields.length === 1 && state.config.display?.series) {
+                    state.config.display.series[
+                        yAxisFields[0].reference
+                    ].label = undefined;
+                }
                 state.config.fieldConfig.y.push({
                     reference: defaultYAxisField,
                     aggregation: VIZ_DEFAULT_AGGREGATION,
@@ -215,6 +233,19 @@ export const cartesianChartConfigSlice = createSlice({
                             }
                         },
                     );
+
+                    // NOTE: When there's only one y-axis left, set the label on the series as well
+                    if (
+                        state.config.fieldConfig.y.length === 1 &&
+                        state.config.display.yAxis
+                    ) {
+                        state.config.display.series = {
+                            [state.config.fieldConfig.y[0].reference]: {
+                                yAxisIndex: 0,
+                                label: state.config.display.yAxis[0].label,
+                            },
+                        };
+                    }
                 }
             }
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11425

### Description:

- Hide legend if only on y axis fieldConfig
- When from 1 series to 2, then clear to default on series 1
- When only 1 series + when setting a label for `y` axis, then that will change the series label as well 

recording:

https://github.com/user-attachments/assets/f79fc029-130a-44c7-94c7-d91baee8a13f



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
