### PR TITLE
fix: address incorrect `yAxisIndex` assignment

### DIFF
--- a/packages/backend/src/database/entities/savedSql.ts
+++ b/packages/backend/src/database/entities/savedSql.ts
@@ -83,8 +83,11 @@ export type InsertSavedSqlVersion = Pick<
     | 'created_by_user_uuid'
 >;
 
+type UpdateSqlVersionConfig = Partial<Pick<DbSavedSqlVersion, 'config'>>;
+
 export type SavedSqlVersionsTable = Knex.CompositeTableType<
     DbSavedSqlVersion,
     InsertSavedSqlVersion,
+    UpdateSqlVersionConfig,
     never
 >;

--- a/packages/backend/src/database/migrations/20240924164737_reset_y_axis_index_in_series_and_fix_reference_to_y.ts
+++ b/packages/backend/src/database/migrations/20240924164737_reset_y_axis_index_in_series_and_fix_reference_to_y.ts
@@ -28,9 +28,7 @@ export async function up(knex: Knex): Promise<void> {
                 const matchingY = yFields[yAxisIndex];
 
                 if (matchingY) {
-                    const newKey = `${matchingY.reference}_${
-                        matchingY.aggregation || 'count'
-                    }`;
+                    const newKey = `${matchingY.reference}_${matchingY.aggregation}`;
 
                     updatedSeries[newKey] = {
                         ...value,
@@ -55,8 +53,7 @@ export async function up(knex: Knex): Promise<void> {
     await Promise.all(updatePromises);
 }
 
-export async function down(knex: Knex): Promise<void> {
-    // If needed, implement a way to revert the changes
-    // This might be complex or impossible without storing the original data
-    return knex.raw('SELECT 1');
+export async function down(): Promise<void> {
+    // This migration is not reversible
+    return Promise.resolve();
 }

--- a/packages/backend/src/database/migrations/20240924164737_reset_y_axis_index_in_series_and_fix_reference_to_y.ts
+++ b/packages/backend/src/database/migrations/20240924164737_reset_y_axis_index_in_series_and_fix_reference_to_y.ts
@@ -1,0 +1,62 @@
+import {
+    CartesianChartDisplay,
+    isVizPieChartConfig,
+    isVizTableConfig,
+    VizChartConfig,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { SavedSqlVersionsTableName } from '../entities/savedSql';
+
+export async function up(knex: Knex): Promise<void> {
+    const rows = await knex(SavedSqlVersionsTableName)
+        .select('saved_sql_uuid', 'config')
+        .whereRaw("config::jsonb -> 'display' -> 'series' IS NOT NULL");
+
+    const updatePromises = rows.map((row) => {
+        const config = row.config as VizChartConfig;
+        if (
+            !isVizTableConfig(config) &&
+            !isVizPieChartConfig(config) &&
+            config.display &&
+            config.display.series
+        ) {
+            const updatedSeries: CartesianChartDisplay['series'] = {};
+            const yFields = config.fieldConfig?.y || [];
+
+            for (const [key, value] of Object.entries(config.display.series)) {
+                const yAxisIndex = value.yAxisIndex || 0;
+                const matchingY = yFields[yAxisIndex];
+
+                if (matchingY) {
+                    const newKey = `${matchingY.reference}_${
+                        matchingY.aggregation || 'count'
+                    }`;
+
+                    updatedSeries[newKey] = {
+                        ...value,
+                        yAxisIndex: 0,
+                    };
+                } else {
+                    updatedSeries[key] = value;
+                }
+            }
+
+            config.display.series = updatedSeries;
+
+            return knex(SavedSqlVersionsTableName)
+                .where('saved_sql_uuid', row.saved_sql_uuid)
+                .update({
+                    config,
+                });
+        }
+        return Promise.resolve();
+    });
+
+    await Promise.all(updatePromises);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // If needed, implement a way to revert the changes
+    // This might be complex or impossible without storing the original data
+    return knex.raw('SELECT 1');
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6879,7 +6879,13 @@ const models: TsoaRoute.Models = {
                                 ],
                             },
                             color: { dataType: 'string' },
-                            yAxisIndex: { dataType: 'double' },
+                            yAxisIndex: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'enum', enums: [0] },
+                                    { dataType: 'enum', enums: [1] },
+                                ],
+                            },
                             format: { ref: 'Format' },
                             label: { dataType: 'string' },
                         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7582,7 +7582,7 @@
                                 },
                                 "yAxisIndex": {
                                     "type": "number",
-                                    "format": "double"
+                                    "enum": [0, 1]
                                 },
                                 "format": {
                                     "$ref": "#/components/schemas/Format"
@@ -10033,7 +10033,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1271.0",
+        "version": "0.1273.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -173,9 +173,7 @@ export class CartesianChartDataModel
         const series = transformedData.valuesColumns.map(
             (seriesColumn, index) => {
                 const isSingleAxis = this.fieldConfig?.y.length === 1;
-                const foundSeries = Object.values(display?.series || {}).find(
-                    (s) => s.yAxisIndex === index,
-                );
+                const foundSeries = display?.series?.[seriesColumn];
                 const {
                     format,
                     color,
@@ -269,11 +267,7 @@ export class CartesianChartDataModel
                     position: display?.yAxis?.[0]?.position || 'left',
                     name:
                         (display?.yAxis && display.yAxis[0]?.label) ||
-                        friendlyName(
-                            transformedData.valuesColumns.length === 1
-                                ? transformedData.valuesColumns[0]
-                                : '',
-                        ),
+                        friendlyName(transformedData.valuesColumns[0]),
                     nameLocation: 'center',
                     nameGap: 50,
                     nameRotate: 90,
@@ -315,7 +309,7 @@ export type CartesianChartDisplay = {
         [key: string]: {
             label?: string;
             format?: Format;
-            yAxisIndex?: number;
+            yAxisIndex?: 0 | 1;
             color?: string;
             type?: ChartKind.LINE | ChartKind.VERTICAL_BAR;
         };

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -61,7 +61,6 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                                 onColorChange={(c) => {
                                                     dispatch(
                                                         actions.setSeriesColor({
-                                                            index,
                                                             color: c,
                                                             reference,
                                                         }),
@@ -78,7 +77,6 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                                             label: e.target
                                                                 .value,
                                                             reference,
-                                                            index,
                                                         }),
                                                     );
                                                 }}
@@ -99,7 +97,6 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                             ) => {
                                                 dispatch(
                                                     actions.setSeriesChartType({
-                                                        index,
                                                         type: value,
                                                         reference,
                                                     }),
@@ -115,7 +112,6 @@ export const CartesianChartSeries: React.FC<SeriesColorProps> = ({
                                             onChangeFormat={(value) => {
                                                 dispatch(
                                                     actions.setSeriesFormat({
-                                                        index,
                                                         format: value,
                                                         reference,
                                                     }),

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -45,20 +45,18 @@ export const CartesianChartStyling = ({
             return [];
         }
         return currentConfig?.config?.fieldConfig?.y.map((f, index) => {
-            const foundSeries = Object.values(
-                currentConfig?.config?.display?.series || {},
-            ).find((s) => s.yAxisIndex === index);
+            const reference = `${f.reference}_${f.aggregation}`;
+            const foundSeries =
+                currentConfig?.config?.display?.series?.[reference];
 
             const seriesFormat = foundSeries?.format;
             const seriesLabel = foundSeries?.label;
             const seriesColor = foundSeries?.color;
             const seriesType = foundSeries?.type;
             return {
-                reference: f.reference,
+                reference,
                 format: seriesFormat,
-                label:
-                    seriesLabel ??
-                    friendlyName(`${f.reference}_${f.aggregation}`),
+                label: seriesLabel ?? friendlyName(reference),
                 color: seriesColor ?? colors[index],
                 type: seriesType,
             };

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -142,7 +142,6 @@ export const cartesianChartConfigSlice = createSlice({
             action: PayloadAction<{
                 reference: string;
                 label: string;
-                index: number;
             }>,
         ) => {
             if (!config) return;
@@ -150,7 +149,7 @@ export const cartesianChartConfigSlice = createSlice({
             config.display.series = config.display.series || {};
             config.display.series[action.payload.reference] = {
                 ...config.display.series[action.payload.reference],
-                yAxisIndex: action.payload.index,
+                yAxisIndex: 0,
                 label: action.payload.label,
             };
         },
@@ -213,23 +212,6 @@ export const cartesianChartConfigSlice = createSlice({
                 if (state.config.display.yAxis) {
                     state.config.display.yAxis.splice(index, 1);
                 }
-
-                if (state.config.display.series) {
-                    Object.entries(state.config.display.series).forEach(
-                        ([key, series]) => {
-                            if (series.yAxisIndex === index) {
-                                // NOTE: Delete series from display object when it's removed from yAxis
-                                delete state.config?.display?.series?.[key];
-                            } else if (
-                                // NOTE: Decrease yAxisIndex for series that are after the removed yAxis
-                                series.yAxisIndex &&
-                                series.yAxisIndex > index
-                            ) {
-                                series.yAxisIndex--;
-                            }
-                        },
-                    );
-                }
             }
         },
         removeXAxisField: (state) => {
@@ -270,27 +252,10 @@ export const cartesianChartConfigSlice = createSlice({
             } else {
                 config.display.yAxis[0].format = validFormat;
             }
-
-            // Update the format for series with yAxisIndex 0
-            if (config.display.series) {
-                Object.values(config.display.series).forEach((series) => {
-                    if (series.yAxisIndex === 0) {
-                        series.format = validFormat;
-                    }
-                });
-            } else if (config.fieldConfig?.y[0].reference) {
-                config.display.series = {
-                    [config.fieldConfig?.y[0].reference]: {
-                        format: validFormat,
-                        yAxisIndex: 0,
-                    },
-                };
-            }
         },
         setSeriesFormat: (
             { config },
             action: PayloadAction<{
-                index: number;
                 format: string;
                 reference: string;
             }>,
@@ -300,28 +265,25 @@ export const cartesianChartConfigSlice = createSlice({
             config.display.yAxis = config.display.yAxis || [];
             config.display.series = config.display.series || {};
 
-            const { index, format, reference } = action.payload;
+            const { format, reference } = action.payload;
             const validFormat = isFormat(format) ? format : undefined;
 
             config.display.series = config.display.series || {};
             config.display.series[reference] = {
+                yAxisIndex: 0,
                 ...config.display.series[reference],
                 format: validFormat,
-                yAxisIndex: index,
             };
 
-            if (index === 0) {
-                config.display.yAxis = config.display.yAxis || [];
-                config.display.yAxis[0] = {
-                    ...config.display.yAxis[0],
-                    format: validFormat,
-                };
-            }
+            config.display.yAxis = config.display.yAxis || [];
+            config.display.yAxis[0] = {
+                ...config.display.yAxis[0],
+                format: validFormat,
+            };
         },
         setSeriesChartType: (
             { config },
             action: PayloadAction<{
-                index: number;
                 type: NonNullable<
                     CartesianChartDisplay['series']
                 >[number]['type'];
@@ -332,12 +294,12 @@ export const cartesianChartConfigSlice = createSlice({
             config.display = config.display || {};
             config.display.series = config.display.series || {};
 
-            const { index, type, reference } = action.payload;
+            const { type, reference } = action.payload;
 
             config.display.series = config.display.series || {};
             config.display.series[reference] = {
+                yAxisIndex: 0,
                 ...config.display.series[reference],
-                yAxisIndex: index,
                 type,
             };
         },
@@ -346,7 +308,6 @@ export const cartesianChartConfigSlice = createSlice({
             action: PayloadAction<{
                 reference: string;
                 color: string;
-                index?: number;
             }>,
         ) => {
             if (!config) return;
@@ -358,19 +319,18 @@ export const cartesianChartConfigSlice = createSlice({
                 const yReference = config.fieldConfig?.y[0].reference;
                 if (yReference) {
                     config.display.series[yReference] = {
-                        ...config.display.series[yReference],
                         yAxisIndex: 0,
+                        ...config.display.series[yReference],
                         color: action.payload.color,
                     };
                 }
             }
-            if (action.payload.index !== undefined) {
-                config.display.series[action.payload.reference] = {
-                    ...config.display.series[action.payload.reference],
-                    yAxisIndex: action.payload.index,
-                    color: action.payload.color,
-                };
-            }
+
+            config.display.series[action.payload.reference] = {
+                yAxisIndex: 0,
+                ...config.display.series[action.payload.reference],
+                color: action.payload.color,
+            };
         },
     },
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Restructures `display.series` with a migration and sets the `yAxisIndex` to `0` for each. 

The changes are: 

### Before
```ts
series: {
  [reference] : {
     ...
     yAxisIndex: 2
  }
}
```

**example**
```ts
series: {
  order_id: {
    ...
    yAxisIndex: 2
  }
}
```

### After
```ts
series: {
   [reference_aggregation]: {
     ...
     yAxisIndex: 0
  }
}
```

**example**

```ts
series: {
   order_id_count {
     ...
     yAxisIndex: 0
  }
}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
