### PR TITLE
fix: invite user with no org

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -41,6 +41,7 @@ const userModel = {
     findUserByEmail: jest.fn(async () => undefined),
     createPendingUser: jest.fn(async () => newUser),
     findSessionUserByPrimaryEmail: jest.fn(async () => sessionUser),
+    joinOrg: jest.fn(async () => sessionUser),
 };
 
 const openIdIdentityModel = {
@@ -465,6 +466,7 @@ describe('UserService', () => {
                     inviteUser,
                 ),
             ).toEqual(inviteLink);
+            expect(userModel.joinOrg as jest.Mock).toHaveBeenCalledTimes(1);
             expect(
                 userModel.createPendingUser as jest.Mock,
             ).toHaveBeenCalledTimes(0);

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -383,6 +383,18 @@ export class UserService extends BaseService {
             userUuid = existingUserWithEmail.userUuid;
         }
 
+        if (existingUserWithEmail && !existingUserWithEmail?.organizationUuid) {
+            Logger.warn(
+                `User with email ${email} already exists but has no org, so we invite them to join`,
+            );
+            await this.userModel.joinOrg(
+                existingUserWithEmail.userUuid,
+                organizationUuid,
+                userRole,
+                undefined,
+            );
+        }
+
         const inviteLink = await this.inviteLinkModel.upsert(
             inviteCode,
             expiresAt,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #11708

### Description:

How to replicate: 

- with `export ALLOW_MULTIPLE_ORGS=false` 
- create a new account using /register
- You will get an error (no other orgs can be created) , this is expected
- Now invite this user to your org.
- You will not see the invite in your users page, and no org will be created :fire: 


<!-- Add a description of the changes proposed in the pull request. -->
Before: 

[Screencast from 30-09-24 09:14:15.webm](https://github.com/user-attachments/assets/efe91454-0f7a-44ef-ac3a-70ed6508137e)


After:

[Screencast from 30-09-24 09:23:11.webm](https://github.com/user-attachments/assets/8e245dac-8058-4d73-83fc-691333706963)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-frontend test-backend