### PR TITLE
feat: select all for tabbed dashboard filters

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -297,35 +297,40 @@ const TileFilterConfiguration: FC<Props> = ({
         [tileTargetList, isAllChecked],
     );
 
-    return tabs.length > 0 ? (
-        <Accordion defaultValue={activeTabUuid} variant="contained">
-            {tabs.map((tab, index) => (
-                <Flex align="center" gap="sm" key={index}>
-                    <Accordion.Item
-                        key={index}
-                        value={tab.uuid}
-                        style={{ flexGrow: 1 }}
-                    >
-                        <Accordion.Control
-                            fw={500}
-                            style={{ fontSize: '14px', fontWeight: 500 }}
+    const tileList =
+        tabs.length > 0 ? (
+            <Accordion defaultValue={activeTabUuid} variant="contained">
+                {tabs.map((tab, index) => (
+                    <Flex align="center" gap="sm" key={index}>
+                        <Accordion.Item
+                            key={index}
+                            value={tab.uuid}
+                            style={{ flexGrow: 1 }}
                         >
-                            {tab.name}
-                        </Accordion.Control>
-                        <Accordion.Panel>
-                            <StackSubComponent
-                                tileList={filteredTileTargetList(tab.uuid)}
-                            />
-                        </Accordion.Panel>
-                    </Accordion.Item>
-                    <SwitchToggle
-                        tileList={filteredTileTargetList(tab.uuid)}
-                        tabName={tab.name}
-                    />
-                </Flex>
-            ))}
-        </Accordion>
-    ) : (
+                            <Accordion.Control
+                                fw={500}
+                                style={{ fontSize: '14px', fontWeight: 500 }}
+                            >
+                                {tab.name}
+                            </Accordion.Control>
+                            <Accordion.Panel>
+                                <StackSubComponent
+                                    tileList={filteredTileTargetList(tab.uuid)}
+                                />
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                        <SwitchToggle
+                            tileList={filteredTileTargetList(tab.uuid)}
+                            tabName={tab.name}
+                        />
+                    </Flex>
+                ))}
+            </Accordion>
+        ) : (
+            <StackSubComponent tileList={tileTargetList} />
+        );
+
+    return (
         <Stack spacing="lg">
             <Checkbox
                 size="xs"
@@ -355,7 +360,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     }
                 }}
             />
-            <StackSubComponent tileList={tileTargetList} />
+            {tileList}
         </Stack>
     );
 };


### PR DESCRIPTION
### Description:
Adds a "Select all" checkbox to the filter "Chart tiles" dropdown/dialog when using tabbed dashboards. Non-tabbed dashboards already have this checkbox.

**All selected**
<img width="539" alt="image" src="https://github.com/user-attachments/assets/07e1d8cd-9f78-47cd-af3a-182bd07f5fcd">

**All de-selected**
<img width="539" alt="image" src="https://github.com/user-attachments/assets/772b48b3-224e-4d46-9648-40bafe48a7f2">

**Mixed selected**
<img width="538" alt="image" src="https://github.com/user-attachments/assets/53d61c69-52dc-43f1-9b98-588307a2b228">

**FYI, indentation formatting changed many lines. Before formatting:**
<img width="526" alt="image" src="https://github.com/user-attachments/assets/3ce0b7c9-807f-41b9-b10b-fda1ff7d55f0">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
