### PR TITLE
fix: reset chart configs on unmount of create and view

### DIFF
--- a/packages/frontend/src/components/DataViz/store/actions/commonChartActions.ts
+++ b/packages/frontend/src/components/DataViz/store/actions/commonChartActions.ts
@@ -39,3 +39,5 @@ export const setChartOptionsAndConfig = createAction<ChartOptionsAndConfig>(
 );
 
 export const setChartConfig = createAction<ChartConfig>('chart/setChartConfig');
+
+export const resetChartState = createAction('chart/resetState');

--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -1,6 +1,7 @@
 import { ChartKind, isVizBarChartConfig } from '@lightdash/common';
 import { createSlice } from '@reduxjs/toolkit';
 import {
+    resetChartState,
     setChartConfig,
     setChartOptionsAndConfig,
 } from './actions/commonChartActions';
@@ -30,6 +31,9 @@ export const barChartConfigSlice = createSlice({
                 state.config = action.payload;
             }
         });
+        builder.addCase(resetChartState, () =>
+            cartesianChartConfigSlice.getInitialState(),
+        );
     },
 });
 

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -1,6 +1,7 @@
 import { ChartKind, isVizLineChartConfig } from '@lightdash/common';
 import { createSlice } from '@reduxjs/toolkit';
 import {
+    resetChartState,
     setChartConfig,
     setChartOptionsAndConfig,
 } from './actions/commonChartActions';
@@ -30,6 +31,9 @@ export const lineChartConfigSlice = createSlice({
                 state.config = action.payload;
             }
         });
+        builder.addCase(resetChartState, () =>
+            cartesianChartConfigSlice.getInitialState(),
+        );
     },
 });
 

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -11,6 +11,7 @@ import {
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import {
+    resetChartState,
     setChartConfig,
     setChartOptionsAndConfig,
 } from './actions/commonChartActions';
@@ -101,6 +102,7 @@ export const pieChartConfigSlice = createSlice({
                 state.config = action.payload;
             }
         });
+        builder.addCase(resetChartState, () => initialState);
     },
 });
 export const { setGroupFieldIds, setYAxisReference, setYAxisAggregation } =

--- a/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
@@ -8,6 +8,7 @@ import {
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import {
+    resetChartState,
     setChartConfig,
     setChartOptionsAndConfig,
 } from './actions/commonChartActions';
@@ -68,6 +69,7 @@ export const tableVisSlice = createSlice({
                 state.config = action.payload;
             }
         });
+        builder.addCase(resetChartState, () => initialState);
     },
 });
 

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -99,9 +99,7 @@ export const sqlRunnerSlice = createSlice({
     name: 'sqlRunner',
     initialState,
     reducers: {
-        resetState: () => {
-            return initialState;
-        },
+        resetState: () => initialState,
         setProjectUuid: (state, action: PayloadAction<string>) => {
             state.projectUuid = action.payload;
         },

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -8,7 +8,10 @@ import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
-import { setChartConfig } from '../components/DataViz/store/actions/commonChartActions';
+import {
+    resetChartState,
+    setChartConfig,
+} from '../components/DataViz/store/actions/commonChartActions';
 import { Sidebar } from '../features/sqlRunner';
 import { ContentPanel } from '../features/sqlRunner/components/ContentPanel';
 import { Header } from '../features/sqlRunner/components/Header';
@@ -38,6 +41,7 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
 
     useUnmount(() => {
         dispatch(resetState());
+        dispatch(resetChartState());
     });
 
     useEffect(() => {

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -17,7 +17,10 @@ import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import { useChartViz } from '../components/DataViz/hooks/useChartViz';
-import { setChartConfig } from '../components/DataViz/store/actions/commonChartActions';
+import {
+    resetChartState,
+    setChartConfig,
+} from '../components/DataViz/store/actions/commonChartActions';
 import { selectChartConfigByKind } from '../components/DataViz/store/selectors';
 import ChartView from '../components/DataViz/visualizations/ChartView';
 import { Table } from '../components/DataViz/visualizations/Table';
@@ -73,6 +76,7 @@ const ViewSqlChart = () => {
 
     useUnmount(() => {
         dispatch(resetState());
+        dispatch(resetChartState());
     });
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Reset chart-related slices on unmount. The current `resetState` doesn't reset chart-related slices on `unmount`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
