### PR TITLE
feat: copy access when promoting new private space

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -5,7 +5,10 @@ import {
     DashboardChartTile,
     DashboardTileTypes,
     OrganizationMemberRole,
+    ProjectMemberRole,
     SessionUser,
+    Space,
+    SpaceMemberRole,
 } from '@lightdash/common';
 import {
     PromotedChart,
@@ -72,6 +75,43 @@ export const upstreamSpace: UpstreamChart['space'] = {
     chartCount: 0,
     dashboardCount: 0,
     slug: 'jaffle-shop',
+};
+
+export const upstreamFullSpace: Space = {
+    ...upstreamSpace,
+    queries: [],
+    dashboards: [],
+    access: [
+        {
+            userUuid: 'userUuid',
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'email',
+            role: SpaceMemberRole.ADMIN,
+            hasDirectAccess: true,
+            projectRole: ProjectMemberRole.VIEWER,
+            inheritedRole: OrganizationMemberRole.VIEWER,
+            inheritedFrom: 'organization',
+        },
+        {
+            userUuid: 'adminUuid',
+            firstName: 'firstName',
+            lastName: 'lastName',
+            email: 'adminemail',
+            role: SpaceMemberRole.ADMIN,
+            hasDirectAccess: false,
+            projectRole: ProjectMemberRole.ADMIN,
+            inheritedRole: undefined,
+            inheritedFrom: undefined,
+        },
+    ],
+    groupsAccess: [
+        {
+            groupUuid: 'groupUuid',
+            groupName: 'groupName',
+            spaceRole: SpaceMemberRole.ADMIN,
+        },
+    ],
 };
 
 export const promotedChart: PromotedChart = {

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -16,6 +16,7 @@ import {
     promotedDashboard,
     promotedDashboardWithChartWithinDashboard,
     promotedDashboardWithNewPrivateSpace,
+    upstreamFullSpace,
     user,
 } from './PromoteService.mock';
 
@@ -32,7 +33,9 @@ const spaceModel = {
     find: jest.fn(async () => [existingUpstreamChart.space]),
     getUserSpaceAccess: jest.fn(async () => []),
     createSpace: jest.fn(async () => existingUpstreamChart.space),
+    getFullSpace: jest.fn(async () => upstreamFullSpace),
     addSpaceAccess: jest.fn(async () => {}),
+    addSpaceGroupAccess: jest.fn(async () => {}),
     update: jest.fn(async () => {}),
 };
 const dashboardModel = {
@@ -462,6 +465,8 @@ describe('PromoteService promoting and mutating changes', () => {
         const newChanges = await service.upsertSpaces(user, changes);
 
         expect(spaceModel.createSpace).toHaveBeenCalledTimes(1);
+        expect(spaceModel.addSpaceAccess).toHaveBeenCalledTimes(0);
+        expect(spaceModel.addSpaceGroupAccess).toHaveBeenCalledTimes(0);
 
         expect(newChanges).toEqual({
             ...changes,
@@ -522,6 +527,7 @@ describe('PromoteService promoting and mutating changes', () => {
             'userUuid',
             'admin',
         );
+        expect(spaceModel.addSpaceGroupAccess).toHaveBeenCalledTimes(1);
     });
 
     test('update space should not affect permissions', async () => {
@@ -543,6 +549,7 @@ describe('PromoteService promoting and mutating changes', () => {
             name: promotedDashboardWithNewPrivateSpace.space.name,
         });
         expect(spaceModel.addSpaceAccess).toHaveBeenCalledTimes(0);
+        expect(spaceModel.addSpaceGroupAccess).toHaveBeenCalledTimes(0);
     });
 
     test('return same changes if no new dashboard is created', async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11469](https://github.com/lightdash/lightdash/issues/11469) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Testing promoting with user that has access in downstream project but not upstream project

<img width="880" alt="Screenshot 2024-09-09 at 14 46 59" src="https://github.com/user-attachments/assets/e33e9da8-61ec-4e12-9142-53331cb5a6e3">

![Sep-09-2024 14-47-42](https://github.com/user-attachments/assets/fc1bc68c-9ecf-4993-8125-b5d6d26f9489)




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
