### PR TITLE
feat: add sql chart to dashboard

### DIFF
--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -171,19 +171,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                         name: dashboardName,
                         description: dashboardDescription,
                         spaceUuid: spaceUuid,
-                        tiles: [
-                            {
-                                uuid: uuid4(),
-                                type: DashboardTileTypes.SAVED_CHART,
-                                tabUuid: undefined,
-                                properties: {
-                                    savedChartUuid: savedChart.uuid,
-                                },
-                                ...getDefaultChartTileSize(
-                                    savedChart?.chartConfig.type,
-                                ),
-                            },
-                        ],
+                        tiles: [chartTile],
                         tabs: [],
                     });
                     onClose?.();

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -1,7 +1,7 @@
 import {
     DashboardTileTypes,
     getDefaultChartTileSize,
-    type DashboardChartTile,
+    type DashboardTile,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -20,8 +20,9 @@ import {
     IconLayoutDashboard,
     IconPlus,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useMemo, useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
+import { useSavedSqlChart } from '../../features/sqlRunner/hooks/useSavedSqlCharts';
 import {
     appendNewTilesToBottom,
     useCreateMutation,
@@ -39,7 +40,8 @@ import MantineIcon from '../common/MantineIcon';
 interface AddTilesToDashboardModalProps {
     isOpen: boolean;
     projectUuid: string;
-    savedChartUuid: string;
+    savedChartUuid?: string;
+    savedSqlChartUuid?: string;
     onClose?: () => void;
 }
 
@@ -47,6 +49,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     isOpen,
     projectUuid,
     savedChartUuid,
+    savedSqlChartUuid,
     onClose,
 }) => {
     const [isCreatingNewDashboard, setIsCreatingNewDashboard] = useState(false);
@@ -54,7 +57,45 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
         useState<boolean>(false);
     const [isLoading, setIsLoading] = useState(false);
 
-    const { data: savedChart } = useSavedQuery({ id: savedChartUuid });
+    const { data: savedExploreChart } = useSavedQuery({ id: savedChartUuid });
+    const { data: savedSqlChart } = useSavedSqlChart({
+        projectUuid,
+        uuid: savedSqlChartUuid,
+    });
+
+    const [savedChart, chartTile] = useMemo(() => {
+        if (savedExploreChart) {
+            const tile: DashboardTile = {
+                uuid: uuid4(),
+                type: DashboardTileTypes.SAVED_CHART,
+                properties: { savedChartUuid: savedExploreChart.uuid },
+                tabUuid: undefined,
+                ...getDefaultChartTileSize(savedExploreChart.chartConfig?.type),
+            };
+
+            return [savedExploreChart, tile];
+        } else if (savedSqlChart) {
+            const chart = {
+                ...savedSqlChart,
+                uuid: savedSqlChart.savedSqlUuid,
+                spaceUuid: savedSqlChart.space.uuid,
+                chartConfig: savedSqlChart.config,
+            };
+            const tile: DashboardTile = {
+                uuid: uuid4(),
+                type: DashboardTileTypes.SQL_CHART,
+                properties: {
+                    savedSqlUuid: savedSqlChart.savedSqlUuid,
+                    chartName: savedSqlChart.name,
+                },
+                tabUuid: undefined,
+                ...getDefaultChartTileSize(savedSqlChart.config?.type),
+            };
+
+            return [chart, tile];
+        }
+        return [undefined, undefined];
+    }, [savedExploreChart, savedSqlChart]);
     const { data: dashboards, isInitialLoading: isLoadingDashboards } =
         useDashboards(
             projectUuid,
@@ -124,15 +165,6 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                     });
                     spaceUuid = newSpace.uuid;
                 }
