### PR TITLE
fix: get correct language and not throw error if format fails

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -18,7 +18,6 @@ import { type editor, type languages } from 'monaco-editor';
 import { LanguageIdEnum, setupLanguageFeatures } from 'monaco-sql-languages';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
-import { useProject } from '../../../hooks/useProject';
 import '../../../styles/monaco.css';
 import { useTables } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -208,7 +207,9 @@ export const SqlEditor: FC<{
     const dispatch = useAppDispatch();
     const quoteChar = useAppSelector((state) => state.sqlRunner.quoteChar);
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
-    const { data, isLoading } = useProject(projectUuid);
+    const warehouseConnectionType = useAppSelector(
+        (state) => state.sqlRunner.warehouseConnectionType,
+    );
     const { data: tablesData, isLoading: isTablesDataLoading } = useTables({
         projectUuid,
         search: undefined,
@@ -216,8 +217,8 @@ export const SqlEditor: FC<{
     const editorRef = useRef<Parameters<OnMount>['0'] | null>(null);
 
     const language = useMemo(
-        () => getLanguage(data?.warehouseConnection?.type),
-        [data],
+        () => getLanguage(warehouseConnectionType),
+        [warehouseConnectionType],
     );
 
     const beforeMount: BeforeMount = useCallback(
@@ -322,7 +323,7 @@ export const SqlEditor: FC<{
         [debouncedSetSql, highlightText, resetHighlightError],
     );
 
-    if (isLoading || isTablesDataLoading) {
+    if (isTablesDataLoading) {
         return (
             <Center h="100%">
                 <Loader color="gray" size="xs" />
@@ -330,10 +331,10 @@ export const SqlEditor: FC<{
         );
     }
 
-    if (!data) {
+    if (!warehouseConnectionType) {
         return (
             <SuboptimalState
-                title="Project data not available"
+                title="Warehouse connection not available"
                 icon={IconAlertCircle}
             />
         );

--- a/packages/frontend/src/features/sqlRunner/store/history.ts
+++ b/packages/frontend/src/features/sqlRunner/store/history.ts
@@ -15,26 +15,33 @@ const DEFAULT_COMPARE_FUNC = <T>(a: T, b: T) => a !== b;
 
 export const createHistoryReducer = <T>({
     maxHistoryItems = DEFAULT_MAX_HISTORY_ITEMS,
-    compareFunc = DEFAULT_COMPARE_FUNC<T>,
 }: {
     maxHistoryItems?: number;
-    compareFunc?: (a: T, b: T) => boolean;
 }) => {
     return {
-        addToHistory: (state: WithHistory<T>, action: PayloadAction<T>) => {
+        addToHistory: (
+            state: WithHistory<T>,
+            action: PayloadAction<{
+                value: T;
+                compareFunc?: (a: T, b: T) => boolean;
+            }>,
+        ) => {
+            const { value, compareFunc } = action.payload;
             const newItem: HistoryItem<NonNullable<T>> = {
-                value: action.payload as NonNullable<T>,
+                value: value as NonNullable<T>,
                 timestamp: Date.now(),
             };
 
             // Remove any existing duplicate using the provided comparison function
             state.past = state.past.filter((item) =>
-                compareFunc(item.value, newItem.value),
+                compareFunc
+                    ? compareFunc(item.value, newItem.value)
+                    : DEFAULT_COMPARE_FUNC(item.value, newItem.value),
             );
 
             // Add the new item to the beginning of the past array
             state.past = [newItem, ...state.past].slice(0, maxHistoryItems);
-            state.current = action.payload;
+            state.current = value;
         },
     };
 };

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -27,6 +27,7 @@ import {
     setProjectUuid,
     setQuoteChar,
     setSavedChartData,
+    setWarehouseConnectionType,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
 import { useProject } from '../hooks/useProject';
 
@@ -65,6 +66,9 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
 
     useEffect(() => {
         if (project?.warehouseConnection?.type) {
+            dispatch(
+                setWarehouseConnectionType(project.warehouseConnection.type),
+            );
             dispatch(
                 setQuoteChar(
                     getFieldQuoteChar(project?.warehouseConnection?.type),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11677

### Description:

Stores warehouse connection in sql runner slice.
Passes the warehouse connection to `sql-formatter`'s `format.language`
If there's a format error, it doesn't normalise/format the sql, leaving it up to the user to fix the query (they will see an error from the error toast if they run an invalid sql query anyway)

Screenshots with different warehouse connections (tested when creating and also editing a chart)

<img width="1909" alt="Screenshot 2024-09-25 at 09 31 13" src="https://github.com/user-attachments/assets/76c008eb-2c14-4ea2-978d-6ecb1819c73e">

<img width="1471" alt="Screenshot 2024-09-25 at 09 27 13" src="https://github.com/user-attachments/assets/c6245651-50d6-4bc4-8b5a-e523a940b500">


## How to test
go to this render env without this change: https://lightdash-pr-11676.onrender.com/projects/85ef7207-b1d4-4d0c-82c7-edb93bded560 and in the snowflake project, paste this: 

```sql
SELECT * FROM "SNOWFLAKE_DATABASE_STAGING"."JAFFLE"."CUSTOMERS"
WHERE customer_id = 'C123'
AND (
  SELECT COUNT(*) FROM "SNOWFLAKE_DATABASE_STAGING"."JAFFLE"."ORDERS"
  WHERE customer_id = "CUSTOMERS".customer_id
  GROUP BY order_date
  HAVING SUM(order_total) > 1000
ORDER BY customer_name DESC
LIMIT 10;
```

see uncaught error from `sql-formatter`
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/47dd312e-eb1b-4e5d-9afa-579d349c7023">


In this PR env (or locally)
Go to the snowflake project, and paste the same query above ⬆️ 

see no error from `sql-formatter`
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/e05b7c2d-745c-419b-b5d6-972fd9d2413e">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
