### PR TITLE
fix: render env test plan

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ databases:
     ipAllowList: []
     postgresMajorVersion: 13
     plan: standard
+    previewPlan: basic-256mb
 
 services:
   - type: pserv


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

sets `previewPlan` to a new instance type  (standard is no longer the default for postgres dbs - 
from `standard` to `basic-256mb`)

https://render.com/changelog/flexible-postgresql-plans-now-available-for-all-workspaces

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
