### PR TITLE
test: fix sql runner redirect in `explore.cy.ts`

### DIFF
--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -372,22 +372,26 @@ describe('Explore', () => {
                 cy.url().should('include', '/sql-runner');
                 cy.get('.monaco-editor').should('exist');
 
-                // get SQL query from SQL Runner and verify it's the same as the one from Explore
-                cy.get('.view-lines')
-                    .invoke('text')
-                    .then((sqlRunnerText) => {
-                        const normalizedExploreQuery = sqlQueryFromExploreLines
-                            .join('')
-                            .replace(/\s+/g, ' ')
-                            .trim();
-                        const normalizedRunnerQuery = sqlRunnerText
-                            .replace(/\s+/g, ' ')
-                            .trim();
+                // Get the entire SQL query from the Monaco editor
+                cy.window().then((win: any) => {
+                    expect(win.monaco).to.be.an('object');
+                    const editor = win.monaco.editor.getModels()[0];
+                    const sqlRunnerText = editor.getValue();
 
-                        expect(normalizedRunnerQuery).to.equal(
-                            normalizedExploreQuery,
-                        );
-                    });
+                    const normalizeQuery = (query: string) =>
+                        query
+                            .replace(/\s+/g, '') // Remove all whitespace
+                            .toLowerCase(); // Convert to lowercase for case-insensitive comparison
+
+                    const normalizedExploreQuery = normalizeQuery(
+                        sqlQueryFromExploreLines.join(''),
+                    );
+                    const normalizedRunnerQuery = normalizeQuery(sqlRunnerText);
+
+                    expect(normalizedRunnerQuery).to.equal(
+                        normalizedExploreQuery,
+                    );
+                });
             });
     });
 

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -372,7 +372,8 @@ describe('Explore', () => {
                 cy.url().should('include', '/sql-runner');
                 cy.get('.monaco-editor').should('exist');
 
-                // Get the entire SQL query from the Monaco editor
+                // Get the entire SQL query from the Monaco editor instance
+                // NOTE: This is probably the most reliable way to get the SQL query from the Monaco editor, without having to target specific classes/ids
                 cy.window().then((win: any) => {
                     expect(win.monaco).to.be.an('object');
                     const editor = win.monaco.editor.getModels()[0];

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -356,7 +356,6 @@ describe('Explore', () => {
         cy.findByText('Open in SQL Runner').parent().should('not.be.disabled');
 
         let sqlQueryFromExploreLines;
-        const sqlQueryFromSqlRunnerLines: string[] = [];
 
         // Get compiled SQL query from Explore
         cy.get('.mantine-Prism-root')
@@ -368,26 +367,25 @@ describe('Explore', () => {
                     .map((el) => (el.innerText === '\n' ? '' : el.innerText));
             })
             .then(() => {
-                // open SQL Runner
+                // open SQL Runner and wait for route change
                 cy.findByText('Open in SQL Runner').parent().click();
-                // wait for URL to change to be in SQL Runner
-                cy.url().should('include', '/sqlRunner');
-                cy.get('.ace_content').should('exist');
+                cy.url().should('include', '/sql-runner');
+                cy.get('.monaco-editor').should('exist');
 
-                // Get SQL query from SQL Runner editor
-                cy.get('.ace_line')
-                    .each(($el) => {
-                        sqlQueryFromSqlRunnerLines.push($el.text());
-                    })
-                    .then(() => {
-                        // compare SQL query from the Explore with the one in SQL Runner
-                        cy.get('.ace_line').should(
-                            'have.length',
-                            sqlQueryFromExploreLines?.length,
-                        );
-                        cy.wrap(sqlQueryFromSqlRunnerLines).should(
-                            'deep.equal',
-                            sqlQueryFromExploreLines,
+                // get SQL query from SQL Runner and verify it's the same as the one from Explore
+                cy.get('.view-lines')
+                    .invoke('text')
+                    .then((sqlRunnerText) => {
+                        const normalizedExploreQuery = sqlQueryFromExploreLines
+                            .join('')
+                            .replace(/\s+/g, ' ')
+                            .trim();
+                        const normalizedRunnerQuery = sqlRunnerText
+                            .replace(/\s+/g, ' ')
+                            .trim();
+
+                        expect(normalizedRunnerQuery).to.equal(
+                            normalizedExploreQuery,
                         );
                     });
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Gets sql from explore and from the new sql runner and then compares them

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-cli  
test-frontend  
test-backend