### PR TITLE
feat: show disabled items when diff semantic layers

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          browser: edge
+          browser: firefox
           project: ./packages/e2e
           # Set the PR deployment url and disable video recording
           config: 'baseUrl=${{needs.prepare-preview.outputs.url}},specPattern=cypress/e2e/app/**/*.cy.{js,jsx,ts,tsx},video=false'
@@ -228,7 +228,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          browser: edge
+          browser: firefox
           project: ./packages/e2e
           spec: packages/e2e/cypress/e2e/app/dates.cy.ts
           # Set the PR deployment url and disable video recording

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
+          browser: firefox
           project: ./packages/e2e
           # Set the PR deployment url and disable video recording
           config: 'baseUrl=${{needs.prepare-preview.outputs.url}},specPattern=cypress/e2e/app/**/*.cy.{js,jsx,ts,tsx},video=false'
@@ -228,6 +228,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
+          browser: firefox
           project: ./packages/e2e
           spec: packages/e2e/cypress/e2e/app/dates.cy.ts
           # Set the PR deployment url and disable video recording

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          browser: firefox
+          browser: edge
           project: ./packages/e2e
           # Set the PR deployment url and disable video recording
           config: 'baseUrl=${{needs.prepare-preview.outputs.url}},specPattern=cypress/e2e/app/**/*.cy.{js,jsx,ts,tsx},video=false'
