### PR TITLE
fix: cmd + enter in sql-runner submits correct values if pressed before debounce

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -139,16 +139,19 @@ export const ContentPanel: FC = () => {
     // in the state to keep them around when the query is re-run.
     const [queryResults, setQueryResults] = useState<ResultsAndColumns>();
 
-    const handleRunQuery = useCallback(async () => {
-        if (!sql) return;
-        const newQueryResults = await runSqlQuery({
-            sql,
-            limit: DEFAULT_SQL_LIMIT,
-        });
+    const handleRunQuery = useCallback(
+        async (sqlToUse: string) => {
+            if (!sqlToUse) return;
+            const newQueryResults = await runSqlQuery({
+                sql: sqlToUse,
+                limit: DEFAULT_SQL_LIMIT,
+            });
 
-        setQueryResults(newQueryResults);
-        notifications.clean();
-    }, [runSqlQuery, sql]);
+            setQueryResults(newQueryResults);
+            notifications.clean();
+        },
+        [runSqlQuery, setQueryResults],
+    );
 
     // Run query on cmd + enter
     useHotkeys([
@@ -157,11 +160,11 @@ export const ContentPanel: FC = () => {
 
     useEffect(() => {
         if (fetchResultsOnLoad && !queryResults) {
-            void handleRunQuery();
+            void handleRunQuery(sql);
         } else if (fetchResultsOnLoad && queryResults) {
             dispatch(setActiveEditorTab(EditorTabs.VISUALIZATION));
         }
-    }, [fetchResultsOnLoad, handleRunQuery, queryResults, dispatch]);
+    }, [fetchResultsOnLoad, handleRunQuery, queryResults, dispatch, sql]);
 
     const resultsRunner = useMemo(() => {
         if (!queryResults) return;
@@ -356,7 +359,7 @@ export const ContentPanel: FC = () => {
                         <RunSqlQueryButton
                             isLoading={isLoading}
                             disabled={!sql}
-                            onSubmit={() => handleRunQuery()}
+                            onSubmit={() => handleRunQuery(sql)}
                             {...(canSetSqlLimit
                                 ? {
                                       onLimitChange: (l) =>
@@ -417,7 +420,9 @@ export const ContentPanel: FC = () => {
                                         resetHighlightError={() =>
                                             setHightlightError(undefined)
                                         }
-                                        onSubmit={() => handleRunQuery()}
+                                        onSubmit={(submittedSQL) =>
+                                            handleRunQuery(submittedSQL ?? '')
+                                        }
                                         highlightText={
                                             hightlightError
                                                 ? {

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -200,7 +200,7 @@ const generateTableCompletions = (
 };
 
 export const SqlEditor: FC<{
-    onSubmit?: (sql?: string) => void;
+    onSubmit?: (sql: string) => void;
     highlightText?: MonacoHighlightLine;
     resetHighlightError?: () => void;
 }> = ({ onSubmit, highlightText, resetHighlightError }) => {
@@ -214,13 +214,6 @@ export const SqlEditor: FC<{
         search: undefined,
     });
     const editorRef = useRef<Parameters<OnMount>['0'] | null>(null);
-    const sqlRef = useRef(sql);
-    const onSubmitRef = useRef(onSubmit);
-
-    useEffect(() => {
-        sqlRef.current = sql;
-        onSubmitRef.current = onSubmit;
-    }, [sql, onSubmit]);
 
     const language = useMemo(
         () => getLanguage(data?.warehouseConnection?.type),
@@ -267,7 +260,8 @@ export const SqlEditor: FC<{
                 monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
                 () => {
                     const currentSql = editorObj.getValue();
-                   onSubmit(currentSql ?? '');
+                    if (!onSubmit) return;
+                    onSubmit(currentSql ?? '');
                 },
             );
         },

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -267,8 +267,7 @@ export const SqlEditor: FC<{
                 monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
                 () => {
                     const currentSql = editorObj.getValue();
-                    if (!onSubmit) return;
-                    onSubmit(currentSql ? currentSql : '');
+                   onSubmit(currentSql ?? '');
                 },
             );
         },

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -200,7 +200,7 @@ const generateTableCompletions = (
 };
 
 export const SqlEditor: FC<{
-    onSubmit?: () => void;
+    onSubmit?: (sql?: string) => void;
     highlightText?: MonacoHighlightLine;
     resetHighlightError?: () => void;
 }> = ({ onSubmit, highlightText, resetHighlightError }) => {
@@ -258,18 +258,22 @@ export const SqlEditor: FC<{
     const decorationsCollectionRef =
         useRef<editor.IEditorDecorationsCollection | null>(null); // Ref to store the decorations collection
 
-    const onMount: OnMount = useCallback((editorObj, monacoObj) => {
-        editorRef.current = editorObj;
-        decorationsCollectionRef.current =
-            editorObj.createDecorationsCollection(); // Initialize the decorations collection
-        editorObj.addCommand(
-            monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
-            () => {
-                // When the editor is mounted, the onSubmit callback should be set to the latest value, otherwise it will be set to the initial value on the first render
-                onSubmitRef.current?.();
-            },
-        );
-    }, []);
+    const onMount: OnMount = useCallback(
+        (editorObj, monacoObj) => {
+            editorRef.current = editorObj;
+            decorationsCollectionRef.current =
+                editorObj.createDecorationsCollection();
+            editorObj.addCommand(
+                monacoObj.KeyMod.CtrlCmd | monacoObj.KeyCode.Enter,
+                () => {
+                    const currentSql = editorObj.getValue();
+                    if (!onSubmit) return;
+                    onSubmit(currentSql ? currentSql : '');
+                },
+            );
+        },
+        [onSubmit],
+    );
 
     useEffect(() => {
         // remove any existing decorations


### PR DESCRIPTION
Closes: [#11282](https://github.com/lightdash/lightdash/issues/11282)

### Description:
When CMD + Enter was pressed fast enough when writing a query, the previous value (before debounce) was sent. 
This has been fixed by directly passing the current value only when CMD + Enter is pressed, since it should not wait for debounce. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
