### PR TITLE
fix: remove query key sql from useChartViz

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -275,7 +275,6 @@ export const ContentPanel: FC = () => {
         config: currentVizConfig,
         sql,
         limit,
-        additionalQueryKey: [sql],
     });
 
     const [activeEchartsInstance, setActiveEchartsInstance] =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Removes `sql` from `useChartViz`'s queryKey when in `ContentPanel` - this was leading to a new query run on every sql change

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
