### PR TITLE
fix: hide edit/delete virtual view if no permission to

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4382,6 +4382,17 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         payload: CreateVirtualViewPayload,
     ) {
+        const { organizationUuid } =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('VirtualView', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         const explore = await this.findExplores({
             user,
             projectUuid,
@@ -4462,7 +4473,7 @@ export class ProjectService extends BaseService {
         if (
             user.ability.cannot(
                 'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
+                subject('VirtualView', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -4493,7 +4504,7 @@ export class ProjectService extends BaseService {
         if (
             user.ability.cannot(
                 'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
+                subject('VirtualView', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -178,6 +178,9 @@ export const organizationMemberAbilities: Record<
     },
     developer(member, { can }) {
         organizationMemberAbilities.editor(member, { can });
+        can('manage', 'VirtualView', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'CustomSql', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -155,6 +155,9 @@ export const projectMemberAbilities: Record<
     },
     developer(member, { can }) {
         projectMemberAbilities.editor(member, { can });
+        can('manage', 'VirtualView', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'CustomSql', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -45,6 +45,7 @@ type Subject =
     | 'CustomSql'
     | 'CompileProject'
     | 'SemanticViewer'
+    | 'VirtualView'
     | 'all';
 
 type PossibleAbilities = [

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     convertFieldRefToFieldId,
     ExploreType,
@@ -14,6 +15,7 @@ import { useParams } from 'react-router-dom';
 import { DeleteVirtualViewModal } from '../../../features/sqlRunner/components/DeleteVirtualViewModal';
 import { EditVirtualViewModal } from '../../../features/sqlRunner/components/EditVirtualViewModal';
 import { useExplore } from '../../../hooks/useExplore';
+import { useApp } from '../../../providers/AppProvider';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
@@ -69,6 +71,15 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         (context) => context.actions.toggleActiveField,
     );
     const { data: explore, status } = useExplore(activeTableName);
+
+    const { user } = useApp();
+    const canManageVirtualViews = user.data?.ability?.can(
+        'manage',
+        subject('VirtualView', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
 
     const missingFields = useMemo(() => {
         if (explore) {
@@ -151,7 +162,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                         },
                     ]}
                 />
-                {explore.type === ExploreType.VIRTUAL && (
+                {canManageVirtualViews && explore.type === ExploreType.VIRTUAL && (
                     <Menu withArrow offset={-2}>
                         <Menu.Target>
                             <ActionIcon


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Manage permissions by adding a new ability 
`>= developers can manage virtual views`

## Admin - can see 3-dot menu

<img width="290" alt="Screenshot 2024-10-09 at 10 22 43" src="https://github.com/user-attachments/assets/4d6a8e09-712b-4037-ba67-81bbab93d761">

## Editor - cannot see 3-dot menu

<img width="419" alt="Screenshot 2024-10-09 at 10 28 30" src="https://github.com/user-attachments/assets/f06e5e9f-3fb9-4f9e-8db1-a5c359fee784">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
