### PR TITLE
feat: semantic layer config loading and success states

### DIFF
--- a/packages/frontend/src/components/SettingsSemanticLayer/DbtSemanticLayerForm.tsx
+++ b/packages/frontend/src/components/SettingsSemanticLayer/DbtSemanticLayerForm.tsx
@@ -71,6 +71,7 @@ const DbtSemanticLayerForm: FC<Props> = ({
         <form onSubmit={form.onSubmit(onSubmit)}>
             <Stack>
                 <PasswordInput
+                    autoComplete="off"
                     {...form.getInputProps('token')}
                     placeholder={
                         semanticLayerConnection ? '**************' : undefined

--- a/packages/frontend/src/components/SettingsSemanticLayer/index.tsx
+++ b/packages/frontend/src/components/SettingsSemanticLayer/index.tsx
@@ -2,6 +2,7 @@ import { assertUnreachable, SemanticLayerType } from '@lightdash/common';
 import { Stack, Text, Title } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { z } from 'zod';
+import useToaster from '../../hooks/toaster/useToaster';
 import {
     useProject,
     useProjectSemanticLayerUpdateMutation,
@@ -26,10 +27,16 @@ interface Props {
 //     },
 // ];
 
+const SemanticLayerLabels: Record<SemanticLayerType, string> = {
+    [SemanticLayerType.CUBE]: 'Cube',
+    [SemanticLayerType.DBT]: 'dbt',
+};
+
 const formSchemas = z.union([dbtSemanticLayerFormSchema, z.never()]);
 
 const SettingsSemanticLayer: FC<Props> = ({ projectUuid }) => {
     const { data } = useProject(projectUuid);
+    const { showToastSuccess } = useToaster();
 
     const [semanticLayerType] = useState<SemanticLayerType>(
         data?.semanticLayerConnection?.type ?? SemanticLayerType.DBT,
@@ -41,6 +48,11 @@ const SettingsSemanticLayer: FC<Props> = ({ projectUuid }) => {
         connectionData: z.infer<typeof formSchemas>,
     ) => {
         await projectMutation.mutateAsync(connectionData);
+
+        showToastSuccess({
+            title: `Successfully updated project's semantic layer connection with ${SemanticLayerLabels[semanticLayerType]} credentials.`,
+        });
+
         return false;
     };
 
@@ -64,7 +76,7 @@ const SettingsSemanticLayer: FC<Props> = ({ projectUuid }) => {
 
                 {semanticLayerType === SemanticLayerType.DBT ? (
                     <DbtSemanticLayerForm
-                        isLoading={false}
+                        isLoading={projectMutation.isLoading}
                         onSubmit={handleSubmit}
                         semanticLayerConnection={
                             semanticLayerType ===


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:


https://github.com/user-attachments/assets/3c9b0789-9844-4c4f-9e15-b0f9ea33b5fb




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
