### PR TITLE
feat: display chart errors on save/edit if invalid

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -106,6 +106,10 @@ export class CartesianChartDataModel
         return this.resultsRunner.pivotChartOptions();
     }
 
+    getConfigErrors() {
+        return this.resultsRunner.getPivotChartLayoutErrors(this.fieldConfig);
+    }
+
     async getTransformedData(
         layout: VizChartLayout | undefined,
         sql?: string,

--- a/packages/common/src/visualizations/PieChartDataModel.ts
+++ b/packages/common/src/visualizations/PieChartDataModel.ts
@@ -56,6 +56,10 @@ export class PieChartDataModel
         };
     }
 
+    getConfigErrors() {
+        return this.resultsRunner.getPivotChartLayoutErrors(this.fieldConfig);
+    }
+
     async getTransformedData(
         layout: VizChartLayout | undefined,
         sql?: string,

--- a/packages/common/src/visualizations/types/IResultsRunner.ts
+++ b/packages/common/src/visualizations/types/IResultsRunner.ts
@@ -1,4 +1,8 @@
-import { type PivotChartData, type VizCartesianChartOptions } from '.';
+import {
+    type PivotChartData,
+    type VizCartesianChartOptions,
+    type VizConfigErrors,
+} from '.';
 import { type RawResultRow } from '../../types/results';
 
 export interface IResultsRunner<TPivotChartLayout> {
@@ -19,6 +23,10 @@ export interface IResultsRunner<TPivotChartLayout> {
     ): TPivotChartLayout | undefined;
 
     pivotChartOptions(): VizCartesianChartOptions;
+
+    getPivotChartLayoutErrors(
+        config: TPivotChartLayout | undefined,
+    ): VizConfigErrors | undefined;
 
     getColumns(): string[];
 

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -188,3 +188,15 @@ export type VizChartConfig =
     | VizLineChartConfig
     | VizPieChartConfig
     | VizTableConfig;
+
+export type VizConfigErrors = {
+    indexFieldError?: {
+        reference: string;
+    };
+    valuesFieldError?: {
+        references: string[];
+    };
+    groupByFieldError?: {
+        references: string[];
+    };
+};

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -4,6 +4,7 @@ import {
     type ChartKind,
     type VizChartLayout,
     type VizColumn,
+    type VizConfigErrors,
     type VizIndexLayoutOptions,
     type VizPivotLayoutOptions,
     type VizValuesLayoutOptions,
@@ -30,7 +31,10 @@ const YFieldsAxisConfig: FC<{
     index: number;
     actions: CartesianChartActionsType;
     columns: VizColumn[];
-}> = ({ field, yLayoutOptions, isSingle, index, actions, columns }) => {
+    error:
+        | NonNullable<VizConfigErrors['valuesFieldError']>['references'][number]
+        | undefined;
+}> = ({ field, yLayoutOptions, isSingle, index, actions, columns, error }) => {
     const dispatch = useVizDispatch();
 
     return (
@@ -53,10 +57,8 @@ const YFieldsAxisConfig: FC<{
                             }))}
                             value={field.reference}
                             error={
-                                yLayoutOptions.find(
-                                    (y) => y.reference === field.reference,
-                                ) === undefined &&
-                                `Column "${field.reference}" does not exist. Choose another`
+                                !!error &&
+                                `Column "${error}" does not exist. Choose another`
                             }
                             placeholder="Select Y axis"
                             onChange={(value) => {
@@ -111,12 +113,13 @@ const XFieldAxisConfig = ({
     xLayoutOptions,
     actions,
     columns,
+    error,
 }: {
     columns: VizColumn[];
-
     field: VizChartLayout['x'] | undefined;
     xLayoutOptions: VizIndexLayoutOptions[];
     actions: CartesianChartActionsType;
+    error: VizConfigErrors['indexFieldError'];
 }) => {
     const dispatch = useVizDispatch();
 
@@ -136,11 +139,8 @@ const XFieldAxisConfig = ({
                     } else dispatch(actions.setXAxisReference(value));
                 }}
                 error={
-                    field?.reference &&
-                    xLayoutOptions.find(
-                        (x) => x.reference === field.reference,
-                    ) === undefined &&
-                    `Column "${field.reference}" does not exist. Choose another`
+                    error &&
+                    `Column "${error.reference}" does not exist. Choose another`
                 }
                 fieldType={
                     (field?.reference &&
@@ -187,23 +187,23 @@ const GroupByFieldAxisConfig = ({
     groupByOptions = [],
     actions,
     columns,
+    error,
 }: {
     columns: VizColumn[];
     field: undefined | { reference: string };
     groupByOptions?: VizPivotLayoutOptions[];
     actions: CartesianChartActionsType;
+    error: VizConfigErrors['groupByFieldError'];
 }) => {
     const dispatch = useVizDispatch();
-    const error =
-        field !== undefined &&
-        !groupByOptions.find((x) => x.reference === field.reference)
-            ? `Column "${field.reference}" does not exist. Choose another`
-            : undefined;
+    const groupByError = error?.references[0]
+        ? `Column "${error.references[0]}" does not exist. Choose another`
+        : undefined;
     return (
         <FieldReferenceSelect
             rightSection={
                 // When the field is deleted, the error state prevents the clear button from showing
-                error && (
+                groupByError && (
                     <ActionIcon
                         onClick={() =>
                             dispatch(actions.unsetGroupByReference())
@@ -220,7 +220,7 @@ const GroupByFieldAxisConfig = ({
             }))}
             value={field?.reference ?? null}
             placeholder="Select group by"
-            error={error}
+            error={groupByError}
             onChange={(value) => {
                 if (!value) {
                     dispatch(actions.unsetGroupByReference());
@@ -273,6 +273,10 @@ export const CartesianChartFieldConfiguration = ({
         cartesianChartSelectors.getPivotLayoutOptions(state, selectedChartType),
     );
 
+    const errors = useVizSelector((state) =>
+        cartesianChartSelectors.getErrors(state, selectedChartType),
+    );
+
     return (
         <Stack spacing="sm">
             <Config>
@@ -284,6 +288,7 @@ export const CartesianChartFieldConfiguration = ({
                             field={xAxisField}
                             xLayoutOptions={xLayoutOptions}
                             actions={actions}
+                            error={errors?.indexFieldError}
                         />
                     )}
                 </Config.Section>
@@ -307,6 +312,10 @@ export const CartesianChartFieldConfiguration = ({
                                 index={index}
                                 actions={actions}
                                 columns={columns}
+                                error={errors?.valuesFieldError?.references.find(
+                                    (reference) =>
+                                        reference === field.reference,
+                                )}
                             />
                         ))}
                 </Config.Section>
@@ -319,6 +328,7 @@ export const CartesianChartFieldConfiguration = ({
                         field={groupByField}
                         groupByOptions={groupByLayoutOptions}
                         actions={actions}
+                        error={errors?.groupByFieldError}
                     />
                 </Config.Section>
             </Config>

--- a/packages/frontend/src/components/DataViz/config/PieChartConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/PieChartConfiguration.tsx
@@ -32,6 +32,8 @@ export const PieChartConfiguration = ({
         (state) => state.pieChartConfig.options.metricFieldOptions,
     );
 
+    const errors = useVizSelector((state) => state.pieChartConfig.errors);
+
     return (
         <Stack spacing="sm" mb="lg">
             <Title order={5} fz="sm" c="gray.9">
@@ -58,11 +60,9 @@ export const PieChartConfiguration = ({
                         dispatch(setGroupFieldIds(field));
                     }}
                     error={
-                        !!groupField &&
-                        groupFieldOptions.find(
-                            (x) => x.reference === groupField,
-                        ) === undefined &&
-                        `Column "${groupField}" not in SQL query`
+                        errors?.groupByFieldError?.references
+                            ? `Column "${errors?.groupByFieldError?.references[0]}" not in SQL query`
+                            : undefined
                     }
                     fieldType={
                         columns?.find((x) => x.reference === groupField)
@@ -81,10 +81,9 @@ export const PieChartConfiguration = ({
                     }))}
                     value={aggregateField?.reference}
                     error={
-                        aggregateFieldOptions.find(
-                            (y) => y.reference === aggregateField?.reference,
-                        ) === undefined &&
-                        `Column "${aggregateField?.reference}" not in SQL query`
+                        errors?.valuesFieldError?.references
+                            ? `Column "${errors?.valuesFieldError?.references[0]}" not in SQL query`
+                            : undefined
                     }
                     placeholder="Select Y axis"
                     onChange={(value) => {

--- a/packages/frontend/src/components/DataViz/store/actions/commonChartActions.ts
+++ b/packages/frontend/src/components/DataViz/store/actions/commonChartActions.ts
@@ -2,6 +2,7 @@ import {
     type ChartKind,
     type VizCartesianChartConfig,
     type VizCartesianChartOptions,
+    type VizConfigErrors,
     type VizPieChartConfig,
     type VizPieChartOptions,
     type VizTableConfig,
@@ -13,18 +14,22 @@ type ChartTypeConfig = {
     [ChartKind.VERTICAL_BAR]: {
         options: VizCartesianChartOptions;
         config: VizCartesianChartConfig;
+        errors: VizConfigErrors | undefined;
     };
     [ChartKind.LINE]: {
         options: VizCartesianChartOptions;
         config: VizCartesianChartConfig;
+        errors: VizConfigErrors | undefined;
     };
     [ChartKind.PIE]: {
         options: VizPieChartOptions;
         config: VizPieChartConfig;
+        errors: VizConfigErrors | undefined;
     };
     [ChartKind.TABLE]: {
         options: VizTableOptions;
         config: VizTableConfig;
+        errors: undefined;
     };
 };
 

--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -24,6 +24,8 @@ export const barChartConfigSlice = createSlice({
             if (!state.config && action.payload.config.fieldConfig) {
                 state.config = action.payload.config;
             }
+
+            state.errors = action.payload.errors;
         });
         builder.addCase(setChartConfig, (state, action) => {
             if (isVizBarChartConfig(action.payload)) {

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -7,6 +7,7 @@ import {
     type VizBarChartConfig,
     type VizCartesianChartOptions,
     type VizChartLayout,
+    type VizConfigErrors,
     type VizLineChartConfig,
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
@@ -16,6 +17,7 @@ export type CartesianChartState = {
     defaultLayout: VizChartLayout | undefined;
     config: VizBarChartConfig | VizLineChartConfig | undefined;
     options: VizCartesianChartOptions;
+    errors: VizConfigErrors | undefined;
 };
 
 const initialState: CartesianChartState = {
@@ -26,6 +28,7 @@ const initialState: CartesianChartState = {
         valuesLayoutOptions: [],
         pivotLayoutOptions: [],
     },
+    errors: undefined,
 };
 
 export const cartesianChartConfigSlice = createSlice({

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -24,6 +24,8 @@ export const lineChartConfigSlice = createSlice({
             if (!state.config && action.payload.config.fieldConfig) {
                 state.config = action.payload.config;
             }
+
+            state.errors = action.payload.errors;
         });
         builder.addCase(setChartConfig, (state, action) => {
             if (isVizLineChartConfig(action.payload)) {

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -4,6 +4,7 @@ import {
     VIZ_DEFAULT_AGGREGATION,
     type VizAggregationOptions,
     type VizChartLayout,
+    type VizConfigErrors,
     type VizIndexType,
     type VizPieChartConfig,
     type VizPieChartOptions,
@@ -19,6 +20,7 @@ export type PieChartState = {
     defaultFieldConfig: VizChartLayout | undefined;
     config: VizPieChartConfig | undefined;
     options: VizPieChartOptions;
+    errors: VizConfigErrors | undefined;
 };
 
 const initialState: PieChartState = {
@@ -28,6 +30,7 @@ const initialState: PieChartState = {
         groupFieldOptions: [],
         metricFieldOptions: [],
     },
+    errors: undefined,
 };
 
 export const pieChartConfigSlice = createSlice({

--- a/packages/frontend/src/components/DataViz/store/selectors.ts
+++ b/packages/frontend/src/components/DataViz/store/selectors.ts
@@ -93,6 +93,11 @@ const getPivotLayoutOptions = createSelector(
     (chartState) => chartState?.options?.pivotLayoutOptions,
 );
 
+const getErrors = createSelector(
+    [(state, chartKind) => selectCurrentCartesianChartState(state, chartKind)],
+    (chartState) => chartState?.errors,
+);
+
 export const cartesianChartSelectors = {
     getIndexLayoutOptions,
     getValuesLayoutOptions,
@@ -100,4 +105,5 @@ export const cartesianChartSelectors = {
     getYAxisFields,
     getGroupByField,
     getPivotLayoutOptions,
+    getErrors,
 };

--- a/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
+++ b/packages/frontend/src/components/DataViz/transformers/ResultsRunner.ts
@@ -8,6 +8,7 @@ import {
     type RawResultRow,
     type VizChartLayout,
     type VizColumn,
+    type VizConfigErrors,
     type VizIndexLayoutOptions,
     type VizPivotLayoutOptions,
     type VizTableConfig,
@@ -103,7 +104,7 @@ export class ResultsRunner implements IResultsRunner<VizChartLayout> {
                 default:
                     return acc;
             }
-        }, [] as VizValuesLayoutOptions[]);
+        }, []);
     }
 
     pivotChartOptions(): {
@@ -115,6 +116,76 @@ export class ResultsRunner implements IResultsRunner<VizChartLayout> {
             indexLayoutOptions: this.pivotChartIndexLayoutOptions(),
             valuesLayoutOptions: this.pivotChartValuesLayoutOptions(),
             pivotLayoutOptions: this.pivotChartLayoutOptions(),
+        };
+    }
+
+    getPivotChartLayoutErrors(
+        config: VizChartLayout | undefined,
+    ): VizConfigErrors | undefined {
+        const { indexLayoutOptions, valuesLayoutOptions, pivotLayoutOptions } =
+            this.pivotChartOptions();
+
+        const indexFieldError = Boolean(
+            config?.x?.reference &&
+                indexLayoutOptions.find(
+                    (x) => x.reference === config?.x?.reference,
+                ) === undefined,
+        );
+
+        const valuesFieldError = Boolean(
+            config?.y?.some(
+                (yField) =>
+                    yField.reference &&
+                    valuesLayoutOptions.find(
+                        (y) => y.reference === yField.reference,
+                    ) === undefined,
+            ),
+        );
+        const groupByFieldError = Boolean(
+            config?.groupBy?.some(
+                (groupByField) =>
+                    groupByField.reference &&
+                    pivotLayoutOptions.find(
+                        (x) => x.reference === groupByField.reference,
+                    ) === undefined,
+            ),
+        );
+
+        if (!indexFieldError && !valuesFieldError && !groupByFieldError) {
+            return undefined;
+        }
+
+        return {
+            ...(indexFieldError &&
+                config?.x?.reference && {
+                    indexFieldError: {
+                        reference: config.x.reference,
+                    },
+                }),
+            ...(valuesFieldError &&
+                config?.y?.map((y) => y.reference) && {
+                    valuesFieldError: {
+                        references: config?.y.reduce<
+                            NonNullable<
+                                VizConfigErrors['valuesFieldError']
+                            >['references']
+                        >((acc, y) => {
+                            const valuesLayoutOption = valuesLayoutOptions.find(
+                                (v) => v.reference === y.reference,
+                            );
+                            if (!valuesLayoutOption) {
+                                acc.push(y.reference);
+                            }
+                            return acc;
+                        }, []),
+                    },
+                }),
+            ...(groupByFieldError &&
+                config?.groupBy?.map((gb) => gb.reference) && {
+                    groupByFieldError: {
+                        references: config.groupBy.map((gb) => gb.reference),
+                    },
+                }),
         };
     }
 

--- a/packages/frontend/src/components/DataViz/transformers/getChartConfigAndOptions.ts
+++ b/packages/frontend/src/components/DataViz/transformers/getChartConfigAndOptions.ts
@@ -34,6 +34,7 @@ const getChartConfigAndOptions = (
                     chartType,
                     currentVizConfig?.display,
                 ),
+                errors: pieChartDataModel.getConfigErrors(),
             } as const;
         case ChartKind.TABLE:
             if (currentVizConfig && !isVizTableConfig(currentVizConfig)) {
@@ -48,6 +49,7 @@ const getChartConfigAndOptions = (
                 type: chartType,
                 options: tableChartDataModel.getResultOptions(),
                 config: tableChartDataModel.mergeConfig(chartType),
+                errors: undefined, // TODO: Implement error tracking for table viz
             } as const;
         case ChartKind.VERTICAL_BAR:
             if (currentVizConfig && !isVizBarChartConfig(currentVizConfig)) {
@@ -66,6 +68,7 @@ const getChartConfigAndOptions = (
                     chartType,
                     currentVizConfig?.display,
                 ),
+                errors: barChartModel.getConfigErrors(),
             } as const;
 
         case ChartKind.LINE:
@@ -85,6 +88,7 @@ const getChartConfigAndOptions = (
                     chartType,
                     currentVizConfig?.display,
                 ),
+                errors: lineChartModel.getConfigErrors(),
             } as const;
         default:
             throw new Error(`Not implemented for chart type: ${chartType}`);

--- a/packages/frontend/src/features/sqlRunner/components/ChartErrorsAlert.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ChartErrorsAlert.tsx
@@ -1,0 +1,59 @@
+import {
+    Alert,
+    Button,
+    Modal,
+    Stack,
+    Text,
+    type ModalProps,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+type Props = ModalProps & {
+    onFixButtonClick: () => void;
+};
+
+export const ChartErrorsAlert: FC<Props> = ({
+    opened,
+    onClose,
+    onFixButtonClick,
+}) => {
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={null}
+            p={0}
+            styles={{
+                header: {
+                    display: 'none',
+                },
+                body: {
+                    padding: 0,
+                },
+            }}
+        >
+            <Alert
+                icon={<MantineIcon icon={IconAlertCircle} color="red" />}
+                color="red"
+                title="Fix errors before saving"
+            >
+                <Stack spacing="xs">
+                    <Text fw={500} size="xs">
+                        You have errors in your chart configuration. Please fix
+                        the errors and try again.
+                    </Text>
+                    <Button
+                        ml="auto"
+                        size="xs"
+                        variant="default"
+                        onClick={onFixButtonClick}
+                    >
+                        Fix errors
+                    </Button>
+                </Stack>
+            </Alert>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -6,6 +6,7 @@ import {
 import {
     Box,
     Group,
+    Indicator,
     LoadingOverlay,
     Paper,
     SegmentedControl,
@@ -39,7 +40,10 @@ import { ConditionalVisibility } from '../../../components/common/ConditionalVis
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useChartViz } from '../../../components/DataViz/hooks/useChartViz';
 import { setChartOptionsAndConfig } from '../../../components/DataViz/store/actions/commonChartActions';
-import { selectChartConfigByKind } from '../../../components/DataViz/store/selectors';
+import {
+    cartesianChartSelectors,
+    selectChartConfigByKind,
+} from '../../../components/DataViz/store/selectors';
 import getChartConfigAndOptions from '../../../components/DataViz/transformers/getChartConfigAndOptions';
 import ChartView from '../../../components/DataViz/visualizations/ChartView';
 import { Table } from '../../../components/DataViz/visualizations/Table';
@@ -279,6 +283,11 @@ export const ContentPanel: FC = () => {
         });
     }, [chartVizQuery.data]);
 
+    const hasErrors = useAppSelector(
+        (state) =>
+            !!cartesianChartSelectors.getErrors(state, selectedChartType),
+    );
+
     return (
         <Stack spacing="none" style={{ flex: 1, overflow: 'hidden' }}>
             <Tooltip.Group>
@@ -296,67 +305,75 @@ export const ContentPanel: FC = () => {
                 >
                     <Group position="apart">
                         <Group position="apart">
-                            <SegmentedControl
-                                styles={(theme) => ({
-                                    root: {
-                                        backgroundColor: theme.colors.gray[2],
-                                    },
-                                })}
-                                size="sm"
-                                radius="md"
-                                data={[
-                                    {
-                                        value: EditorTabs.SQL,
-                                        label: (
-                                            <Group spacing={4} noWrap>
-                                                <MantineIcon
-                                                    color="gray.6"
-                                                    icon={IconCodeCircle}
-                                                />
-                                                <Text>SQL</Text>
-                                            </Group>
-                                        ),
-                                    },
-                                    {
-                                        value: EditorTabs.VISUALIZATION,
-                                        label: (
-                                            <Tooltip
-                                                disabled={
-                                                    !!queryResults?.results
-                                                }
-                                                variant="xs"
-                                                withinPortal
-                                                label="Run a query to see the chart"
-                                            >
+                            <Indicator
+                                color="red.6"
+                                offset={10}
+                                disabled={!hasErrors}
+                            >
+                                <SegmentedControl
+                                    styles={(theme) => ({
+                                        root: {
+                                            backgroundColor:
+                                                theme.colors.gray[2],
+                                        },
+                                    })}
+                                    size="sm"
+                                    radius="md"
+                                    data={[
+                                        {
+                                            value: EditorTabs.SQL,
+                                            label: (
                                                 <Group spacing={4} noWrap>
                                                     <MantineIcon
                                                         color="gray.6"
-                                                        icon={
-                                                            IconChartHistogram
-                                                        }
+                                                        icon={IconCodeCircle}
                                                     />
-                                                    <Text>Chart</Text>
+                                                    <Text>SQL</Text>
                                                 </Group>
-                                            </Tooltip>
-                                        ),
-                                    },
-                                ]}
-                                value={activeEditorTab}
-                                onChange={(value: EditorTabs) => {
-                                    if (isLoading) {
-                                        return;
-                                    }
+                                            ),
+                                        },
+                                        {
+                                            value: EditorTabs.VISUALIZATION,
+                                            label: (
+                                                <Tooltip
+                                                    disabled={
+                                                        !!queryResults?.results
+                                                    }
+                                                    variant="xs"
+                                                    withinPortal
+                                                    label="Run a query to see the chart"
+                                                >
+                                                    <Group spacing={4} noWrap>
+                                                        <MantineIcon
+                                                            color="gray.6"
+                                                            icon={
+                                                                IconChartHistogram
+                                                            }
+                                                        />
+                                                        <Text>Chart</Text>
+                                                    </Group>
+                                                </Tooltip>
+                                            ),
+                                        },
+                                    ]}
+                                    value={activeEditorTab}
+                                    onChange={(value: EditorTabs) => {
+                                        if (isLoading) {
+                                            return;
+                                        }
 
-                                    if (
-                                        value === EditorTabs.VISUALIZATION &&
-                                        !queryResults?.results
-                                    ) {
-                                        return;
-                                    }
+                                        if (
+                                            value ===
+                                                EditorTabs.VISUALIZATION &&
+                                            !queryResults?.results
+                                        ) {
+                                            return;
+                                        }
 
-                                    dispatch(setActiveEditorTab(value));
-                                }}
-                            />
+                                        dispatch(setActiveEditorTab(value));
+                                    }}
+                                />
+                            </Indicator>
                         </Group>
                         <Group>
                             <RunSqlQueryButton

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -32,7 +32,7 @@ export const HeaderView: FC = () => {
     const savedSqlChart = useAppSelector(
         (state) => state.sqlRunner.savedSqlChart,
     );
-    const isAddToDashboard = useAppSelector(
+    const isAddToDashboardModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.addToDashboard.isOpen,
     );
     const onCloseAddToDashboardModal = useCallback(() => {
@@ -176,7 +176,7 @@ export const HeaderView: FC = () => {
                 onClose={onCloseDeleteModal}
                 onSuccess={() => history.push(`/projects/${projectUuid}/home`)}
             />
-            {isAddToDashboard && (
+            {isAddToDashboardModalOpen && (
                 <AddTilesToDashboardModal
                     isOpen={true}
                     projectUuid={projectUuid}

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -19,16 +19,15 @@ import {
     validationSchema,
 } from '../../../components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard';
 import {
+    selectChartConfigByKind,
+    selectTableVisConfigState,
+} from '../../../components/DataViz/store/selectors';
+import {
     useCreateMutation as useSpaceCreateMutation,
     useSpaceSummaries,
 } from '../../../hooks/useSpaces';
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-
-import {
-    selectChartConfigByKind,
-    selectTableVisConfigState,
-} from '../../../components/DataViz/store/selectors';
 import { updateName } from '../store/sqlRunnerSlice';
 
 type FormValues = z.infer<typeof validationSchema>;

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -51,6 +51,9 @@ export interface SqlRunnerState {
         saveCustomExploreModal: {
             isOpen: boolean;
         };
+        chartErrorsAlert: {
+            isOpen: boolean;
+        };
     };
     quoteChar: string;
     sqlColumns: VizColumn[] | undefined;
@@ -86,6 +89,9 @@ const initialState: SqlRunnerState = {
             isOpen: false,
         },
         saveCustomExploreModal: {
+            isOpen: false,
+        },
+        chartErrorsAlert: {
             isOpen: false,
         },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/11486

### Description:

Keeps track of errors in chart config (specifically for bar, line, and pie)

Alerts the user that the chart is invalid and tells them to fix them before saving, preventing the saving of invalid chart configs. With this, I've also improved the error tracking on the form. We generate/check for errors every time there's a new query/sql.

**Create action**

https://github.com/user-attachments/assets/4fac5dc1-71ab-42d4-a09a-7741c6173ebd



**Edit action**

https://github.com/user-attachments/assets/e70d17d2-e7be-4642-ab41-251ec936c674





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
