### PR TITLE
fix: allow saving columns config on save

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4604,6 +4604,7 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    executionProject: { dataType: 'string' },
                 },
                 validators: {},
             },
@@ -6884,18 +6885,30 @@ const models: TsoaRoute.Models = {
         enums: ['table'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.VizColumnConfig_': {
+    VizColumnConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
+            nestedProperties: {
+                aggregation: { ref: 'VizAggregationOptions' },
+                order: { dataType: 'double' },
+                frozen: { dataType: 'boolean', required: true },
+                label: { dataType: 'string', required: true },
+                reference: { dataType: 'string', required: true },
+                visible: { dataType: 'boolean', required: true },
+            },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VizColumnsConfig: {
         dataType: 'refAlias',
-        type: { ref: 'Record_string.VizColumnConfig_', validators: {} },
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { ref: 'VizColumnConfig' },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VizTableConfig: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5110,6 +5110,9 @@
                     "maximumBytesBilled": {
                         "type": "number",
                         "format": "double"
+                    },
+                    "executionProject": {
+                        "type": "string"
                     }
                 },
                 "required": ["type", "project", "dataset"],
@@ -7575,13 +7578,37 @@
                 "enum": ["table"],
                 "type": "string"
             },
-            "Record_string.VizColumnConfig_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
+            "VizColumnConfig": {
+                "properties": {
+                    "aggregation": {
+                        "$ref": "#/components/schemas/VizAggregationOptions"
+                    },
+                    "order": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "frozen": {
+                        "type": "boolean"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "reference": {
+                        "type": "string"
+                    },
+                    "visible": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["frozen", "label", "reference", "visible"],
+                "type": "object"
             },
             "VizColumnsConfig": {
-                "$ref": "#/components/schemas/Record_string.VizColumnConfig_"
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/VizColumnConfig"
+                },
+                "type": "object"
             },
             "VizTableConfig": {
                 "allOf": [
@@ -9558,7 +9585,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1244.1",
+        "version": "0.1248.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -92,7 +92,7 @@ export type VizColumnConfig = {
     aggregation?: VizAggregationOptions;
 };
 
-export type VizColumnsConfig = Record<string, VizColumnConfig>;
+export type VizColumnsConfig = { [key: string]: VizColumnConfig };
 
 export type VizTableColumnsConfig = {
     columns: VizColumnsConfig;

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -39,8 +39,6 @@ export const Table = <T extends ResultsRunner>({
     const columnsCount = getColumnsCount();
     const { headerGroups, virtualRows, rowModelRows } = getTableData();
 
-    console.log({ virtualRows });
-
     return (
         <Flex
             ref={tableWrapperRef}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Allow saving table viz config.

To replicate: 
- Run a query
- Go to `Chart`
- Choose Table viz type
- Hide some tables etc
- Save

Should see that reflected on the saved chart. 

> [!NOTE]
> I know there's an issue with the table rendering when it doesn't have many columns visible. Tracking here: https://github.com/lightdash/lightdash/issues/11458

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
