### PR TITLE
fix: changed dropdown position to top

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/CreateGroupModal.tsx
@@ -138,6 +138,7 @@ const CreateGroupModal: FC<
                                 })),
                             });
                         }}
+                        dropdownPosition="top"
                     />
 
                     <Button


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11495 

### Description:
This pull request addresses an issue where the MultiSelect dropdown for `Group Members` would cover the save button, leading to a poor user experience. Users were often confused and accidentally clicked the 'X' button instead of saving their changes.

## Before Changes:
<img width="762" alt="Screenshot 2024-09-11 at 4 27 59 AM" src="https://github.com/user-attachments/assets/6ddb2c8f-e8b5-4f71-a32d-b2ce6ac69796">

## After Changes:
<img width="720" alt="Screenshot 2024-09-11 at 4 29 02 AM" src="https://github.com/user-attachments/assets/e5475a1a-f4f4-48eb-96dd-164c16bb2d75">


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging

