### PR TITLE
feat: running query using CMD + ENTER

### DIFF
--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mantine/core';
 import { useHotkeys, useOs } from '@mantine/hooks';
 import { IconPlayerPlay } from '@tabler/icons-react';
-import { memo, useCallback, type FC } from 'react';
+import { memo, useCallback, useEffect, type FC } from 'react';
 import useHealth from '../hooks/health/useHealth';
 import { useExplorerContext } from '../providers/ExplorerProvider';
 import { useTracking } from '../providers/TrackingProvider';
@@ -50,6 +50,21 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     }, [fetchResults, track, canRunQuery]);
 
     useHotkeys([['mod + enter', onClick, { preventDefault: true }]]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                event.preventDefault();
+                onClick();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [onClick]);
 
     return (
         <Button.Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->#11590

### Description: 
Add functionality so that when user hit CMD+ENTER to run the query while they are in the input field, the query runs.
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [✅] I have manually tested the changes in the preview environment
- [✅] I have reviewed the code
- [✅] I understand that "request changes" will block this PR from merging
