### PR TITLE
fix: project admin can create preview projects

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -424,7 +424,10 @@ export class ProjectService extends BaseService {
             ) ||
             user.ability.cannot(
                 'create',
-                subject('Project', { organizationUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    type: data.type,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -1,6 +1,7 @@
 import { type AbilityBuilder } from '@casl/ability';
 import { type ProjectMemberProfile } from '../types/projectMemberProfile';
 import { type ProjectMemberRole } from '../types/projectMemberRole';
+import { ProjectType } from '../types/projects';
 import { SpaceMemberRole } from '../types/space';
 import { type MemberAbility } from './types';
 
@@ -194,6 +195,9 @@ export const projectMemberAbilities: Record<
         projectMemberAbilities.developer(member, { can });
         can('manage', 'Project', {
             projectUuid: member.projectUuid,
+        });
+        can('create', 'Project', {
+            type: ProjectType.PREVIEW,
         });
         can('manage', 'Space', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -193,11 +193,11 @@ export const projectMemberAbilities: Record<
     },
     admin(member, { can }) {
         projectMemberAbilities.developer(member, { can });
-        can('manage', 'Project', {
-            projectUuid: member.projectUuid,
-        });
         can('create', 'Project', {
             type: ProjectType.PREVIEW,
+        });
+        can('manage', 'Project', {
+            projectUuid: member.projectUuid,
         });
         can('manage', 'Space', {
             projectUuid: member.projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11876 

### Description:

From the docs page, a project admin should be able to create project previews: https://docs.lightdash.com/references/roles/#organization-roles

**Before**
![image](https://github.com/user-attachments/assets/07db8bdf-2f0b-4d91-94b4-957cd1e01d65)

**After**
![image](https://github.com/user-attachments/assets/d015ab64-7680-4a30-95d9-cced7b12ff64)

**Steps to reproduce:**
1. Create a user that has `member` role at the org level and `admin` at the project level
2. Run `lightdash preview` with that user


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
