### PR TITLE
feat: save table when viz tab hasn't been clicked

### DIFF
--- a/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
@@ -57,9 +57,13 @@ export const tableVisSlice = createSlice({
 
             state.options = action.payload.options;
 
+            const newConfigHasColumns =
+                Object.entries(action.payload.config.columns).length > 0;
+
             if (
-                !state.config ||
-                !deepEqual(state.config, action.payload.config)
+                (!state.config ||
+                    !deepEqual(state.config, action.payload.config)) &&
+                newConfigHasColumns
             ) {
                 state.config = action.payload.config;
             }

--- a/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
@@ -1,12 +1,12 @@
 import {
     ChartKind,
-    deepEqual,
     isVizTableConfig,
     type VizTableConfig,
     type VizTableOptions,
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
+import { isEqual } from 'lodash';
 import {
     resetChartState,
     setChartConfig,
@@ -62,7 +62,7 @@ export const tableVisSlice = createSlice({
 
             if (
                 (!state.config ||
-                    !deepEqual(state.config, action.payload.config)) &&
+                    !isEqual(state.config, action.payload.config)) &&
                 newConfigHasColumns
             ) {
                 state.config = action.payload.config;

--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -96,7 +96,7 @@ const Content: FC = () => {
 
         const chartResultOptions = getChartConfigAndOptions(
             resultsRunner,
-            activeChartKind || ChartKind.TABLE,
+            activeChartKind ?? ChartKind.TABLE,
             currentVizConfig,
         );
 

--- a/packages/frontend/src/features/semanticViewer/components/Content.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Content.tsx
@@ -1,3 +1,4 @@
+import { ChartKind } from '@lightdash/common';
 import { Center, Group, SegmentedControl, Text } from '@mantine/core';
 import { IconChartHistogram, IconCodeCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
@@ -95,7 +96,7 @@ const Content: FC = () => {
 
         const chartResultOptions = getChartConfigAndOptions(
             resultsRunner,
-            activeChartKind,
+            activeChartKind || ChartKind.TABLE,
             currentVizConfig,
         );
 

--- a/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartContent.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartContent.tsx
@@ -21,7 +21,7 @@ const SemanticViewerSaveChartContent: FC = () => {
         (state) => state.semanticViewer.activeChartKind,
     );
     const selectedChartConfig = useAppSelector((state) =>
-        selectChartConfigByKind(state, activeChartKind || ChartKind.TABLE),
+        selectChartConfigByKind(state, activeChartKind ?? ChartKind.TABLE),
     );
 
     const handleOpenSaveModal = () => {

--- a/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartContent.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartContent.tsx
@@ -1,10 +1,11 @@
+import { ChartKind } from '@lightdash/common';
 import { Button, Input, useMantineTheme } from '@mantine/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { selectChartConfigByKind } from '../../../../components/DataViz/store/selectors';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { selectSemanticLayerQuery } from '../../store/selectors';
+import { selectAllSelectedFieldNames } from '../../store/selectors';
 import {
     updateName,
     updateSaveModalOpen,
@@ -15,19 +16,19 @@ const SemanticViewerSaveChartContent: FC = () => {
     const dispatch = useAppDispatch();
 
     const name = useAppSelector((state) => state.semanticViewer.name);
-    const semanticLayerQuery = useAppSelector(selectSemanticLayerQuery);
+    const selectedFieldNames = useAppSelector(selectAllSelectedFieldNames);
     const activeChartKind = useAppSelector(
         (state) => state.semanticViewer.activeChartKind,
     );
     const selectedChartConfig = useAppSelector((state) =>
-        selectChartConfigByKind(state, activeChartKind),
+        selectChartConfigByKind(state, activeChartKind || ChartKind.TABLE),
     );
 
     const handleOpenSaveModal = () => {
         dispatch(updateSaveModalOpen(true));
     };
 
-    const canSave = !!semanticLayerQuery && !!selectedChartConfig;
+    const canSave = selectedFieldNames.length > 0 && !!selectedChartConfig;
 
     return (
         <>

--- a/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartModal.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartModal.tsx
@@ -1,3 +1,4 @@
+import { ChartKind } from '@lightdash/common';
 import {
     Button,
     Group,
@@ -49,7 +50,7 @@ const SemanticViewerSaveChartModal: FC = () => {
         (state) => state.semanticViewer.activeChartKind,
     );
     const selectedChartConfig = useAppSelector((state) =>
-        selectChartConfigByKind(state, activeChartKind),
+        selectChartConfigByKind(state, activeChartKind || ChartKind.TABLE),
     );
 
     const spacesQuery = useSpaceSummaries(projectUuid, true);

--- a/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartModal.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/SaveChart/SemanticViewerSaveChartModal.tsx
@@ -50,7 +50,7 @@ const SemanticViewerSaveChartModal: FC = () => {
         (state) => state.semanticViewer.activeChartKind,
     );
     const selectedChartConfig = useAppSelector((state) =>
-        selectChartConfigByKind(state, activeChartKind || ChartKind.TABLE),
+        selectChartConfigByKind(state, activeChartKind ?? ChartKind.TABLE),
     );
 
     const spacesQuery = useSpaceSummaries(projectUuid, true);

--- a/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
+++ b/packages/frontend/src/features/semanticViewer/store/semanticViewerSlice.ts
@@ -117,7 +117,7 @@ export interface SemanticViewerState {
 
     activeEditorTab: EditorTabs;
     activeSidebarTab: SidebarTabs;
-    activeChartKind: ChartKind;
+    activeChartKind: ChartKind | undefined;
 
     resultsTableConfig: VizTableConfig | undefined;
 
@@ -150,7 +150,7 @@ const initialState: SemanticViewerState = {
 
     activeEditorTab: EditorTabs.QUERY,
     activeSidebarTab: SidebarTabs.TABLES,
-    activeChartKind: ChartKind.VERTICAL_BAR,
+    activeChartKind: undefined,
 
     resultsTableConfig: undefined,
 
@@ -258,6 +258,10 @@ export const semanticViewerSlice = createSlice({
             }
             if (action.payload === EditorTabs.VIZ) {
                 state.activeSidebarTab = SidebarTabs.VISUALIZATION;
+
+                if (!state.activeChartKind) {
+                    state.activeChartKind = ChartKind.VERTICAL_BAR;
+                }
             }
         },
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11455 

### Description:

- Allows selected chart kind to be `undefined` (this reflects a bit better when a user hasn't clicked the chart tab)
- If chart kind is undefined when saving, use table chart kind

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
