### PR TITLE
fix: total count pagination bug

### DIFF
--- a/packages/backend/src/database/pagination/index.ts
+++ b/packages/backend/src/database/pagination/index.ts
@@ -26,24 +26,24 @@ export default class KnexPaginate {
             const totalRecordsCountPromise = query.client.raw(
                 `
                 WITH count_cte AS (?)
-                SELECT count(*) FROM count_cte
+                SELECT count(*) as count FROM count_cte
             `,
                 [query.clone().clear('limit').clear('offset')],
             );
             const dataPromise = query.clone().offset(offset).limit(pageSize);
-            const [count, data] = await Promise.all([
+            const [countData, data] = await Promise.all([
                 totalRecordsCountPromise,
                 dataPromise,
             ]);
+
+            const count = Number(countData?.rows?.[0]?.count) || 0;
 
             return {
                 data: data as TResult,
                 pagination: {
                     page,
                     pageSize,
-                    totalPageCount: Math.ceil(
-                        (Number(count?.count) || 0) / pageSize,
-                    ),
+                    totalPageCount: Math.ceil(count / pageSize),
                 },
             };
         }

--- a/packages/backend/src/database/pagination/index.ts
+++ b/packages/backend/src/database/pagination/index.ts
@@ -23,13 +23,13 @@ export default class KnexPaginate {
             }
 
             const offset = (page - 1) * pageSize;
-            const totalRecordsCountPromise = query
-                .clone()
-                .clear('select')
-                .clear('group')
-                .clear('order')
-                .count<{ count: string }[]>()
-                .first();
+            const totalRecordsCountPromise = query.client.raw(
+                `
+                WITH count_cte AS (?)
+                SELECT count(*) FROM count_cte
+            `,
+                [query.clone().clear('limit').clear('offset')],
+            );
             const dataPromise = query.clone().offset(offset).limit(pageSize);
             const [count, data] = await Promise.all([
                 totalRecordsCountPromise,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #11496

### Description:

#### What the issue is: 
By removing select and group, we are not filtering out duplicated data on the results, so the count can be innacurate. The worst thing is that this bug is hard to catch, and it will depend on the `query` que pass as parameter. We need a solution that is consistent and error-proneless

#### How I fixed this: 
Replace the count custom query with a CTE that simply counts all the results in the original subquery. Hopefully, this is more generic and less hacky. 

#### Considerations: 
This is virtually running the same query twice, one just for counting results. However, this is not different to what we had previosly anyway...

An alternative option is to get all the results from the query, count and filter on javascript, this is potentially more memory heavy and not a big improvement... 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
