### PR TITLE
fix: reduce url on explore

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -2,6 +2,7 @@ import {
     ChartType,
     CustomDimensionType,
     DateGranularity,
+    isCartesianChartConfig,
     type CreateSavedChartVersion,
     type CustomBinDimension,
     type CustomDimension,
@@ -44,10 +45,32 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     createSavedChart: CreateSavedChartVersion,
 ): { pathname: string; search: string } => {
     const newParams = new URLSearchParams();
-    newParams.set(
-        'create_saved_chart_version',
-        JSON.stringify(createSavedChart),
-    );
+
+    let stringifiedChart = JSON.stringify(createSavedChart);
+    const stringifiedChartSize = stringifiedChart.length;
+    if (
+        stringifiedChartSize > 3000 &&
+        isCartesianChartConfig(createSavedChart.chartConfig.config)
+    ) {
+        console.warn(
+            `Chart config is too large to store in url "${stringifiedChartSize}", removing series to reduce size`,
+        );
+        const reducedCreateSavedChart = {
+            ...createSavedChart,
+            chartConfig: {
+                ...createSavedChart.chartConfig,
+                config: {
+                    ...createSavedChart.chartConfig.config,
+                    eChartsConfig: {},
+                },
+            },
+        };
+        stringifiedChart = JSON.stringify(reducedCreateSavedChart);
+        console.info(
+            `Reduced chart config size from "${stringifiedChartSize}" to "${stringifiedChart.length}"`,
+        );
+    }
+    newParams.set('create_saved_chart_version', stringifiedChart);
 
     return {
         pathname: `/projects/${projectUuid}/tables/${createSavedChart.tableName}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11710

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

What was happening: adding pivots was causing a really long metricquery, and we were adding all the series config into the URL 

What's new: We check the URL, if it is bigger than `3000` chars (just on queyr parameters) (limit seems to be ~4000 , including the host+path) then we remove the `series from the metric query config`

Expected side effect: CUstom configuration on series (eg: color, value labels, mixed chart types...) will be lost after refreshing. 
![Screenshot from 2024-10-11 10-20-06](https://github.com/user-attachments/assets/41b59452-4dca-47c1-be50-b0fab16728f7)
![image](https://github.com/user-attachments/assets/2194757c-2cc2-43a3-832e-e0cc1b53da6a)


Alternative solutions: If we don't want to lose information (custom serie config), we will have to store it somewhere, perhaps in local storage, or save a draft in the backend . I don't think this needs to be done, the side effect is very small. 

How to test: 
- go to an explore
- select dimensions and columns
- add a big pivot value (eg: orders day) 
- if you refresh now the page or copy the URL into a new tab, it should load fine (except the custom serie config) 

![Screenshot from 2024-10-11 10-20-06](https://github.com/user-attachments/assets/9205b2a9-0ef7-45e0-9ab2-0942dbc66ee0)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