-                const newTile: DashboardChartTile = {
-                    uuid: uuid4(),
-                    type: DashboardTileTypes.SAVED_CHART,
-                    properties: {
-                        savedChartUuid: savedChart.uuid,
-                    },
-                    tabUuid: undefined,
-                    ...getDefaultChartTileSize(savedChart.chartConfig?.type),
-                };
 
                 if (isCreatingNewDashboard) {
                     await createDashboard({
@@ -166,10 +198,10 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                         tiles: appendNewTilesToBottom(selectedDashboard.tiles, [
                             firstTab
                                 ? {
-                                      ...newTile,
+                                      ...chartTile,
                                       tabUuid: firstTab.uuid,
                                   }
-                                : newTile, // TODO: add to first tab by default, need ux to allow user select tab
+                                : chartTile, // TODO: add to first tab by default, need ux to allow user select tab
                         ]),
                         tabs: selectedDashboard.tabs,
                     });

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -276,7 +276,16 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                 <AddTilesToDashboardModal
                     isOpen
                     projectUuid={projectUuid}
-                    savedChartUuid={action.item.data.uuid}
+                    savedSqlChartUuid={
+                        action.item.data.source === ChartSourceType.SQL
+                            ? action.item.data.uuid
+                            : undefined
+                    }
+                    savedChartUuid={
+                        action.item.data.source === ChartSourceType.DBT_EXPLORE
+                            ? action.item.data.uuid
+                            : undefined
+                    }
                     onClose={handleReset}
                 />
             );

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -278,7 +278,6 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                         item,
                                     });
                                 }}
-                                sx={isSqlChart ? { display: 'none' } : {}}
                             >
                                 Add to Dashboard
                             </Menu.Item>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -3,18 +3,20 @@ import {
     ActionIcon,
     Button,
     Group,
+    Menu,
     Paper,
     Stack,
     Title,
-    Tooltip,
 } from '@mantine/core';
-import { IconTrash } from '@tabler/icons-react';
+import { useDisclosure } from '@mantine/hooks';
+import { IconDots, IconLayoutGridAdd, IconTrash } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
 import { ResourceInfoPopup } from '../../../../components/common/ResourceInfoPopup/ResourceInfoPopup';
 import { TitleBreadCrumbs } from '../../../../components/Explorer/SavedChartsHeader/TitleBreadcrumbs';
+import AddTilesToDashboardModal from '../../../../components/SavedDashboards/AddTilesToDashboardModal';
 import { useApp } from '../../../../providers/AppProvider';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { toggleModal } from '../../store/sqlRunnerSlice';
@@ -31,6 +33,8 @@ export const HeaderView: FC = () => {
     const savedSqlChart = useAppSelector(
         (state) => state.sqlRunner.savedSqlChart,
     );
+    const [isAddToDashboardModalOpen, addToDashboardModalHandlers] =
+        useDisclosure();
     const isDeleteModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.deleteChartModal.isOpen,
     );
