### PR TITLE
feat: allow setting custom sql on results download

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -67,7 +67,7 @@ import { ResultsDownload } from './Download/ResultsDownload';
 import { SqlEditor, type MonacoHighlightChar } from './SqlEditor';
 import { SqlQueryHistory } from './SqlQueryHistory';
 
-const DEFAULT_SQL_LIMIT = 500;
+export const DEFAULT_SQL_LIMIT = 500;
 
 export const ContentPanel: FC = () => {
     const dispatch = useAppDispatch();

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownload.tsx
@@ -1,8 +1,16 @@
-import { ActionIcon, Tooltip } from '@mantine/core';
+import {
+    ActionIcon,
+    Button,
+    NumberInput,
+    Popover,
+    Stack,
+    Tooltip,
+} from '@mantine/core';
 import { IconDownload } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useDownloadResults } from '../../hooks/useDownloadResults';
+import { DEFAULT_SQL_LIMIT } from '../ContentPanel';
 
 type Props = {
     fileUrl: string | undefined;
@@ -11,20 +19,48 @@ type Props = {
 };
 
 export const ResultsDownload: FC<Props> = ({ fileUrl, columns, chartName }) => {
-    const { handleDownload } = useDownloadResults({
+    const [customLimit, setCustomLimit] = useState(DEFAULT_SQL_LIMIT);
+    const { handleDownload, isLoading } = useDownloadResults({
         fileUrl,
         columns,
         chartName,
+        customLimit:
+            customLimit !== DEFAULT_SQL_LIMIT ? customLimit : undefined,
     });
     return (
-        <Tooltip variant="xs" label="Download results as .csv">
-            <ActionIcon
-                variant="default"
-                disabled={!fileUrl}
-                onClick={handleDownload}
-            >
-                <MantineIcon icon={IconDownload} />
-            </ActionIcon>
-        </Tooltip>
+        <Popover
+            withArrow
+            disabled={!fileUrl}
+            closeOnClickOutside={!isLoading}
+            closeOnEscape={!isLoading}
+        >
+            <Popover.Target>
+                <Tooltip variant="xs" label="Download results as .csv">
+                    <ActionIcon variant="default" disabled={!fileUrl}>
+                        <MantineIcon icon={IconDownload} />
+                    </ActionIcon>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Stack>
+                    <NumberInput
+                        size="xs"
+                        type="number"
+                        label="Limit"
+                        defaultValue={DEFAULT_SQL_LIMIT}
+                        onChange={(value: number) => setCustomLimit(value)}
+                    />
+                    <Button
+                        size="xs"
+                        ml="auto"
+                        leftIcon={<MantineIcon icon={IconDownload} />}
+                        onClick={handleDownload}
+                        loading={isLoading}
+                    >
+                        Download
+                    </Button>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11643

### Description:

When on the SQL tab or when visualising a Table, users can: 
- Apply a custom limit to their query so that they can download the results as csv

Recording:



https://github.com/user-attachments/assets/400bc98d-4c6b-4044-a2bf-2124387421da


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
