### PR TITLE
fix: allow deletion of charts within dashboards

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -218,8 +218,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
         return resultsData?.fields;
     }, [resultsData]);
 
-    const { clearIsEditingDashboardChart, getIsEditingDashboardChart } =
-        useDashboardStorage();
+    const { clearIsEditingDashboardChart } = useDashboardStorage();
 
     const [blockedNavigationLocation, setBlockedNavigationLocation] =
         useState<string>();
@@ -902,31 +901,22 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                                     <>
                                         <Menu.Divider />
 
-                                        <Tooltip
-                                            disabled={
-                                                !getIsEditingDashboardChart()
-                                            }
-                                            position="bottom"
-                                            label="This chart can be deleted from its dashboard"
-                                        >
-                                            <Box>
-                                                <Menu.Item
-                                                    icon={
-                                                        <MantineIcon
-                                                            icon={IconTrash}
-                                                            color="red"
-                                                        />
-                                                    }
-                                                    color="red"
-                                                    disabled={getIsEditingDashboardChart()}
-                                                    onClick={
-                                                        deleteModalHandlers.open
-                                                    }
-                                                >
-                                                    Delete
-                                                </Menu.Item>
-                                            </Box>
-                                        </Tooltip>
+                                        <Box>
+                                            <Menu.Item
+                                                icon={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                        color="red"
+                                                    />
+                                                }
+                                                color="red"
+                                                onClick={
+                                                    deleteModalHandlers.open
+                                                }
+                                            >
+                                                Delete
+                                            </Menu.Item>
+                                        </Box>
                                     </>
                                 )}
                             </Menu.Dropdown>
@@ -983,7 +973,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                         } else {
                             history.push(`/`);
                         }
-
+                        clearIsEditingDashboardChart();
                         deleteModalHandlers.close();
                     }}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #11617

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
> Since we don't delete orphan charts within dashboards anymore, it is impossible to delete a chart that was removed from a dashboard.
This is particularly annoying if this chart has validation errors


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
