### PR TITLE
fix: add additional query key to dashboard sql tile

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -100,6 +100,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
         sql: data?.chart.sql,
         slug: data?.chart.slug,
         limit: data?.chart.limit,
+        additionalQueryKey: [data?.chart.slug, data?.chart.sql, savedSqlUuid],
     });
 
     if (isLoading) {

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -270,6 +270,7 @@ export const ContentPanel: FC = () => {
         config: currentVizConfig,
         sql,
         limit,
+        additionalQueryKey: [sql],
     });
 
     const chartFileUrl = chartVizQuery?.data?.fileUrl;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11629

### Description:

Add query keys to `useChartViz` dashboard sql tiles: uuid & slug
Add query keys to `useChartViz` to Content panel charts: `sql` 

This ensures we don't return cached data for different charts, by applying unique query keys.



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
