### PR TITLE
perf: use web workers to get results from stream

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -172,6 +172,9 @@ export const DashboardSqlChartTile: FC<Props> = ({
                         <Table
                             resultsRunner={resultsRunner}
                             columnsConfig={data.chart.config.columns}
+                            flexProps={{
+                                mah: '100%',
+                            }}
                         />
                     </Box>
                 )}

--- a/packages/frontend/src/features/sqlRunner/hooks/useDashboardSqlChart.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDashboardSqlChart.tsx
@@ -1,5 +1,6 @@
 import { ChartKind, type ApiError, type SqlChart } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
+import { useResultsFromStreamWorker } from './useResultsFromStreamWorker';
 import { fetchSavedSqlChart } from './useSavedSqlCharts';
 import { getSqlChartResults } from './useSqlChartResults';
 import { type ResultsAndColumns } from './useSqlQueryRun';
@@ -7,9 +8,13 @@ import { type ResultsAndColumns } from './useSqlQueryRun';
 const getDashboardSqlChartAndPossibleResults = async ({
     projectUuid,
     savedSqlUuid,
+    getResultsFromStream,
 }: {
     projectUuid: string;
     savedSqlUuid: string;
+    getResultsFromStream: ReturnType<
+        typeof useResultsFromStreamWorker
+    >['getResultsFromStream'];
 }): Promise<{ resultsAndColumns: ResultsAndColumns; chart: SqlChart }> => {
     const chart = await fetchSavedSqlChart({
         projectUuid,
@@ -31,6 +36,7 @@ const getDashboardSqlChartAndPossibleResults = async ({
     const resultsTest = await getSqlChartResults({
         projectUuid,
         slug: chart.slug,
+        getResultsFromStream,
     });
 
     return {
@@ -56,6 +62,7 @@ export const useDashboardSqlChart = ({
     savedSqlUuid: string | null;
     projectUuid: string;
 }) => {
+    const { getResultsFromStream } = useResultsFromStreamWorker();
     return useQuery<
         { resultsAndColumns: ResultsAndColumns; chart: SqlChart },
         ApiError & { slug?: string }
@@ -65,6 +72,7 @@ export const useDashboardSqlChart = ({
             return getDashboardSqlChartAndPossibleResults({
                 projectUuid,
                 savedSqlUuid: savedSqlUuid!,
+                getResultsFromStream,
             });
         },
         {

--- a/packages/frontend/src/features/sqlRunner/hooks/useResultsFromStreamWorker.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useResultsFromStreamWorker.tsx
@@ -1,0 +1,21 @@
+import type { RawResultRow } from '@lightdash/common';
+import { createWorkerFactory, useWorker } from '@shopify/react-web-worker';
+import { useCallback } from 'react';
+import { type getResultsFromStream } from '../../../utils/request';
+
+const createWorker = createWorkerFactory<{
+    getResultsFromStream: typeof getResultsFromStream<RawResultRow>;
+}>(() => import('../../../utils/request'));
+
+export const useResultsFromStreamWorker = () => {
+    const worker = useWorker(createWorker);
+
+    const getResultsFromStream = useCallback(
+        async (url: string | undefined): Promise<RawResultRow[]> => {
+            return worker.getResultsFromStream(url);
+        },
+        [worker],
+    );
+
+    return { getResultsFromStream };
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useResultsFromStreamWorker.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useResultsFromStreamWorker.tsx
@@ -7,6 +7,10 @@ const createWorker = createWorkerFactory<{
     getResultsFromStream: typeof getResultsFromStream<RawResultRow>;
 }>(() => import('../../../utils/request'));
 
+/**
+ * Hook to get the results from a stream worker - used to fetch the results of a SQL query
+ * @returns The results from the stream worker
+ */
 export const useResultsFromStreamWorker = () => {
     const worker = useWorker(createWorker);
 

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlChartResults.ts
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlChartResults.ts
@@ -4,20 +4,23 @@ import {
     isErrorDetails,
     type ApiError,
     type ApiJobScheduledResponse,
-    type RawResultRow,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
-import { getResultsFromStream } from '../../../utils/request';
 import { getSqlRunnerCompleteJob } from './requestUtils';
+import { useResultsFromStreamWorker } from './useResultsFromStreamWorker';
 import { type ResultsAndColumns } from './useSqlQueryRun';
 
 export const getSqlChartResults = async ({
     projectUuid,
     slug,
+    getResultsFromStream,
 }: {
     projectUuid: string;
     slug: string;
+    getResultsFromStream: ReturnType<
+        typeof useResultsFromStreamWorker
+    >['getResultsFromStream'];
 }) => {
     const scheduledJob = await lightdashApi<ApiJobScheduledResponse['results']>(
         {
@@ -37,7 +40,7 @@ export const getSqlChartResults = async ({
         !isErrorDetails(job.details)
             ? job.details.fileUrl
             : undefined;
-    const results = await getResultsFromStream<RawResultRow>(url);
+    const results = await getResultsFromStream(url);
 
     return {
         results,
@@ -61,12 +64,14 @@ export const useSqlChartResults = (
     projectUuid: string,
     slug: string | undefined,
 ) => {
+    const { getResultsFromStream } = useResultsFromStreamWorker();
     return useQuery<ResultsAndColumns | undefined, ApiError>(
         ['sqlChartResults', projectUuid, slug],
         () => {
             return getSqlChartResults({
                 projectUuid,
                 slug: slug!,
+                getResultsFromStream,
             });
         },
         {

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -69,10 +69,6 @@ export const useSqlQueryRun = (
                         ? job.details.fileUrl
                         : undefined;
 
-                if (!url) {
-                    throw new Error('No file URL provided');
-                }
-
                 const results = await getResultsFromStream(url);
 
                 return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11494

### Description:

Runs `getResultsFromStream` in a worker 
Virtualises Table rows in Dashboard SQL tiles

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
