### PR TITLE
fix: fix xAxisLabel setter, not set axis type

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6838,7 +6838,7 @@ const models: TsoaRoute.Models = {
                 xAxis: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        type: { ref: 'VizIndexType', required: true },
+                        type: { ref: 'VizIndexType' },
                         label: { dataType: 'string' },
                     },
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7562,7 +7562,6 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["type"],
                         "type": "object"
                     }
                 },

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -289,7 +289,7 @@ export class CartesianChartDataModel
 export type CartesianChartDisplay = {
     xAxis?: {
         label?: string;
-        type: VizIndexType;
+        type?: VizIndexType;
     };
     yAxis?: {
         label?: string;

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -1,7 +1,6 @@
 import {
     ECHARTS_DEFAULT_COLORS,
     friendlyName,
-    VizIndexType,
     type ChartKind,
 } from '@lightdash/common';
 import { Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
@@ -135,7 +134,6 @@ export const CartesianChartStyling = ({
                             dispatch(
                                 actions.setXAxisLabel({
                                     label: e.target.value,
-                                    type: VizIndexType.CATEGORY,
                                 }),
                             )
                         }

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -107,16 +107,14 @@ export const cartesianChartConfigSlice = createSlice({
         },
         setXAxisLabel: (
             { config },
-            action: PayloadAction<CartesianChartDisplay['xAxis']>,
+            action: PayloadAction<
+                Pick<Required<CartesianChartDisplay>['xAxis'], 'label'>
+            >,
         ) => {
             if (!config) return;
-            if (!config.display) {
-                config.display = {
-                    xAxis: action.payload,
-                };
-            } else {
-                config.display.xAxis = action.payload;
-            }
+            if (!config.display) config.display = {};
+            if (!config.display.xAxis) config.display.xAxis = {};
+            config.display.xAxis.label = action.payload.label;
         },
         setYAxisLabel: (
             { config },


### PR DESCRIPTION
Prevents x-axis from returning to `CATEGORY` type when updating the xaxis label