### PR TITLE
feat: allow changing the chart type of each series

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6871,6 +6871,13 @@ const models: TsoaRoute.Models = {
                     additionalProperties: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
+                            type: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'ChartKind.LINE' },
+                                    { ref: 'ChartKind.VERTICAL_BAR' },
+                                ],
+                            },
                             color: { dataType: 'string' },
                             yAxisIndex: { dataType: 'double' },
                             format: { ref: 'Format' },
@@ -8535,6 +8542,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'SemanticLayerFieldType.STRING': {
+        dataType: 'refEnum',
+        enums: ['string'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerStringFilter: {
         dataType: 'refAlias',
         type: {
@@ -8553,11 +8565,20 @@ const models: TsoaRoute.Models = {
                             ref: 'SemanticLayerFilterBaseOperator',
                             required: true,
                         },
+                        fieldType: {
+                            ref: 'SemanticLayerFieldType.STRING',
+                            required: true,
+                        },
                     },
                 },
             ],
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'SemanticLayerFieldType.TIME': {
+        dataType: 'refEnum',
+        enums: ['time'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SemanticLayerExactTimeFilter: {
@@ -8578,6 +8599,10 @@ const models: TsoaRoute.Models = {
                         },
                         operator: {
                             ref: 'SemanticLayerFilterBaseOperator',
+                            required: true,
+                        },
+                        fieldType: {
+                            ref: 'SemanticLayerFieldType.TIME',
                             required: true,
                         },
                     },
@@ -8613,6 +8638,10 @@ const models: TsoaRoute.Models = {
                         },
                         operator: {
                             ref: 'SemanticLayerFilterBaseOperator',
+                            required: true,
+                        },
+                        fieldType: {
+                            ref: 'SemanticLayerFieldType.TIME',
                             required: true,
                         },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7567,6 +7567,16 @@
                         "properties": {},
                         "additionalProperties": {
                             "properties": {
+                                "type": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ChartKind.LINE"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
+                                        }
+                                    ]
+                                },
                                 "color": {
                                     "type": "string"
                                 },
@@ -9402,6 +9412,10 @@
                 "required": ["fieldType", "fieldKind", "fieldRef", "uuid"],
                 "type": "object"
             },
+            "SemanticLayerFieldType.STRING": {
+                "enum": ["string"],
+                "type": "string"
+            },
             "SemanticLayerStringFilter": {
                 "allOf": [
                     {
@@ -9417,12 +9431,19 @@
                             },
                             "operator": {
                                 "$ref": "#/components/schemas/SemanticLayerFilterBaseOperator"
+                            },
+                            "fieldType": {
+                                "$ref": "#/components/schemas/SemanticLayerFieldType.STRING"
                             }
                         },
-                        "required": ["values", "operator"],
+                        "required": ["values", "operator", "fieldType"],
                         "type": "object"
                     }
                 ]
+            },
+            "SemanticLayerFieldType.TIME": {
+                "enum": ["time"],
+                "type": "string"
             },
             "SemanticLayerExactTimeFilter": {
                 "allOf": [
@@ -9442,9 +9463,12 @@
                             },
                             "operator": {
                                 "$ref": "#/components/schemas/SemanticLayerFilterBaseOperator"
+                            },
+                            "fieldType": {
+                                "$ref": "#/components/schemas/SemanticLayerFieldType.TIME"
                             }
                         },
-                        "required": ["values", "operator"],
+                        "required": ["values", "operator", "fieldType"],
                         "type": "object"
                     }
                 ]
@@ -9471,9 +9495,12 @@
                             },
                             "operator": {
                                 "$ref": "#/components/schemas/SemanticLayerFilterBaseOperator"
+                            },
+                            "fieldType": {
+                                "$ref": "#/components/schemas/SemanticLayerFieldType.TIME"
                             }
                         },
-                        "required": ["values", "operator"],
+                        "required": ["values", "operator", "fieldType"],
                         "type": "object"
                     }
                 ]
