### PR TITLE
fix: apply w100 to chart view

### DIFF
--- a/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartView.tsx
@@ -51,7 +51,7 @@ const ChartView = memo<Props>(
         }
 
         return (
-            <Box h="100%" data-testid={`chart-view-${config?.type}`}>
+            <Box h="100%" w="100%" data-testid={`chart-view-${config?.type}`}>
                 <LoadingOverlay visible={isLoading} />
 
                 {spec && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After merging #11679 we introduced a wrapper to apply a data test id with h=100% (I couldn't pass the test id to the Echarts component)
But the dashboard tiles need this to be w=100% so it fills the tile

Before
<img width="741" alt="Screenshot 2024-09-26 at 14 31 49" src="https://github.com/user-attachments/assets/44771718-2835-40dc-b21e-4ad714ecf7d6">

After

<img width="843" alt="Screenshot 2024-09-26 at 14 32 07" src="https://github.com/user-attachments/assets/142cdfd0-d4d9-4f90-ae49-2e7a79460d86">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
