### PR TITLE
fix: get correct uuid column for resource actions

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -997,7 +997,7 @@ export class SpaceModel {
                     slug: string;
                 }[]
             >([
-                `${chartTable}.${uuidColumnName}`,
+                `${chartTable}.${uuidColumnName} as uuid`,
                 `${chartTable}.name`,
                 `${chartTable}.description`,
                 `${chartTable}.last_version_updated_at as created_at`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #11367

### Description:

Fixes the `uuid` column reference so users can add charts to dashboards from the resource actions (which get `uuid` and not the `slug`)

Before


https://github.com/user-attachments/assets/80e28361-432b-46e8-a0fd-82812cef2ae1



After


https://github.com/user-attachments/assets/b7939b04-5701-409b-a8a5-91b89f677e64



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
