### PR TITLE
feat: warn users that changes will be discarded before editing

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -12,7 +12,6 @@ import { IconDots, IconPencil } from '@tabler/icons-react';
 import { memo, useMemo, useState, useTransition, type FC } from 'react';
 import { EditVirtualViewModal } from '../../../features/sqlRunner/components/EditVirtualViewModal';
 import { useExplore } from '../../../hooks/useExplore';
-import useSearchParams from '../../../hooks/useSearchParams';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
@@ -38,17 +37,9 @@ interface ExplorePanelProps {
 }
 
 const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
-    const hasUnsavedChanges = !!useSearchParams('create_saved_chart_version');
     const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
     const [, startTransition] = useTransition();
 
-    const [modalStep, setModalStep] = useState<
-        'unsavedChanges' | 'closingConfirmation' | 'editVirtualView' | undefined
-    >(undefined);
-
-    const clearQuery = useExplorerContext(
-        (context) => context.actions.clearQuery,
-    );
     const activeTableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );
@@ -124,20 +115,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         }
     }, [explore, additionalMetrics, metrics, dimensions, customDimensions]);
 
-    const handleCloseEditVirtualView = () => {
-        if (modalStep === 'closingConfirmation') {
-            setIsEditVirtualViewOpen(false);
-            setModalStep(undefined);
-        } else {
-            setModalStep('closingConfirmation');
-        }
-    };
-
-    const resetModalState = () => {
-        setModalStep(undefined);
-        setIsEditVirtualViewOpen(false);
-    };
-
     if (status === 'loading') {
         return <LoadingSkeleton />;
     }
@@ -186,11 +163,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                                 icon={<MantineIcon icon={IconPencil} />}
                                 onClick={() => {
                                     startTransition(() => {
-                                        setModalStep(
-                                            hasUnsavedChanges
-                                                ? 'unsavedChanges'
-                                                : 'editVirtualView',
-                                        );
                                         setIsEditVirtualViewOpen(true);
                                     });
                                 }}
@@ -219,9 +191,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
             {isEditVirtualViewOpen && (
                 <EditVirtualViewModal
                     opened={isEditVirtualViewOpen}
-                    onClose={handleCloseEditVirtualView}
-                    isClosingConfirmation={isClosingConfirmation}
-                    setIsClosingConfirmation={setIsClosingConfirmation}
+                    onClose={() => setIsEditVirtualViewOpen(false)}
                     activeTableName={activeTableName}
                     setIsEditVirtualViewOpen={setIsEditVirtualViewOpen}
                     explore={explore}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11830 

### Description:

Refactored modal to listen to modal step changes (now there's 3)
Center modals that provide warnings
Clear unsaved chart version if the user wants to discard them and continue editing the virtual view

Demo:

https://github.com/user-attachments/assets/5a0f94fb-5ebd-4630-a9fa-c575a1dcad5c



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
