### PR TITLE
fix: Require query tags for all warehouse queries

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -100,6 +100,13 @@ type SchedulerTaskArguments = {
     semanticLayerService: SemanticLayerService;
 };
 
+type RunQueryTags = {
+    project_uuid?: string;
+    user_uuid?: string;
+    organization_uuid?: string;
+    chart_uuid?: string;
+    dashboard_uuid?: string;
+};
 export default class SchedulerTask {
     protected readonly lightdashConfig: LightdashConfig;
 
@@ -988,6 +995,11 @@ export default class SchedulerTask {
             const user = await this.userService.getSessionByUserUuid(
                 payload.userUuid,
             );
+            const queryTags: RunQueryTags = {
+                project_uuid: payload.projectUuid,
+                user_uuid: payload.userUuid,
+                organization_uuid: payload.organizationUuid
+            }
 
             const { rows } = await this.projectService.runMetricQuery({
                 user,
@@ -997,7 +1009,9 @@ export default class SchedulerTask {
                 csvLimit: undefined,
                 context: QueryExecutionContext.GSHEETS,
                 chartUuid: undefined,
+                queryTags,
             });
+
             const refreshToken = await this.userService.getRefreshToken(
                 payload.userUuid,
             );

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -998,8 +998,8 @@ export default class SchedulerTask {
             const queryTags: RunQueryTags = {
                 project_uuid: payload.projectUuid,
                 user_uuid: payload.userUuid,
-                organization_uuid: payload.organizationUuid
-            }
+                organization_uuid: payload.organizationUuid,
+            };
 
             const { rows } = await this.projectService.runMetricQuery({
                 user,

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -435,8 +435,8 @@ export class CsvService extends BaseService {
             project_uuid: chart.projectUuid,
             user_uuid: user.userUuid,
             organization_uuid: user.organizationUuid,
-            chart_uuid: chartUuid
-        }
+            chart_uuid: chartUuid,
+        };
 
         const { rows, fields } = await this.projectService.runMetricQuery({
             user,
@@ -447,7 +447,7 @@ export class CsvService extends BaseService {
             context: QueryExecutionContext.CSV,
             granularity: dateZoomGranularity,
             chartUuid,
-            queryTags
+            queryTags,
         });
         const numberRows = rows.length;
 
@@ -795,7 +795,7 @@ export class CsvService extends BaseService {
                 project_uuid: projectUuid,
                 user_uuid: user.userUuid,
                 organization_uuid: user.organizationUuid,
-            }
+            };
 
             const { rows } = await this.projectService.runMetricQuery({
                 user,
@@ -805,7 +805,7 @@ export class CsvService extends BaseService {
                 csvLimit,
                 context: QueryExecutionContext.CSV,
                 chartUuid: undefined,
-                queryTags
+                queryTags,
             });
             const numberRows = rows.length;
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -72,6 +72,14 @@ type CsvServiceArguments = {
     schedulerClient: SchedulerClient;
 };
 
+type RunQueryTags = {
+    project_uuid?: string;
+    user_uuid?: string;
+    organization_uuid?: string;
+    chart_uuid?: string;
+    dashboard_uuid?: string;
+};
+
 const isRowValueTimestamp = (
     value: unknown,
     field: { type: DimensionType },
@@ -423,6 +431,13 @@ export class CsvService extends BaseService {
               )
             : metricQuery;
 
+        const queryTags: RunQueryTags = {
+            project_uuid: chart.projectUuid,
+            user_uuid: user.userUuid,
+            organization_uuid: user.organizationUuid,
+            chart_uuid: chartUuid
+        }
+
         const { rows, fields } = await this.projectService.runMetricQuery({
             user,
             metricQuery: metricQueryWithDashboardFilters,
@@ -432,6 +447,7 @@ export class CsvService extends BaseService {
             context: QueryExecutionContext.CSV,
             granularity: dateZoomGranularity,
             chartUuid,
+            queryTags
         });
         const numberRows = rows.length;
 
@@ -775,6 +791,12 @@ export class CsvService extends BaseService {
                 properties: analyticsProperties,
             });
 
+            const queryTags: RunQueryTags = {
+                project_uuid: projectUuid,
+                user_uuid: user.userUuid,
+                organization_uuid: user.organizationUuid,
+            }
+
             const { rows } = await this.projectService.runMetricQuery({
                 user,
                 metricQuery,
@@ -783,6 +805,7 @@ export class CsvService extends BaseService {
                 csvLimit,
                 context: QueryExecutionContext.CSV,
                 chartUuid: undefined,
+                queryTags
             });
             const numberRows = rows.length;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1466,7 +1466,7 @@ export class ProjectService extends BaseService {
         exploreName: string;
         csvLimit: number | null | undefined;
         context: QueryExecutionContext;
-        queryTags?: RunQueryTags;
+        queryTags: RunQueryTags;
         invalidateCache?: boolean;
         explore?: Explore;
         granularity?: DateGranularity;
@@ -1554,6 +1554,11 @@ export class ProjectService extends BaseService {
                 const chart = await this.savedChartModel.get(chartUuid);
                 const { metricQuery } = chart;
                 const exploreId = chart.tableName;
+                const queryTags: RunQueryTags = {
+                    project_uuid: chart.projectUuid,
+                    user_uuid: user.userUuid,
+                    chart_uuid: chartUuid
+                };
 
                 return this.runMetricQuery({
                     user,
@@ -1563,6 +1568,7 @@ export class ProjectService extends BaseService {
                     csvLimit: undefined,
                     context,
                     chartUuid,
+                    queryTags
                 });
             },
         );
@@ -1709,7 +1715,7 @@ export class ProjectService extends BaseService {
         exploreName: string;
         csvLimit: number | null | undefined;
         context: QueryExecutionContext;
-        queryTags?: RunQueryTags;
+        queryTags: RunQueryTags;
         invalidateCache?: boolean;
         explore?: Explore;
         granularity?: DateGranularity;

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1557,7 +1557,7 @@ export class ProjectService extends BaseService {
                 const queryTags: RunQueryTags = {
                     project_uuid: chart.projectUuid,
                     user_uuid: user.userUuid,
-                    chart_uuid: chartUuid
+                    chart_uuid: chartUuid,
                 };
 
                 return this.runMetricQuery({
@@ -1568,7 +1568,7 @@ export class ProjectService extends BaseService {
                     csvLimit: undefined,
                     context,
                     chartUuid,
-                    queryTags
+                    queryTags,
                 });
             },
         );

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -50,7 +50,7 @@ export interface WarehouseClient {
         streamCallback: (data: WarehouseResults) => void,
         options: {
             values?: any[];
-            tags?: Record<string, string>;
+            tags: Record<string, string>;
             timezone?: string;
         },
     ): Promise<void>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->#10009

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Change the optional `queryTags` method into mandatory one for `runMetricQuery` method inside `getResultsForChart` and `streamQuery` method inside `WarehouseClient`. Also, added `queryTags` in all necessary places.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [✅] I have manually tested the changes in the preview environment
- [✅] I have reviewed the code
- [✅] I understand that "request changes" will block this PR from merging
