### PR TITLE
style: change sql runner edit buttons

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -7,12 +7,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine/core';
-import {
-    IconArrowBackUp,
-    IconDeviceFloppy,
-    IconPencil,
-    IconTrash,
-} from '@tabler/icons-react';
+import { IconPencil, IconTrash } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -113,8 +108,8 @@ export const HeaderEdit: FC = () => {
 
                     <Group spacing="md">
                         <Button
-                            variant="default"
                             size="xs"
+                            color="green.7"
                             disabled={!config || !sql}
                             loading={isLoading}
                             onClick={() => {
@@ -128,7 +123,6 @@ export const HeaderEdit: FC = () => {
                                     });
                                 }
                             }}
-                            leftIcon={<MantineIcon icon={IconDeviceFloppy} />}
                         >
                             Save
                         </Button>
@@ -137,7 +131,8 @@ export const HeaderEdit: FC = () => {
                             label="Back to view page"
                             position="bottom"
                         >
-                            <ActionIcon
+                            <Button
+                                variant="default"
                                 size="xs"
                                 onClick={() =>
                                     history.push(
@@ -145,8 +140,8 @@ export const HeaderEdit: FC = () => {
                                     )
                                 }
                             >
-                                <MantineIcon icon={IconArrowBackUp} />
-                            </ActionIcon>
+                                Cancel
+                            </Button>
                         </Tooltip>
                         <Tooltip variant="xs" label="Delete" position="bottom">
                             <ActionIcon

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,6 +1,14 @@
 import { subject } from '@casl/ability';
-import { ActionIcon, Group, Paper, Stack, Title, Tooltip } from '@mantine/core';
-import { IconPencil, IconTrash } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Button,
+    Group,
+    Paper,
+    Stack,
+    Title,
+    Tooltip,
+} from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -91,22 +99,17 @@ export const HeaderView: FC = () => {
                     </Stack>
                     <Group spacing="md">
                         {canManageSqlRunner && canManageChart && (
-                            <Tooltip
-                                variant="xs"
-                                label="Edit chart"
-                                position="bottom"
+                            <Button
+                                size="xs"
+                                variant="default"
+                                onClick={() =>
+                                    history.push(
+                                        `/projects/${projectUuid}/sql-runner/${savedSqlChart.slug}/edit`,
+                                    )
+                                }
                             >
-                                <ActionIcon
-                                    size="xs"
-                                    onClick={() =>
-                                        history.push(
-                                            `/projects/${projectUuid}/sql-runner/${savedSqlChart.slug}/edit`,
-                                        )
-                                    }
-                                >
-                                    <MantineIcon icon={IconPencil} />
-                                </ActionIcon>
-                            </Tooltip>
+                                Edit chart
+                            </Button>
                         )}
                         {canManageSqlRunner && canManageChart && (
                             <Tooltip


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #11275

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

 - [ ] `Edit chart` should be a text CTA (because this is consistent with the rest of the app)


- [ ] The 'back button' here, looks like 'undo/redo'. Change `Save` to green CTA and use the 'Cancel' CTA from normal charts. I agree this needs to change, but for now, its best to stick to patterns people are used to!
- [ ] The Save button should be greyed out if I havent actually made any changes
### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
