### PR TITLE
fix: avoid duplicating slugs on all charts, dashboards and spaces

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -157,9 +157,13 @@ describe('DashboardModel', () => {
         tracker.on.select(SavedChartsTableName).responseOnce([savedChartEntry]);
         tracker.on.insert(DashboardTileChartTableName).responseOnce([]);
         tracker.on.update(DashboardViewsTableName).responseOnce([]);
+        tracker.on.select(DashboardsTableName).responseOnce('slug');
 
         jest.spyOn(model, 'getById').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
+        );
+        jest.spyOn(DashboardModel, 'generateUniqueSlug').mockResolvedValue(
+            createDashboard.slug,
         );
 
         await model.create('spaceUuid', createDashboard, user, projectUuid);

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -977,6 +977,13 @@ export class DashboardModel {
         };
     }
 
+    /*
+    This utility method wraps the slug generation functionality for testing purposes
+    */
+    static async generateUniqueSlug(trx: Knex, slug: string): Promise<string> {
+        return generateUniqueSlug(trx, DashboardsTableName, slug);
+    }
+
     async create(
         spaceUuid: string,
         dashboard: CreateDashboard & { slug: string },
@@ -997,9 +1004,8 @@ export class DashboardModel {
                     name: dashboard.name,
                     description: dashboard.description,
                     space_id: space.space_id,
-                    slug: await generateUniqueSlug(
+                    slug: await DashboardModel.generateUniqueSlug(
                         trx,
-                        DashboardsTableName,
                         dashboard.slug,
                     ),
                 })

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -72,6 +72,7 @@ import { SavedSqlTableName } from '../../database/entities/savedSql';
 import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTable, UserTableName } from '../../database/entities/users';
 import { DbValidationTable } from '../../database/entities/validation';
+import { generateUniqueSlug } from '../../utils/SlugUtils';
 import { SpaceModel } from '../SpaceModel';
 import Transaction = Knex.Transaction;
 
@@ -996,7 +997,11 @@ export class DashboardModel {
                     name: dashboard.name,
                     description: dashboard.description,
                     space_id: space.space_id,
-                    slug: dashboard.slug,
+                    slug: await generateUniqueSlug(
+                        trx,
+                        DashboardsTableName,
+                        dashboard.slug,
+                    ),
                 })
                 .returning(['dashboard_id', 'dashboard_uuid']);
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -59,6 +59,7 @@ import {
 } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
+import { generateUniqueSlug } from '../utils/SlugUtils';
 import { SpaceModel } from './SpaceModel';
 
 type DbSavedChartDetails = {
@@ -332,7 +333,7 @@ export const createSavedChart = async (
                 getChartKind(chartConfig.type, chartConfig.config) ||
                 ChartKind.VERTICAL_BAR,
             last_version_updated_by_user_uuid: userUuid,
-            slug,
+            slug: await generateUniqueSlug(trx, SavedChartsTableName, slug),
         };
         if (dashboardUuid) {
             chart = {

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -1,0 +1,26 @@
+import { generateSlug } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const generateUniqueSlug = async (
+    trx: Knex,
+    tableName:
+        | 'saved_semantic_viewer_charts'
+        | 'saved_queries'
+        | 'saved_sql'
+        | 'dashboards'
+        | 'spaces',
+    name: string,
+) => {
+    const baseSlug = generateSlug(name);
+    const matchingSlugs: string[] = await trx(tableName)
+        .select('slug')
+        .where('slug', 'like', `${baseSlug}%`)
+        .pluck('slug');
+    let slug = generateSlug(name);
+    let inc = 0;
+    while (matchingSlugs.includes(slug)) {
+        inc += 1;
+        slug = `${baseSlug}-${inc}`; // generate new slug with number suffix
+    }
+    return slug;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11616

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Now saving a chat/space/dashboard with the same name doesn't generate a duplicated slug 

Before

[Screencast from 20-09-24 15:40:08.webm](https://github.com/user-attachments/assets/01a75a82-68df-4e2a-8cfa-5f99a9e83f34)


After

[Screencast from 20-09-24 15:43:12.webm](https://github.com/user-attachments/assets/050d3c75-ba5e-4bfe-b971-48ce69a14021)

[Screencast from 20-09-24 15:46:50.webm](https://github.com/user-attachments/assets/8d0959ce-8e38-48d4-945d-9b930aa342cf)

[Screencast from 20-09-24 15:48:34.webm](https://github.com/user-attachments/assets/cd3afc42-6166-401d-bcee-827afe053bd2)

Also, as expected, when creating a preview project and copying content, we copy the same slug, this is required for promotion to work correctly.

![image](https://github.com/user-attachments/assets/1be6b404-d7dd-44cb-9929-eaaae9f9bcb4)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
