### PR TITLE
fix: add 25px padding to grid instead of 5%

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/index.tsx
@@ -5,8 +5,8 @@ import { UnitInputsGrid } from '../common/UnitInputsGrid';
 
 export const defaultGrid = {
     containLabel: true,
-    left: '5%', // small padding
-    right: '5%', // small padding
+    left: '25px', // small padding
+    right: '25px', // small padding
     top: '70px', // pixels from top (makes room for legend)
     bottom: '30px', // pixels from bottom (makes room for x-axis)
 } as const;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11850

### Description:

Before:
![image](https://github.com/user-attachments/assets/c3570ae3-754a-41ae-b60e-43eb2b222151)

After:
![image](https://github.com/user-attachments/assets/d4fff633-ee89-4632-95cc-416db1354c79)

Note: this makes the padding of fixed instead of %, which means that when a chart tile is bigger the padding will be the same, previously it got bigger

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
