### PR TITLE
feat: add semantic viewer permissions

### DIFF
--- a/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
+++ b/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
@@ -210,15 +210,6 @@ export class SavedSemanticViewerChartService extends BaseService {
             projectUuid,
         );
 
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('SemanticViewer', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const { hasAccess: hasCreateAccess } = await this.hasAccess(
             user,
             'create',
@@ -278,6 +269,7 @@ export class SavedSemanticViewerChartService extends BaseService {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
+
         if (
             user.ability.cannot(
                 'manage',
@@ -298,6 +290,7 @@ export class SavedSemanticViewerChartService extends BaseService {
             'update',
             savedChart,
         );
+
         if (!hasUpdateAccess) {
             throw new ForbiddenError(
                 "You don't have permission to update this chart",
@@ -367,11 +360,13 @@ export class SavedSemanticViewerChartService extends BaseService {
             projectUuid,
             savedSemanticViewerChartUuid,
         );
+
         const { hasAccess: hasDeleteAccess } = await this.hasSavedChartAccess(
             user,
             'delete',
             savedChart,
         );
+
         if (!hasDeleteAccess) {
             throw new ForbiddenError(
                 "You don't have permission to delete this chart",

--- a/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
+++ b/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
@@ -208,15 +208,16 @@ export class SavedSemanticViewerChartService extends BaseService {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
+
         if (
             user.ability.cannot(
                 'manage',
-                // TODO: add it's own ability
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('SemanticViewer', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
         }
+
         const { hasAccess: hasCreateAccess } = await this.hasAccess(
             user,
             'create',
@@ -232,6 +233,7 @@ export class SavedSemanticViewerChartService extends BaseService {
                 "You don't have permission to create this chart",
             );
         }
+
         const createdChart = await this.savedSemanticViewerChartModel.create(
             user.userUuid,
             projectUuid,

--- a/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
+++ b/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
@@ -11,6 +11,7 @@ import {
     SpaceShare,
     SpaceSummary,
     VIZ_DEFAULT_AGGREGATION,
+    type AbilityAction,
     type SemanticViewerChartCreate,
     type SemanticViewerChartCreateResult,
     type SemanticViewerChartUpdate,
@@ -98,7 +99,7 @@ export class SavedSemanticViewerChartService extends BaseService {
 
     private async hasAccess(
         user: SessionUser,
-        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        action: AbilityAction,
         {
             spaceUuid,
             projectUuid,
@@ -131,7 +132,7 @@ export class SavedSemanticViewerChartService extends BaseService {
     // I think it should be combined now
     async hasSavedChartAccess(
         user: SessionUser,
-        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        action: AbilityAction,
         savedChart: {
             project: Pick<Project, 'projectUuid'>;
             organization: Pick<Organization, 'organizationUuid'>;

--- a/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
+++ b/packages/backend/src/services/SavedSemanticViewerChartService/SavedSemanticViewerChartService.ts
@@ -270,16 +270,6 @@ export class SavedSemanticViewerChartService extends BaseService {
             projectUuid,
         );
 
-        if (
-            user.ability.cannot(
-                'manage',
-                // TODO: add it's own ability
-                subject('CustomSql', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const savedChart = await this.savedSemanticViewerChartModel.getByUuid(
             projectUuid,
             savedSemanticViewerChartUuid,

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -84,6 +84,9 @@ export class SearchService extends BaseService {
                 ...results.savedCharts.map(
                     (savedChart) => savedChart.spaceUuid,
                 ),
+                ...results.semanticViewerCharts.map(
+                    (semanticViewerChart) => semanticViewerChart.spaceUuid,
+                ),
                 ...results.spaces.map((space) => space.uuid),
             ]),
         ];

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -180,16 +180,23 @@ export class SearchService extends BaseService {
         const hasDashboardAccess = await Promise.all(
             results.dashboards.map(filterItem),
         );
+
         const hasSavedChartAccess = await Promise.all(
             results.savedCharts.map(filterItem),
         );
+
         const hasSqlChartAccess = await Promise.all(
             results.sqlCharts.map(filterItem),
+        );
+
+        const hasSemanticViewerChartAccess = await Promise.all(
+            results.semanticViewerCharts.map(filterItem),
         );
 
         const hasSpaceAccess = await Promise.all(
             results.spaces.map(filterItem),
         );
+
         const filteredResults = {
             ...results,
             tables: filteredTables,
@@ -203,6 +210,9 @@ export class SearchService extends BaseService {
             sqlCharts: results.sqlCharts.filter(
                 (_, index) => hasSqlChartAccess[index],
             ),
+            semanticViewerCharts: results.semanticViewerCharts.filter(
+                (_, index) => hasSemanticViewerChartAccess[index],
+            ),
             spaces: results.spaces.filter((_, index) => hasSpaceAccess[index]),
             pages: user.ability.can(
                 'view',
@@ -213,6 +223,7 @@ export class SearchService extends BaseService {
                 ? results.pages
                 : [], // For now there is only 1 page and it is for admins only
         };
+
         this.analytics.track({
             event: 'project.search',
             userId: user.userUuid,
@@ -222,10 +233,13 @@ export class SearchService extends BaseService {
                 dashboardsResultsCount: filteredResults.dashboards.length,
                 savedChartsResultsCount: filteredResults.savedCharts.length,
                 sqlChartsResultsCount: filteredResults.sqlCharts.length,
+                semanticViewerChartsResultsCount:
+                    filteredResults.semanticViewerCharts.length,
                 tablesResultsCount: filteredResults.tables.length,
                 fieldsResultsCount: filteredResults.fields.length,
             },
         });
+
         return filteredResults;
     }
 }

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -742,6 +742,9 @@ describe('Organization member permissions', () => {
         it('cannot run SQL Queries', () => {
             expect(ability.can('manage', 'SqlRunner')).toEqual(false);
         });
+        it('can use the SemanticViewer', () => {
+            expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
+        });
     });
     describe('when user is an developer', () => {
         beforeEach(() => {
@@ -752,6 +755,10 @@ describe('Organization member permissions', () => {
 
         it('can run SQL Queries', () => {
             expect(ability.can('manage', 'SqlRunner')).toEqual(true);
+        });
+
+        it('can use the SemanticViewer', () => {
+            expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
         });
     });
     describe('when user is a member', () => {
@@ -1319,6 +1326,9 @@ describe('Organization member permissions', () => {
                 ),
             ).toEqual(false);
         });
+        it('cannot view the SemanticViewer', () => {
+            expect(ability.can('view', 'SemanticViewer')).toEqual(false);
+        });
     });
     describe('when user is an interactive viewer', () => {
         beforeEach(() => {
@@ -1393,6 +1403,17 @@ describe('Organization member permissions', () => {
                 ability.can(
                     'manage',
                     subject('SqlRunner', {
+                        organizationUuid:
+                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                    }),
+                ),
+            ).toEqual(false);
+        });
+        it('cannot use the SemanticViewer', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SemanticViewer', {
                         organizationUuid:
                             ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
                     }),

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -172,6 +172,9 @@ export const organizationMemberAbilities: Record<
         can('manage', 'DashboardComments', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'SemanticViewer', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     developer(member, { can }) {
         organizationMemberAbilities.editor(member, { can });
@@ -179,9 +182,6 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'SqlRunner', {
-            organizationUuid: member.organizationUuid,
-        });
-        can('manage', 'SemanticViewer', {
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'Validation', {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -83,6 +83,9 @@ export const organizationMemberAbilities: Record<
         can('view', 'UnderlyingData', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'SemanticViewer', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'ChangeCsvResults', {
             organizationUuid: member.organizationUuid,
         });
@@ -105,6 +108,16 @@ export const organizationMemberAbilities: Record<
             },
         });
         can('manage', 'SavedChart', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                },
+            },
+        });
+
+        can('manage', 'SemanticViewer', {
             organizationUuid: member.organizationUuid,
             access: {
                 $elemMatch: {
@@ -166,6 +179,9 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'SqlRunner', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'SemanticViewer', {
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'Validation', {

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -741,6 +741,15 @@ describe('Project member permissions', () => {
                 ability.can('manage', subject('SqlRunner', { projectUuid })),
             ).toEqual(false);
         });
+
+        it('can use the SemanticViewer', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SemanticViewer', { projectUuid }),
+                ),
+            ).toEqual(true);
+        });
     });
 
     describe('when user is an developer', () => {
@@ -751,6 +760,15 @@ describe('Project member permissions', () => {
         it('can use SQL runner', () => {
             expect(
                 ability.can('manage', subject('SqlRunner', { projectUuid })),
+            ).toEqual(true);
+        });
+
+        it('can use the SemanticViewer', () => {
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SemanticViewer', { projectUuid }),
+                ),
             ).toEqual(true);
         });
     });
@@ -1107,6 +1125,12 @@ describe('Project member permissions', () => {
             expect(
                 ability.can('manage', subject('SqlRunner', { projectUuid })),
             ).toEqual(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SemanticViewer', { projectUuid }),
+                ),
+            ).toEqual(false);
         });
         it('can download CSV', () => {
             expect(
@@ -1159,6 +1183,9 @@ describe('Project member permissions', () => {
             ).toEqual(true);
             expect(
                 ability.can('view', subject('Project', { projectUuid })),
+            ).toEqual(true);
+            expect(
+                ability.can('view', subject('SemanticViewer', { projectUuid })),
             ).toEqual(true);
         });
         it('can not view private resources', () => {
@@ -1258,6 +1285,12 @@ describe('Project member permissions', () => {
             ).toEqual(false);
             expect(
                 ability.can('manage', subject('SqlRunner', { projectUuid })),
+            ).toEqual(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('SemanticViewer', { projectUuid }),
+                ),
             ).toEqual(false);
         });
         it('can download CSV', () => {

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -61,6 +61,9 @@ export const projectMemberAbilities: Record<
         can('view', 'UnderlyingData', {
             projectUuid: member.projectUuid,
         });
+        can('view', 'SemanticViewer', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'Explore', {
             projectUuid: member.projectUuid,
         });
@@ -83,6 +86,15 @@ export const projectMemberAbilities: Record<
             },
         });
         can('manage', 'SavedChart', {
+            projectUuid: member.projectUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                },
+            },
+        });
+        can('manage', 'SemanticViewer', {
             projectUuid: member.projectUuid,
             access: {
                 $elemMatch: {
@@ -144,6 +156,9 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
         can('manage', 'SqlRunner', {
+            projectUuid: member.projectUuid,
+        });
+        can('manage', 'SemanticViewer', {
             projectUuid: member.projectUuid,
         });
         can('manage', 'Validation', {

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -149,6 +149,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'DashboardComments', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'SemanticViewer', {
+            projectUuid: member.projectUuid,
+        });
     },
     developer(member, { can }) {
         projectMemberAbilities.editor(member, { can });
@@ -156,9 +159,6 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
         can('manage', 'SqlRunner', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'SemanticViewer', {
             projectUuid: member.projectUuid,
         });
         can('manage', 'Validation', {

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -38,6 +38,7 @@ type Subject =
     | 'DashboardComments'
     | 'CustomSql'
     | 'CompileProject'
+    | 'SemanticViewer'
     | 'all';
 
 type PossibleAbilities = [

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -1,7 +1,13 @@
 import { type Ability, type ForcedSubject } from '@casl/ability';
 import { type OrganizationMemberProfile } from '../types/organizationMemberProfile';
 
-type Action = 'manage' | 'update' | 'view' | 'create' | 'delete' | 'promote';
+export type AbilityAction =
+    | 'manage'
+    | 'update'
+    | 'view'
+    | 'create'
+    | 'delete'
+    | 'promote';
 
 interface Project {
     organizationUuid: string;
@@ -42,7 +48,7 @@ type Subject =
     | 'all';
 
 type PossibleAbilities = [
-    Action,
+    AbilityAction,
     Subject | ForcedSubject<Exclude<Subject, 'all'>>,
 ];
 

--- a/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
@@ -46,15 +46,7 @@ export const HeaderView: FC<Props> = ({
         { open: openAddToDashboardModal, close: closeAddToDashboardModal },
     ] = useDisclosure(false);
 
-    const savedChartSpaceUserAccess = useMemo(() => {
-        const access: SpaceShare[] = [];
-
-        if (chart.space.userAccess) {
-            access.push(chart.space.userAccess);
-        }
-
-        return access;
-    }, [chart]);
+    const savedChartSpaceUserAccess = chart.space.userAccess ? [chart.space.userAccess] : [];
 
     const canManageSemanticViewer = user.data?.ability?.can(
         'manage',

--- a/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import {
     DashboardTileTypes,
     type SavedSemanticViewerChart,
-    type SpaceShare,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -15,7 +14,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconDots, IconLayoutGridAdd, IconTrash } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
@@ -46,7 +45,9 @@ export const HeaderView: FC<Props> = ({
         { open: openAddToDashboardModal, close: closeAddToDashboardModal },
     ] = useDisclosure(false);
 
-    const savedChartSpaceUserAccess = chart.space.userAccess ? [chart.space.userAccess] : [];
+    const savedChartSpaceUserAccess = chart.space.userAccess
+        ? [chart.space.userAccess]
+        : [];
 
     const canManageSemanticViewer = user.data?.ability?.can(
         'manage',

--- a/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DashboardTileTypes,
     type SavedSemanticViewerChart,
+    type SpaceShare,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -14,7 +15,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconDots, IconLayoutGridAdd, IconTrash } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
@@ -45,12 +46,22 @@ export const HeaderView: FC<Props> = ({
         { open: openAddToDashboardModal, close: closeAddToDashboardModal },
     ] = useDisclosure(false);
 
-    const canManageSemanticViewerChart = user.data?.ability?.can(
+    const savedChartSpaceUserAccess = useMemo(() => {
+        const access: SpaceShare[] = [];
+
+        if (chart.space.userAccess) {
+            access.push(chart.space.userAccess);
+        }
+
+        return access;
+    }, [chart]);
+
+    const canManageSemanticViewer = user.data?.ability?.can(
         'manage',
-        // TODO: change to permissions for semantic viewer
-        subject('SqlRunner', {
+        subject('SemanticViewer', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
+            access: savedChartSpaceUserAccess,
         }),
     );
 
@@ -60,7 +71,7 @@ export const HeaderView: FC<Props> = ({
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
             isPrivate: chart.space.isPrivate,
-            access: chart.space.userAccess,
+            access: savedChartSpaceUserAccess,
         }),
     );
 
@@ -99,7 +110,7 @@ export const HeaderView: FC<Props> = ({
                     </Stack>
 
                     <Group spacing="md">
-                        {canManageSemanticViewerChart && canManageChart && (
+                        {canManageSemanticViewer && canManageChart && (
                             <Button
                                 size="xs"
                                 variant="default"
@@ -145,7 +156,7 @@ export const HeaderView: FC<Props> = ({
                                     color="red"
                                     disabled={
                                         !(
-                                            canManageSemanticViewerChart &&
+                                            canManageSemanticViewer &&
                                             canManageChart
                                         )
                                     }

--- a/packages/frontend/src/features/semanticViewer/components/Sidebar.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { ChartKind } from '@lightdash/common';
 import {
     ActionIcon,
@@ -12,6 +13,7 @@ import { IconChevronLeft } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useApp } from '../../../providers/AppProvider';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { selectSemanticLayerInfo } from '../store/selectors';
 import {
@@ -30,7 +32,7 @@ const Sidebar: FC = () => {
         (state) => state.semanticViewer,
     );
     const history = useHistory();
-
+    const { user } = useApp();
     const dispatch = useAppDispatch();
 
     const handleExitView = () => {
@@ -47,6 +49,23 @@ const Sidebar: FC = () => {
         );
     };
 
+    const canManageSemanticViewer = user.data?.ability?.can(
+        'manage',
+        subject('SemanticViewer', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
+    const canSaveChart = user.data?.ability?.can(
+        'create',
+        subject('SavedChart', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+            // TODO: this needs access that comes from saved chart (only available when view and edit mode are merged)
+        }),
+    );
+
     return (
         <Stack spacing="xs" sx={{ flex: 1, overflow: 'hidden' }}>
             <Group
@@ -61,7 +80,7 @@ const Sidebar: FC = () => {
                     borderBottom: `1px solid ${theme.colors.gray[3]}`,
                 })}
             >
-                {semanticLayerView && (
+                {semanticLayerView && canManageSemanticViewer && canSaveChart && (
                     <>
                         <SaveChart.Content />
                         {saveModalOpen && (

--- a/packages/frontend/src/features/semanticViewer/components/Sidebar.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import { ChartKind } from '@lightdash/common';
 import {
     ActionIcon,
@@ -13,7 +12,6 @@ import { IconChevronLeft } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useApp } from '../../../providers/AppProvider';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { selectSemanticLayerInfo } from '../store/selectors';
 import {
@@ -26,13 +24,16 @@ import { SemanticViewerVizConfig } from './SemanticViewerVizConfig';
 import SidebarViewFields from './SidebarViewFields';
 import SidebarViews from './SidebarViews';
 
-const Sidebar: FC = () => {
+type SidebarProps = {
+    shouldShowSave?: boolean;
+};
+
+const Sidebar: FC<SidebarProps> = ({ shouldShowSave }) => {
     const { features, projectUuid } = useAppSelector(selectSemanticLayerInfo);
     const { semanticLayerView, saveModalOpen } = useAppSelector(
         (state) => state.semanticViewer,
     );
     const history = useHistory();
-    const { user } = useApp();
     const dispatch = useAppDispatch();
 
     const handleExitView = () => {
@@ -49,23 +50,6 @@ const Sidebar: FC = () => {
         );
     };
 
-    const canManageSemanticViewer = user.data?.ability?.can(
-        'manage',
-        subject('SemanticViewer', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-        }),
-    );
-
-    const canSaveChart = user.data?.ability?.can(
-        'create',
-        subject('SavedChart', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-            // TODO: this needs access that comes from saved chart (only available when view and edit mode are merged)
-        }),
-    );
-
     return (
         <Stack spacing="xs" sx={{ flex: 1, overflow: 'hidden' }}>
             <Group
@@ -80,7 +64,7 @@ const Sidebar: FC = () => {
                     borderBottom: `1px solid ${theme.colors.gray[3]}`,
                 })}
             >
-                {semanticLayerView && canManageSemanticViewer && canSaveChart && (
+                {semanticLayerView && shouldShowSave && (
                     <>
                         <SaveChart.Content />
                         {saveModalOpen && (

--- a/packages/frontend/src/pages/SemanticViewerEdit.tsx
+++ b/packages/frontend/src/pages/SemanticViewerEdit.tsx
@@ -96,8 +96,8 @@ const SemanticViewerEditorPageWithStore = () => {
     ]);
 
     const savedChartSpaceUserAccess =
-        chartQuery.isSuccess && chartQuery.data.chart.space.userAccess
-            ? [chartQuery.data.chart.space.userAccess]
+        chartQuery.isSuccess && chartQuery.data.space.userAccess
+            ? [chartQuery.data.space.userAccess]
             : [];
 
     const canManageSemanticViewer = user.data?.ability?.can(

--- a/packages/frontend/src/pages/SemanticViewerEdit.tsx
+++ b/packages/frontend/src/pages/SemanticViewerEdit.tsx
@@ -1,5 +1,4 @@
 import { subject } from '@casl/ability';
-import type { SpaceShare } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { useHistory, useParams, useRouteMatch } from 'react-router-dom';
@@ -96,9 +95,10 @@ const SemanticViewerEditorPageWithStore = () => {
         projectUuid,
     ]);
 
-    const savedChartSpaceUserAccess = chartQuery.isSuccess && chartQuery.data.chart.space.userAccess 
-        ? [chartQuery.data.chart.space.userAccess] 
-        : [];
+    const savedChartSpaceUserAccess =
+        chartQuery.isSuccess && chartQuery.data.chart.space.userAccess
+            ? [chartQuery.data.chart.space.userAccess]
+            : [];
 
     const canManageSemanticViewer = user.data?.ability?.can(
         'manage',

--- a/packages/frontend/src/pages/SemanticViewerEdit.tsx
+++ b/packages/frontend/src/pages/SemanticViewerEdit.tsx
@@ -96,15 +96,9 @@ const SemanticViewerEditorPageWithStore = () => {
         projectUuid,
     ]);
 
-    const savedChartSpaceUserAccess = useMemo(() => {
-        const access: SpaceShare[] = [];
-
-        if (chartQuery.isSuccess && chartQuery.data.chart.space.userAccess) {
-            access.push(chartQuery.data.chart.space.userAccess);
-        }
-
-        return access;
-    }, [chartQuery]);
+    const savedChartSpaceUserAccess = chartQuery.isSuccess && chartQuery.data.chart.space.userAccess 
+        ? [chartQuery.data.chart.space.userAccess] 
+        : [];
 
     const canManageSemanticViewer = user.data?.ability?.can(
         'manage',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11592

### Description:

- Adds permissions for `Semantic Viewer` access

**Acceptance criteria**

- [ ] viewers cannot access the semantic viewer. They can only view semantic viewer charts in view mode.
- [ ] an interactive viewer can use the semantic viewer, but not save charts. They can open charts in the semantic viewer, but there is no option to save.
- [ ] An editor and above can use + save semantic viewer charts.
- [ ] space permissions work, e.g. interactive viewer with editor access in space should be able to edit a chart in that space

**interactive viewer with editor access to chart space**
![image](https://github.com/user-attachments/assets/0c55b94b-8906-4005-b9ac-12fc9d237b58)
![image](https://github.com/user-attachments/assets/d46d61e5-e727-497b-ad61-ca316db1b162)

**interactive viewer**
![image](https://github.com/user-attachments/assets/575ae3d1-425b-409a-bde4-78ce7ee2faa4)
![image](https://github.com/user-attachments/assets/adcb7264-25ea-4db7-9ee8-aa9b48665e22)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
