### PR TITLE
chore: refetch data on sort or filter in semantic viewer

### DIFF
--- a/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
@@ -71,7 +71,7 @@ export const useChartViz = <T extends ResultsRunner>({
             projectUuid,
             limit,
             JSON.stringify(config.fieldConfig),
-            additionalQueryKey,
+            ...(additionalQueryKey ?? []),
         ];
     }, [projectUuid, limit, config, additionalQueryKey]);
 

--- a/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
@@ -9,7 +9,7 @@ import {
     type AllVizChartConfig,
     type PivotChartData,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { type ResultsRunner } from '../transformers/ResultsRunner';
@@ -26,7 +26,7 @@ type Args<T extends ResultsRunner> = {
     // Consumers can provide additional query keys to force a re-fetch.
     // Different pages may need to refresh this query based on parameters
     // that are unused in this hook.
-    additionalQueryKey?: string;
+    additionalQueryKey?: UseQueryOptions['queryKey'];
 };
 export const useChartViz = <T extends ResultsRunner>({
     projectUuid,

--- a/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useChartViz.ts
@@ -22,6 +22,11 @@ type Args<T extends ResultsRunner> = {
     uuid?: string;
     resultsRunner: T | undefined;
     config: AllVizChartConfig | undefined;
+
+    // Consumers can provide additional query keys to force a re-fetch.
+    // Different pages may need to refresh this query based on parameters
+    // that are unused in this hook.
+    additionalQueryKey?: string;
 };
 export const useChartViz = <T extends ResultsRunner>({
     projectUuid,
@@ -31,6 +36,7 @@ export const useChartViz = <T extends ResultsRunner>({
     uuid,
     resultsRunner,
     config,
+    additionalQueryKey,
 }: Args<T>) => {
     const org = useOrganization();
 
@@ -61,8 +67,13 @@ export const useChartViz = <T extends ResultsRunner>({
         if (!config) return undefined;
         if (isVizTableConfig(config)) return undefined;
 
-        return [projectUuid, limit, JSON.stringify(config.fieldConfig)];
-    }, [projectUuid, limit, config]);
+        return [
+            projectUuid,
+            limit,
+            JSON.stringify(config.fieldConfig),
+            additionalQueryKey,
+        ];
+    }, [projectUuid, limit, config, additionalQueryKey]);
 
     const transformedDataQuery = useQuery<PivotChartData | undefined, Error>({
         queryKey: queryKey!,

--- a/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
@@ -25,9 +25,8 @@ const ContentCharts: FC = () => {
     const { projectUuid } = useAppSelector(selectSemanticLayerInfo);
     const semanticQuery = useAppSelector(selectSemanticLayerQuery);
 
-    const { results, columns, activeChartKind, fields } = useAppSelector(
-        (state) => state.semanticViewer,
-    );
+    const { results, columns, activeChartKind, fields, sortBy, filters } =
+        useAppSelector((state) => state.semanticViewer);
 
     const resultsRunner = useMemo(() => {
         return new SemanticViewerResultsRunner({
@@ -57,6 +56,10 @@ const ContentCharts: FC = () => {
         resultsRunner,
         config: vizConfig,
         projectUuid,
+        additionalQueryKey: JSON.stringify({
+            filters,
+            sortBy,
+        }),
     });
 
     const pivotResultsRunner = useMemo(() => {

--- a/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ContentCharts.tsx
@@ -56,10 +56,7 @@ const ContentCharts: FC = () => {
         resultsRunner,
         config: vizConfig,
         projectUuid,
-        additionalQueryKey: JSON.stringify({
-            filters,
-            sortBy,
-        }),
+        additionalQueryKey: [filters, sortBy],
     });
 
     const pivotResultsRunner = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11490 

### Description:

- Refetch chart data on sort and query change. This updates query keys based on fitler and sort updates. Note that the hook itself doesn't get the sorts or filters directly, but now exposes a cache key that can be updated. This is because the useChartViz can be used in multiple places and shouldnt rely on page-specific types

This handles charts and and I'm posting it so we could use it for the demo. More to do:
- Tables don't go through this useQuery so don't get updated with this cache key. To update them, the query needs to be run again
- Filters get updated too often, it should only be on apply. I'm working on this. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
