### PR TITLE
chore: fix chart loading in semantic viewer

### DIFF
--- a/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
@@ -89,7 +89,6 @@ export const useChartViz = <T extends ResultsRunner>({
             }
         },
         enabled: !!chartDataModel && !!queryKey,
-        keepPreviousData: true,
     });
 
     const chartSpec = useMemo(() => {

--- a/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
@@ -89,6 +89,7 @@ export const useChartViz = <T extends ResultsRunner>({
             }
         },
         enabled: !!chartDataModel && !!queryKey,
+        keepPreviousData: true,
     });
 
     const chartSpec = useMemo(() => {

--- a/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
@@ -98,7 +98,7 @@ const ContentCharts: FC = () => {
                         <ChartView
                             config={vizConfig}
                             spec={chartSpec}
-                            isLoading={chartVizQuery.isLoading}
+                            isLoading={chartVizQuery.isFetching}
                             error={chartVizQuery.error}
                             style={{
                                 flexGrow: 1,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixes the loading state when interacting with charts. Use isFetching instead of isLoading on updated chart queries.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
