### PR TITLE
fix: check for pgversion before querying for matviews

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -50,32 +50,57 @@ describe('PostgresWarehouseClient', () => {
     });
     it('expect schema with postgres types mapped to dimension types', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
-        (pg.Pool as unknown as jest.Mock).mockImplementationOnce(() => ({
-            connect: jest.fn((callback) => {
-                callback(
-                    null,
-                    {
-                        query: jest.fn(() => {
-                            const mockedStream = new PassThrough();
-                            setTimeout(() => {
-                                columns.forEach((column) => {
+        (pg.Pool as unknown as jest.Mock)
+            .mockImplementationOnce(() => ({
+                connect: jest.fn((callback) => {
+                    callback(
+                        null,
+                        {
+                            query: jest.fn(() => {
+                                const mockedStream = new PassThrough();
+                                setTimeout(() => {
                                     mockedStream.emit('data', {
-                                        row: column,
+                                        row: { supports_matviews: true },
                                         fields: [],
                                     });
-                                });
-                                mockedStream.end();
-                            }, 100);
-                            return mockedStream;
-                        }),
-                        on: jest.fn(async () => undefined),
-                    },
-                    jest.fn(),
-                );
-            }),
-            end: jest.fn(async () => undefined),
-            on: jest.fn(async () => undefined),
-        }));
+                                    mockedStream.end();
+                                }, 100);
+                                return mockedStream;
+                            }),
+                            on: jest.fn(async () => undefined),
+                        },
+                        jest.fn(),
+                    );
+                }),
+                end: jest.fn(async () => undefined),
+                on: jest.fn(async () => undefined),
+            }))
+            .mockImplementationOnce(() => ({
+                connect: jest.fn((callback) => {
+                    callback(
+                        null,
+                        {
+                            query: jest.fn(() => {
+                                const mockedStream = new PassThrough();
+                                setTimeout(() => {
+                                    columns.forEach((column) => {
+                                        mockedStream.emit('data', {
+                                            row: column,
+                                            fields: [],
+                                        });
+                                    });
+                                    mockedStream.end();
+                                }, 100);
+                                return mockedStream;
+                            }),
+                            on: jest.fn(async () => undefined),
+                        },
+                        jest.fn(),
+                    );
+                }),
+                end: jest.fn(async () => undefined),
+                on: jest.fn(async () => undefined),
+            }));
         expect(await warehouse.getCatalog(config)).toEqual(
             expectedWarehouseSchema,
         );

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -315,14 +315,11 @@ export class PostgresClient<
             return {};
         }
 
-        const { rows: pgVersionRows } = await this.runQuery('SELECT version()');
-        const pgVersionString = pgVersionRows[0]?.version ?? '';
-        const versionRegex = /PostgreSQL (\d+)\./;
-        const versionMatch = pgVersionString.match(versionRegex);
+        const { rows: supportsMatViewsRows } = await this.runQuery(
+            `SELECT current_setting('server_version_num')::integer >= 120000 as supports_matviews`,
+        );
         const supportsMatviews =
-            versionMatch && versionMatch[1]
-                ? parseInt(versionMatch[1], 10) >= 12
-                : false;
+            supportsMatViewsRows[0]?.supports_matviews ?? '';
 
         const query = `
             SELECT table_catalog,

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -319,7 +319,7 @@ export class PostgresClient<
             `SELECT current_setting('server_version_num')::integer >= 120000 as supports_matviews`,
         );
         const supportsMatviews =
-            supportsMatViewsRows[0]?.supports_matviews ?? '';
+            supportsMatViewsRows[0]?.supports_matviews ?? false;
 
         const query = `
             SELECT table_catalog,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11885

### Description:

Previously we were querying `pg_catalog.pg_matviews` without checking first for the PG version.
`pg_matviews` is only available from PostgreSQL >= 12: https://www.postgresql.org/docs/current/view-pg-matviews.html

Logs added for debug purposes:

**PG 11 (doesn't support matviews)**

![image](https://github.com/user-attachments/assets/47796c4c-c95b-44d5-a7b6-5f95338b573b)

**PG 15 (supports matviews)**
![image (1)](https://github.com/user-attachments/assets/f996fff4-df72-484a-925b-2987434e0bc8)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