@@ -228,7 +228,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          browser: firefox
+          browser: edge
           project: ./packages/e2e
           spec: packages/e2e/cypress/e2e/app/dates.cy.ts
           # Set the PR deployment url and disable video recording

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -13,6 +13,7 @@ import {
     DashboardVersionedFields,
     OrganizationMemberRole,
     SessionUser,
+    type DashboardBasicDetailsWithTileTypes,
 } from '@lightdash/common';
 import {
     DashboardTable,
@@ -312,7 +313,7 @@ export const expectedDashboard: DashboardDAO = {
     tabs: [],
 };
 
-export const expectedAllDashboards: DashboardBasicDetails[] = [
+export const expectedAllDashboards: DashboardBasicDetailsWithTileTypes[] = [
     {
         organizationUuid: 'organizationUuid',
         projectUuid: projectEntry.project_uuid,
@@ -331,6 +332,7 @@ export const expectedAllDashboards: DashboardBasicDetails[] = [
         views: 1,
         firstViewedAt: new Date(1),
         validationErrors: [],
+        tileTypes: [DashboardTileTypes.SAVED_CHART],
     },
 ];
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -1,5 +1,6 @@
 import {
     CreateDashboardMarkdownTile,
+    DashboardTileTypes,
     deepEqual,
     NotFoundError,
 } from '@lightdash/common';
@@ -136,10 +137,16 @@ describe('DashboardModel', () => {
                 },
             ]);
 
+        tracker.on.select(queryMatcher(DashboardTilesTableName, [0])).response([
+            {
+                type: DashboardTileTypes.SAVED_CHART,
+            },
+        ]);
+
         const dashboard = await model.getAllByProject(projectUuid);
 
         expect(dashboard).toEqual(expectedAllDashboards);
-        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select).toHaveLength(2);
     });
 
     test('should create dashboard with tile ids', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -24,7 +24,7 @@ import {
     TogglePinnedItemInfo,
     UpdateDashboard,
     UpdateMultipleDashboards,
-    type DashboardTile,
+    type DashboardBasicDetailsWithTileTypes,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
 import { v4 as uuidv4 } from 'uuid';
@@ -159,7 +159,7 @@ export class DashboardService extends BaseService {
         projectUuid: string,
         chartUuid?: string,
         includePrivate?: boolean,
-    ): Promise<DashboardBasicDetails[]> {
+    ): Promise<DashboardBasicDetailsWithTileTypes[]> {
         const dashboards = await this.dashboardModel.getAllByProject(
             projectUuid,
             chartUuid,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -211,6 +211,10 @@ export type DashboardBasicDetails = Pick<
     | 'pinnedListOrder'
 > & { validationErrors?: ValidationSummary[] };
 
+export type DashboardBasicDetailsWithTileTypes = DashboardBasicDetails & {
+    tileTypes: DashboardTileTypes[];
+};
+
 export type SpaceDashboard = DashboardBasicDetails;
 
 export type DashboardUnversionedFields = Pick<

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -22,12 +22,11 @@ export default defineConfig({
         ],
         trashAssetsBeforeRuns: true,
         experimentalMemoryManagement: true,
-        numTestsKeptInMemory: 0,
         setupNodeEvents(on, config) {
             cypressSplit(on, config);
 
             on('before:browser:launch', (_browser, launchOptions) => {
-                launchOptions.args.push('--js-flags=--max-old-space-size=4000');
+                launchOptions.args.push('--js-flags=--max-old-space-size=3000');
 
                 return launchOptions;
             });

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -21,8 +21,15 @@ export default defineConfig({
             'analytics.lightdash.com',
         ],
         trashAssetsBeforeRuns: true,
+        experimentalMemoryManagement: true,
         setupNodeEvents(on, config) {
             cypressSplit(on, config);
+
+            on('before:browser:launch', (_browser, launchOptions) => {
+                launchOptions.args.push('--js-flags=--max-old-space-size=3500');
+
+                return launchOptions;
+            });
 
             // Delete videos for specs without failing or retried tests
             // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         ],
         trashAssetsBeforeRuns: true,
         experimentalMemoryManagement: true,
+        numTestsKeptInMemory: 0,
         setupNodeEvents(on, config) {
             cypressSplit(on, config);
 

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
             cypressSplit(on, config);
 
             on('before:browser:launch', (_browser, launchOptions) => {
-                launchOptions.args.push('--js-flags=--max-old-space-size=3500');
+                launchOptions.args.push('--js-flags=--max-old-space-size=4000');
 
                 return launchOptions;
             });

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -25,8 +25,19 @@ export default defineConfig({
         setupNodeEvents(on, config) {
             cypressSplit(on, config);
 
-            on('before:browser:launch', (_browser, launchOptions) => {
-                launchOptions.args.push('--js-flags=--max-old-space-size=3000');
+            on('before:browser:launch', (browser, launchOptions) => {
+                if (['chrome', 'edge'].includes(browser.name)) {
+                    if (browser.isHeadless) {
+                        launchOptions.args.push('--no-sandbox');
+                        launchOptions.args.push(
+                            '--disable-gl-drawing-for-tests',
+                        );
+                        launchOptions.args.push('--disable-gpu');
+                    }
+                    launchOptions.args.push(
+                        '--js-flags=--max-old-space-size=3500',
+                    );
+                }
 
                 return launchOptions;
             });

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
                         );
                         launchOptions.args.push('--disable-gpu');
                     }
+
                     launchOptions.args.push(
                         '--js-flags=--max-old-space-size=3500',
                     );

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -3,7 +3,8 @@ import cypressSplit from 'cypress-split';
 import { unlinkSync } from 'fs';
 
 export default defineConfig({
-    viewportWidth: 1080,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
     defaultCommandTimeout: 10000,
     retries: {
         runMode: 2,

--- a/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
@@ -31,6 +31,7 @@ describe('SQL Runner (new)', () => {
 
     it('Should verify that the query is autocompleted, run, and the results are displayed', () => {
         // Verify the autocomplete SQL query
+        cy.get('.monaco-editor').should('be.visible');
         cy.contains('jaffle').click().wait(500);
         cy.contains('orders').click();
         cy.contains(
@@ -92,6 +93,7 @@ describe('SQL Runner (new)', () => {
         cy.contains('Run query').should('be.disabled');
 
         // Verify that the query is run
+        cy.get('.monaco-editor').should('be.visible');
         cy.contains('jaffle').click().wait(500);
         cy.contains('customers').click();
         cy.contains(
@@ -144,6 +146,7 @@ describe('SQL Runner (new)', () => {
         cy.contains('Run query').should('be.disabled');
 
         // Verify that the query is run
+        cy.get('.monaco-editor').should('be.visible');
         cy.contains('jaffle').click().wait(500);
         cy.contains('customers').click();
         cy.contains(
@@ -196,6 +199,7 @@ describe('SQL Runner (new)', () => {
         cy.contains('Run query').should('be.disabled');
 
         // Verify that the query is run
+        cy.get('.monaco-editor').should('be.visible');
         cy.contains('jaffle').click().wait(500);
         cy.contains('customers').click();
         cy.contains(
@@ -230,9 +234,8 @@ describe('SQL Runner (new)', () => {
 
         cy.contains('label', 'SQL').click();
         cy.get('.monaco-editor').should('be.visible');
-        cy.get('.monaco-editor').type('{selectall}{backspace}');
         cy.get('.monaco-editor')
-            .type(`SELECT * FROM "${schema}"."jaffle"."orders"`)
+            .type(`{selectall}{del}SELECT * FROM "${schema}"."jaffle"."orders"`)
             .wait(1000);
         cy.contains('Run query').click();
         cy.get('table thead th').eq(0).should('contain.text', 'order_id');
@@ -271,6 +274,7 @@ describe('SQL Runner (new)', () => {
         cy.contains('Run query').should('be.disabled');
 
         // Verify that the query is run
+        cy.get('.monaco-editor').should('be.visible');
         cy.contains('jaffle').click().wait(500);
         cy.contains('customers').click();
         cy.contains(

--- a/packages/e2e/dockerfile
+++ b/packages/e2e/dockerfile
@@ -1,4 +1,3 @@
-# https://github.com/cypress-io/cypress/issues/27415#issuecomment-2277464049
-FROM cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+FROM cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
 
 RUN apt-get update && apt-get install build-essential -y

--- a/packages/e2e/dockerfile
+++ b/packages/e2e/dockerfile
@@ -1,3 +1,4 @@
-FROM cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
+# https://github.com/cypress-io/cypress/issues/27415#issuecomment-2277464049
+FROM cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
 
 RUN apt-get update && apt-get install build-essential -y

--- a/packages/e2e/dockerfile
+++ b/packages/e2e/dockerfile
@@ -1,3 +1,3 @@
-FROM cypress/browsers:node-22.7.0-chrome-127.0.6533.119-1-ff-129.0.1-edge-127.0.2651.98-1
+FROM cypress/browsers:node-20.17.0-chrome-129.0.6668.70-1-ff-130.0.1-edge-129.0.2792.52-1
 
 RUN apt-get update && apt-get install build-essential -y

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -4,6 +4,7 @@ import {
     ChartSourceType,
     DashboardTileTypes,
     defaultTileSize,
+    type ChartContent,
     type Dashboard,
 } from '@lightdash/common';
 import {
@@ -20,7 +21,7 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconChartAreaLine } from '@tabler/icons-react';
-import React, { forwardRef, useMemo, type FC } from 'react';
+import React, { forwardRef, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';
@@ -35,24 +36,34 @@ type Props = {
 
 interface ItemProps extends React.ComponentPropsWithoutRef<'div'> {
     label: string;
-    description?: string;
     chartKind: ChartKind;
+    tooltipLabel?: string;
+    disabled?: boolean;
 }
 
 const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
-    ({ label, description, chartKind, ...others }: ItemProps, ref) => (
+    (
+        { label, tooltipLabel, chartKind, disabled, ...others }: ItemProps,
+        ref,
+    ) => (
         <div ref={ref} {...others}>
             <Stack spacing="one">
                 <Tooltip
-                    label={description}
-                    disabled={!description}
+                    label={tooltipLabel}
+                    disabled={!tooltipLabel}
                     position="top-start"
+                    withinPortal
                 >
                     <Group spacing="xs">
                         <ChartIcon
                             chartKind={chartKind ?? ChartKind.VERTICAL_BAR}
+                            color={disabled ? 'gray.5' : undefined}
                         />
-                        <Text c="gray.8" fw={500} fz="xs">
+                        <Text
+                            c={disabled ? 'gray.5' : 'gray.8'}
+                            fw={500}
+                            fz="xs"
+                        >
                             {label}
                         </Text>
                     </Group>
@@ -105,6 +116,37 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
         );
     }, [dashboard?.tiles, form.values.savedChartsUuids, savedQueries]);
 
+    const isChartItemDisabled = useCallback(
+        (chart: ChartContent) => {
+            const chartSourceType = chart.source;
+
+            if (currentChartTypes.length === 0) {
+                return true;
+            }
+
+            switch (chartSourceType) {
+                case ChartSourceType.DBT_EXPLORE:
+                case ChartSourceType.SQL:
+                    return currentChartTypes.includes(
+                        DashboardTileTypes.SEMANTIC_VIEWER_CHART,
+                    );
+                case ChartSourceType.SEMANTIC_LAYER:
+                    return (
+                        currentChartTypes.includes(
+                            DashboardTileTypes.SAVED_CHART,
+                        ) ||
+                        currentChartTypes.includes(DashboardTileTypes.SQL_CHART)
+                    );
+                default:
+                    return assertUnreachable(
+                        chartSourceType,
+                        `Unknown chart source type: ${chartSourceType}`,
+                    );
+            }
+        },
+        [currentChartTypes],
+    );
+
     const allSavedCharts = useMemo(() => {
         const reorderedCharts = savedQueries?.sort((chartA, chartB) =>
             chartA.space.uuid === dashboard?.spaceUuid
@@ -114,61 +156,40 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                 : 0,
         );
 
-        return (reorderedCharts || [])
-            .filter((chart) => {
-                const chartSourceType = chart.source;
-
-                if (currentChartTypes.length === 0) {
-                    return true;
-                }
-
-                switch (chartSourceType) {
-                    case ChartSourceType.DBT_EXPLORE:
-                    case ChartSourceType.SQL:
-                        return !currentChartTypes.includes(
-                            DashboardTileTypes.SEMANTIC_VIEWER_CHART,
-                        );
-                    case ChartSourceType.SEMANTIC_LAYER:
-                        return (
-                            !currentChartTypes.includes(
-                                DashboardTileTypes.SAVED_CHART,
-                            ) &&
-                            !currentChartTypes.includes(
-                                DashboardTileTypes.SQL_CHART,
-                            )
-                        );
-                    default:
-                        return assertUnreachable(
-                            chartSourceType,
-                            `Unknown chart source type: ${chartSourceType}`,
-                        );
-                }
-            })
-            .map(({ uuid, name, space, chartKind }) => {
-                const alreadyAddedChart = dashboardTiles?.find((tile) => {
-                    return (
-                        (tile.type === DashboardTileTypes.SAVED_CHART &&
-                            tile.properties.savedChartUuid === uuid) ||
-                        (tile.type === DashboardTileTypes.SQL_CHART &&
-                            tile.properties.savedSqlUuid === uuid) ||
-                        (tile.type ===
-                            DashboardTileTypes.SEMANTIC_VIEWER_CHART &&
-                            tile.properties.savedSemanticViewerChartUuid ===
-                                uuid)
-                    );
-                });
-
-                return {
-                    value: uuid,
-                    label: name,
-                    group: space.name,
-                    description: alreadyAddedChart
-                        ? 'This chart has already been added to this dashboard'
-                        : undefined,
-                    chartKind,
-                };
+        return (reorderedCharts || []).map((chart) => {
+            const { uuid, name, space, chartKind } = chart;
+            const isAlreadyAdded = dashboardTiles?.find((tile) => {
+                return (
+                    (tile.type === DashboardTileTypes.SAVED_CHART &&
+                        tile.properties.savedChartUuid === uuid) ||
+                    (tile.type === DashboardTileTypes.SQL_CHART &&
+                        tile.properties.savedSqlUuid === uuid) ||
+                    (tile.type === DashboardTileTypes.SEMANTIC_VIEWER_CHART &&
+                        tile.properties.savedSemanticViewerChartUuid === uuid)
+                );
             });
-    }, [currentChartTypes, savedQueries, dashboard?.spaceUuid, dashboardTiles]);
+
+            const disabled = isChartItemDisabled(chart);
+
+            return {
+                value: uuid,
+                label: name,
+                group: space.name,
+                tooltipLabel: disabled
+                    ? 'You cannot mix charts created from different semantic layer connections on a dashboard'
+                    : isAlreadyAdded
+                    ? 'This chart has already been added to this dashboard'
+                    : undefined,
+                chartKind,
+                disabled,
+            };
+        });
+    }, [
+        savedQueries,
+        dashboard?.spaceUuid,
+        dashboardTiles,
+        isChartItemDisabled,
+    ]);
 
     const handleSubmit = form.onSubmit(({ savedChartsUuids }) => {
         onAddTiles(

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -60,7 +60,7 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
                             color={disabled ? 'gray.5' : undefined}
                         />
                         <Text
-                            c={disabled ? 'gray.5' : 'gray.8'}
+                            c={disabled ? 'dimmed' : 'gray.8'}
                             fw={500}
                             fz="xs"
                         >

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -121,7 +121,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
             const chartSourceType = chart.source;
 
             if (currentChartTypes.length === 0) {
-                return true;
+                return false;
             }
 
             switch (chartSourceType) {

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -24,7 +24,14 @@ import {
     IconLayoutDashboard,
     IconPlus,
 } from '@tabler/icons-react';
-import { forwardRef, useCallback, useMemo, useState, type FC } from 'react';
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type FC,
+} from 'react';
 import { v4 as uuid4 } from 'uuid';
 import { useSavedSemanticViewerChart } from '../../features/semanticViewer/api/hooks';
 import { useSavedSqlChart } from '../../features/sqlRunner/hooks/useSavedSqlCharts';
@@ -68,7 +75,7 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
                 position="top-start"
                 withinPortal
             >
-                <Text c={disabled ? 'gray.5' : 'gray.8'} fw={500} fz="xs">
+                <Text c={disabled ? 'dimmed' : 'gray.8'} fw={500} fz="xs">
                     {label}
                 </Text>
             </Tooltip>
@@ -270,7 +277,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
 
     const form = useForm({
         initialValues: {
-            dashboardUuid: undefined, // ? Needs to be undefined so that default value in select can be set
+            dashboardUuid: '',
             dashboardName: '',
             dashboardDescription: '',
             spaceUuid: currentSpace?.uuid ?? '',
@@ -357,13 +364,13 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
         [currentSpace?.uuid, dashboardSelectItems],
     );
 
-    if (
-        isLoadingDashboards ||
-        !dashboards ||
-        isLoadingSpaces ||
-        !spaces ||
-        !defaultSelectValue
-    ) {
+    useEffect(() => {
+        if (defaultSelectValue) {
+            form.setValues({ dashboardUuid: defaultSelectValue });
+        }
+    });
+
+    if (isLoadingDashboards || !dashboards || isLoadingSpaces || !spaces) {
         return null;
     }
 
@@ -395,7 +402,6 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                 id="select-dashboard"
                                 label="Select a dashboard"
                                 data={dashboardSelectItems}
-                                defaultValue={defaultSelectValue}
                                 searchable
                                 nothingFound="No matching dashboards found"
                                 filter={(value, dashboard) =>

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -365,10 +365,10 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     );
 
     useEffect(() => {
-        if (defaultSelectValue) {
+        if (defaultSelectValue && !form.values.dashboardUuid) {
             form.setValues({ dashboardUuid: defaultSelectValue });
         }
-    });
+    }, [defaultSelectValue, form]);
 
     if (isLoadingDashboards || !dashboards || isLoadingSpaces || !spaces) {
         return null;

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     DashboardTileTypes,
     getDefaultChartTileSize,
+    type Dashboard,
     type DashboardTile,
 } from '@lightdash/common';
 import {
@@ -11,9 +12,11 @@ import {
     Modal,
     Select,
     Stack,
+    Text,
     Textarea,
     TextInput,
     Title,
+    Tooltip,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import {
@@ -21,12 +24,14 @@ import {
     IconLayoutDashboard,
     IconPlus,
 } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { forwardRef, useCallback, useMemo, useState, type FC } from 'react';
+import { useAsync } from 'react-use';
 import { v4 as uuid4 } from 'uuid';
 import { useSavedSemanticViewerChart } from '../../features/semanticViewer/api/hooks';
 import { useSavedSqlChart } from '../../features/sqlRunner/hooks/useSavedSqlCharts';
 import {
     appendNewTilesToBottom,
+    getDashboard,
     useCreateMutation,
     useDashboardQuery,
     useUpdateDashboard,
@@ -46,6 +51,32 @@ interface AddTilesToDashboardModalProps {
     dashboardTileType: DashboardTileTypes;
     onClose?: () => void;
 }
+
+interface ItemProps extends React.ComponentPropsWithoutRef<'div'> {
+    label: string;
+    value: string;
+    disabled?: boolean;
+    spaceUuid: string;
+}
+
+const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
+    ({ label, disabled, ...others }: ItemProps, ref) => (
+        <div ref={ref} {...others}>
+            <Tooltip
+                label={
+                    'Dashboard has charts created from a different semantic layer connection'
+                }
+                disabled={!disabled}
+                position="top-start"
+                withinPortal
+            >
+                <Text c={disabled ? 'gray.5' : 'gray.8'} fw={500} fz="xs">
+                    {label}
+                </Text>
+            </Tooltip>
+        </div>
+    ),
+);
 
 const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     isOpen,
@@ -184,6 +215,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
             },
             true, // includePrivateSpaces
         );
+
     const { data: spaces, isInitialLoading: isLoadingSpaces } =
         useSpaceSummaries(projectUuid, true, {
             staleTime: 0,
@@ -196,11 +228,60 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
 
     const currentSpace = spaces?.find((s) => s.uuid === tile?.props.spaceUuid);
 
+    const isDashboardSelectItemDisabled = useCallback(
+        (dashboard: Dashboard) => {
+            const allDashboardTileTypes = Array.from(
+                new Set(dashboard.tiles.map((t) => t.type)),
+            );
+
+            switch (dashboardTileType) {
+                case DashboardTileTypes.SAVED_CHART:
+                case DashboardTileTypes.SQL_CHART:
+                    return allDashboardTileTypes.includes(
+                        DashboardTileTypes.SEMANTIC_VIEWER_CHART,
+                    );
+                case DashboardTileTypes.SEMANTIC_VIEWER_CHART:
+                    return (
+                        allDashboardTileTypes.includes(
+                            DashboardTileTypes.SAVED_CHART,
+                        ) ||
+                        allDashboardTileTypes.includes(
+                            DashboardTileTypes.SQL_CHART,
+                        )
+                    );
+                case DashboardTileTypes.LOOM:
+                case DashboardTileTypes.MARKDOWN:
+                    return false;
+                default:
+                    return assertUnreachable(
+                        dashboardTileType,
+                        `Unknown tile type: ${dashboardTileType}`,
+                    );
+            }
+        },
+        [dashboardTileType],
+    );
+
+    // ! Don't really like this here, it is suposed to be temporary until we make semantic layer a type of project connection
+    const dashboardsWithTiles = useAsync(() => {
+        return Promise.all(dashboards?.map((d) => getDashboard(d.uuid)) ?? []);
+    }, [dashboards]);
+
+    const dashboardSelectItems = useMemo(() => {
+        return (
+            dashboardsWithTiles?.value?.map<ItemProps>((d) => ({
+                value: d.uuid,
+                label: d.name,
+                group: spaces?.find((s) => s.uuid === d.spaceUuid)?.name,
+                disabled: isDashboardSelectItemDisabled(d),
+                spaceUuid: d.spaceUuid, // ? Adding spaceUuid here for simplicity of selecting the default value in the select
+            })) ?? []
+        );
+    }, [dashboardsWithTiles?.value, isDashboardSelectItemDisabled, spaces]);
+
     const form = useForm({
         initialValues: {
-            dashboardUuid:
-                dashboards?.find((d) => d.spaceUuid === currentSpace?.uuid)
-                    ?.uuid ?? '',
+            dashboardUuid: undefined, // ? Needs to be undefined so that default value in select can be set
             dashboardName: '',
             dashboardDescription: '',
             spaceUuid: currentSpace?.uuid ?? '',
@@ -279,7 +360,21 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
         },
     );
 
-    if (isLoadingDashboards || !dashboards || isLoadingSpaces || !spaces) {
+    const defaultSelectValue = useMemo(
+        () =>
+            dashboardSelectItems.find(
+                (d) => d.spaceUuid === currentSpace?.uuid && !d.disabled,
+            )?.value,
+        [currentSpace?.uuid, dashboardSelectItems],
+    );
+
+    if (
+        isLoadingDashboards ||
+        !dashboards ||
+        isLoadingSpaces ||
+        !spaces ||
+        !defaultSelectValue
+    ) {
         return null;
     }
 
@@ -310,19 +405,8 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                             <Select
                                 id="select-dashboard"
                                 label="Select a dashboard"
-                                data={dashboards.map((d) => ({
-                                    value: d.uuid,
-                                    label: d.name,
-                                    group: spaces.find(
-                                        (s) => s.uuid === d.spaceUuid,
-                                    )?.name,
-                                }))}
-                                defaultValue={
-                                    dashboards.find(
-                                        (d) =>
-                                            d.spaceUuid === currentSpace?.uuid,
-                                    )?.uuid
-                                }
+                                data={dashboardSelectItems}
+                                defaultValue={defaultSelectValue}
                                 searchable
                                 nothingFound="No matching dashboards found"
                                 filter={(value, dashboard) =>
@@ -332,6 +416,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                                 }
                                 withinPortal
                                 required
+                                itemComponent={SelectItem}
                                 {...form.getInputProps('dashboardUuid')}
                             />
                             <Anchor

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -100,12 +100,13 @@ export const getChartIcon = (chartKind: ChartKind | undefined) => {
     }
 };
 
-export const ChartIcon: FC<{ chartKind: ChartKind | undefined }> = ({
-    chartKind,
-}) => (
+export const ChartIcon: FC<{
+    chartKind: ChartKind | undefined;
+    color?: string;
+}> = ({ chartKind, color }) => (
     <IconBox
         icon={getChartIcon(chartKind)}
-        color="blue.8"
+        color={color ?? 'blue.8'}
         transform={
             chartKind === ChartKind.HORIZONTAL_BAR ? 'rotate(90)' : undefined
         }

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -21,7 +21,7 @@ import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 import useQueryError from '../useQueryError';
 
-export const getDashboard = async (id: string) =>
+const getDashboard = async (id: string) =>
     lightdashApi<Dashboard>({
         url: `/dashboards/${id}`,
         method: 'GET',

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -21,7 +21,7 @@ import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 import useQueryError from '../useQueryError';
 
-const getDashboard = async (id: string) =>
+export const getDashboard = async (id: string) =>
     lightdashApi<Dashboard>({
         url: `/dashboards/${id}`,
         method: 'GET',

--- a/packages/frontend/src/hooks/dashboard/useDashboards.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboards.tsx
@@ -1,6 +1,6 @@
 import {
     type ApiError,
-    type DashboardBasicDetails,
+    type DashboardBasicDetailsWithTileTypes,
     type UpdateMultipleDashboards,
 } from '@lightdash/common';
 import {
@@ -17,7 +17,7 @@ const getDashboards = async (
     projectUuid: string,
     includePrivateSpaces: boolean,
 ) =>
-    lightdashApi<DashboardBasicDetails[]>({
+    lightdashApi<DashboardBasicDetailsWithTileTypes[]>({
         url: `/projects/${projectUuid}/dashboards?includePrivate=${includePrivateSpaces}`,
         method: 'GET',
         body: undefined,
@@ -28,7 +28,7 @@ const getDashboardsContainingChart = async (
     chartId: string,
     includePrivate: boolean,
 ) =>
-    lightdashApi<DashboardBasicDetails[]>({
+    lightdashApi<DashboardBasicDetailsWithTileTypes[]>({
         url: `/projects/${projectUuid}/dashboards?chartUuid=${chartId}&includePrivate=${includePrivate}`,
         method: 'GET',
         body: undefined,
@@ -36,12 +36,15 @@ const getDashboardsContainingChart = async (
 
 export const useDashboards = (
     projectUuid: string,
-    useQueryOptions?: UseQueryOptions<DashboardBasicDetails[], ApiError>,
+    useQueryOptions?: UseQueryOptions<
+        DashboardBasicDetailsWithTileTypes[],
+        ApiError
+    >,
     includePrivateSpaces: boolean = false,
 ) => {
     const setErrorResponse = useQueryError();
 
-    return useQuery<DashboardBasicDetails[], ApiError>(
+    return useQuery<DashboardBasicDetailsWithTileTypes[], ApiError>(
         ['dashboards', projectUuid, includePrivateSpaces],
         () => getDashboards(projectUuid, includePrivateSpaces),
         {
@@ -60,7 +63,7 @@ export const useDashboardsContainingChart = (
     includePrivate = true,
 ) => {
     const setErrorResponse = useQueryError();
-    return useQuery<DashboardBasicDetails[], ApiError>({
+    return useQuery<DashboardBasicDetailsWithTileTypes[], ApiError>({
         queryKey: [
             'dashboards-containing-chart',
             projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11726 

### Description:

- Disables dashboard select items when dashboard has tiles from a different semantic layer (adding charts via chart view/list menus)
- Disables chart select items when dashboard has tiles from a different semantic layer (adding charts from dashboard view)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