@@ -97,6 +101,7 @@ export const HeaderView: FC = () => {
                             />
                         </Group>
                     </Stack>
+
                     <Group spacing="md">
                         {canManageSqlRunner && canManageChart && (
                             <Button
@@ -111,24 +116,50 @@ export const HeaderView: FC = () => {
                                 Edit chart
                             </Button>
                         )}
-                        {canManageSqlRunner && canManageChart && (
-                            <Tooltip
-                                variant="xs"
-                                label="Delete"
-                                position="bottom"
-                            >
-                                <ActionIcon
-                                    size="xs"
+
+                        <Menu
+                            position="bottom"
+                            withArrow
+                            withinPortal
+                            shadow="md"
+                            width={200}
+                        >
+                            <Menu.Target>
+                                <ActionIcon variant="default">
+                                    <MantineIcon icon={IconDots} />
+                                </ActionIcon>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                <Menu.Label>Manage</Menu.Label>
+                                <Menu.Item
+                                    icon={
+                                        <MantineIcon icon={IconLayoutGridAdd} />
+                                    }
+                                    onClick={addToDashboardModalHandlers.open}
+                                >
+                                    Add to dashboard
+                                </Menu.Item>
+                                <Menu.Item
+                                    icon={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            color="red"
+                                        />
+                                    }
+                                    color="red"
+                                    disabled={
+                                        !(canManageSqlRunner && canManageChart)
+                                    }
                                     onClick={() =>
                                         dispatch(
                                             toggleModal('deleteChartModal'),
                                         )
                                     }
                                 >
-                                    <MantineIcon icon={IconTrash} />
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
+                                    Delete
+                                </Menu.Item>
+                            </Menu.Dropdown>
+                        </Menu>
                     </Group>
                 </Group>
             </Paper>
@@ -140,6 +171,14 @@ export const HeaderView: FC = () => {
                 onClose={onCloseDeleteModal}
                 onSuccess={() => history.push(`/projects/${projectUuid}/home`)}
             />
+            {isAddToDashboardModalOpen && (
+                <AddTilesToDashboardModal
+                    isOpen={isAddToDashboardModalOpen}
+                    projectUuid={projectUuid}
+                    savedSqlChartUuid={savedSqlChart.savedSqlUuid}
+                    onClose={addToDashboardModalHandlers.close}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -8,7 +8,6 @@ import {
     Stack,
     Title,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import { IconDots, IconLayoutGridAdd, IconTrash } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -33,8 +32,12 @@ export const HeaderView: FC = () => {
     const savedSqlChart = useAppSelector(
         (state) => state.sqlRunner.savedSqlChart,
     );
-    const [isAddToDashboardModalOpen, addToDashboardModalHandlers] =
-        useDisclosure();
+    const isAddToDashboard = useAppSelector(
+        (state) => state.sqlRunner.modals.addToDashboard.isOpen,
+    );
+    const onCloseAddToDashboardModal = useCallback(() => {
+        dispatch(toggleModal('addToDashboard'));
+    }, [dispatch]);
     const isDeleteModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.deleteChartModal.isOpen,
     );
@@ -135,7 +138,9 @@ export const HeaderView: FC = () => {
                                     icon={
                                         <MantineIcon icon={IconLayoutGridAdd} />
                                     }
-                                    onClick={addToDashboardModalHandlers.open}
+                                    onClick={() =>
+                                        dispatch(toggleModal('addToDashboard'))
+                                    }
                                 >
                                     Add to dashboard
                                 </Menu.Item>
@@ -171,12 +176,12 @@ export const HeaderView: FC = () => {
                 onClose={onCloseDeleteModal}
                 onSuccess={() => history.push(`/projects/${projectUuid}/home`)}
             />
-            {isAddToDashboardModalOpen && (
+            {isAddToDashboard && (
                 <AddTilesToDashboardModal
-                    isOpen={isAddToDashboardModalOpen}
+                    isOpen={true}
                     projectUuid={projectUuid}
                     savedSqlChartUuid={savedSqlChart.savedSqlUuid}
-                    onClose={addToDashboardModalHandlers.close}
+                    onClose={onCloseAddToDashboardModal}
                 />
             )}
         </>

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -44,6 +44,9 @@ export interface SqlRunnerState {
         updateChartModal: {
             isOpen: boolean;
         };
+        addToDashboard: {
+            isOpen: boolean;
+        };
     };
     quoteChar: string;
     sqlColumns: VizColumn[] | undefined;
@@ -72,6 +75,9 @@ const initialState: SqlRunnerState = {
             isOpen: false,
         },
         updateChartModal: {
+            isOpen: false,
+        },
+        addToDashboard: {
             isOpen: false,
         },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/11390

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- [x] When you create a SQL runner chart and save it, there should be an option to `add to dashboard` in the view mode, just like with regular charts. 

- [x] You should also be able to `add to dashboard` from the charts list, just like with regular charts
<!-- Even better add a screenshot / gif / loom -->
[Screencast from 10-09-24 09:30:26.webm](https://github.com/user-attachments/assets/36533b59-8acf-4257-acc3-025cd5ec209d)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
