### PR TITLE
fix: Improve domain check in emails 

### DIFF
--- a/packages/common/src/utils/email.test.ts
+++ b/packages/common/src/utils/email.test.ts
@@ -1,0 +1,93 @@
+/* eslint-disable no-useless-escape */
+import { getEmailDomain } from './email';
+
+describe('getEmailDomain', () => {
+    it('should return the correct domain for a valid email', () => {
+        expect(getEmailDomain('user@example.com')).toBe('example.com');
+        expect(getEmailDomain('another.user@sub.domain.co.uk')).toBe(
+            'sub.domain.co.uk',
+        );
+    });
+
+    it('should convert the domain to lowercase', () => {
+        expect(getEmailDomain('user@EXAMPLE.COM')).toBe('example.com');
+        expect(getEmailDomain('user@Example.Com')).toBe('example.com');
+    });
+
+    it('should throw an error for emails containing whitespace', () => {
+        expect(() => getEmailDomain('user @example.com')).toThrow(
+            'Invalid email, contains whitespace',
+        );
+        expect(() => getEmailDomain(' user@example.com')).toThrow(
+            'Invalid email, contains whitespace',
+        );
+        expect(() => getEmailDomain('user@example.com ')).toThrow(
+            'Invalid email, contains whitespace',
+        );
+    });
+
+    it('should throw an error for emails without exactly one @ symbol', () => {
+        expect(() => getEmailDomain('userexample.com')).toThrow(
+            'Invalid email',
+        );
+        expect(() => getEmailDomain('user@example@com')).toThrow(
+            'Invalid email',
+        );
+    });
+
+    it('should handle email addresses with special characters in the local part', () => {
+        expect(getEmailDomain('user+tag@example.com')).toBe('example.com');
+        expect(getEmailDomain('user.name@example.com')).toBe('example.com');
+        expect(getEmailDomain('user-name@example.com')).toBe('example.com');
+    });
+
+    it('should correctly handle email addresses with multiple @ symbols', () => {
+        expect(() => getEmailDomain('user@domain.com@example.com')).toThrow(
+            'Invalid email',
+        );
+        expect(() => getEmailDomain('"user@domain.com"@example.com')).toThrow(
+            'Invalid email',
+        );
+        expect(() => getEmailDomain('"@domain.com@"@example.com')).toThrow(
+            'Invalid email',
+        );
+    });
+
+    it('should not be fooled by attempts to manipulate the domain extraction', () => {
+        expect(() =>
+            getEmailDomain('user@malicious.com@legitimate.org'),
+        ).toThrow('Invalid email');
+        expect(() =>
+            getEmailDomain('"@organization.com@"@attacker.com'),
+        ).toThrow('Invalid email');
+        expect(() =>
+            getEmailDomain('user+@company.com@personal.email'),
+        ).toThrow('Invalid email');
+    });
+
+    it('should throw an error for invalid email constructions', () => {
+        expect(() => getEmailDomain('user@@domain.com')).toThrow(
+            'Invalid email',
+        );
+        expect(() => getEmailDomain('@domain.com@')).toThrow('Invalid email');
+        expect(() => getEmailDomain('user@')).toThrow('Invalid email');
+    });
+
+    it('should handle complex but valid email addresses', () => {
+        // Unusual email without extra @
+        expect(
+            getEmailDomain(
+                '"very.(),:;<>[]".VERY."very\\"very".unusual"@strange.example.com',
+            ),
+        ).toBe('strange.example.com');
+        // Unusual email with extra @
+        expect(() =>
+            getEmailDomain(
+                '"very.(),:;<>[]".VERY."very@\\"very".unusual"@strange.example.com',
+            ),
+        ).toThrow('Invalid email');
+        expect(getEmailDomain("!#$%&'*+-/=?^_`{}|~@example.org")).toBe(
+            'example.org',
+        );
+    });
+});

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -4,7 +4,7 @@ export const getEmailDomain = (email: string): string => {
     }
 
     const domains = email.split('@');
-    if (domains.length !== 2) {
+    if (domains.length !== 2 || !domains[1]) {
         throw new Error(`Invalid email: ${email}`);
     }
     return domains[1].toLowerCase();

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -3,11 +3,11 @@ export const getEmailDomain = (email: string): string => {
         throw new Error(`Invalid email, contains whitespace: ${email}`);
     }
 
-    const domain = email.split('@')[1];
-    if (!domain) {
+    const domains = email.split('@');
+    if (domains.length !== 2) {
         throw new Error(`Invalid email: ${email}`);
     }
-    return domain.toLowerCase();
+    return domains[1].toLowerCase();
 };
 
 const EMAIL_PROVIDER_LIST = [


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash-internal-work/issues/2099

### Description:
This fixes a security vulnerability where malicious users could sign up with an account which could be classed as another organisations email, therefore joining that organization if the "let users with this domain" setting is enabled. As emails can contain more than one emails an email such as `"@organization.com@"@gmail.com` would with the old code be classed as organization.com

This bug hasn't been tested as I don't have a spare email server but in theory looking at this code there is no reason why this wouldn't work.

https://stackoverflow.com/questions/12355858/how-many-symbol-can-be-in-an-email-address

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
