### PR TITLE
chore: make semantic layer sort buttons gray

### DIFF
--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -1,4 +1,8 @@
-import { FieldType, SemanticLayerSortByDirection } from '@lightdash/common';
+import {
+    DimensionType,
+    FieldType,
+    SemanticLayerSortByDirection,
+} from '@lightdash/common';
 import { Button, Center, Group, SegmentedControl, Text } from '@mantine/core';
 import {
     IconArrowDown,
@@ -9,6 +13,7 @@ import {
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { TableFieldIcon } from '../../../components/DataViz/Icons';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
     selectAllSelectedFieldNames,
@@ -133,14 +138,19 @@ const Content: FC = () => {
                                         variant={
                                             sortDirection ? 'filled' : 'outline'
                                         }
+                                        leftIcon={
+                                            <TableFieldIcon
+                                                fieldType={
+                                                    kind === 'metrics'
+                                                        ? DimensionType.NUMBER
+                                                        : DimensionType.STRING
+                                                }
+                                            />
+                                        }
                                         size="sm"
                                         mr="xs"
                                         mb="xs"
-                                        color={
-                                            kind === 'metrics'
-                                                ? 'orange'
-                                                : 'blue'
-                                        }
+                                        color="gray"
                                         compact
                                         onClick={() =>
                                             handleAddSortBy(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Makes the semantic layer sort buttons gray. This is probably not their final form, but we are making them more subtle for the demo. 

<img width="1031" alt="Screenshot 2024-09-08 at 15 32 13" src="https://github.com/user-attachments/assets/5cd39906-97c9-4c8d-bd09-e681ada8f917">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
