### PR TITLE
style: add px to viz panel

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -83,6 +83,7 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                 offsetScrollbars
                 variant="primary"
                 className="only-vertical"
+                px="sm"
                 sx={{
                     flex: 1,
                     display:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A
Relates to: https://github.com/lightdash/lightdash/pull/11481

### Description:

Adds `px` to viz config panel

before: 

<img width="419" alt="Screenshot 2024-09-10 at 09 32 41" src="https://github.com/user-attachments/assets/338cc687-b9c2-42cc-a40b-23679154f5ce">


after:

<img width="401" alt="Screenshot 2024-09-10 at 09 31 37" src="https://github.com/user-attachments/assets/d6387993-43b1-460c-94d5-b4e42fbbadd9">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
