### PR TITLE
feat: redirect sql runner to new runner

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
@@ -20,7 +20,7 @@ const OpenInSqlRunnerButton: FC<OpenInSqlRunnerButtonProps> = memo(
                 component={Link}
                 to={{
                     pathname: `/projects/${projectUuid}/sql-runner`,
-                    state: { sql: data ?? '' }, // pass SQL as location state
+                    state: { sql: data }, // pass SQL as location state
                 }}
                 leftIcon={<MantineIcon icon={IconTerminal2} color="gray" />}
                 disabled={isInitialLoading || !!error}

--- a/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
@@ -13,15 +13,15 @@ interface OpenInSqlRunnerButtonProps {
 const OpenInSqlRunnerButton: FC<OpenInSqlRunnerButtonProps> = memo(
     ({ projectUuid }) => {
         const { data, isInitialLoading, error } = useCompiledSql();
-        const searchParams = new URLSearchParams({
-            sql_runner: JSON.stringify({ sql: data ?? '' }),
-        });
 
         return (
             <Button
                 {...COLLAPSABLE_CARD_BUTTON_PROPS}
                 component={Link}
-                to={`/projects/${projectUuid}/sqlRunner?${searchParams.toString()}`}
+                to={{
+                    pathname: `/projects/${projectUuid}/sql-runner`,
+                    state: { sql: data ?? '' }, // pass SQL as location state
+                }}
                 leftIcon={<MantineIcon icon={IconTerminal2} color="gray" />}
                 disabled={isInitialLoading || !!error}
             >

--- a/packages/frontend/src/features/metricFlow/components/MetricFlowSqlCard.tsx
+++ b/packages/frontend/src/features/metricFlow/components/MetricFlowSqlCard.tsx
@@ -29,7 +29,7 @@ const MetricFlowSqlCard: FC<Props> = ({
     const sqlRunnerLink = useMemo(
         () => ({
             pathname: `/projects/${projectUuid}/sql-runner`,
-            state: { sql: sql ?? '' }, // pass SQL as state
+            state: { sql }, // pass SQL as state
         }),
         [projectUuid, sql],
     );

--- a/packages/frontend/src/features/metricFlow/components/MetricFlowSqlCard.tsx
+++ b/packages/frontend/src/features/metricFlow/components/MetricFlowSqlCard.tsx
@@ -25,14 +25,15 @@ const MetricFlowSqlCard: FC<Props> = ({
     canRedirectToSqlRunner = false,
 }) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
-    const sqlRunnerUrl = useMemo(() => {
-        const params = new URLSearchParams({
-            sql_runner: JSON.stringify({
-                sql: sql ?? '',
-            }),
-        });
-        return `/projects/${projectUuid}/sqlRunner?${params.toString()}`;
-    }, [projectUuid, sql]);
+
+    const sqlRunnerLink = useMemo(
+        () => ({
+            pathname: `/projects/${projectUuid}/sql-runner`,
+            state: { sql: sql ?? '' }, // pass SQL as state
+        }),
+        [projectUuid, sql],
+    );
+
     return (
         <CollapsableCard
             title="SQL"
@@ -45,7 +46,7 @@ const MetricFlowSqlCard: FC<Props> = ({
                         variant="default"
                         size="xs"
                         component={Link}
-                        to={sqlRunnerUrl}
+                        to={sqlRunnerLink}
                         leftIcon={
                             <MantineIcon icon={IconTerminal2} color="gray" />
                         }

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -3,7 +3,7 @@ import { ActionIcon, Group, Paper, Stack, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -39,6 +39,7 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
     const params = useParams<{ projectUuid: string; slug?: string }>();
 
     const location = useLocation<{ sql?: string }>();
+    const history = useHistory();
 
     const [isLeftSidebarOpen, setLeftSidebarOpen] = useState(true);
     const { data: project } = useProject(projectUuid);
@@ -59,8 +60,10 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
     useEffect(() => {
         if (location.state?.sql) {
             dispatch(setSql(location.state.sql));
+            // clear the location state - this prevents state from being preserved on page refresh
+            history.replace({ ...location, state: undefined });
         }
-    }, [dispatch, location.state]);
+    }, [dispatch, location, history]);
 
     const { data, error: chartError } = useSavedSqlChart({
         projectUuid,

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -3,7 +3,7 @@ import { ActionIcon, Group, Paper, Stack, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -27,6 +27,7 @@ import {
     setProjectUuid,
     setQuoteChar,
     setSavedChartData,
+    setSql,
     setWarehouseConnectionType,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
 import { useProject } from '../hooks/useProject';
@@ -36,6 +37,8 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
 
     const params = useParams<{ projectUuid: string; slug?: string }>();
+
+    const location = useLocation<{ sql?: string }>();
 
     const [isLeftSidebarOpen, setLeftSidebarOpen] = useState(true);
     const { data: project } = useProject(projectUuid);
@@ -51,6 +54,13 @@ const SqlRunnerNew = ({ isEditMode }: { isEditMode?: boolean }) => {
             dispatch(setFetchResultsOnLoad(!!isEditMode));
         }
     }, [dispatch, params.projectUuid, projectUuid, isEditMode]);
+
+    // Use the SQL string from the location state if available
+    useEffect(() => {
+        if (location.state?.sql) {
+            dispatch(setSql(location.state.sql));
+        }
+    }, [dispatch, location.state]);
 
     const { data, error: chartError } = useSavedSqlChart({
         projectUuid,
@@ -136,4 +146,5 @@ const SqlRunnerNewPage = ({ isEditMode }: { isEditMode?: boolean }) => {
         </Provider>
     );
 };
+
 export default SqlRunnerNewPage;


### PR DESCRIPTION
Closes: #11628

### Description:
- when "Open in SQL runner" is clicked in an Explore chart it now goes to the new runner, passing the sql to it

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
