### PR TITLE
fix: show minimal table cell context menu

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -25,8 +25,9 @@ const UrlMenuItem: FC<{
     itemIdsInRow: string[];
     value: ResultValue;
     row: Record<string, Record<string, ResultValue>>;
-}> = ({ urlConfig, itemsMap, itemIdsInRow, value, row }) => {
-    const { track } = useTracking();
+    showError?: boolean;
+}> = ({ urlConfig, itemsMap, itemIdsInRow, value, row, showError = true }) => {
+    const tracking = useTracking(true);
     const [url, renderError] = useMemo(() => {
         let parsedUrl: string | undefined = undefined;
         let errorMessage: string | undefined = undefined;
@@ -74,7 +75,9 @@ const UrlMenuItem: FC<{
         return errorMessage;
     }, [itemIdsInRow, itemsMap, urlConfig]);
     const error: string | undefined = validationError || renderError;
-
+    if (!showError && error) {
+        return null;
+    }
     return (
         <Tooltip
             withinPortal
@@ -96,7 +99,7 @@ const UrlMenuItem: FC<{
                     }
                     disabled={!url}
                     onClick={() => {
-                        track({
+                        tracking?.track({
                             name: EventName.GO_TO_LINK_CLICKED,
                         });
                         window.open(url, '_blank');
@@ -113,7 +116,8 @@ const UrlMenuItems: FC<{
     urls: FieldUrl[] | undefined;
     cell: Cell<ResultRow, ResultRow[0]>;
     itemsMap?: Record<string, Field | TableCalculation>;
-}> = ({ urls, cell, itemsMap }) => {
+    showErrors?: boolean;
+}> = ({ urls, cell, itemsMap, showErrors }) => {
     const value: ResultValue = cell.getValue()?.value || {};
     const [itemIdsInRow, rowData] = useMemo(() => {
         const itemIds: string[] = [];
@@ -147,6 +151,7 @@ const UrlMenuItems: FC<{
                     itemIdsInRow={itemIdsInRow}
                     row={rowData}
                     value={value}
+                    showError={showErrors}
                 />
             ))}
         </>

--- a/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
@@ -1,0 +1,48 @@
+import { isField, type ResultValue } from '@lightdash/common';
+import { Menu } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy } from '@tabler/icons-react';
+import { useCallback, useMemo, type FC } from 'react';
+import useToaster from '../../hooks/toaster/useToaster';
+import MantineIcon from '../common/MantineIcon';
+import { type CellContextMenuProps } from '../common/Table/types';
+import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+
+const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
+    cell,
+}) => {
+    const { showToastSuccess } = useToaster();
+    const meta = cell.column.columnDef.meta;
+    const item = meta?.item;
+
+    const value: ResultValue = useMemo(
+        () => cell.getValue()?.value || {},
+        [cell],
+    );
+
+    const clipboard = useClipboard({ timeout: 200 });
+
+    const handleCopyToClipboard = useCallback(() => {
+        clipboard.copy(value.formatted);
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [clipboard, showToastSuccess, value.formatted]);
+
+    return (
+        <>
+            {item && value.raw && isField(item) && (
+                <UrlMenuItems urls={item.urls} cell={cell} showErrors={false} />
+            )}
+
+            {isField(item) && (item.urls || []).length > 0 && <Menu.Divider />}
+
+            <Menu.Item
+                icon={<MantineIcon icon={IconCopy} size="md" fillOpacity={0} />}
+                onClick={handleCopyToClipboard}
+            >
+                Copy value
+            </Menu.Item>
+        </>
+    );
+};
+
+export default MinimalCellContextMenu;

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -11,6 +11,7 @@ import { LoadingChart } from '../SimpleChart';
 import CellContextMenu from './CellContextMenu';
 import DashboardCellContextMenu from './DashboardCellContextMenu';
 import DashboardHeaderContextMenu from './DashboardHeaderContextMenu';
+import MinimalCellContextMenu from './MinimalCellContextMenu';
 
 type SimpleTableProps = {
     isDashboard: boolean;
@@ -134,6 +135,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 }}
                 cellContextMenu={(props) => {
                     if (isSqlRunner) return <>{props.children}</>;
+                    if (minimal) {
+                        return <MinimalCellContextMenu {...props} />;
+                    }
                     if (isDashboard && tileUuid) {
                         return (
                             <DashboardCellContextMenu

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -49,7 +49,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     const [isTooltipOpen, { open: openTooltip, close: closeTooltip }] =
         useDisclosure(false);
 
-    const canHaveMenu = !!cellContextMenu && hasData && !minimal;
+    const canHaveMenu = !!cellContextMenu && hasData;
     const canHaveTooltip = !!tooltipContent && !minimal;
 
     const shouldRenderMenu = canHaveMenu && isMenuOpen && elementRef.current;

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -235,7 +235,8 @@ const VirtualizedTableBody: FC<{
 };
 
 const NormalTableBody: FC = () => {
-    const { table, conditionalFormattings } = useTableContext();
+    const { table, cellContextMenu, conditionalFormattings } =
+        useTableContext();
     const { rows } = table.getRowModel();
 
     return (
@@ -246,6 +247,7 @@ const NormalTableBody: FC = () => {
                     minimal
                     index={index}
                     row={row}
+                    cellContextMenu={cellContextMenu}
                     conditionalFormattings={conditionalFormattings}
                 />
             ))}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11292](https://github.com/lightdash/lightdash/issues/11292) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Show minimal table cell context for mobile page and embed. 

Mobile (load the Lightdash home page in a small browser window and then navigate to a dashboard):
<img width="790" alt="Screenshot 2024-09-09 at 10 42 53" src="https://github.com/user-attachments/assets/df17d894-8f0b-4ba6-87c1-e03c8df85214">

Embed: ( FYI: you can't test this in this repo but also uses `minimal=true`)
<img width="1841" alt="Screenshot 2024-09-09 at 10 42 29" src="https://github.com/user-attachments/assets/ccbde240-2cf3-4983-9481-a6c07471cd51">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
