### PR TITLE
fix: cast float on quick table calculations

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
@@ -3,11 +3,11 @@ import {
     CustomFormatType,
     getFieldQuoteChar,
     MetricType,
+    WarehouseTypes,
     type CustomFormat,
     type Metric,
     type SortField,
     type TableCalculation,
-    type WarehouseTypes,
 } from '@lightdash/common';
 import { Menu } from '@mantine/core';
 import { type FC } from 'react';
@@ -96,7 +96,8 @@ const getSqlForQuickCalculation = (
     warehouseType: WarehouseTypes | undefined,
 ) => {
     const fieldQuoteChar = getFieldQuoteChar(warehouseType);
-
+    const floatType =
+        warehouseType === WarehouseTypes.BIGQUERY ? 'FLOAT64' : 'FLOAT';
     const orderSql = (reverseSorting: boolean = false) =>
         sorts.length > 0
             ? `ORDER BY ${sorts
@@ -114,19 +115,22 @@ const getSqlForQuickCalculation = (
     switch (quickCalculation) {
         case QuickCalculation.PERCENT_CHANGE_FROM_PREVIOUS:
             return `(
-              \${${fieldReference}} / NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
+               CAST( \${${fieldReference}} AS ${floatType}) / 
+               CAST(NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
                 true,
-            )}) ,0)
+            )}) ,0)  AS ${floatType}) 
             ) - 1`;
         case QuickCalculation.PERCENT_OF_PREVIOUS_VALUE:
             return `(
-              \${${fieldReference}} / NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
+              CAST(\${${fieldReference}} AS ${floatType}) / 
+              CAST(NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
                 true,
-            )}),0)
+            )}),0) AS ${floatType}) 
             )`;
         case QuickCalculation.PERCENT_OF_COLUMN_TOTAL:
             return `(
-              \${${fieldReference}} / NULLIF(SUM(\${${fieldReference}}) OVER(),0) 
+              CAST(\${${fieldReference}} AS ${floatType}) / 
+              CAST(NULLIF(SUM(\${${fieldReference}}) OVER(),0) AS ${floatType}) 
             )`;
         case QuickCalculation.RANK_IN_COLUMN:
             return `RANK() OVER(ORDER BY \${${fieldReference}} ASC)`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #11586

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
I tried replicating on snowflake, bigquery and postgres, and I couldn't, even when using INT

It is possible this is only affecting redshift, or some specific versions. In any case, I added a casting for all warehouses. 

[Screencast from 19-09-24 15:50:56.webm](https://github.com/user-attachments/assets/2c9546d0-204e-49ad-9898-80e1f58f45bf)

I don't think we need to update the docs , having this feature. 
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
