### PR TITLE
docs: Update chart-types.mdx

### DIFF
--- a/docs/docs/references/chart-types.mdx
+++ b/docs/docs/references/chart-types.mdx
@@ -187,7 +187,7 @@ You can add subtotals to your tables by selecting `Show subtotals` in the chart 
 
 Subtotals are only calculated for `count` and `sum` metrics. Other metric types or table calculations are not supported yet.
 
-To use subtotals, you need to have at least 2 or more dimensions in your table visualization. You cannot use subtotals on a pivoted table.
+To use subtotals, you need to have at least 2 or more dimensions in your table visualization.
 
 #### Locking columns from scroll
 


### PR DESCRIPTION
removes sentence saying that subtotals don't work on pivot tables. 