### PR TITLE
feat: show pivoted results for non-table sql chart view

### DIFF
--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -110,6 +110,15 @@ const ViewSqlChart = () => {
         limit: sqlChart?.limit,
     });
 
+    const chartVizResultsRunner = useMemo(() => {
+        if (!chartVizQuery.data) return;
+
+        return new SqlRunnerResultsRunner({
+            rows: chartVizQuery.data.results,
+            columns: chartVizQuery.data.columns,
+        });
+    }, [chartVizQuery.data]);
+
     return (
         <Page
             title="SQL chart"
@@ -218,17 +227,40 @@ const ViewSqlChart = () => {
                             <ConditionalVisibility
                                 isVisible={activeTab === TabOption.RESULTS}
                             >
-                                {resultsTableConfig?.columns && (
+                                {chartVizQuery.data && chartVizResultsRunner ? (
+                                    <Table
+                                        resultsRunner={chartVizResultsRunner}
+                                        columnsConfig={Object.fromEntries(
+                                            chartVizQuery.data.columns.map(
+                                                (field) => [
+                                                    field.reference,
+                                                    {
+                                                        visible: true,
+                                                        reference:
+                                                            field.reference,
+                                                        label: field.reference,
+                                                        frozen: false,
+                                                        // TODO: add aggregation
+                                                        // aggregation?: VizAggregationOptions;
+                                                    },
+                                                ],
+                                            ),
+                                        )}
+                                        flexProps={{
+                                            mah: 'calc(100vh - 250px)',
+                                        }}
+                                    />
+                                ) : resultsTableConfig ? (
                                     <Table
                                         resultsRunner={resultsRunner}
                                         columnsConfig={
-                                            resultsTableConfig.columns
+                                            resultsTableConfig?.columns
                                         }
                                         flexProps={{
                                             mah: 'calc(100vh - 250px)',
                                         }}
                                     />
-                                )}
+                                ) : null}
                             </ConditionalVisibility>
                         </Box>
                     )}

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -227,40 +227,47 @@ const ViewSqlChart = () => {
                             <ConditionalVisibility
                                 isVisible={activeTab === TabOption.RESULTS}
                             >
-                                {chartVizQuery.data && chartVizResultsRunner ? (
-                                    <Table
-                                        resultsRunner={chartVizResultsRunner}
-                                        columnsConfig={Object.fromEntries(
-                                            chartVizQuery.data.columns.map(
-                                                (field) => [
-                                                    field.reference,
-                                                    {
-                                                        visible: true,
-                                                        reference:
-                                                            field.reference,
-                                                        label: field.reference,
-                                                        frozen: false,
-                                                        // TODO: add aggregation
-                                                        // aggregation?: VizAggregationOptions;
-                                                    },
-                                                ],
-                                            ),
-                                        )}
-                                        flexProps={{
-                                            mah: 'calc(100vh - 250px)',
-                                        }}
-                                    />
-                                ) : resultsTableConfig ? (
-                                    <Table
-                                        resultsRunner={resultsRunner}
-                                        columnsConfig={
-                                            resultsTableConfig?.columns
-                                        }
-                                        flexProps={{
-                                            mah: 'calc(100vh - 250px)',
-                                        }}
-                                    />
-                                ) : null}
+                                {!isVizTableConfig(currentVisConfig) &&
+                                    chartVizQuery.data &&
+                                    chartVizResultsRunner && (
+                                        <Table
+                                            resultsRunner={
+                                                chartVizResultsRunner
+                                            }
+                                            columnsConfig={Object.fromEntries(
+                                                chartVizQuery.data.columns.map(
+                                                    (field) => [
+                                                        field.reference,
+                                                        {
+                                                            visible: true,
+                                                            reference:
+                                                                field.reference,
+                                                            label: field.reference,
+                                                            frozen: false,
+                                                            // TODO: add aggregation
+                                                            // aggregation?: VizAggregationOptions;
+                                                        },
+                                                    ],
+                                                ),
+                                            )}
+                                            flexProps={{
+                                                mah: 'calc(100vh - 250px)',
+                                            }}
+                                        />
+                                    )}
+
+                                {isVizTableConfig(currentVisConfig) &&
+                                    resultsTableConfig && (
+                                        <Table
+                                            resultsRunner={resultsRunner}
+                                            columnsConfig={
+                                                resultsTableConfig?.columns
+                                            }
+                                            flexProps={{
+                                                mah: 'calc(100vh - 250px)',
+                                            }}
+                                        />
+                                    )}
                             </ConditionalVisibility>
                         </Box>
                     )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11210 

### Description:

Display pivoted table for non-table sql charts in view mode

<img width="500" alt="Screenshot 2024-09-10 at 16 25 37" src="https://github.com/user-attachments/assets/7f9e61dd-2156-4ea5-820d-d9f8bd5d0a47">
<img width="500" alt="Screenshot 2024-09-10 at 16 25 43" src="https://github.com/user-attachments/assets/c13fdd36-b8cf-4a23-b605-12d6efc43fb9">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
