### PR TITLE
feat: added clear all filters button

### DIFF
--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -248,7 +248,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
             {isEditMode && (
                 <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
                     {!isOpen ? (
-                        <Group>
+                        <Group align="center" position="apart" sx={{ flex: 1 }}>
                             <Button
                                 variant="outline"
                                 size="xs"
@@ -258,20 +258,22 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                             >
                                 Add filter
                             </Button>
-                            <Tooltip
-                                label="Clear all filters"
-                                position="bottom"
-                            >
-                                <Button
-                                    variant="outline"
-                                    size="xs"
-                                    color="red"
-                                    onClick={clearAllFilters}
-                                    disabled={totalFilterRules.length === 0}
+                            {totalFilterRules.length > 0 && (
+                                <Tooltip
+                                    label="Clear all filters"
+                                    position="bottom"
                                 >
-                                    Clear all
-                                </Button>
-                            </Tooltip>
+                                    <Button
+                                        variant="light"
+                                        size="xs"
+                                        color="gray"
+                                        onClick={clearAllFilters}
+                                        disabled={totalFilterRules.length === 0}
+                                    >
+                                        Clear all
+                                    </Button>
+                                </Tooltip>
+                            )}
                         </Group>
                     ) : (
                         <FieldSelect

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -21,6 +21,7 @@ import {
     Group,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine/core';
 import { IconAlertCircle, IconPlus, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
@@ -66,6 +67,9 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
     }, [itemsMap]);
 
     const totalFilterRules = getTotalFilterRules(filters);
+    const clearAllFilters = useCallback(() => {
+        setFilters({}, false);
+    }, [setFilters]);
     const invalidFilterRules = getInvalidFilterRules(fields, totalFilterRules);
     const hasInvalidFilterRules = invalidFilterRules.length > 0;
 
@@ -241,18 +245,34 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                     </Stack>
                 ))}
 
-            {isEditMode ? (
+            {isEditMode && (
                 <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
                     {!isOpen ? (
-                        <Button
-                            variant="outline"
-                            size="xs"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                            disabled={fields.length <= 0}
-                            onClick={toggleFieldInput}
-                        >
-                            Add filter
-                        </Button>
+                        <Group>
+                            <Button
+                                variant="outline"
+                                size="xs"
+                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                disabled={fields.length <= 0}
+                                onClick={toggleFieldInput}
+                            >
+                                Add filter
+                            </Button>
+                            <Tooltip
+                                label="Clear all filters"
+                                position="bottom"
+                            >
+                                <Button
+                                    variant="outline"
+                                    size="xs"
+                                    color="red"
+                                    onClick={clearAllFilters}
+                                    disabled={totalFilterRules.length === 0}
+                                >
+                                    Clear all
+                                </Button>
+                            </Tooltip>
+                        </Group>
                     ) : (
                         <FieldSelect
                             size="xs"
@@ -275,7 +295,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                         />
                     )}
                 </Box>
-            ) : null}
+            )}
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11298 

### Description:
This PR introduces a new "Clear All" button next to the existing "Add Filter" button in the filters section. The button allows users to clear all active filters with a single click, improving the overall user experience by simplifying the filter reset process.

Currently, users must remove filters one by one, which can be cumbersome. This new feature streamlines that workflow by adding a convenient option to clear all filters at once.

## Before:
The filters section does not have an option to clear all filters, requiring users to manually remove each filter individually.
![actual](https://github.com/user-attachments/assets/63fe4d07-60a1-4433-ad7a-f7e49638d2c2)
## After:
With the "Clear All" button, users can clear all active filters with one click, making the process faster and more efficient.

https://github.com/user-attachments/assets/d9d3094e-a091-4e08-b086-ff092d6c6113



### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
