### PR TITLE
chore: upgrade @reduxjs/toolkit

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -40,7 +40,7 @@
         "@mantine/tiptap": "6.0.21",
         "@monaco-editor/react": "^4.6.0",
         "@popsql/monaco-sql-languages": "^0.2.0",
-        "@reduxjs/toolkit": "^2.2.6",
+        "@reduxjs/toolkit": "^2.2.7",
         "@sentry/react": "^8.9.2",
         "@shopify/react-web-worker": "^5.0.13",
         "@tabler/icons-react": "^2.32.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -40,7 +40,7 @@
         "@mantine/tiptap": "6.0.21",
         "@monaco-editor/react": "^4.6.0",
         "@popsql/monaco-sql-languages": "^0.2.0",
-        "@reduxjs/toolkit": "^2.2.7",
+        "@reduxjs/toolkit": "2.2.7",
         "@sentry/react": "^8.9.2",
         "@shopify/react-web-worker": "^5.0.13",
         "@tabler/icons-react": "^2.32.0",

--- a/packages/frontend/src/components/DataViz/store/index.ts
+++ b/packages/frontend/src/components/DataViz/store/index.ts
@@ -1,6 +1,3 @@
-// FIXES ts2742 issue with configureStore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-import type * as rtk from '@reduxjs/toolkit';
 import { configureStore } from '@reduxjs/toolkit';
 import { useDispatch, useSelector } from 'react-redux';
 import { barChartConfigSlice, type BarChartActionsType } from './barChartSlice';

--- a/packages/frontend/src/features/semanticViewer/store/index.ts
+++ b/packages/frontend/src/features/semanticViewer/store/index.ts
@@ -1,8 +1,4 @@
-// FIXES ts2742 issue with configureStore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-import type * as rtk from '@reduxjs/toolkit';
 import { configureStore } from '@reduxjs/toolkit';
-
 import { barChartConfigSlice } from '../../../components/DataViz/store/barChartSlice';
 import { lineChartConfigSlice } from '../../../components/DataViz/store/lineChartSlice';
 import { pieChartConfigSlice } from '../../../components/DataViz/store/pieChartSlice';

--- a/packages/frontend/src/features/sqlRunner/store/index.ts
+++ b/packages/frontend/src/features/sqlRunner/store/index.ts
@@ -1,6 +1,3 @@
-// FIXES ts2742 issue with configureStore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-import type * as rtk from '@reduxjs/toolkit';
 import { configureStore } from '@reduxjs/toolkit';
 import { barChartConfigSlice } from '../../../components/DataViz/store/barChartSlice';
 import { lineChartConfigSlice } from '../../../components/DataViz/store/lineChartSlice';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,10 +4229,10 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@reduxjs/toolkit@^2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.6.tgz#4a8356dad9d0c1ab255607a555d492168e0e3bc1"
-  integrity sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==
+"@reduxjs/toolkit@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.7.tgz#199e3d10ccb39267cb5aee92c0262fd9da7fdfb2"
+  integrity sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==
   dependencies:
     immer "^10.0.3"
     redux "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,7 +4229,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@reduxjs/toolkit@^2.2.7":
+"@reduxjs/toolkit@2.2.7":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.7.tgz#199e3d10ccb39267cb5aee92c0262fd9da7fdfb2"
   integrity sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Introduces a fix to: 

```
Type error: The inferred type of 'configureStore' cannot be named without a reference to '@reduxjs/toolkit/node_modules/redux'. This is likely not portable. A type annotation is necessary.
```

so we don't have to have a hacky fix for this anymore.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
