### PR TITLE
feat: allow editing a virtual view in explore view

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -1,10 +1,12 @@
 import {
     ApiCompiledQueryResults,
+    ApiCreateCustomExplore,
     ApiErrorPayload,
     ApiExploreResults,
     ApiExploresResults,
     ApiSuccessEmpty,
     MetricQuery,
+    UpdateCustomExplorePayload,
 } from '@lightdash/common';
 import {
     Body,
@@ -183,6 +185,28 @@ export class ExploreController extends BaseController {
             status: 'ok',
             results: {
                 jobId,
+            },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('updateVirtualView')
+    @OperationId('UpdateVirtualView')
+    async UpdateVirtualView(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: UpdateCustomExplorePayload,
+    ): Promise<ApiCreateCustomExplore> {
+        this.setStatus(200);
+        const { name } = await this.services
+            .getProjectService()
+            .updateVirtualView(req.user!, projectUuid, body);
+
+        return {
+            status: 'ok',
+            results: {
+                name,
             },
         };
     }

--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -1,12 +1,10 @@
 import {
     ApiCompiledQueryResults,
-    ApiCreateCustomExplore,
     ApiErrorPayload,
     ApiExploreResults,
     ApiExploresResults,
     ApiSuccessEmpty,
     MetricQuery,
-    UpdateCustomExplorePayload,
 } from '@lightdash/common';
 import {
     Body,
@@ -185,28 +183,6 @@ export class ExploreController extends BaseController {
             status: 'ok',
             results: {
                 jobId,
-            },
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Post('updateVirtualView')
-    @OperationId('UpdateVirtualView')
-    async UpdateVirtualView(
-        @Path() projectUuid: string,
-        @Request() req: express.Request,
-        @Body() body: UpdateCustomExplorePayload,
-    ): Promise<ApiCreateCustomExplore> {
-        this.setStatus(200);
-        const { name } = await this.services
-            .getProjectService()
-            .updateVirtualView(req.user!, projectUuid, body);
-
-        return {
-            status: 'ok',
-            results: {
-                name,
             },
         };
     }

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -14,6 +14,7 @@ import {
     CreateVirtualViewPayload,
     SqlRunnerBody,
     SqlRunnerPivotQueryBody,
+    UpdateCustomExplorePayload,
     UpdateSqlChart,
 } from '@lightdash/common';
 import {
@@ -26,6 +27,7 @@ import {
     Patch,
     Path,
     Post,
+    Put,
     Query,
     Request,
     Response,
@@ -34,10 +36,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import {
-    getContextFromHeader,
-    getContextFromQueryOrHeader,
-} from '../analytics/LightdashAnalytics';
+import { getContextFromQueryOrHeader } from '../analytics/LightdashAnalytics';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -412,6 +411,28 @@ export class SqlRunnerController extends BaseController {
         return {
             status: 'ok',
             results: virtualViewName,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('update-virtualView')
+    @OperationId('UpdateVirtualView')
+    async UpdateVirtualView(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: UpdateCustomExplorePayload,
+    ): Promise<ApiCreateCustomExplore> {
+        this.setStatus(200);
+        const { name } = await this.services
+            .getProjectService()
+            .updateVirtualView(req.user!, projectUuid, body);
+
+        return {
+            status: 'ok',
+            results: {
+                name,
+            },
         };
     }
 

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -14,8 +14,8 @@ import {
     CreateVirtualViewPayload,
     SqlRunnerBody,
     SqlRunnerPivotQueryBody,
-    UpdateCustomExplorePayload,
     UpdateSqlChart,
+    UpdateVirtualViewPayload,
 } from '@lightdash/common';
 import {
     Body,
@@ -390,7 +390,7 @@ export class SqlRunnerController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
-    @Post('create-virtual-view')
+    @Post('virtual-view')
     @OperationId('createVirtualView')
     async createVirtualView(
         @Path() projectUuid: string,
@@ -416,22 +416,26 @@ export class SqlRunnerController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Put('update-virtualView')
-    @OperationId('UpdateVirtualView')
-    async UpdateVirtualView(
+    @Put('virtual-view/{name}')
+    @OperationId('updateVirtualView')
+    async updateVirtualView(
         @Path() projectUuid: string,
+        @Path() name: string,
         @Request() req: express.Request,
-        @Body() body: UpdateCustomExplorePayload,
-    ): Promise<ApiCreateCustomExplore> {
+        @Body() body: Omit<UpdateVirtualViewPayload, 'name'>,
+    ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
-        const { name } = await this.services
+        const { name: virtualViewName } = await this.services
             .getProjectService()
-            .updateVirtualView(req.user!, projectUuid, body);
+            .updateVirtualView(req.user!, projectUuid, {
+                ...body,
+                name,
+            });
 
         return {
             status: 'ok',
             results: {
-                name,
+                name: virtualViewName,
             },
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2860,6 +2860,73 @@ const models: TsoaRoute.Models = {
         type: { dataType: 'string', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Explore.name_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateCustomExplore: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Pick_Explore.name_', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizColumn: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'DimensionType' },
+                reference: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateCustomExplorePayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                columns: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'VizColumn' },
+                    required: true,
+                },
+                sql: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateCustomExplorePayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CreateCustomExplorePayload' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        exploreName: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GitRepo: {
         dataType: 'refAlias',
         type: {
@@ -10270,6 +10337,68 @@ export function RegisterRoutes(app: express.Router) {
                 }
 
                 const promise = controller.DownloadCsvFromExplore.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/updateVirtualView',
+        ...fetchMiddlewares<RequestHandler>(ExploreController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExploreController.prototype.UpdateVirtualView,
+        ),
+
+        async function ExploreController_UpdateVirtualView(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'UpdateCustomExplorePayload',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ExploreController>(
+                    ExploreController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.UpdateVirtualView.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2860,73 +2860,6 @@ const models: TsoaRoute.Models = {
         type: { dataType: 'string', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Explore.name_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiCreateCustomExplore: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'Pick_Explore.name_', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    VizColumn: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                type: { ref: 'DimensionType' },
-                reference: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateCustomExplorePayload: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                columns: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'VizColumn' },
-                    required: true,
-                },
-                sql: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UpdateCustomExplorePayload: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'CreateCustomExplorePayload' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        exploreName: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GitRepo: {
         dataType: 'refAlias',
         type: {
@@ -7510,6 +7443,31 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_UpdateVirtualViewPayload.Exclude_keyofUpdateVirtualViewPayload.name__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    sql: { dataType: 'string', required: true },
+                    columns: {
+                        dataType: 'array',
+                        array: { dataType: 'refAlias', ref: 'VizColumn' },
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_UpdateVirtualViewPayload.name_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_UpdateVirtualViewPayload.Exclude_keyofUpdateVirtualViewPayload.name__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGithubDbtWritePreview: {
         dataType: 'refAlias',
         type: {
@@ -10337,68 +10295,6 @@ export function RegisterRoutes(app: express.Router) {
                 }
 
                 const promise = controller.DownloadCsvFromExplore.apply(
-                    controller,
-                    validatedArgs as any,
-                );
-                promiseHandler(controller, promise, response, 200, next);
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    app.post(
-        '/api/v1/projects/:projectUuid/explores/updateVirtualView',
-        ...fetchMiddlewares<RequestHandler>(ExploreController),
-        ...fetchMiddlewares<RequestHandler>(
-            ExploreController.prototype.UpdateVirtualView,
-        ),
-
-        async function ExploreController_UpdateVirtualView(
-            request: any,
-            response: any,
-            next: any,
-        ) {
-            const args = {
-                projectUuid: {
-                    in: 'path',
-                    name: 'projectUuid',
-                    required: true,
-                    dataType: 'string',
-                },
-                req: {
-                    in: 'request',
-                    name: 'req',
-                    required: true,
-                    dataType: 'object',
-                },
-                body: {
-                    in: 'body',
-                    name: 'body',
-                    required: true,
-                    ref: 'UpdateCustomExplorePayload',
-                },
-            };
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = getValidatedArgs(args, request, response);
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<ExploreController>(
-                    ExploreController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                const promise = controller.UpdateVirtualView.apply(
                     controller,
                     validatedArgs as any,
                 );
@@ -16271,7 +16167,7 @@ export function RegisterRoutes(app: express.Router) {
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.post(
-        '/api/v1/projects/:projectUuid/sqlRunner/create-virtual-view',
+        '/api/v1/projects/:projectUuid/sqlRunner/virtual-view',
         ...fetchMiddlewares<RequestHandler>(SqlRunnerController),
         ...fetchMiddlewares<RequestHandler>(
             SqlRunnerController.prototype.createVirtualView,
@@ -16323,6 +16219,75 @@ export function RegisterRoutes(app: express.Router) {
                 }
 
                 const promise = controller.createVirtualView.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.put(
+        '/api/v1/projects/:projectUuid/sqlRunner/virtual-view/:name',
+        ...fetchMiddlewares<RequestHandler>(SqlRunnerController),
+        ...fetchMiddlewares<RequestHandler>(
+            SqlRunnerController.prototype.updateVirtualView,
+        ),
+
+        async function SqlRunnerController_updateVirtualView(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                name: {
+                    in: 'path',
+                    name: 'name',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    required: true,
+                    ref: 'Omit_UpdateVirtualViewPayload.name_',
+                },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<SqlRunnerController>(
+                        SqlRunnerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.updateVirtualView.apply(
                     controller,
                     validatedArgs as any,
                 );

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3123,76 +3123,6 @@
             "ApiCompiledQueryResults": {
                 "type": "string"
             },
-            "Pick_Explore.name_": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "required": ["name"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "ApiCreateCustomExplore": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/Pick_Explore.name_"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "VizColumn": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/DimensionType"
-                    },
-                    "reference": {
-                        "type": "string"
-                    }
-                },
-                "required": ["reference"],
-                "type": "object"
-            },
-            "CreateCustomExplorePayload": {
-                "properties": {
-                    "columns": {
-                        "items": {
-                            "$ref": "#/components/schemas/VizColumn"
-                        },
-                        "type": "array"
-                    },
-                    "sql": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "required": ["columns", "sql", "name"],
-                "type": "object"
-            },
-            "UpdateCustomExplorePayload": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/CreateCustomExplorePayload"
-                    },
-                    {
-                        "properties": {
-                            "exploreName": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["exploreName"],
-                        "type": "object"
-                    }
-                ]
-            },
             "GitRepo": {
                 "properties": {
                     "ownerLogin": {
@@ -8273,6 +8203,26 @@
                 "required": ["columns", "sql", "name"],
                 "type": "object"
             },
+            "Pick_UpdateVirtualViewPayload.Exclude_keyofUpdateVirtualViewPayload.name__": {
+                "properties": {
+                    "sql": {
+                        "type": "string"
+                    },
+                    "columns": {
+                        "items": {
+                            "$ref": "#/components/schemas/VizColumn"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["sql", "columns"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_UpdateVirtualViewPayload.name_": {
+                "$ref": "#/components/schemas/Pick_UpdateVirtualViewPayload.Exclude_keyofUpdateVirtualViewPayload.name__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
             "ApiGithubDbtWritePreview": {
                 "properties": {
                     "results": {
@@ -10267,7 +10217,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1295.2",
+        "version": "0.1295.4",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -11207,55 +11157,6 @@
                                         "type": "object"
                                     }
                                 ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/projects/{projectUuid}/explores/updateVirtualView": {
-            "post": {
-                "operationId": "UpdateVirtualView",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiCreateCustomExplore"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateCustomExplorePayload"
                             }
                         }
                     }

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3123,6 +3123,76 @@
             "ApiCompiledQueryResults": {
                 "type": "string"
             },
+            "Pick_Explore.name_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ApiCreateCustomExplore": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Pick_Explore.name_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "VizColumn": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DimensionType"
+                    },
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": ["reference"],
+                "type": "object"
+            },
+            "CreateCustomExplorePayload": {
+                "properties": {
+                    "columns": {
+                        "items": {
+                            "$ref": "#/components/schemas/VizColumn"
+                        },
+                        "type": "array"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["columns", "sql", "name"],
+                "type": "object"
+            },
+            "UpdateCustomExplorePayload": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CreateCustomExplorePayload"
+                    },
+                    {
+                        "properties": {
+                            "exploreName": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["exploreName"],
+                        "type": "object"
+                    }
+                ]
+            },
             "GitRepo": {
                 "properties": {
                     "ownerLogin": {
@@ -11137,6 +11207,55 @@
                                         "type": "object"
                                     }
                                 ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/updateVirtualView": {
+            "post": {
+                "operationId": "UpdateVirtualView",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCreateCustomExplore"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateCustomExplorePayload"
                             }
                         }
                     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2102,7 +2102,7 @@ export class ProjectModel {
             .andWhere('name', payload.name)
             .returning(['name', 'cached_explore_uuid']);
 
-        // append to cached_explores
+        // append to cached_explores if it doesn't exist; otherwise, update
         await this.database(CachedExploresTableName)
             .where('project_uuid', projectUuid)
             .update({

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -28,9 +28,9 @@ import {
     SupportedDbtVersions,
     TablesConfiguration,
     UnexpectedServerError,
-    UpdateCustomExplorePayload,
     UpdateMetadata,
     UpdateProject,
+    UpdateVirtualViewPayload,
     WarehouseClient,
     WarehouseCredentials,
     WarehouseTypes,
@@ -2080,10 +2080,10 @@ export class ProjectModel {
 
     async updateVirtualView(
         projectUuid: string,
-        payload: UpdateCustomExplorePayload,
+        payload: UpdateVirtualViewPayload,
         warehouseClient: WarehouseClient,
     ) {
-        const translatedToExplore = createCustomExplore(
+        const translatedToExplore = createVirtualView(
             payload.name,
             payload.sql,
             payload.columns,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -28,6 +28,7 @@ import {
     SupportedDbtVersions,
     TablesConfiguration,
     UnexpectedServerError,
+    UpdateCustomExplorePayload,
     UpdateMetadata,
     UpdateProject,
     WarehouseClient,
@@ -2075,6 +2076,66 @@ export class ProjectModel {
             .returning('*');
 
         return { name };
+    }
+
+    async updateVirtualView(
+        projectUuid: string,
+        payload: UpdateCustomExplorePayload,
+        warehouseClient: WarehouseClient,
+    ) {
+        const translatedToExplore = createCustomExplore(
+            payload.name,
+            payload.sql,
+            payload.columns,
+            warehouseClient,
+        );
+
+        // insert into cached_explore
+        await this.database(CachedExploreTableName)
+            .update({
+                project_uuid: projectUuid,
+                name: translatedToExplore.name,
+                table_names: Object.keys(translatedToExplore.tables || {}),
+                explore: JSON.stringify(translatedToExplore),
+            })
+            .where('project_uuid', projectUuid)
+            .andWhere('name', payload.name)
+            .returning(['name', 'cached_explore_uuid']);
+
+        // append to cached_explores
+        await this.database(CachedExploresTableName)
+            .where('project_uuid', projectUuid)
+            .update({
+                explores: this.database.raw(
+                    `
+                    CASE
+                        WHEN explores IS NULL THEN ?::jsonb
+                        ELSE (
+                            SELECT jsonb_agg(
+                                CASE
+                                    WHEN (value->>'name') = ? THEN ?::jsonb
+                                    ELSE value
+                                END
+                            )
+                            FROM jsonb_array_elements(
+                                CASE
+                                    WHEN jsonb_typeof(explores) = 'array' THEN explores
+                                    ELSE '[]'::jsonb
+                                END
+                            )
+                        )
+                    END
+                `,
+                    [
+                        JSON.stringify([translatedToExplore]),
+                        translatedToExplore.name,
+                        JSON.stringify(translatedToExplore),
+                    ],
+                ),
+            })
+            .returning('*');
+
+        return { name: translatedToExplore.name };
     }
 
     async updateSemanticLayerConnection(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -96,10 +96,10 @@ import {
     TablesConfiguration,
     TableSelectionType,
     UnexpectedServerError,
-    UpdateCustomExplorePayload,
     UpdateMetadata,
     UpdateProject,
     UpdateProjectMember,
+    UpdateVirtualViewPayload,
     UserAttributeValueMap,
     UserWarehouseCredentials,
     VizColumn,
@@ -4414,10 +4414,8 @@ export class ProjectService extends BaseService {
     async updateVirtualView(
         user: SessionUser,
         projectUuid: string,
-        payload: UpdateCustomExplorePayload,
+        payload: UpdateVirtualViewPayload,
     ) {
-        console.log({ payload, readyToFind: payload.exploreName });
-
         const explore = await this.findExplores({
             user,
             projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4422,9 +4422,21 @@ export class ProjectService extends BaseService {
             exploreNames: [payload.name],
         });
 
-        // if (user.ability.cannot('update', subject('Explore', explore))) {
-        //     throw new ForbiddenError();
-        // }
+        if (!explore) {
+            throw new NotFoundError('Explore not found');
+        }
+
+        const { organizationUuid } =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         const { warehouseClient } = await this._getWarehouseClient(
             projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2937,8 +2937,6 @@ export class ProjectService extends BaseService {
                     exploreNames,
                 );
 
-                console.log({ explores });
-
                 const userAttributes =
                     await this.userAttributesModel.getAttributeValuesForOrgMember(
                         {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -96,6 +96,7 @@ import {
     TablesConfiguration,
     TableSelectionType,
     UnexpectedServerError,
+    UpdateCustomExplorePayload,
     UpdateMetadata,
     UpdateProject,
     UpdateProjectMember,
@@ -2936,6 +2937,8 @@ export class ProjectService extends BaseService {
                     exploreNames,
                 );
 
+                console.log({ explores });
+
                 const userAttributes =
                     await this.userAttributesModel.getAttributeValuesForOrgMember(
                         {
@@ -4406,5 +4409,36 @@ export class ProjectService extends BaseService {
             await this.projectModel.deleteSemanticLayerConnection(projectUuid);
 
         return updatedProject;
+    }
+
+    async updateVirtualView(
+        user: SessionUser,
+        projectUuid: string,
+        payload: UpdateCustomExplorePayload,
+    ) {
+        console.log({ payload, readyToFind: payload.exploreName });
+
+        const explore = await this.findExplores({
+            user,
+            projectUuid,
+            exploreNames: [payload.name],
+        });
+
+        // if (user.ability.cannot('update', subject('Explore', explore))) {
+        //     throw new ForbiddenError();
+        // }
+
+        const { warehouseClient } = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+        );
+
+        const updatedExplore = await this.projectModel.updateVirtualView(
+            projectUuid,
+            payload,
+            warehouseClient,
+        );
+
+        return updatedExplore;
     }
 }

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -208,9 +208,7 @@ export type CreateVirtualViewPayload = {
     columns: VizColumn[];
 };
 
-export type UpdateCustomExplorePayload = CreateCustomExplorePayload & {
-    exploreName: string;
-};
+export type UpdateVirtualViewPayload = CreateVirtualViewPayload;
 
 export type ApiGithubDbtWriteBack = {
     status: 'ok';

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -208,6 +208,10 @@ export type CreateVirtualViewPayload = {
     columns: VizColumn[];
 };
 
+export type UpdateCustomExplorePayload = CreateCustomExplorePayload & {
+    exploreName: string;
+};
+
 export type ApiGithubDbtWriteBack = {
     status: 'ok';
     results: PullRequestCreated;

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -11,7 +11,7 @@ import { type VizColumn } from '../visualizations/types';
 import { getFieldQuoteChar } from './warehouse';
 
 export const createVirtualView = (
-    customExploreName: string,
+    virtualViewName: string,
     sql: string,
     columns: VizColumn[],
     warehouseClient: WarehouseClient,
@@ -26,10 +26,10 @@ export const createVirtualView = (
                 name: column.reference,
                 label: friendlyName(column.reference),
                 type: column.type ?? DimensionType.STRING,
-                table: customExploreName,
+                table: virtualViewName,
                 fieldType: FieldType.DIMENSION,
                 sql: `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
-                tableLabel: friendlyName(customExploreName),
+                tableLabel: friendlyName(virtualViewName),
                 hidden: false,
             };
             return acc;
@@ -38,8 +38,8 @@ export const createVirtualView = (
     );
 
     const compiledTable: Table = {
-        name: customExploreName,
-        label: friendlyName(customExploreName),
+        name: virtualViewName,
+        label: friendlyName(virtualViewName),
         sqlTable: `(${sql})`, // Wrap the sql in a subquery to avoid issues with reserved words
         dimensions,
         metrics: {},
@@ -49,12 +49,12 @@ export const createVirtualView = (
     };
 
     const explore = exploreCompiler.compileExplore({
-        name: customExploreName,
-        label: friendlyName(customExploreName),
+        name: virtualViewName,
+        label: friendlyName(virtualViewName),
         tags: [],
-        baseTable: customExploreName,
+        baseTable: virtualViewName,
         joinedTables: [],
-        tables: { [customExploreName]: compiledTable },
+        tables: { [virtualViewName]: compiledTable },
         targetDatabase: warehouseClient.getAdapterType(),
     });
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -10,7 +10,9 @@ import {
 import {
     ActionIcon,
     Box,
+    Button,
     Center,
+    Group,
     Loader,
     Menu,
     Modal,
@@ -18,7 +20,7 @@ import {
     Stack,
     Text,
 } from '@mantine/core';
-import { IconDots, IconPencil } from '@tabler/icons-react';
+import { IconAlertCircle, IconDots, IconPencil } from '@tabler/icons-react';
 import {
     lazy,
     memo,
@@ -57,6 +59,7 @@ interface ExplorePanelProps {
 
 const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
+    const [isClosingConfirmation, setIsClosingConfirmation] = useState(false);
     const [, startTransition] = useTransition();
 
     const activeTableName = useExplorerContext(
@@ -134,6 +137,15 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         }
     }, [explore, additionalMetrics, metrics, dimensions, customDimensions]);
 
+    const handleCloseEditVirtualView = () => {
+        if (isClosingConfirmation) {
+            setIsEditVirtualViewOpen(false);
+            setIsClosingConfirmation(false);
+        } else {
+            setIsClosingConfirmation(true);
+        }
+    };
+
     if (status === 'loading') {
         return <LoadingSkeleton />;
     }
@@ -210,8 +222,15 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
             {isEditVirtualViewOpen && (
                 <Modal
                     opened={isEditVirtualViewOpen}
-                    onClose={() => setIsEditVirtualViewOpen(false)}
-                    title={null}
+                    onClose={handleCloseEditVirtualView}
+                    title={
+                        isClosingConfirmation ? (
+                            <Group spacing="xs">
+                                <MantineIcon icon={IconAlertCircle} />
+                                <Text fw={500}>You have unsaved changes</Text>
+                            </Group>
+                        ) : null
+                    }
                     size="95vw"
                     yOffset="3vh"
                     xOffset="2vw"
@@ -220,29 +239,66 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             padding: `${theme.spacing.xs} ${theme.spacing.lg}`,
                         },
                         body: {
-                            padding: 0,
+                            padding: isClosingConfirmation
+                                ? theme.spacing.md
+                                : 0,
+                        },
+                        // TODO: This is a hack to position the close button a bit better with the Save button
+                        close: {
+                            position: 'absolute',
+                            top: theme.spacing.xs,
+                            right: theme.spacing.xs,
                         },
                     })}
-                    withCloseButton={false}
                 >
-                    <Suspense
-                        fallback={
-                            <Center h="95vh" w="95vw">
-                                <Stack align="center" justify="center">
-                                    <Loader variant="bars" />
-                                    <Text fw={500}>Loading SQL Runner...</Text>
-                                </Stack>
-                            </Center>
-                        }
-                    >
-                        <SqlRunnerNewPage
-                            isEditMode
-                            virtualViewState={{
-                                name: explore.name,
-                                sql: explore.tables[activeTableName].sqlTable,
-                            }}
-                        />
-                    </Suspense>
+                    {isClosingConfirmation ? (
+                        <Stack>
+                            <Text fz="sm">
+                                Are you sure you want to close? Your changes
+                                will be lost.
+                            </Text>
+                            <Group position="right">
+                                <Button
+                                    variant="outline"
+                                    onClick={() =>
+                                        setIsClosingConfirmation(false)
+                                    }
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    color="red"
+                                    onClick={() =>
+                                        setIsEditVirtualViewOpen(false)
+                                    }
+                                >
+                                    Close
+                                </Button>
+                            </Group>
+                        </Stack>
+                    ) : (
+                        <Suspense
+                            fallback={
+                                <Center h="95vh" w="95vw">
+                                    <Stack align="center" justify="center">
+                                        <Loader variant="bars" />
+                                        <Text fw={500}>
+                                            Loading SQL Runner...
+                                        </Text>
+                                    </Stack>
+                                </Center>
+                            }
+                        >
+                            <SqlRunnerNewPage
+                                isEditMode
+                                virtualViewState={{
+                                    name: explore.name,
+                                    sql: explore.tables[activeTableName]
+                                        .sqlTable,
+                                }}
+                            />
+                        </Suspense>
+                    )}
                 </Modal>
             )}
         </>

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -1,18 +1,42 @@
 import {
     convertFieldRefToFieldId,
+    ExploreType,
     getAllReferences,
     getItemId,
     getVisibleFields,
     isCustomBinDimension,
     isCustomSqlDimension,
 } from '@lightdash/common';
-import { Skeleton, Stack } from '@mantine/core';
-import { memo, useMemo, type FC } from 'react';
+import {
+    ActionIcon,
+    Box,
+    Center,
+    Loader,
+    Menu,
+    Modal,
+    Skeleton,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconDots, IconPencil } from '@tabler/icons-react';
+import {
+    lazy,
+    memo,
+    Suspense,
+    useMemo,
+    useState,
+    useTransition,
+    type FC,
+} from 'react';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
+import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import ExploreTree from '../ExploreTree';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailContext';
+
+const SqlRunnerNewPage = lazy(() => import('../../../pages/SqlRunnerNew'));
+
 const LoadingSkeleton = () => (
     <Stack>
         <Skeleton h="md" />
@@ -32,6 +56,9 @@ interface ExplorePanelProps {
 }
 
 const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
+    const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
+    const [, startTransition] = useTransition();
+
     const activeTableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );
@@ -120,23 +147,53 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     return (
         <>
-            <PageBreadcrumbs
-                size="md"
-                items={[
-                    ...(onBack
-                        ? [
-                              {
-                                  title: 'Tables',
-                                  onClick: onBack,
-                              },
-                          ]
-                        : []),
-                    {
-                        title: explore.label,
-                        active: true,
-                    },
-                ]}
-            />
+            <Box pos="relative">
+                <PageBreadcrumbs
+                    size="md"
+                    items={[
+                        ...(onBack
+                            ? [
+                                  {
+                                      title: 'Tables',
+                                      onClick: onBack,
+                                  },
+                              ]
+                            : []),
+                        {
+                            title: explore.label,
+                            active: true,
+                        },
+                    ]}
+                />
+                {explore.type === ExploreType.VIRTUAL && (
+                    <Menu>
+                        <Menu.Target>
+                            <ActionIcon
+                                variant="transparent"
+                                pos="absolute"
+                                top="0"
+                                right="0"
+                            >
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                icon={<MantineIcon icon={IconPencil} />}
+                                onClick={() => {
+                                    startTransition(() => {
+                                        setIsEditVirtualViewOpen(true);
+                                    });
+                                }}
+                            >
+                                <Text fz="xs" fw={500}>
+                                    Edit virtual view
+                                </Text>
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                )}
+            </Box>
 
             <ItemDetailProvider>
                 <ExploreTree
@@ -149,6 +206,45 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     missingFields={missingFields}
                 />
             </ItemDetailProvider>
+
+            {isEditVirtualViewOpen && (
+                <Modal
+                    opened={isEditVirtualViewOpen}
+                    onClose={() => setIsEditVirtualViewOpen(false)}
+                    title={null}
+                    size="95vw"
+                    yOffset="3vh"
+                    xOffset="2vw"
+                    styles={(theme) => ({
+                        header: {
+                            padding: `${theme.spacing.xs} ${theme.spacing.lg}`,
+                        },
+                        body: {
+                            padding: 0,
+                        },
+                    })}
+                    withCloseButton={false}
+                >
+                    <Suspense
+                        fallback={
+                            <Center h="95vh" w="95vw">
+                                <Stack align="center" justify="center">
+                                    <Loader variant="bars" />
+                                    <Text fw={500}>Loading SQL Runner...</Text>
+                                </Stack>
+                            </Center>
+                        }
+                    >
+                        <SqlRunnerNewPage
+                            isEditMode
+                            virtualViewState={{
+                                name: explore.name,
+                                sql: explore.tables[activeTableName].sqlTable,
+                            }}
+                        />
+                    </Suspense>
+                </Modal>
+            )}
         </>
     );
 });

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -178,7 +178,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     ]}
                 />
                 {explore.type === ExploreType.VIRTUAL && (
-                    <Menu>
+                    <Menu withArrow offset={-2}>
                         <Menu.Target>
                             <ActionIcon
                                 variant="transparent"

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -325,6 +325,11 @@ export const ContentPanel: FC = () => {
                                 disabled={!hasErrors || mode === 'virtualView'}
                             >
                                 <SegmentedControl
+                                    display={
+                                        mode === 'virtualView'
+                                            ? 'none'
+                                            : undefined
+                                    }
                                     styles={(theme) => ({
                                         root: {
                                             backgroundColor:
@@ -367,38 +372,30 @@ export const ContentPanel: FC = () => {
                                                 </Tooltip>
                                             ),
                                         },
-                                        ...(mode === 'default'
-                                            ? [
-                                                  {
-                                                      value: EditorTabs.VISUALIZATION,
-                                                      label: (
-                                                          <Tooltip
-                                                              disabled={
-                                                                  !!queryResults?.results
-                                                              }
-                                                              variant="xs"
-                                                              withinPortal
-                                                              label="Run a query to see the chart"
-                                                          >
-                                                              <Group
-                                                                  spacing={4}
-                                                                  noWrap
-                                                              >
-                                                                  <MantineIcon
-                                                                      color="gray.6"
-                                                                      icon={
-                                                                          IconChartHistogram
-                                                                      }
-                                                                  />
-                                                                  <Text>
-                                                                      Chart
-                                                                  </Text>
-                                                              </Group>
-                                                          </Tooltip>
-                                                      ),
-                                                  },
-                                              ]
-                                            : []),
+
+                                        {
+                                            value: EditorTabs.VISUALIZATION,
+                                            label: (
+                                                <Tooltip
+                                                    disabled={
+                                                        !!queryResults?.results
+                                                    }
+                                                    variant="xs"
+                                                    withinPortal
+                                                    label="Run a query to see the chart"
+                                                >
+                                                    <Group spacing={4} noWrap>
+                                                        <MantineIcon
+                                                            color="gray.6"
+                                                            icon={
+                                                                IconChartHistogram
+                                                            }
+                                                        />
+                                                        <Text>Chart</Text>
+                                                    </Group>
+                                                </Tooltip>
+                                            ),
+                                        },
                                     ]}
                                     value={activeEditorTab}
                                     onChange={(value: EditorTabs) => {

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -82,6 +82,8 @@ export const ContentPanel: FC = () => {
         MonacoHighlightChar | undefined
     >(undefined);
 
+    const mode = useAppSelector((state) => state.sqlRunner.mode);
+
     const {
         ref: inputSectionRef,
         width: inputSectionWidth,
@@ -171,10 +173,10 @@ export const ContentPanel: FC = () => {
     useEffect(() => {
         if (fetchResultsOnLoad && !queryResults) {
             void handleRunQuery(sql);
-        } else if (fetchResultsOnLoad && queryResults) {
+        } else if (fetchResultsOnLoad && queryResults && mode === 'default') {
             dispatch(setActiveEditorTab(EditorTabs.VISUALIZATION));
         }
-    }, [fetchResultsOnLoad, handleRunQuery, queryResults, dispatch, sql]);
+    }, [fetchResultsOnLoad, handleRunQuery, queryResults, dispatch, sql, mode]);
 
     const resultsRunner = useMemo(() => {
         if (!queryResults) return;
@@ -320,7 +322,7 @@ export const ContentPanel: FC = () => {
                             <Indicator
                                 color="red.6"
                                 offset={10}
-                                disabled={!hasErrors}
+                                disabled={!hasErrors || mode === 'virtualView'}
                             >
                                 <SegmentedControl
                                     styles={(theme) => ({
@@ -365,29 +367,38 @@ export const ContentPanel: FC = () => {
                                                 </Tooltip>
                                             ),
                                         },
-                                        {
-                                            value: EditorTabs.VISUALIZATION,
-                                            label: (
-                                                <Tooltip
-                                                    disabled={
-                                                        !!queryResults?.results
-                                                    }
-                                                    variant="xs"
-                                                    withinPortal
-                                                    label="Run a query to see the chart"
-                                                >
-                                                    <Group spacing={4} noWrap>
-                                                        <MantineIcon
-                                                            color="gray.6"
-                                                            icon={
-                                                                IconChartHistogram
-                                                            }
-                                                        />
-                                                        <Text>Chart</Text>
-                                                    </Group>
-                                                </Tooltip>
-                                            ),
-                                        },
+                                        ...(mode === 'default'
+                                            ? [
+                                                  {
+                                                      value: EditorTabs.VISUALIZATION,
+                                                      label: (
+                                                          <Tooltip
+                                                              disabled={
+                                                                  !!queryResults?.results
+                                                              }
+                                                              variant="xs"
+                                                              withinPortal
+                                                              label="Run a query to see the chart"
+                                                          >
+                                                              <Group
+                                                                  spacing={4}
+                                                                  noWrap
+                                                              >
+                                                                  <MantineIcon
+                                                                      color="gray.6"
+                                                                      icon={
+                                                                          IconChartHistogram
+                                                                      }
+                                                                  />
+                                                                  <Text>
+                                                                      Chart
+                                                                  </Text>
+                                                              </Group>
+                                                          </Tooltip>
+                                                      ),
+                                                  },
+                                              ]
+                                            : []),
                                     ]}
                                     value={activeEditorTab}
                                     onChange={(value: EditorTabs) => {
@@ -434,11 +445,13 @@ export const ContentPanel: FC = () => {
                                     echartsInstance={activeEchartsInstance}
                                 />
                             ) : (
-                                <ResultsDownload
-                                    fileUrl={resultsFileUrl}
-                                    columns={queryResults?.columns ?? []}
-                                    chartName={savedSqlChart?.name}
-                                />
+                                mode === 'default' && (
+                                    <ResultsDownload
+                                        fileUrl={resultsFileUrl}
+                                        columns={queryResults?.columns ?? []}
+                                        chartName={savedSqlChart?.name}
+                                    />
+                                )
                             )}
                         </Group>
                     </Group>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
@@ -5,9 +5,7 @@ import {
     HoverCard,
     LoadingOverlay,
     Text,
-    TextInput,
 } from '@mantine/core';
-import { useForm } from '@mantine/form';
 import { IconTableAlias } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -29,11 +27,6 @@ export const HeaderVirtualView: FC<{
 
     const { mutateAsync: updateCustomExplore, isLoading } =
         useUpdateCustomExplore(projectUuid);
-    const form = useForm({
-        initialValues: {
-            name: virtualViewState.name,
-        },
-    });
 
     const handleUpdateVirtualView = async () => {
         if (!columns) {
@@ -42,7 +35,8 @@ export const HeaderVirtualView: FC<{
         await updateCustomExplore({
             projectUuid,
             exploreName: virtualViewState.name,
-            name: form.values.name,
+            // TODO: Allow editing name
+            name: virtualViewState.name,
             sql: sql,
             columns,
         });
@@ -68,20 +62,10 @@ export const HeaderVirtualView: FC<{
                 <Group spacing="xs">
                     <MantineIcon icon={IconTableAlias} />
                     <Text fz="sm" fw={500}>
-                        Editing virtual view
+                        {/* TODO: Allow editing name */}
+                        Editing {virtualViewState.name}
                     </Text>
                 </Group>
-                <form
-                    onSubmit={form.onSubmit((values) => {
-                        console.log(values);
-                    })}
-                >
-                    <TextInput
-                        size="xs"
-                        radius="md"
-                        {...form.getInputProps('name')}
-                    />
-                </form>
             </Group>
             <HoverCard disabled={!hasUnrunChanges} withArrow>
                 <HoverCard.Target>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
@@ -1,0 +1,105 @@
+import {
+    Box,
+    Button,
+    Group,
+    HoverCard,
+    LoadingOverlay,
+    Text,
+    TextInput,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconTableAlias } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useHistory } from 'react-router-dom';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useUpdateCustomExplore } from '../../hooks/useCustomExplore';
+import { useAppSelector } from '../../store/hooks';
+import { SqlQueryBeforeSaveAlert } from '../SqlQueryBeforeSaveAlert';
+
+export const HeaderVirtualView: FC<{
+    virtualViewState: { name: string; sql: string };
+}> = ({ virtualViewState }) => {
+    const history = useHistory();
+    const sql = useAppSelector((state) => state.sqlRunner.sql);
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const columns = useAppSelector((state) => state.sqlRunner.sqlColumns);
+    const hasUnrunChanges = useAppSelector(
+        (state) => state.sqlRunner.hasUnrunChanges,
+    );
+
+    const { mutateAsync: updateCustomExplore, isLoading } =
+        useUpdateCustomExplore(projectUuid);
+    const form = useForm({
+        initialValues: {
+            name: virtualViewState.name,
+        },
+    });
+
+    const handleUpdateVirtualView = async () => {
+        if (!columns) {
+            return;
+        }
+        await updateCustomExplore({
+            projectUuid,
+            exploreName: virtualViewState.name,
+            name: form.values.name,
+            sql: sql,
+            columns,
+        });
+
+        history.push(`/projects/${projectUuid}/tables`);
+    };
+    return (
+        <Group
+            p="md"
+            py="xs"
+            position="apart"
+            sx={(theme) => ({
+                borderBottom: `1px solid ${theme.colors.gray[3]}`,
+            })}
+        >
+            <LoadingOverlay
+                visible={isLoading}
+                loaderProps={{
+                    variant: 'bars',
+                }}
+            />
+            <Group spacing="xs">
+                <Group spacing="xs">
+                    <MantineIcon icon={IconTableAlias} />
+                    <Text fz="sm" fw={500}>
+                        Editing virtual view
+                    </Text>
+                </Group>
+                <form
+                    onSubmit={form.onSubmit((values) => {
+                        console.log(values);
+                    })}
+                >
+                    <TextInput
+                        size="xs"
+                        radius="md"
+                        {...form.getInputProps('name')}
+                    />
+                </form>
+            </Group>
+            <HoverCard disabled={!hasUnrunChanges} withArrow>
+                <HoverCard.Target>
+                    <Box>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            onClick={handleUpdateVirtualView}
+                            disabled={hasUnrunChanges}
+                        >
+                            Save
+                        </Button>
+                    </Box>
+                </HoverCard.Target>
+                <HoverCard.Dropdown p={0} bg="yellow.0">
+                    <SqlQueryBeforeSaveAlert withDescription={false} />
+                </HoverCard.Dropdown>
+            </HoverCard>
+        </Group>
+    );
+};

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
@@ -77,6 +77,7 @@ export const HeaderVirtualView: FC<{
             </Group>
 
             <Button
+                mr="lg"
                 size="xs"
                 variant="default"
                 onClick={handleUpdateVirtualView}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderVirtualView.tsx
@@ -10,7 +10,7 @@ import { IconTableAlias } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useHistory } from 'react-router-dom';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { useUpdateCustomExplore } from '../../hooks/useCustomExplore';
+import { useUpdateVirtualView } from '../../hooks/useVirtualView';
 import { useAppSelector } from '../../store/hooks';
 import { SqlQueryBeforeSaveAlert } from '../SqlQueryBeforeSaveAlert';
 
@@ -25,19 +25,18 @@ export const HeaderVirtualView: FC<{
         (state) => state.sqlRunner.hasUnrunChanges,
     );
 
-    const { mutateAsync: updateCustomExplore, isLoading } =
-        useUpdateCustomExplore(projectUuid);
+    const { mutateAsync: updateVirtualView, isLoading } =
+        useUpdateVirtualView(projectUuid);
 
     const handleUpdateVirtualView = async () => {
         if (!columns) {
             return;
         }
-        await updateCustomExplore({
+        await updateVirtualView({
             projectUuid,
-            exploreName: virtualViewState.name,
             // TODO: Allow editing name
             name: virtualViewState.name,
-            sql: sql,
+            sql,
             columns,
         });
 

--- a/packages/frontend/src/features/sqlRunner/components/Header/index.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/index.tsx
@@ -5,7 +5,9 @@ import { HeaderCreate } from './HeaderCreate';
 import { HeaderEdit } from './HeaderEdit';
 import { HeaderView } from './HeaderView';
 
-export const Header: FC<{ mode: 'create' | 'view' | 'edit' }> = ({ mode }) => {
+export const Header: FC<{
+    mode: 'create' | 'view' | 'edit';
+}> = ({ mode }) => {
     const isChartLoaded = useAppSelector(
         (state) => !!state.sqlRunner.savedSqlChart?.savedSqlUuid,
     );

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryBeforeSaveAlert.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryBeforeSaveAlert.tsx
@@ -3,17 +3,21 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 
-export const SqlQueryBeforeSaveAlert: FC = () => {
+export const SqlQueryBeforeSaveAlert: FC<{ withDescription?: boolean }> = ({
+    withDescription = true,
+}) => {
     return (
         <Alert
             icon={<MantineIcon icon={IconAlertCircle} color="yellow" />}
             color="yellow"
             title="You haven't run your query yet"
         >
-            <Text fw={500} size="xs">
-                You can verify your query before saving or you can review it
-                later.
-            </Text>
+            {withDescription && (
+                <Text fw={500} size="xs">
+                    You can verify your query before saving or you can review it
+                    later.
+                </Text>
+            )}
         </Alert>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/hooks/useVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useVirtualView.tsx
@@ -2,7 +2,7 @@ import {
     type ApiCreateVirtualView,
     type ApiError,
     type CreateVirtualViewPayload,
-    type UpdateCustomExplorePayload,
+    type UpdateVirtualViewPayload,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -18,7 +18,7 @@ const createVirtualView = async ({
     projectUuid: string;
 } & CreateVirtualViewPayload) =>
     lightdashApi<ApiCreateVirtualView['results']>({
-        url: `/projects/${projectUuid}/sqlRunner/create-virtual-view`,
+        url: `/projects/${projectUuid}/sqlRunner/virtual-view`,
         method: 'POST',
         body: JSON.stringify({
             name,
@@ -67,36 +67,32 @@ export const useCreateVirtualView = ({
     });
 };
 
-const updateCustomExplore = async ({
+const updateVirtualView = async ({
     projectUuid,
     name,
     sql,
     columns,
-    exploreName,
 }: {
     projectUuid: string;
-} & UpdateCustomExplorePayload) =>
+} & UpdateVirtualViewPayload) =>
     lightdashApi<ApiCreateVirtualView['results']>({
-        url: `/projects/${projectUuid}/explores/updateVirtualView`,
-        // TODO: should be patch/put in probably in sqlRunnerController
-        method: 'POST',
+        url: `/projects/${projectUuid}/sqlRunner/virtual-view/${name}`,
+        method: 'PUT',
         body: JSON.stringify({
-            name,
             sql,
             columns,
-            exploreName,
         }),
     });
 
-export const useUpdateCustomExplore = (projectUuid: string) => {
+export const useUpdateVirtualView = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
     return useMutation<
         ApiCreateVirtualView['results'],
         ApiError,
-        { projectUuid: string } & UpdateCustomExplorePayload
+        { projectUuid: string } & UpdateVirtualViewPayload
     >({
-        mutationFn: updateCustomExplore,
+        mutationFn: updateVirtualView,
         onSuccess: async ({ name }) => {
             await queryClient.invalidateQueries({
                 queryKey: ['tables', projectUuid, 'filtered'],

--- a/packages/frontend/src/features/sqlRunner/hooks/useVirtualView.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useVirtualView.tsx
@@ -2,9 +2,10 @@ import {
     type ApiCreateVirtualView,
     type ApiError,
     type CreateVirtualViewPayload,
+    type UpdateCustomExplorePayload,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
 
@@ -61,6 +62,55 @@ export const useCreateVirtualView = ({
         onError: () => {
             showToastError({
                 title: 'Error creating virtual view',
+            });
+        },
+    });
+};
+
+const updateCustomExplore = async ({
+    projectUuid,
+    name,
+    sql,
+    columns,
+    exploreName,
+}: {
+    projectUuid: string;
+} & UpdateCustomExplorePayload) =>
+    lightdashApi<ApiCreateVirtualView['results']>({
+        url: `/projects/${projectUuid}/explores/updateVirtualView`,
+        // TODO: should be patch/put in probably in sqlRunnerController
+        method: 'POST',
+        body: JSON.stringify({
+            name,
+            sql,
+            columns,
+            exploreName,
+        }),
+    });
+
+export const useUpdateCustomExplore = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastError } = useToaster();
+    return useMutation<
+        ApiCreateVirtualView['results'],
+        ApiError,
+        { projectUuid: string } & UpdateCustomExplorePayload
+    >({
+        mutationFn: updateCustomExplore,
+        onSuccess: async ({ name }) => {
+            await queryClient.invalidateQueries({
+                queryKey: ['tables', projectUuid, 'filtered'],
+            });
+            await queryClient.invalidateQueries({
+                queryKey: ['tables', name, projectUuid],
+            });
+            showToastSuccess({
+                title: 'Success! Virtual view updated',
+            });
+        },
+        onError: () => {
+            showToastError({
+                title: 'Error updating virtual view',
             });
         },
     });

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -108,9 +108,11 @@ export interface SqlRunnerState {
     sqlColumns: VizColumn[] | undefined;
     activeConfigs: ChartKind[];
     fetchResultsOnLoad: boolean;
+    mode: 'default' | 'virtualView';
 }
 
 const initialState: SqlRunnerState = {
+    mode: 'default',
     projectUuid: '',
     activeTable: undefined,
     activeSchema: undefined,
@@ -168,9 +170,15 @@ export const sqlRunnerSlice = createSlice({
         setProjectUuid: (state, action: PayloadAction<string>) => {
             state.projectUuid = action.payload;
         },
-        setFetchResultsOnLoad: (state, action: PayloadAction<boolean>) => {
-            state.fetchResultsOnLoad = action.payload;
-            if (action.payload === true) {
+        setFetchResultsOnLoad: (
+            state,
+            action: PayloadAction<{
+                shouldFetch: boolean;
+                shouldOpenChartOnLoad: boolean;
+            }>,
+        ) => {
+            state.fetchResultsOnLoad = action.payload.shouldFetch;
+            if (action.payload.shouldOpenChartOnLoad) {
                 state.activeEditorTab = EditorTabs.VISUALIZATION;
             }
         },
@@ -232,6 +240,9 @@ export const sqlRunnerSlice = createSlice({
         },
         updateName: (state, action: PayloadAction<string>) => {
             state.name = action.payload;
+        },
+        setMode: (state, action: PayloadAction<'default' | 'virtualView'>) => {
+            state.mode = action.payload;
         },
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
@@ -329,4 +340,5 @@ export const {
     resetState,
     setQuoteChar,
     setWarehouseConnectionType,
+    setMode,
 } = sqlRunnerSlice.actions;

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -76,7 +76,7 @@ const SqlRunnerNew = ({
             dispatch(
                 setFetchResultsOnLoad({
                     shouldFetch: !!isEditMode || !!virtualViewState,
-                    shouldOpenChartOnLoad: !virtualViewState,
+                    shouldOpenChartOnLoad: !virtualViewState && !!isEditMode,
                 }),
             );
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11794](https://github.com/lightdash/lightdash/issues/11794)

### Description:

This PR: 
- Adds a new endpoint (`virtual-view/name`) to update a virtual view
- Updates it in the new explores-related tables
- Opens a modal and lazy loads Sql Runner in the Explore panel
- Alerts the user if there are unsaved changes and to confirm the closing of the modal - this can be refined later
- **doesn't** allow editing the name - that can be done later IMO
- Hides some components in the sql runner, depending on the `mode` - default or virtual view
- If the user has `unrunChanges`, then it will run a query with limit 1 just to get the schema correctly from the warehouse.
- It doesn't have proper error handling yet, tickets below will cover what's remaining: 

on broken content: https://github.com/lightdash/lightdash/issues/11795
on name change: https://github.com/lightdash/lightdash/issues/11796
on warning that changes will be discarded: https://github.com/lightdash/lightdash/issues/11830


Demo: 


https://github.com/user-attachments/assets/5c85c67a-3ede-4cf7-a6b7-9cce650ecd56



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