@@ -10006,7 +10033,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1266.2",
+        "version": "0.1271.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -584,13 +584,11 @@ export const getChartKind = (
 };
 
 export const getEChartsChartTypeFromChartKind = (
-    chartKind: Extract<
-        ChartKind,
+    chartKind:
         | ChartKind.VERTICAL_BAR
         | ChartKind.LINE
         | ChartKind.AREA
-        | ChartKind.SCATTER
-    >,
+        | ChartKind.SCATTER,
 ): CartesianSeriesType => {
     switch (chartKind) {
         case ChartKind.VERTICAL_BAR:

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -583,6 +583,32 @@ export const getChartKind = (
     }
 };
 
+export const getEChartsChartTypeFromChartKind = (
+    chartKind: Extract<
+        ChartKind,
+        | ChartKind.VERTICAL_BAR
+        | ChartKind.LINE
+        | ChartKind.AREA
+        | ChartKind.SCATTER
+    >,
+): CartesianSeriesType => {
+    switch (chartKind) {
+        case ChartKind.VERTICAL_BAR:
+            return CartesianSeriesType.BAR;
+        case ChartKind.LINE:
+            return CartesianSeriesType.LINE;
+        case ChartKind.AREA:
+            return CartesianSeriesType.AREA;
+        case ChartKind.SCATTER:
+            return CartesianSeriesType.SCATTER;
+        default:
+            return assertUnreachable(
+                chartKind,
+                `Unknown chart kind: ${chartKind}`,
+            );
+    }
+};
+
 export type ChartSummary = Pick<
     SavedChart,
     | 'uuid'

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -4,7 +4,11 @@ import {
     Format,
     friendlyName,
 } from '../types/field';
-import { ChartKind, ECHARTS_DEFAULT_COLORS } from '../types/savedCharts';
+import {
+    ChartKind,
+    ECHARTS_DEFAULT_COLORS,
+    getEChartsChartTypeFromChartKind,
+} from '../types/savedCharts';
 import { applyCustomFormat } from '../utils/formatting';
 import {
     type VizCartesianChartConfig,
@@ -168,35 +172,41 @@ export class CartesianChartDataModel
 
         const series = transformedData.valuesColumns.map(
             (seriesColumn, index) => {
-                const seriesFormat = Object.values(display?.series || {}).find(
+                const isSingleAxis = this.fieldConfig?.y.length === 1;
+                const foundSeries = Object.values(display?.series || {}).find(
                     (s) => s.yAxisIndex === index,
-                )?.format;
+                );
+                const {
+                    format,
+                    color,
+                    label,
+                    type: seriesChartType,
+                } = foundSeries || {};
 
                 const singleYAxisLabel =
                     // NOTE: When there's only one y-axis left, set the label on the series as well
-                    this.fieldConfig?.y.length === 1 &&
-                    display?.yAxis?.[0]?.label
+                    isSingleAxis && display?.yAxis?.[0]?.label
                         ? display.yAxis[0].label
                         : undefined;
-                const seriesLabel =
-                    singleYAxisLabel ??
-                    Object.values(display?.series || {}).find(
-                        (s) => s.yAxisIndex === index,
-                    )?.label;
-
-                const seriesColor = Object.values(display?.series || {}).find(
-                    (s) => s.yAxisIndex === index,
-                )?.color;
+                const singleYAxisFormat =
+                    // NOTE: When there's only one y-axis left, set the format on the series as well
+                    isSingleAxis && display?.yAxis?.[0]?.format
+                        ? display.yAxis[0].format
+                        : undefined;
 
                 return {
                     dimensions: [
                         transformedData.indexColumn?.reference,
                         seriesColumn,
                     ],
-                    type: defaultSeriesType,
+                    type:
+                        seriesChartType && !isSingleAxis
+                            ? getEChartsChartTypeFromChartKind(seriesChartType)
+                            : defaultSeriesType,
                     stack: shouldStack ? 'stack-all-series' : undefined, // TODO: we should implement more sophisticated stacking logic once we have multi-pivoted charts
                     name:
-                        seriesLabel ||
+                        singleYAxisLabel ||
+                        label ||
                         capitalize(seriesColumn.toLowerCase()).replaceAll(
                             '_',
                             ' ',
@@ -210,14 +220,15 @@ export class CartesianChartDataModel
                             display.series[seriesColumn]?.yAxisIndex) ||
                         0,
                     tooltip: {
-                        valueFormatter: seriesFormat
-                            ? CartesianChartDataModel.getTooltipFormatter(
-                                  seriesFormat,
-                              )
-                            : undefined,
+                        valueFormatter:
+                            singleYAxisFormat || format
+                                ? CartesianChartDataModel.getTooltipFormatter(
+                                      singleYAxisFormat ?? format,
+                                  )
+                                : undefined,
                     },
                     color:
-                        seriesColor ||
+                        color ||
                         CartesianChartDataModel.getDefaultColor(
                             index,
                             orgColors,
@@ -306,6 +317,7 @@ export type CartesianChartDisplay = {
             format?: Format;
             yAxisIndex?: number;
             color?: string;
+            type?: Extract<ChartKind, ChartKind.LINE | ChartKind.VERTICAL_BAR>;
         };
     };
     legend?: {

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -317,7 +317,7 @@ export type CartesianChartDisplay = {
             format?: Format;
             yAxisIndex?: number;
             color?: string;
-            type?: Extract<ChartKind, ChartKind.LINE | ChartKind.VERTICAL_BAR>;
+            type?: ChartKind.LINE | ChartKind.VERTICAL_BAR;
         };
     };
     legend?: {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -247,7 +247,6 @@ export const CartesianChartFieldConfiguration = ({
 }: {
     selectedChartType: ChartKind;
     columns: VizColumn[];
-
     actions: CartesianChartActionsType;
 }) => {
     const dispatch = useVizDispatch();

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -4,21 +4,20 @@ import {
     type ChartKind,
     type VizChartLayout,
 } from '@lightdash/common';
-import { Group, Stack, TextInput, Tooltip } from '@mantine/core';
-import { IconBrush } from '@tabler/icons-react';
+import { Group, Stack, TextInput } from '@mantine/core';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
-import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';
 import { Config } from '../../VisualizationConfigs/common/Config';
 import { useVizDispatch, type CartesianChartActionsType } from '../store';
 import { CartesianChartFormatConfig } from './CartesianChartFormatConfig';
+import { CartesianChartTypeConfig } from './CartesianChartTypeConfig';
 
 export type ConfigurableSeries = {
     reference: VizChartLayout['y'][number]['reference'];
-    format: NonNullable<CartesianChartDisplay['series']>[number]['format'];
-    label: NonNullable<CartesianChartDisplay['series']>[number]['label'];
-    color: NonNullable<CartesianChartDisplay['series']>[number]['color'];
-};
+} & Pick<
+    NonNullable<CartesianChartDisplay['series']>[number],
+    'format' | 'label' | 'color' | 'type'
+>;
 
 type SeriesColorProps = {
     selectedChartType: ChartKind;
@@ -27,6 +26,7 @@ type SeriesColorProps = {
 };
 
 export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
+    selectedChartType,
     actions,
     series,
 }) => {
@@ -39,67 +39,94 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
             <Config.Section>
                 <Config.Heading>Series</Config.Heading>
                 <Stack spacing="xs">
-                    {Object.entries(series).map(
-                        ([reference, { label, color, format }], index) => (
-                            <Group
-                                key={reference}
-                                spacing="xs"
-                                noWrap
-                                position="apart"
-                            >
-                                <Group spacing="two" noWrap>
-                                    <ColorSelector
-                                        color={color ?? colors[index]}
-                                        onColorChange={(c) => {
-                                            dispatch(
-                                                actions.setSeriesColor({
-                                                    index,
-                                                    color: c,
-                                                    reference,
-                                                }),
-                                            );
-                                        }}
-                                        swatches={colors}
-                                    />
-                                    <TextInput
-                                        radius="md"
-                                        value={label}
-                                        onChange={(e) => {
-                                            dispatch(
-                                                actions.setSeriesLabel({
-                                                    label: e.target.value,
-                                                    reference,
-                                                    index,
-                                                }),
-                                            );
-                                        }}
-                                    />
-                                </Group>
-                                <Group spacing="two" noWrap>
-                                    <Tooltip
-                                        label="Format"
-                                        variant="xs"
-                                        withinPortal
-                                    >
-                                        <MantineIcon
-                                            color="gray.5"
-                                            icon={IconBrush}
+                    {series.map(
+                        ({ reference, label, color, type, format }, index) => (
+                            <Stack key={reference} spacing="xs">
+                                <Stack
+                                    pl="sm"
+                                    spacing="xs"
+                                    sx={(theme) => ({
+                                        borderLeft: `1px solid ${theme.colors.gray[2]}`,
+                                    })}
+                                >
+                                    <Config.Subheading>
+                                        {reference}
+                                    </Config.Subheading>
+                                    <Config.Group>
+                                        <Config.Label>Label</Config.Label>
+
+                                        <Group spacing="two" noWrap>
+                                            <ColorSelector
+                                                color={color ?? colors[index]}
+                                                onColorChange={(c) => {
+                                                    dispatch(
+                                                        actions.setSeriesColor({
+                                                            index,
+                                                            color: c,
+                                                            reference,
+                                                        }),
+                                                    );
+                                                }}
+                                                swatches={colors}
+                                            />
+                                            <TextInput
+                                                radius="md"
+                                                value={label}
+                                                onChange={(e) => {
+                                                    dispatch(
+                                                        actions.setSeriesLabel({
+                                                            label: e.target
+                                                                .value,
+                                                            reference,
+                                                            index,
+                                                        }),
+                                                    );
+                                                }}
+                                            />
+                                        </Group>
+                                    </Config.Group>
+                                    <Config.Group>
+                                        <Config.Label>Chart Type</Config.Label>
+                                        <CartesianChartTypeConfig
+                                            canSelectDifferentTypeFromBaseChart={
+                                                true
+                                            }
+                                            type={type ?? selectedChartType}
+                                            onChangeType={(
+                                                value: Extract<
+                                                    ChartKind,
+                                                    | ChartKind.LINE
+                                                    | ChartKind.VERTICAL_BAR
+                                                >,
+                                            ) => {
+                                                dispatch(
+                                                    actions.setSeriesChartType({
+                                                        index,
+                                                        type: value,
+                                                        reference,
+                                                    }),
+                                                );
+                                            }}
                                         />
-                                    </Tooltip>
-                                    <CartesianChartFormatConfig
-                                        format={format}
-                                        onChangeFormat={(value) => {
-                                            dispatch(
-                                                actions.setSeriesFormat({
-                                                    index,
-                                                    format: value,
-                                                    reference,
-                                                }),
-                                            );
-                                        }}
-                                    />
-                                </Group>
-                            </Group>
+                                    </Config.Group>
+                                    <Config.Group>
+                                        <Config.Label>Format</Config.Label>
+
+                                        <CartesianChartFormatConfig
+                                            format={format}
+                                            onChangeFormat={(value) => {
+                                                dispatch(
+                                                    actions.setSeriesFormat({
+                                                        index,
+                                                        format: value,
+                                                        reference,
+                                                    }),
+                                                );
+                                            }}
+                                        />
+                                    </Config.Group>
+                                </Stack>
+                            </Stack>
                         ),
                     )}
                 </Stack>

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -93,11 +93,9 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                             }
                                             type={type ?? selectedChartType}
                                             onChangeType={(
-                                                value: Extract<
-                                                    ChartKind,
-                                                    | ChartKind.LINE
-                                                    | ChartKind.VERTICAL_BAR
-                                                >,
+                                                value: NonNullable<
+                                                    CartesianChartDisplay['series']
+                                                >[number]['type'],
                                             ) => {
                                                 dispatch(
                                                     actions.setSeriesChartType({

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -45,23 +45,22 @@ export const CartesianChartStyling = ({
             return [];
         }
         return currentConfig?.config?.fieldConfig?.y.map((f, index) => {
-            const seriesFormat = Object.values(
+            const foundSeries = Object.values(
                 currentConfig?.config?.display?.series || {},
-            ).find((s) => s.yAxisIndex === index)?.format;
-            const seriesLabel =
-                Object.values(
-                    currentConfig?.config?.display?.series || {},
-                ).find((s) => s.yAxisIndex === index)?.label ??
-                friendlyName(`${f.reference}_${f.aggregation}`);
+            ).find((s) => s.yAxisIndex === index);
 
-            const seriesColor = Object.values(
-                currentConfig?.config?.display?.series || {},
-            ).find((s) => s.yAxisIndex === index)?.color;
+            const seriesFormat = foundSeries?.format;
+            const seriesLabel = foundSeries?.label;
+            const seriesColor = foundSeries?.color;
+            const seriesType = foundSeries?.type;
             return {
                 reference: f.reference,
                 format: seriesFormat,
-                label: seriesLabel,
+                label:
+                    seriesLabel ??
+                    friendlyName(`${f.reference}_${f.aggregation}`),
                 color: seriesColor ?? colors[index],
+                type: seriesType,
             };
         });
     }, [

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -1,0 +1,80 @@
+import { ChartKind } from '@lightdash/common';
+import { Box, Group, Select, Text } from '@mantine/core';
+import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import { getChartIcon } from '../../common/ResourceIcon';
+
+type Props = {
+    type: ChartKind | undefined;
+    onChangeType: (
+        value: Extract<ChartKind, ChartKind.LINE | ChartKind.VERTICAL_BAR>,
+    ) => void;
+    canSelectDifferentTypeFromBaseChart: boolean;
+};
+
+const ChartTypeIcon: FC<{ type: ChartKind }> = ({ type }) => (
+    <MantineIcon icon={getChartIcon(type)} color="indigo.4" />
+);
+
+const ChartTypeItem = forwardRef<
+    HTMLDivElement,
+    ComponentPropsWithoutRef<'div'> & { value: ChartKind; label: string }
+>(({ value, label, ...others }, ref) => (
+    <Box ref={ref} {...others}>
+        <Group noWrap spacing="xs">
+            <ChartTypeIcon type={value} />
+            <Text>{label}</Text>
+        </Group>
+    </Box>
+));
+
+export const CartesianChartTypeConfig: FC<Props> = ({ onChangeType, type }) => {
+    const options = [
+        {
+            value: ChartKind.VERTICAL_BAR,
+            label: 'Vertical Bar',
+        },
+        {
+            value: ChartKind.LINE,
+            label: 'Line',
+        },
+    ];
+
+    return (
+        <Select
+            radius="md"
+            data={options.map((option) => ({
+                value: option.value,
+                label: option.label,
+            }))}
+            itemComponent={ChartTypeItem}
+            icon={type && <ChartTypeIcon type={type} />}
+            value={type}
+            onChange={(
+                value: Extract<
+                    ChartKind,
+                    ChartKind.LINE | ChartKind.VERTICAL_BAR
+                >,
+            ) => value && onChangeType(value)}
+            styles={(theme) => ({
+                input: {
+                    width: '150px',
+                    fontWeight: 500,
+                },
+                item: {
+                    '&[data-selected="true"]': {
+                        color: theme.colors.gray[7],
+                        fontWeight: 500,
+                        backgroundColor: theme.colors.gray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.gray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[1],
+                    },
+                },
+            })}
+        />
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -1,4 +1,4 @@
-import { ChartKind } from '@lightdash/common';
+import { ChartKind, type CartesianChartDisplay } from '@lightdash/common';
 import { Box, Group, Select, Text } from '@mantine/core';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -7,7 +7,7 @@ import { getChartIcon } from '../../common/ResourceIcon';
 type Props = {
     type: ChartKind | undefined;
     onChangeType: (
-        value: Extract<ChartKind, ChartKind.LINE | ChartKind.VERTICAL_BAR>,
+        value: NonNullable<CartesianChartDisplay['series']>[number]['type'],
     ) => void;
     canSelectDifferentTypeFromBaseChart: boolean;
 };

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -3,7 +3,6 @@ import {
     VizIndexType,
     VIZ_DEFAULT_AGGREGATION,
     type CartesianChartDisplay,
-    type ChartKind,
     type VizAggregationOptions,
     type VizBarChartConfig,
     type VizCartesianChartOptions,
@@ -323,10 +322,9 @@ export const cartesianChartConfigSlice = createSlice({
             { config },
             action: PayloadAction<{
                 index: number;
-                type: Extract<
-                    ChartKind,
-                    ChartKind.LINE | ChartKind.VERTICAL_BAR
-                >;
+                type: NonNullable<
+                    CartesianChartDisplay['series']
+                >[number]['type'];
                 reference: string;
             }>,
         ) => {

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -3,6 +3,7 @@ import {
     VizIndexType,
     VIZ_DEFAULT_AGGREGATION,
     type CartesianChartDisplay,
+    type ChartKind,
     type VizAggregationOptions,
     type VizBarChartConfig,
     type VizCartesianChartOptions,
@@ -295,7 +296,10 @@ export const cartesianChartConfigSlice = createSlice({
                 reference: string;
             }>,
         ) => {
-            if (!config?.display) return;
+            if (!config) return;
+            config.display = config.display || {};
+            config.display.yAxis = config.display.yAxis || [];
+            config.display.series = config.display.series || {};
 
             const { index, format, reference } = action.payload;
             const validFormat = isFormat(format) ? format : undefined;
@@ -314,6 +318,30 @@ export const cartesianChartConfigSlice = createSlice({
                     format: validFormat,
                 };
             }
+        },
+        setSeriesChartType: (
+            { config },
+            action: PayloadAction<{
+                index: number;
+                type: Extract<
+                    ChartKind,
+                    ChartKind.LINE | ChartKind.VERTICAL_BAR
+                >;
+                reference: string;
+            }>,
+        ) => {
+            if (!config) return;
+            config.display = config.display || {};
+            config.display.series = config.display.series || {};
+
+            const { index, type, reference } = action.payload;
+
+            config.display.series = config.display.series || {};
+            config.display.series[reference] = {
+                ...config.display.series[reference],
+                yAxisIndex: index,
+                type,
+            };
         },
         setSeriesColor: (
             { config },

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -30,9 +30,13 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
         error,
     } = useRefreshTables({ projectUuid });
 
-    const { selectedChartType, activeSidebarTab, sqlColumns } = useAppSelector(
-        (state) => state.sqlRunner,
+    const selectedChartType = useAppSelector(
+        (state) => state.sqlRunner.selectedChartType,
     );
+    const activeSidebarTab = useAppSelector(
+        (state) => state.sqlRunner.activeSidebarTab,
+    );
+    const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
 
     return (
         <Stack spacing="xs" sx={{ flex: 1, overflow: 'hidden' }}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11638](https://github.com/lightdash/lightdash/issues/11638)

### Description:

- Can change the chart type of each series
- It's quick 
- When you have 2 series and then delete one, it resets the chosen chart type to ensure the visualization matches. The user can just switch the base chart type as they wish. 

Demo:


https://github.com/user-attachments/assets/70e699ce-3ccb-4222-a25d-5a1ea3e9c88a



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
