### PR TITLE
feat: enable saving sql runner model

### DIFF
--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -1,4 +1,5 @@
 import {
+    ApiCreateCustomExplore,
     ApiCreateSqlChart,
     ApiErrorPayload,
     ApiJobScheduledResponse,
@@ -7,6 +8,7 @@ import {
     ApiUpdateSqlChart,
     ApiWarehouseCatalog,
     ApiWarehouseTableFields,
+    CreateCustomExplorePayload,
     CreateSqlChart,
     SqlRunnerBody,
     SqlRunnerPivotQueryBody,
@@ -361,6 +363,40 @@ export class SqlRunnerController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Create a custom explore
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('create-custom-explore')
+    @OperationId('createCustomExplore')
+    async createCustomExplore(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: CreateCustomExplorePayload,
+    ): Promise<ApiCreateCustomExplore> {
+        this.setStatus(200);
+        const { name, sql, columns } = body;
+
+        const exploreName = await this.services
+            .getProjectService()
+            .createCustomExplore(req.user!, projectUuid, {
+                name,
+                sql,
+                columns,
+            });
+
+        return {
+            status: 'ok',
+            results: exploreName,
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7324,6 +7324,56 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Explore.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateCustomExplore: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Pick_Explore.name_', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizColumn: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'DimensionType' },
+                reference: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateCustomExplorePayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                columns: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'VizColumn' },
+                    required: true,
+                },
+                sql: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SshKeyPair.publicKey_': {
         dataType: 'refAlias',
         type: {
@@ -15903,6 +15953,69 @@ export function RegisterRoutes(app: express.Router) {
                 }
 
                 const promise = controller.refreshSqlRunnerCatalog.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/sqlRunner/create-custom-explore',
+        ...fetchMiddlewares<RequestHandler>(SqlRunnerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SqlRunnerController.prototype.createCustomExplore,
+        ),
+
+        async function SqlRunnerController_createCustomExplore(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'CreateCustomExplorePayload',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<SqlRunnerController>(
+                        SqlRunnerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.createCustomExplore.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8058,6 +8058,60 @@
                 },
                 "type": "object"
             },
+            "Pick_Explore.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiCreateCustomExplore": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Pick_Explore.name_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "VizColumn": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DimensionType"
+                    },
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": ["reference"],
+                "type": "object"
+            },
+            "CreateCustomExplorePayload": {
+                "properties": {
+                    "columns": {
+                        "items": {
+                            "$ref": "#/components/schemas/VizColumn"
+                        },
+                        "type": "array"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["columns", "sql", "name"],
+                "type": "object"
+            },
             "Pick_SshKeyPair.publicKey_": {
                 "properties": {
                     "publicKey": {
@@ -9832,7 +9886,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1255.6",
+        "version": "0.1256.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -9,6 +9,7 @@ import {
     DbtProjectConfig,
     Explore,
     ExploreError,
+    friendlyName,
     generateSlug,
     isExploreError,
     NotExistsError,
@@ -1833,10 +1834,10 @@ export class ProjectModel {
         const toAddToCached: Explore = {
             name,
             tags: [],
-            label: name,
+            label: friendlyName(name),
             tables: translatedToExplore.tables,
             baseTable: name,
-            groupLabel: name,
+            groupLabel: 'Custom explores',
             joinedTables: [],
             targetDatabase: SupportedDbtAdapter.POSTGRES,
         };

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1,5 +1,7 @@
 import {
     AlreadyExistsError,
+    createCustomExplore,
+    CreateCustomExplorePayload,
     CreateDbtCloudIntegration,
     CreateProject,
     CreateWarehouseCredentials,
@@ -21,11 +23,13 @@ import {
     sensitiveCredentialsFieldNames,
     sensitiveDbtCredentialsFieldNames,
     SpaceSummary,
+    SupportedDbtAdapter,
     SupportedDbtVersions,
     TablesConfiguration,
     UnexpectedServerError,
     UpdateMetadata,
     UpdateProject,
+    WarehouseClient,
     WarehouseCredentials,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -1801,5 +1805,61 @@ export class ProjectModel {
     // eslint-disable-next-line class-methods-use-this
     getWarehouseClientFromCredentials(credentials: CreateWarehouseCredentials) {
         return warehouseClientFromCredentials(credentials);
+    }
+
+    async createCustomExplore(
+        projectUuid: string,
+        { name, sql, columns }: CreateCustomExplorePayload,
+        warehouseClient: WarehouseClient,
+    ): Promise<Pick<Explore, 'name'>> {
+        const translatedToExplore = createCustomExplore(
+            name,
+            sql,
+            columns,
+            warehouseClient,
+        );
+
+        // insert into cached_explore
+        await this.database(CachedExploreTableName)
+            .insert({
+                project_uuid: projectUuid,
+                name: translatedToExplore.name,
+                table_names: Object.keys(translatedToExplore.tables || {}),
+                explore: JSON.stringify(translatedToExplore),
+            })
+            .onConflict(['project_uuid', 'name'])
+            .merge()
+            .returning(['name', 'cached_explore_uuid']);
+        const toAddToCached: Explore = {
+            name,
+            tags: [],
+            label: name,
+            tables: translatedToExplore.tables,
+            baseTable: name,
+            groupLabel: name,
+            joinedTables: [],
+            targetDatabase: SupportedDbtAdapter.POSTGRES,
+        };
+
+        // append to cached_explores
+        await this.database(CachedExploresTableName)
+            .where('project_uuid', projectUuid)
+            .update({
+                explores: this.database.raw(
+                    `
+                CASE
+                    WHEN explores IS NULL THEN ?::jsonb
+                    ELSE explores || ?::jsonb
+                END
+            `,
+                    [
+                        JSON.stringify([toAddToCached]),
+                        JSON.stringify([toAddToCached]),
+                    ],
+                ),
+            })
+            .returning('*');
+
+        return { name };
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -14,6 +14,7 @@ import {
     convertCustomMetricToDbt,
     countCustomDimensionsInMetricQuery,
     countTotalFilterRules,
+    CreateCustomExplorePayload,
     CreateDbtCloudIntegration,
     createDimensionWithGranularity,
     CreateJob,
@@ -4354,5 +4355,22 @@ export class ProjectService extends BaseService {
 
             return metrics;
         }, []);
+    }
+
+    async createCustomExplore(
+        user: SessionUser,
+        projectUuid: string,
+        payload: CreateCustomExplorePayload,
+    ) {
+        const { warehouseClient } = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+        );
+        const explore = await this.projectModel.createCustomExplore(
+            projectUuid,
+            payload,
+            warehouseClient,
+        );
+        return explore;
     }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -126,6 +126,7 @@ import {
     type ApiSemanticLayerGetChart,
 } from './types/semanticLayer';
 import {
+    type ApiCreateCustomExplore,
     type ApiCreateSqlChart,
     type ApiSqlChart,
     type ApiSqlRunnerJobStatusResponse,
@@ -218,6 +219,7 @@ export * from './utils/api';
 export { default as assertUnreachable } from './utils/assertUnreachable';
 export * from './utils/conditionalFormatting';
 export * from './utils/convertToDbt';
+export * from './utils/customExplore';
 export * from './utils/email';
 export * from './utils/fields';
 export * from './utils/filters';
@@ -679,7 +681,8 @@ type ApiResults =
     | ApiSqlRunnerJobStatusResponse['results']
     | ApiSemanticLayerClientInfo['results']
     | ApiSemanticLayerCreateChart['results']
-    | ApiSemanticLayerGetChart['results'];
+    | ApiSemanticLayerGetChart['results']
+    | ApiCreateCustomExplore['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -33,4 +33,9 @@ export enum FeatureFlags {
 
     /* Send local timezone to the warehouse session */
     EnableUserTimezones = 'enable-user-timezones',
+
+    /**
+     * Enable saving custom explores from the SQL Runner
+     */
+    SaveCustomExploreFromSqlRunner = 'save-custom-explore-from-sql-runner',
 }

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -1,4 +1,4 @@
-import { type ApiError, type PivotChartData } from '..';
+import { type ApiError, type Explore, type PivotChartData } from '..';
 import {
     type PivotIndexColum,
     type VizAggregationOptions,
@@ -187,4 +187,15 @@ export type ApiUpdateSqlChart = {
         savedSqlUuid: string;
         savedSqlVersionUuid: string | null;
     };
+};
+
+export type ApiCreateCustomExplore = {
+    status: 'ok';
+    results: Pick<Explore, 'name'>;
+};
+
+export type CreateCustomExplorePayload = {
+    name: string;
+    sql: string;
+    columns: VizColumn[];
 };

--- a/packages/common/src/utils/customExplore.ts
+++ b/packages/common/src/utils/customExplore.ts
@@ -1,0 +1,62 @@
+import { ExploreCompiler } from '../compiler/exploreCompiler';
+import { type Explore, type Table } from '../types/explore';
+import {
+    DimensionType,
+    FieldType,
+    friendlyName,
+    type Dimension,
+} from '../types/field';
+import { type WarehouseClient } from '../types/warehouse';
+import { type VizColumn } from '../visualizations/types';
+import { getFieldQuoteChar } from './warehouse';
+
+export const createCustomExplore = (
+    name: string,
+    sql: string,
+    columns: VizColumn[],
+    warehouseClient: WarehouseClient,
+): Explore => {
+    const exploreCompiler = new ExploreCompiler(warehouseClient);
+
+    const fieldQuoteChar = getFieldQuoteChar(warehouseClient.credentials.type);
+
+    const dimensions = columns.reduce<Record<string, Dimension>>(
+        (acc, column) => {
+            acc[column.reference] = {
+                name: column.reference,
+                label: friendlyName(column.reference),
+                type: column.type ?? DimensionType.STRING,
+                table: name,
+                fieldType: FieldType.DIMENSION,
+                sql: `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
+                tableLabel: friendlyName(name),
+                hidden: false,
+            };
+            return acc;
+        },
+        {},
+    );
+
+    const compiledTable: Table = {
+        name,
+        label: friendlyName(name),
+        sqlTable: `(${sql})`, // Wrap the sql in a subquery to avoid issues with reserved words
+        dimensions,
+        metrics: {},
+        lineageGraph: { nodes: [], edges: [] },
+        database: warehouseClient.credentials.type,
+        schema: '', // TODO: what should this be?
+    };
+
+    const explore = exploreCompiler.compileExplore({
+        name,
+        label: friendlyName(name),
+        tags: [],
+        baseTable: name,
+        joinedTables: [],
+        tables: { [name]: compiledTable },
+        targetDatabase: warehouseClient.getAdapterType(),
+    });
+
+    return explore;
+};

--- a/packages/common/src/utils/customExplore.ts
+++ b/packages/common/src/utils/customExplore.ts
@@ -11,7 +11,7 @@ import { type VizColumn } from '../visualizations/types';
 import { getFieldQuoteChar } from './warehouse';
 
 export const createCustomExplore = (
-    name: string,
+    customExploreName: string,
     sql: string,
     columns: VizColumn[],
     warehouseClient: WarehouseClient,
@@ -26,10 +26,10 @@ export const createCustomExplore = (
                 name: column.reference,
                 label: friendlyName(column.reference),
                 type: column.type ?? DimensionType.STRING,
-                table: name,
+                table: customExploreName,
                 fieldType: FieldType.DIMENSION,
                 sql: `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
-                tableLabel: friendlyName(name),
+                tableLabel: friendlyName(customExploreName),
                 hidden: false,
             };
             return acc;
@@ -38,8 +38,8 @@ export const createCustomExplore = (
     );
 
     const compiledTable: Table = {
-        name,
-        label: friendlyName(name),
+        name: customExploreName,
+        label: friendlyName(customExploreName),
         sqlTable: `(${sql})`, // Wrap the sql in a subquery to avoid issues with reserved words
         dimensions,
         metrics: {},
@@ -49,12 +49,12 @@ export const createCustomExplore = (
     };
 
     const explore = exploreCompiler.compileExplore({
-        name,
-        label: friendlyName(name),
+        name: customExploreName,
+        label: friendlyName(customExploreName),
         tags: [],
-        baseTable: name,
+        baseTable: customExploreName,
         joinedTables: [],
-        tables: { [name]: compiledTable },
+        tables: { [customExploreName]: compiledTable },
         targetDatabase: warehouseClient.getAdapterType(),
     });
 

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Button, Group, Paper, Tooltip } from '@mantine/core';
-import { IconWand } from '@tabler/icons-react';
+import { IconSparkles } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { EditableText } from '../../../../components/VisualizationConfigs/common/EditableText';
@@ -66,7 +66,7 @@ export const HeaderCreate: FC = () => {
                                     leftIcon={
                                         <MantineIcon
                                             size={12}
-                                            icon={IconWand}
+                                            icon={IconSparkles}
                                         />
                                     }
                                     onClick={() => {
@@ -78,7 +78,7 @@ export const HeaderCreate: FC = () => {
                                     }}
                                     disabled={!loadedColumns}
                                 >
-                                    Save explore
+                                    Create custom explore
                                 </Button>
                             </Tooltip>
                         )}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,8 +1,10 @@
-import { Button, Group, Paper } from '@mantine/core';
+import { FeatureFlags } from '@lightdash/common';
+import { Button, Group, Paper, Tooltip } from '@mantine/core';
 import { IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { EditableText } from '../../../../components/VisualizationConfigs/common/EditableText';
+import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
     DEFAULT_NAME,
@@ -13,6 +15,9 @@ import { SaveCustomExploreModal } from '../SaveCustomExploreModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 
 export const HeaderCreate: FC = () => {
+    const isSaveCustomExploreFromSqlRunnerEnabled = useFeatureFlagEnabled(
+        FeatureFlags.SaveCustomExploreFromSqlRunner,
+    );
     const dispatch = useAppDispatch();
     const name = useAppSelector((state) => state.sqlRunner.name);
     const loadedColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
@@ -46,18 +51,37 @@ export const HeaderCreate: FC = () => {
                     </Group>
 
                     <Group>
-                        <Button
-                            color="indigo.6"
-                            variant="light"
-                            size="xs"
-                            leftIcon={<MantineIcon icon={IconWand} />}
-                            onClick={() => {
-                                dispatch(toggleModal('saveCustomExploreModal'));
-                            }}
-                            disabled={!loadedColumns}
-                        >
-                            Save as Custom Explore
-                        </Button>
+                        {isSaveCustomExploreFromSqlRunnerEnabled && (
+                            <Tooltip
+                                label="You can save your query as a custom explore for future use"
+                                position="bottom"
+                                withArrow
+                                variant="xs"
+                            >
+                                <Button
+                                    radius="md"
+                                    color="indigo.6"
+                                    variant="light"
+                                    size="xs"
+                                    leftIcon={
+                                        <MantineIcon
+                                            size={12}
+                                            icon={IconWand}
+                                        />
+                                    }
+                                    onClick={() => {
+                                        dispatch(
+                                            toggleModal(
+                                                'saveCustomExploreModal',
+                                            ),
+                                        );
+                                    }}
+                                    disabled={!loadedColumns}
+                                >
+                                    Save explore
+                                </Button>
+                            </Tooltip>
+                        )}
 
                         <Button
                             color={'green.7'}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,5 +1,7 @@
 import { Button, Group, Paper } from '@mantine/core';
+import { IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
 import { EditableText } from '../../../../components/VisualizationConfigs/common/EditableText';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
@@ -7,6 +9,7 @@ import {
     toggleModal,
     updateName,
 } from '../../store/sqlRunnerSlice';
+import { SaveCustomExploreModal } from '../SaveCustomExploreModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 
 export const HeaderCreate: FC = () => {
@@ -16,8 +19,14 @@ export const HeaderCreate: FC = () => {
     const isSaveModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.saveChartModal.isOpen,
     );
+    const isSaveCustomExploreModalOpen = useAppSelector(
+        (state) => state.sqlRunner.modals.saveCustomExploreModal.isOpen,
+    );
     const onCloseSaveModal = useCallback(() => {
         dispatch(toggleModal('saveChartModal'));
+    }, [dispatch]);
+    const onCloseSaveCustomExploreModal = useCallback(() => {
+        dispatch(toggleModal('saveCustomExploreModal'));
     }, [dispatch]);
 
     return (
@@ -36,22 +45,42 @@ export const HeaderCreate: FC = () => {
                         />
                     </Group>
 
-                    <Button
-                        color={'green.7'}
-                        size="xs"
-                        disabled={!loadedColumns}
-                        onClick={() => {
-                            dispatch(toggleModal('saveChartModal'));
-                        }}
-                    >
-                        Save
-                    </Button>
+                    <Group>
+                        <Button
+                            color="indigo.6"
+                            variant="light"
+                            size="xs"
+                            leftIcon={<MantineIcon icon={IconWand} />}
+                            onClick={() => {
+                                dispatch(toggleModal('saveCustomExploreModal'));
+                            }}
+                            disabled={!loadedColumns}
+                        >
+                            Save as Custom Explore
+                        </Button>
+
+                        <Button
+                            color={'green.7'}
+                            size="xs"
+                            disabled={!loadedColumns}
+                            onClick={() => {
+                                dispatch(toggleModal('saveChartModal'));
+                            }}
+                        >
+                            Save
+                        </Button>
+                    </Group>
                 </Group>
             </Paper>
             <SaveSqlChartModal
                 key={`${isSaveModalOpen}-saveChartModal`}
                 opened={isSaveModalOpen}
                 onClose={onCloseSaveModal}
+            />
+            <SaveCustomExploreModal
+                key={`${isSaveCustomExploreModalOpen}-saveCustomExploreModal`}
+                opened={isSaveCustomExploreModalOpen}
+                onClose={onCloseSaveCustomExploreModal}
             />
         </>
     );

--- a/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
@@ -1,5 +1,6 @@
 import { snakeCaseName } from '@lightdash/common';
 import {
+    Accordion,
     Button,
     Group,
     Modal,
@@ -9,7 +10,7 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconWand } from '@tabler/icons-react';
+import { IconInfoCircle, IconSparkles } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -63,8 +64,8 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
             keepMounted={false}
             title={
                 <Group spacing="xs">
-                    <MantineIcon icon={IconWand} size="lg" color="gray.7" />
-                    <Text fw={500}>Save explore</Text>
+                    <MantineIcon icon={IconSparkles} size="lg" color="gray.7" />
+                    <Text fw={500}>Create custom explore</Text>
                 </Group>
             }
             styles={(theme) => ({
@@ -73,9 +74,31 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
             })}
         >
             <form onSubmit={form.onSubmit(handleSubmit)}>
+                <Accordion variant="separated" radius="md" m="xs">
+                    <Accordion.Item value="custom-explores">
+                        <Accordion.Control
+                            icon={
+                                <MantineIcon icon={IconInfoCircle} size={16} />
+                            }
+                        >
+                            <Text fz="sm" fw="500">
+                                What are custom explores?
+                            </Text>
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                            <Text fz="xs">
+                                Custom explores are a way to save a query that
+                                you can reuse later when 'Querying from tables'.
+                                You can use them to save time when you and your
+                                organization want to run the same query again.
+                            </Text>
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Accordion>
                 <Stack p="md">
                     <Stack spacing="xs">
                         <TextInput
+                            radius="md"
                             label="Name"
                             required
                             {...form.getInputProps('name')}
@@ -83,19 +106,13 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
                     </Stack>
                 </Stack>
 
-                <Group
-                    position="right"
-                    w="100%"
-                    sx={(theme) => ({
-                        borderTop: `1px solid ${theme.colors.gray[4]}`,
-                        bottom: 0,
-                        padding: theme.spacing.md,
-                    })}
-                >
+                <Group position="right" w="100%" p="md">
                     <Button
+                        color="gray.7"
                         onClick={onClose}
                         variant="outline"
                         disabled={isLoading}
+                        size="xs"
                     >
                         Cancel
                     </Button>
@@ -104,8 +121,9 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
                         type="submit"
                         disabled={!form.values.name || !sql}
                         loading={isLoading}
+                        size="xs"
                     >
-                        Create explore
+                        Create
                     </Button>
                 </Group>
             </form>

--- a/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
@@ -9,7 +9,7 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconChartBar } from '@tabler/icons-react';
+import { IconWand } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -63,8 +63,8 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
             keepMounted={false}
             title={
                 <Group spacing="xs">
-                    <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
-                    <Text fw={500}>Save custom explore</Text>
+                    <MantineIcon icon={IconWand} size="lg" color="gray.7" />
+                    <Text fw={500}>Save explore</Text>
                 </Group>
             }
             styles={(theme) => ({
@@ -76,7 +76,7 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
                 <Stack p="md">
                     <Stack spacing="xs">
                         <TextInput
-                            label="Custom explore name"
+                            label="Name"
                             required
                             {...form.getInputProps('name')}
                         />
@@ -105,7 +105,7 @@ export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
                         disabled={!form.values.name || !sql}
                         loading={isLoading}
                     >
-                        Create Custom Explore
+                        Create explore
                     </Button>
                 </Group>
             </form>

--- a/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveCustomExploreModal.tsx
@@ -1,0 +1,114 @@
+import { snakeCaseName } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Text,
+    TextInput,
+    type ModalProps,
+} from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconChartBar } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { z } from 'zod';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useCreateCustomExplore } from '../hooks/useCustomExplore';
+import { useAppSelector } from '../store/hooks';
+
+const validationSchema = z.object({
+    name: z.string().min(1),
+});
+
+type FormValues = z.infer<typeof validationSchema>;
+
+type Props = ModalProps;
+
+export const SaveCustomExploreModal: FC<Props> = ({ opened, onClose }) => {
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const sql = useAppSelector((state) => state.sqlRunner.sql);
+    const columns = useAppSelector((state) => state.sqlRunner.sqlColumns);
+    const { mutateAsync: createCustomExplore, isLoading } =
+        useCreateCustomExplore({
+            projectUuid,
+        });
+    const form = useForm<FormValues>({
+        initialValues: {
+            name: '',
+        },
+        validate: zodResolver(validationSchema),
+    });
+
+    const handleSubmit = useCallback(
+        async (data: { name: string }) => {
+            if (!columns) {
+                return;
+            }
+
+            await createCustomExplore({
+                name: snakeCaseName(data.name),
+                sql,
+                columns,
+                projectUuid,
+            });
+            onClose();
+        },
+        [createCustomExplore, sql, columns, onClose, projectUuid],
+    );
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            keepMounted={false}
+            title={
+                <Group spacing="xs">
+                    <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
+                    <Text fw={500}>Save custom explore</Text>
+                </Group>
+            }
+            styles={(theme) => ({
+                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
+                body: { padding: 0 },
+            })}
+        >
+            <form onSubmit={form.onSubmit(handleSubmit)}>
+                <Stack p="md">
+                    <Stack spacing="xs">
+                        <TextInput
+                            label="Custom explore name"
+                            required
+                            {...form.getInputProps('name')}
+                        />
+                    </Stack>
+                </Stack>
+
+                <Group
+                    position="right"
+                    w="100%"
+                    sx={(theme) => ({
+                        borderTop: `1px solid ${theme.colors.gray[4]}`,
+                        bottom: 0,
+                        padding: theme.spacing.md,
+                    })}
+                >
+                    <Button
+                        onClick={onClose}
+                        variant="outline"
+                        disabled={isLoading}
+                    >
+                        Cancel
+                    </Button>
+
+                    <Button
+                        type="submit"
+                        disabled={!form.values.name || !sql}
+                        loading={isLoading}
+                    >
+                        Create Custom Explore
+                    </Button>
+                </Group>
+            </form>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useCustomExplore.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useCustomExplore.tsx
@@ -1,0 +1,65 @@
+import {
+    type ApiCreateCustomExplore,
+    type ApiError,
+    type CreateCustomExplorePayload,
+} from '@lightdash/common';
+import { IconArrowRight } from '@tabler/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { useHistory } from 'react-router-dom';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+const createCustomExplore = async ({
+    projectUuid,
+    name,
+    sql,
+    columns,
+}: {
+    projectUuid: string;
+} & CreateCustomExplorePayload) =>
+    lightdashApi<ApiCreateCustomExplore['results']>({
+        url: `/projects/${projectUuid}/sqlRunner/create-custom-explore`,
+        method: 'POST',
+        body: JSON.stringify({
+            name,
+            sql,
+            columns,
+        }),
+    });
+
+export const useCreateCustomExplore = ({
+    projectUuid,
+}: {
+    projectUuid: string;
+}) => {
+    const history = useHistory();
+    const { showToastSuccess, showToastError } = useToaster();
+    return useMutation<
+        ApiCreateCustomExplore['results'],
+        ApiError,
+        {
+            projectUuid: string;
+        } & CreateCustomExplorePayload
+    >({
+        mutationFn: createCustomExplore,
+        onSuccess: (data) => {
+            showToastSuccess({
+                title: 'Success! Custom explore created',
+                action: {
+                    children: 'Query from new explore',
+                    icon: IconArrowRight,
+                    onClick: () => {
+                        history.push(
+                            `/projects/${projectUuid}/tables/${data.name}`,
+                        );
+                    },
+                },
+            });
+        },
+        onError: () => {
+            showToastError({
+                title: 'Error creating custom explore',
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useCustomExplore.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useCustomExplore.tsx
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { useHistory } from 'react-router-dom';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
 
@@ -32,7 +31,6 @@ export const useCreateCustomExplore = ({
 }: {
     projectUuid: string;
 }) => {
-    const history = useHistory();
     const { showToastSuccess, showToastError } = useToaster();
     return useMutation<
         ApiCreateCustomExplore['results'],
@@ -49,8 +47,9 @@ export const useCreateCustomExplore = ({
                     children: 'Query from new explore',
                     icon: IconArrowRight,
                     onClick: () => {
-                        history.push(
+                        window.open(
                             `/projects/${projectUuid}/tables/${data.name}`,
+                            '_blank',
                         );
                     },
                 },

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -48,6 +48,9 @@ export interface SqlRunnerState {
         addToDashboard: {
             isOpen: boolean;
         };
+        saveCustomExploreModal: {
+            isOpen: boolean;
+        };
     };
     quoteChar: string;
     sqlColumns: VizColumn[] | undefined;
@@ -80,6 +83,9 @@ const initialState: SqlRunnerState = {
             isOpen: false,
         },
         addToDashboard: {
+            isOpen: false,
+        },
+        saveCustomExploreModal: {
             isOpen: false,
         },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11557

### Description:

- Hides this feature behind a feature flag
- Allows users to save sql runner queries as explores to be used when querying from tables
- Can go to explore and query dimensions, create custom metrics, and also save charts!

Limitations
- Can't edit 
- When clicking `refresh dbt`, it clears the saved explores
- Missing some core features

> [!IMPORTANT]
> This doesn't cover **everything** on the issue, but this is for demo purposes. The scope has been verified by @owlas.


Demo: 


https://github.com/user-attachments/assets/4d245988-7b78-4191-b0e8-518b18260c42




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
