### PR TITLE
fix: persist virtual views when refreshing dbt

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -21,7 +21,6 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { CsvService } from '../services/CsvService/CsvService';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2546,6 +2546,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExploreType: {
+        dataType: 'refEnum',
+        enums: ['custom', 'default'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Explore.SummaryExploreFields_': {
         dataType: 'refAlias',
         type: {
@@ -2554,6 +2559,7 @@ const models: TsoaRoute.Models = {
                 name: { dataType: 'string', required: true },
                 label: { dataType: 'string', required: true },
                 groupLabel: { dataType: 'string' },
+                type: { ref: 'ExploreType' },
                 tags: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -2585,6 +2591,7 @@ const models: TsoaRoute.Models = {
                 name: { dataType: 'string', required: true },
                 label: { dataType: 'string', required: true },
                 groupLabel: { dataType: 'string' },
+                type: { ref: 'ExploreType' },
                 tags: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -2813,6 +2820,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                type: { ref: 'ExploreType' },
                 sqlPath: { dataType: 'string' },
                 ymlPath: { dataType: 'string' },
                 warehouse: { dataType: 'string' },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2548,7 +2548,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExploreType: {
         dataType: 'refEnum',
-        enums: ['custom', 'default'],
+        enums: ['virtual', 'default'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Explore.SummaryExploreFields_': {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2770,6 +2770,10 @@
                 "required": ["status"],
                 "type": "object"
             },
+            "ExploreType": {
+                "enum": ["custom", "default"],
+                "type": "string"
+            },
             "Pick_Explore.SummaryExploreFields_": {
                 "properties": {
                     "name": {
@@ -2780,6 +2784,9 @@
                     },
                     "groupLabel": {
                         "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ExploreType"
                     },
                     "tags": {
                         "items": {
@@ -2817,6 +2824,9 @@
                     },
                     "groupLabel": {
                         "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ExploreType"
                     },
                     "tags": {
                         "items": {
@@ -3049,6 +3059,9 @@
             },
             "Explore": {
                 "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/ExploreType"
+                    },
                     "sqlPath": {
                         "type": "string"
                     },
@@ -10184,7 +10197,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1290.0",
+        "version": "0.1292.2",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2771,7 +2771,7 @@
                 "type": "object"
             },
             "ExploreType": {
-                "enum": ["custom", "default"],
+                "enum": ["virtual", "default"],
                 "type": "string"
             },
             "Pick_Explore.SummaryExploreFields_": {
@@ -10197,7 +10197,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1292.2",
+        "version": "0.1293.2",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -1,9 +1,9 @@
+import { ExploreType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import isEqual from 'lodash/isEqual';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
-import { CatalogTableName } from '../../database/entities/catalog';
 import {
     CachedExploresTableName,
     CachedExploreTableName,
@@ -106,6 +106,16 @@ describe('ProjectModel', () => {
 
     describe('saveExploresToCache', () => {
         test('should discard explores with duplicate name', async () => {
+            // Mock for selecting custom explores/virtual views
+            tracker.on
+                .select(
+                    queryMatcher(CachedExploreTableName, [
+                        projectUuid,
+                        ExploreType.CUSTOM,
+                    ]),
+                )
+                .response([]);
+
             tracker.on
                 .delete(queryMatcher(CachedExploreTableName, [projectUuid]))
                 .response([]);
@@ -129,6 +139,8 @@ describe('ProjectModel', () => {
                 .response([]);
 
             await model.saveExploresToCache(projectUuid, exploresWithSameName);
+
+            expect(tracker.history.select).toHaveLength(1);
             expect(tracker.history.delete).toHaveLength(1);
             expect(tracker.history.insert).toHaveLength(2);
         });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -111,7 +111,7 @@ describe('ProjectModel', () => {
                 .select(
                     queryMatcher(CachedExploreTableName, [
                         projectUuid,
-                        ExploreType.CUSTOM,
+                        ExploreType.VIRTUAL,
                     ]),
                 )
                 .response([]);

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -948,7 +948,7 @@ export class ProjectModel {
 
                 // We don't support multiple explores with the same name at the moment
                 const uniqueExplores = uniqWith(
-                    explores,
+                    [...explores, ...customExplores.map((e) => e.explore)],
                     (a, b) => a.name === b.name,
                 );
 
@@ -984,10 +984,7 @@ export class ProjectModel {
                 )
                     .insert({
                         project_uuid: projectUuid,
-                        explores: JSON.stringify([
-                            ...uniqueExplores,
-                            ...customExplores.map((e) => e.explore),
-                        ]),
+                        explores: JSON.stringify(uniqueExplores),
                     })
                     .onConflict('project_uuid')
                     .merge()

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -939,7 +939,7 @@ export class ProjectModel {
                 )
                     .select('explore')
                     .where('project_uuid', projectUuid)
-                    .whereRaw("explore->>'type' = ?", [ExploreType.CUSTOM]);
+                    .whereRaw("explore->>'type' = ?", [ExploreType.VIRTUAL]);
 
                 // delete previous individually cached explores
                 await this.database(CachedExploreTableName)

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -2,6 +2,7 @@ import {
     DashboardSearchResult,
     Explore,
     ExploreError,
+    ExploreType,
     FieldSearchResult,
     hasIntersection,
     isDimension,
@@ -438,14 +439,18 @@ export class SearchModel {
             return explores[0].explores.filter(
                 (explore: Explore | ExploreError) => {
                     if (tableSelection.type === TableSelectionType.WITH_TAGS) {
-                        return hasIntersection(
-                            explore.tags || [],
-                            tableSelection.value || [],
+                        return (
+                            hasIntersection(
+                                explore.tags || [],
+                                tableSelection.value || [],
+                            ) || explore.type === ExploreType.CUSTOM
                         );
                     }
                     if (tableSelection.type === TableSelectionType.WITH_NAMES) {
-                        return (tableSelection.value || []).includes(
-                            explore.name,
+                        return (
+                            (tableSelection.value || []).includes(
+                                explore.name,
+                            ) || explore.type === ExploreType.CUSTOM
                         );
                     }
                     return true;

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -443,14 +443,14 @@ export class SearchModel {
                             hasIntersection(
                                 explore.tags || [],
                                 tableSelection.value || [],
-                            ) || explore.type === ExploreType.CUSTOM
+                            ) || explore.type === ExploreType.VIRTUAL
                         );
                     }
                     if (tableSelection.type === TableSelectionType.WITH_NAMES) {
                         return (
                             (tableSelection.value || []).includes(
                                 explore.name,
-                            ) || explore.type === ExploreType.CUSTOM
+                            ) || explore.type === ExploreType.VIRTUAL
                         );
                     }
                     return true;

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -106,15 +106,17 @@ export class CatalogService<
         explore: Pick<SummaryExplore, 'tags' | 'name'>,
     ) {
         // Optimization tip:
-        // Perhaps we should filter these in catalong on `index` rather than in real time (requires dbt refresh on table config changes)
+        // Perhaps we should filter these in catalog on `index` rather than in real time (requires dbt refresh on table config changes)
         const {
             tableSelection: { type, value },
         } = tablesConfiguration;
 
         if (type === TableSelectionType.WITH_TAGS) {
+            // TODO: Add support for custom explores - don't filter them out
             return hasIntersection(explore.tags || [], value || []);
         }
         if (type === TableSelectionType.WITH_NAMES) {
+            // TODO: Add support for custom explores - don't filter them out
             return (value || []).includes(explore.name);
         }
         return true;

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -3,7 +3,6 @@ import {
     ApiQueryResults,
     ChartKind,
     ChartType,
-    DbtCloudIDEProjectConfig,
     DbtProjectType,
     DefaultSupportedDbtVersion,
     DimensionType,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -8,6 +8,7 @@ import {
     DimensionType,
     Explore,
     ExploreError,
+    ExploreType,
     FieldType,
     Job,
     JobLabels,
@@ -63,6 +64,7 @@ export const validExplore: Explore = {
     label: 'valid_explore',
     tags: [],
     baseTable: 'a',
+    type: ExploreType.DEFAULT,
     joinedTables: [],
     tables: {
         a: {
@@ -171,6 +173,7 @@ export const expectedAllExploreSummary: SummaryExplore[] = [
         databaseName: validExplore.tables[validExplore.baseTable].database,
         schemaName: validExplore.tables[validExplore.baseTable].schema,
         description: validExplore.tables[validExplore.baseTable].description,
+        type: ExploreType.DEFAULT,
     },
     {
         name: exploreWithError.name,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -35,6 +35,7 @@ import {
     DownloadFileType,
     Explore,
     ExploreError,
+    ExploreType,
     FilterableDimension,
     FilterGroupItem,
     FilterOperator,
@@ -2826,6 +2827,7 @@ export class ProjectService extends BaseService {
                                 explore.tables[explore.baseTable].schema,
                             description:
                                 explore.tables[explore.baseTable].description,
+                            type: explore.type ?? ExploreType.DEFAULT,
                         },
                     ];
                 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2844,14 +2844,14 @@ export class ProjectService extends BaseService {
                 return allExploreSummaries.filter(
                     (explore) =>
                         hasIntersection(explore.tags || [], value || []) ||
-                        explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
+                        explore.type === ExploreType.VIRTUAL, // Custom explores/Virtual views are included by default
                 );
             }
             if (type === TableSelectionType.WITH_NAMES) {
                 return allExploreSummaries.filter(
                     (explore) =>
                         (value || []).includes(explore.name) ||
-                        explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
+                        explore.type === ExploreType.VIRTUAL, // Custom explores/Virtual views are included by default
                 );
             }
         }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2841,13 +2841,17 @@ export class ProjectService extends BaseService {
                 tableSelection: { type, value },
             } = await this.getTablesConfiguration(user, projectUuid);
             if (type === TableSelectionType.WITH_TAGS) {
-                return allExploreSummaries.filter((explore) =>
-                    hasIntersection(explore.tags || [], value || []),
+                return allExploreSummaries.filter(
+                    (explore) =>
+                        hasIntersection(explore.tags || [], value || []) ||
+                        explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
                 );
             }
             if (type === TableSelectionType.WITH_NAMES) {
-                return allExploreSummaries.filter((explore) =>
-                    (value || []).includes(explore.name),
+                return allExploreSummaries.filter(
+                    (explore) =>
+                        (value || []).includes(explore.name) ||
+                        explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
                 );
             }
         }

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -134,13 +134,13 @@ export class ValidationService extends BaseService {
                                         tag,
                                     ),
                                 )) ||
-                            explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
+                            explore.type === ExploreType.VIRTUAL, // Custom explores/Virtual views are included by default
                     );
                     const exploreIsSelectedWithTags = explore.tags?.some(
                         (tag) =>
                             tablesConfiguration.tableSelection.value?.includes(
                                 tag,
-                            ) || explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
+                            ) || explore.type === ExploreType.VIRTUAL, // Custom explores/Virtual views are included by default
                     );
                     return (
                         hasSelectedJoinedExploredWithTags ||
@@ -156,12 +156,12 @@ export class ValidationService extends BaseService {
                                 tablesConfiguration.tableSelection.value?.includes(
                                     e.name,
                                 )) ||
-                            explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
+                            explore.type === ExploreType.VIRTUAL, // Custom explores/Virtual views are included by default
                     );
                     const exploreIsSelected =
                         tablesConfiguration.tableSelection.value?.includes(
                             explore.name,
-                        ) || explore.type === ExploreType.CUSTOM; // Custom explores/Virtual views are included by default
+                        ) || explore.type === ExploreType.VIRTUAL; // Custom explores/Virtual views are included by default
 
                     return hasSelectedJoinedExplored || exploreIsSelected;
                 default:

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -9,6 +9,7 @@ import {
     DashboardTileTarget,
     Explore,
     ExploreError,
+    ExploreType,
     ForbiddenError,
     getFilterRules,
     getItemId,
@@ -125,20 +126,21 @@ export class ValidationService extends BaseService {
                 case TableSelectionType.WITH_TAGS:
                     const hasSelectedJoinedExploredWithTags = explores.some(
                         (e) =>
-                            e.joinedTables?.some(
+                            (e.joinedTables?.some(
                                 (jt) => jt.table === explore.name,
                             ) &&
-                            e.tags?.some((tag) =>
-                                tablesConfiguration.tableSelection.value?.includes(
-                                    tag,
-                                ),
-                            ),
+                                e.tags?.some((tag) =>
+                                    tablesConfiguration.tableSelection.value?.includes(
+                                        tag,
+                                    ),
+                                )) ||
+                            explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
                     );
                     const exploreIsSelectedWithTags = explore.tags?.some(
                         (tag) =>
                             tablesConfiguration.tableSelection.value?.includes(
                                 tag,
-                            ),
+                            ) || explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
                     );
                     return (
                         hasSelectedJoinedExploredWithTags ||
@@ -148,17 +150,18 @@ export class ValidationService extends BaseService {
                 case TableSelectionType.WITH_NAMES:
                     const hasSelectedJoinedExplored = explores.some(
                         (e) =>
-                            e.joinedTables?.some(
+                            (e.joinedTables?.some(
                                 (jt) => jt.table === explore.name,
                             ) &&
-                            tablesConfiguration.tableSelection.value?.includes(
-                                e.name,
-                            ),
+                                tablesConfiguration.tableSelection.value?.includes(
+                                    e.name,
+                                )) ||
+                            explore.type === ExploreType.CUSTOM, // Custom explores/Virtual views are included by default
                     );
                     const exploreIsSelected =
                         tablesConfiguration.tableSelection.value?.includes(
                             explore.name,
-                        );
+                        ) || explore.type === ExploreType.CUSTOM; // Custom explores/Virtual views are included by default
 
                     return hasSelectedJoinedExplored || exploreIsSelected;
                 default:

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -39,7 +39,7 @@ export type CompiledTable = TableBase & {
 };
 
 export enum ExploreType {
-    CUSTOM = 'custom',
+    VIRTUAL = 'virtual',
     DEFAULT = 'default',
 }
 

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -38,6 +38,11 @@ export type CompiledTable = TableBase & {
     uncompiledSqlWhere?: string;
 };
 
+export enum ExploreType {
+    CUSTOM = 'custom',
+    DEFAULT = 'default',
+}
+
 export type Explore = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
@@ -50,6 +55,7 @@ export type Explore = {
     warehouse?: string;
     ymlPath?: string;
     sqlPath?: string;
+    type?: ExploreType;
 };
 
 export enum InlineErrorType {
@@ -71,7 +77,7 @@ export const isExploreError = (
     explore: Explore | ExploreError,
 ): explore is ExploreError => 'errors' in explore;
 
-type SummaryExploreFields = 'name' | 'label' | 'tags' | 'groupLabel';
+type SummaryExploreFields = 'name' | 'label' | 'tags' | 'groupLabel' | 'type';
 type SummaryExploreErrorFields = SummaryExploreFields | 'errors';
 type SummaryExtraFields = {
     description?: string;

--- a/packages/common/src/utils/customExplore.ts
+++ b/packages/common/src/utils/customExplore.ts
@@ -1,5 +1,5 @@
 import { ExploreCompiler } from '../compiler/exploreCompiler';
-import { type Explore, type Table } from '../types/explore';
+import { ExploreType, type Explore, type Table } from '../types/explore';
 import {
     DimensionType,
     FieldType,
@@ -58,5 +58,8 @@ export const createCustomExplore = (
         targetDatabase: warehouseClient.getAdapterType(),
     });
 
-    return explore;
+    return {
+        ...explore,
+        type: ExploreType.CUSTOM,
+    };
 };

--- a/packages/common/src/utils/customExplore.ts
+++ b/packages/common/src/utils/customExplore.ts
@@ -60,6 +60,6 @@ export const createCustomExplore = (
 
     return {
         ...explore,
-        type: ExploreType.CUSTOM,
+        type: ExploreType.VIRTUAL,
     };
 };

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -89,7 +89,7 @@ const BasePanel = () => {
                                 acc[2],
                             ];
                         }
-                        if (explore.type === ExploreType.CUSTOM) {
+                        if (explore.type === ExploreType.VIRTUAL) {
                             return [acc[0], acc[1], [...acc[2], explore]];
                         }
                         return [acc[0], [...acc[1], explore], acc[2]];

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -182,11 +182,16 @@ const BasePanel = () => {
                                 />
                             ))}
 
-                        <Divider size={0.5} c="gray.5" my="xs" />
+                        {customUngroupedExplores.length ? (
+                            <>
+                                <Divider size={0.5} c="gray.5" my="xs" />
 
-                        <Text fw={500} fz="xs" c="gray.6" mb="xs">
-                            Virtual Views
-                        </Text>
+                                <Text fw={500} fz="xs" c="gray.6" mb="xs">
+                                    Virtual Views
+                                </Text>
+                            </>
+                        ) : null}
+
                         {customUngroupedExplores
                             .sort((a, b) => a.label.localeCompare(b.label))
                             .map((explore) => (

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -49,8 +49,6 @@ const BasePanel = () => {
     const [search, setSearch] = useState<string>('');
     const exploresResult = useExplores(projectUuid, true);
 
-    console.log({ exploresResult: exploresResult.data });
-
     const [exploreGroupMap, defaultUngroupedExplores, customUngroupedExplores] =
         useMemo(() => {
             const validSearch = search ? search.toLowerCase() : '';

--- a/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
+++ b/packages/frontend/src/components/ProjectTablesConfiguration/ProjectTablesConfiguration.tsx
@@ -239,7 +239,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                                             <DocumentationHelpButton href="https://docs.getdbt.com/reference/resource-configs/tags#examples" />
                                         </>
                                     }
-                                    description="Write a list of tags you want to include, separated by commas."
+                                    description="Write a list of tags you want to include, separated by commas. Virtual views are included by default."
                                     disabled={disabled}
                                 />
 
@@ -308,7 +308,7 @@ const ProjectTablesConfiguration: FC<Props> = ({ projectUuid, onSuccess }) => {
                                 <Radio
                                     value={TableSelectionType.WITH_NAMES}
                                     label="Show models in this list"
-                                    description="Write a list of models you want to include, separated by commas."
+                                    description="Write a list of models you want to include, separated by commas. Virtual views are included by default."
                                     disabled={disabled}
                                 />
 

--- a/packages/frontend/src/features/sqlRunner/components/CreateVirtualViewModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/CreateVirtualViewModal.tsx
@@ -115,6 +115,7 @@ export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
                         radius="md"
                         label="Name"
                         required
+                        // TODO - don't allow duplicate names
                         {...form.getInputProps('name')}
                     />
                 </Stack>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14751,7 +14751,7 @@ klona@^2.0.6:
 
 knex-mock-client@^1.11.0:
   version "1.11.0"
-  resolved "https://registry.npmjs.org/knex-mock-client/-/knex-mock-client-1.11.0.tgz"
+  resolved "https://registry.yarnpkg.com/knex-mock-client/-/knex-mock-client-1.11.0.tgz#356513462d19cf769ca2e92e4be033ff244b2238"
   integrity sha512-6Mf2jscz6XMVfk7Jhp7pnRe37HsupVfScPf8pyiL6X51B7sporDVQPra4oyj7Ea5ssuqE3XnVhRgUeP50+Yrog==
   dependencies:
     lodash.clonedeep "^4.5.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11749](https://github.com/lightdash/lightdash/issues/11749)

### Description:

This PR allows the persistence of `virtual views`/`custom explores` when the user refreshes dbt.
It also moved these below all _default_ explores

<img width="406" alt="Screenshot 2024-10-02 at 15 32 48" src="https://github.com/user-attachments/assets/4d9eb4c1-63e2-430f-a326-df665651ab95">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
