### PR TITLE
style: improve resize handlers design & spacings

### DIFF
--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -64,7 +64,7 @@ export const Table = <T extends ResultsRunner>({
                                         backgroundColor: TABLE_HEADER_BG,
                                     }}
                                 >
-                                    <Group spacing="two">
+                                    <Group spacing="two" fz={13}>
                                         {columnsConfig[header.id]
                                             ?.aggregation && (
                                             <Badge

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -12,7 +12,11 @@ import { SectionName } from '../../../types/Events';
 import AboutFooter, { FOOTER_HEIGHT, FOOTER_MARGIN } from '../../AboutFooter';
 import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../../NavBar';
 import { PAGE_HEADER_HEIGHT } from './PageHeader';
-import Sidebar, { SidebarPosition, type SidebarWidthProps } from './Sidebar';
+import Sidebar, {
+    SidebarPosition,
+    type SidebarProps,
+    type SidebarWidthProps,
+} from './Sidebar';
 
 type StyleProps = {
     withCenteredContent?: boolean;
@@ -171,12 +175,14 @@ type Props = {
     isRightSidebarOpen?: boolean;
     rightSidebarWidthProps?: SidebarWidthProps;
     header?: React.ReactNode;
+    sidebarProps?: SidebarProps;
 } & Omit<StyleProps, 'withSidebar' | 'withHeader'>;
 
 const Page: FC<React.PropsWithChildren<Props>> = ({
     title,
     header,
     sidebar,
+    sidebarProps,
     isSidebarOpen = true,
     rightSidebar,
     isRightSidebarOpen = false,
@@ -251,6 +257,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                         isOpen={isSidebarOpen}
                         onResizeStart={startSidebarResizing}
                         onResizeEnd={stopSidebarResizing}
+                        sidebarProps={sidebarProps}
                     >
                         <ErrorBoundary wrapper={{ mt: '4xl' }}>
                             {sidebar}

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -32,10 +32,14 @@ export type SidebarWidthProps = {
     maxWidth?: number;
 };
 
+export type SidebarProps = {
+    cardProps?: Omit<CardProps, 'children'>;
+};
+
 type Props = {
     isOpen?: boolean;
     containerProps?: FlexProps;
-    cardProps?: CardProps;
+    sidebarProps?: SidebarProps;
     position?: SidebarPosition;
     widthProps?: SidebarWidthProps;
     mainWidth?: number;
@@ -46,7 +50,7 @@ type Props = {
 const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     isOpen = true,
     containerProps,
-    cardProps,
+    sidebarProps,
     position = SidebarPosition.LEFT,
     widthProps = {},
     mainWidth,
@@ -111,8 +115,9 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                 padding="lg"
                                 pb={0}
                                 w={sidebarWidth}
-                                style={style}
                                 sx={{ flexGrow: 1 }}
+                                style={style}
+                                {...sidebarProps?.cardProps}
                             >
                                 {children}
                             </Card>
@@ -126,7 +131,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                     ? { right: -SIDEBAR_RESIZE_HANDLE_WIDTH }
                                     : { left: -SIDEBAR_RESIZE_HANDLE_WIDTH })}
                                 onMouseDown={startResizing}
-                                {...cardProps}
+                                {...sidebarProps?.cardProps}
                                 sx={(theme) => ({
                                     cursor: 'col-resize',
                                     zIndex: getDefaultZIndex('app') + 1,

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -16,7 +16,11 @@ import {
 } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { IconChartHistogram, IconCodeCircle } from '@tabler/icons-react';
+import {
+    IconChartHistogram,
+    IconCodeCircle,
+    IconGripHorizontal,
+} from '@tabler/icons-react';
 import {
     useCallback,
     useEffect,
@@ -505,25 +509,32 @@ export const ContentPanel: FC = () => {
                     <Box
                         hidden={hideResultsPanel}
                         component={PanelResizeHandle}
-                        bg="gray.3"
-                        h={showLimitText ? 20 : 10}
+                        bg="gray.1"
+                        h={15}
                         sx={(theme) => ({
                             transition: 'background-color 0.2s ease-in-out',
-                            '&[data-resize-handle-state="hover"]': {
-                                backgroundColor: theme.colors.gray[3],
-                            },
-                            '&[data-resize-handle-state="drag"]': {
+                            cursor: 'row-resize',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            '&:hover': {
                                 backgroundColor: theme.colors.gray[2],
                             },
+                            '&[data-resize-handle-state="drag"]': {
+                                backgroundColor: theme.colors.gray[3],
+                            },
+                            gap: 5,
                         })}
                     >
-                        {showLimitText ? (
-                            <Group position="center">
-                                <Text fz="sm" fw={500}>
+                        <IconGripHorizontal size={12} color="gray" />
+                        {showLimitText && (
+                            <>
+                                <Text fz="xs" fw={400} c="gray.7">
                                     Showing first {DEFAULT_SQL_LIMIT} rows
                                 </Text>
-                            </Group>
-                        ) : undefined}
+                                <IconGripHorizontal size={12} color="gray" />
+                            </>
+                        )}
                     </Box>
 
                     <Panel

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -526,13 +526,22 @@ export const ContentPanel: FC = () => {
                             gap: 5,
                         })}
                     >
-                        <IconGripHorizontal size={12} color="gray" />
+                        <MantineIcon
+                            color="gray"
+                            icon={IconGripHorizontal}
+                            size={12}
+                        />
+
                         {showLimitText && (
                             <>
                                 <Text fz="xs" fw={400} c="gray.7">
                                     Showing first {DEFAULT_SQL_LIMIT} rows
                                 </Text>
-                                <IconGripHorizontal size={12} color="gray" />
+                                <MantineIcon
+                                    color="gray"
+                                    icon={IconGripHorizontal}
+                                    size={12}
+                                />
                             </>
                         )}
                     </Box>

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -37,7 +37,7 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
     );
     return (
         <Stack spacing="xs" sx={{ flex: 1, overflow: 'hidden' }}>
-            <Group position="apart">
+            <Group position="apart" p="sm">
                 <Group noWrap spacing="xs">
                     <Title order={5} fz="sm" c="gray.6">
                         {activeSidebarTab === SidebarTabs.TABLES

--- a/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
@@ -1,5 +1,7 @@
 import { Box } from '@mantine/core';
+import { IconGripHorizontal } from '@tabler/icons-react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { useAppSelector } from '../store/hooks';
 import { TableFields } from './TableFields';
 import { Tables } from './Tables';
@@ -16,6 +18,7 @@ export const TablesPanel = () => {
                 style={{
                     display: 'flex',
                     flexDirection: 'column',
+                    padding: '0px 14px',
                 }}
             >
                 <Tables />
@@ -25,18 +28,28 @@ export const TablesPanel = () => {
                 <>
                     <Box
                         component={PanelResizeHandle}
-                        bg="gray.3"
-                        h={3}
+                        bg="gray.1"
+                        h={6}
                         sx={(theme) => ({
                             transition: 'background-color 0.2s ease-in-out',
-                            '&[data-resize-handle-state="hover"]': {
-                                backgroundColor: theme.colors.gray[3],
-                            },
-                            '&[data-resize-handle-state="drag"]': {
+                            cursor: 'row-resize',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            '&:hover': {
                                 backgroundColor: theme.colors.gray[2],
                             },
+                            '&[data-resize-handle-state="drag"]': {
+                                backgroundColor: theme.colors.gray[3],
+                            },
                         })}
-                    />
+                    >
+                        <MantineIcon
+                            color="gray"
+                            icon={IconGripHorizontal}
+                            size={8}
+                        />
+                    </Box>
 
                     <Panel
                         id="sql-runner-table-fields"
@@ -45,6 +58,7 @@ export const TablesPanel = () => {
                         style={{
                             display: 'flex',
                             flexDirection: 'column',
+                            padding: '0px 14px',
                         }}
                     >
                         <TableFields />

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -81,6 +81,11 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
             header={<Header mode={params.slug ? 'edit' : 'create'} />}
             isSidebarOpen={isLeftSidebarOpen}
             sidebar={<Sidebar setSidebarOpen={setLeftSidebarOpen} />}
+            sidebarProps={{
+                cardProps: {
+                    p: 0,
+                },
+            }}
         >
             <Group
                 align={'stretch'}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11273](https://github.com/lightdash/lightdash/issues/11273)

### Description:

Header groups (table column names) are now `13px`

Resize handlers are shorter + have a grip icon

`Page` can now take `sidebarProps` which is basically being passed, for now, as the `cardProps` - no other place in the app was using this prop so I rewrote that. 

Screenshot: 


https://github.com/user-attachments/assets/999c6dc9-f2fa-4355-9b25-5d34dfcfa49a



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
