### PR TITLE
fix: check for empty rows when updating warehouse available tables

### DIFF
--- a/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
+++ b/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
@@ -100,7 +100,9 @@ export class WarehouseAvailableTablesModel {
                 )
                 .del();
 
-            await trx(WarehouseAvailableTablesTableName).insert(rows);
+            if (rows.length !== 0) {
+                await trx(WarehouseAvailableTablesTableName).insert(rows);
+            }
         });
     }
 
@@ -122,7 +124,9 @@ export class WarehouseAvailableTablesModel {
                     userWarehouseCredentialsUuid,
                 )
                 .del();
-            await trx(WarehouseAvailableTablesTableName).insert(rows);
+            if (rows.length !== 0) {
+                await trx(WarehouseAvailableTablesTableName).insert(rows);
+            }
         });
     }
 }


### PR DESCRIPTION
Closes: #11383

Knex throws on empty insert rows: https://github.com/lightdash/lightdash/issues/11434

**Updated wiki**: https://www.notion.so/lightdash/Knex-6a3615a169044daeaa7a54465c631960

User complained about receiving this error, which is a combination of this bug and https://github.com/lightdash/lightdash/issues/11434