### PR TITLE
feat: allow for two levels of filter groups

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -36,7 +36,7 @@ import FilterRuleForm from './FilterRuleForm';
 type Props = {
     hideButtons?: boolean;
     hideLine?: boolean;
-    allowConvertToGroup?: boolean;
+    groupDepth?: number;
     fields: FilterableField[];
     filterGroup: FilterGroup;
     isEditMode: boolean;
@@ -44,10 +44,12 @@ type Props = {
     onDelete: () => void;
 };
 
+const ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH = 2;
+
 const FilterGroupForm: FC<Props> = ({
     hideButtons,
     hideLine,
-    allowConvertToGroup,
+    groupDepth = 0,
     fields,
     filterGroup,
     isEditMode,
@@ -214,7 +216,8 @@ const FilterGroupForm: FC<Props> = ({
                                 onChange={(value) => onChangeItem(index, value)}
                                 onDelete={() => onDeleteItem(index)}
                                 onConvertToGroup={
-                                    allowConvertToGroup
+                                    ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH >
+                                    groupDepth
                                         ? () =>
                                               onChangeItem(
                                                   index,
@@ -234,7 +237,7 @@ const FilterGroupForm: FC<Props> = ({
                             />
                         ) : (
                             <FilterGroupForm
-                                allowConvertToGroup={false}
+                                groupDepth={groupDepth + 1}
                                 isEditMode={isEditMode}
                                 filterGroup={item}
                                 fields={availableFieldsForGroupRules}

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -199,7 +199,6 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                                 isEditMode={isEditMode}
                                 onChange={updateFiltersFromGroup}
                                 onDelete={() => setFilters({}, true)}
-                                allowConvertToGroup
                             />
                         )}
                     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

For more advanced filter logic, users need multiple levels of groups.
Example:
```
in the last 30 days 
AND (
  (
   day IN (1, 30)
   AND value > X
  )
  OR day NOT IN (1, 30)
)
```

We only allowed for 1 level which was a blocker for such logic. 
We are now allowing 2 levels as it solves most of the use cases and doesn't break the UI. 


<img width="1335" alt="Screenshot 2024-09-16 at 15 51 08" src="https://github.com/user-attachments/assets/f4f116d7-e6ea-49ce-ba4c-1805e76fb78f">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
