### PR TITLE
chore: dont update filters until apply on semantic viewer

### DIFF
--- a/packages/frontend/src/features/semanticViewer/components/FiltersModal/index.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/FiltersModal/index.tsx
@@ -160,7 +160,7 @@ const FiltersModal: FC<FiltersModalProps> = ({
                             setDraftFilters((prev) => [...prev, newFilter]);
                         }}
                         onCancel={
-                            filters.length > 0
+                            draftFilters.length > 0
                                 ? () => setIsAddingFilter(false)
                                 : undefined
                         }

--- a/packages/frontend/src/features/semanticViewer/components/FiltersModal/index.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/FiltersModal/index.tsx
@@ -1,6 +1,7 @@
 import {
     FieldType as FieldKind,
     SemanticLayerFieldType,
+    type SemanticLayerFilter,
 } from '@lightdash/common';
 import {
     Button,
@@ -16,11 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { selectAllSelectedFieldNames } from '../../store/selectors';
-import {
-    addFilter,
-    removeFilter,
-    updateFilter,
-} from '../../store/semanticViewerSlice';
+import { setFilters } from '../../store/semanticViewerSlice';
 import Filter from './Filter';
 import FilterButton from './FilterButton';
 import FilterFieldSelect from './FilterFieldSelect';
@@ -35,8 +32,12 @@ const FiltersModal: FC<FiltersModalProps> = ({
     ...props
 }) => {
     const [isAddingFilter, setIsAddingFilter] = useState(false);
+
     const { filters, fields } = useAppSelector((state) => state.semanticViewer);
     const allSelectedFieldNames = useAppSelector(selectAllSelectedFieldNames);
+
+    const [draftFilters, setDraftFilters] =
+        useState<SemanticLayerFilter[]>(filters);
 
     const dispatch = useAppDispatch();
 
@@ -68,10 +69,26 @@ const FiltersModal: FC<FiltersModalProps> = ({
             });
     }, [allSelectedFieldNames, fields]);
 
+    const handleUpdateFilter = (updatedFilter: SemanticLayerFilter) => {
+        setDraftFilters((prev) => {
+            const updatedFilters = [...prev];
+            const filterIndex = updatedFilters.findIndex(
+                (f) => f.uuid === updatedFilter.uuid,
+            );
+            updatedFilters[filterIndex] = updatedFilter;
+            return updatedFilters;
+        });
+    };
+
+    const handleRemoveFilter = (uuid: string) => {
+        setDraftFilters((prev) => prev.filter((f) => f.uuid !== uuid));
+    };
+
     const handleApply = useCallback(() => {
+        dispatch(setFilters(draftFilters));
         onApply?.();
         onClose?.();
-    }, [onApply, onClose]);
+    }, [dispatch, draftFilters, onApply, onClose]);
 
     return (
         <Modal
@@ -87,20 +104,18 @@ const FiltersModal: FC<FiltersModalProps> = ({
         >
             {/* data-autofocus so that the focus remains inside the modal but doesn't try to focus a filter input and open the dropdown */}
             <Stack align="flex-start" spacing="sm" data-autofocus>
-                {filters.map((filter, index) => (
+                {draftFilters.map((filter, index) => (
                     <Filter
                         key={filter.uuid}
                         isFirstRootFilter={index === 0}
                         filter={filter}
                         fieldOptions={availableFieldOptions}
                         allFields={fields ?? []}
-                        onDelete={() => dispatch(removeFilter(filter.uuid))}
-                        onUpdate={(updatedFilter) =>
-                            dispatch(updateFilter(updatedFilter))
-                        }
+                        onDelete={() => handleRemoveFilter(filter.uuid)}
+                        onUpdate={handleUpdateFilter}
                     />
                 ))}
-                {Boolean(!isAddingFilter && filters.length > 0) ? (
+                {Boolean(!isAddingFilter && draftFilters.length > 0) ? (
                     <FilterButton
                         icon={IconPlus}
                         onClick={() => setIsAddingFilter(true)}
@@ -133,17 +148,16 @@ const FiltersModal: FC<FiltersModalProps> = ({
                                 });
                                 return;
                             }
+                            const newFilter = {
+                                uuid: uuidv4(),
+                                field: value,
+                                fieldKind: field.kind,
+                                fieldType: field.type,
+                                operator: defaultOperator,
+                                values: [],
+                            };
 
-                            dispatch(
-                                addFilter({
-                                    uuid: uuidv4(),
-                                    field: value,
-                                    fieldKind: field.kind,
-                                    fieldType: field.type,
-                                    operator: defaultOperator,
-                                    values: [],
-                                }),
-                            );
+                            setDraftFilters((prev) => [...prev, newFilter]);
                         }}
                         onCancel={
                             filters.length > 0

--- a/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
+++ b/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
@@ -273,17 +273,8 @@ export const semanticViewerSlice = createSlice({
         setFields: (state, action: PayloadAction<SemanticLayerField[]>) => {
             state.fields = action.payload;
         },
-        addFilter: (state, action: PayloadAction<SemanticLayerFilter>) => {
-            state.filters.push(action.payload);
-        },
-        removeFilter: (state, action: PayloadAction<string>) => {
-            const filterIndex = state.filters.findIndex(
-                (filter) => filter.uuid === action.payload,
-            );
-
-            if (filterIndex !== -1) {
-                state.filters.splice(filterIndex, 1);
-            }
+        setFilters: (state, action: PayloadAction<SemanticLayerFilter[]>) => {
+            state.filters = action.payload;
         },
         updateFilter: (state, action: PayloadAction<SemanticLayerFilter>) => {
             const filterIndex = state.filters.findIndex(
@@ -346,9 +337,7 @@ export const {
     deselectField,
     setLimit,
     updateTimeDimensionGranularity,
-    addFilter,
-    removeFilter,
-    updateFilter,
+    setFilters,
     setIsFiltersModalOpen,
     addFilterAndOpenModal,
     updateSortBy,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11490 

### Description:

In the semantic layer, don't apply filters until the Apply button is clicked

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
