### PR TITLE
fix: Rename cancel button when dashboard chart has no changes

### DIFF
--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -41,7 +41,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
                 return 'Return to dashboard';
             case 'creating':
             case 'editing':
-                return 'Cancel';
+                return 'Return to dashboard';
             default:
                 return assertUnreachable(
                     action,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->#11335

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Rename cancel button from "Cancel" to "Return to dashboard" when dashboard chart has no changes

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [✅] I have manually tested the changes in the preview environment
- [✅] I have reviewed the code
- [✅] I understand that "request changes" will block this PR from merging
