### PR TITLE
fix: update explore when metric query changes instead of on success

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -156,7 +156,7 @@ export const useExplorerRoute = () => {
 
     // Update url params based on pristine state
     useEffect(() => {
-        if (metricQuery) {
+        if (metricQuery && unsavedChartVersion.tableName) {
             history.replace(
                 getExplorerUrlFromCreateSavedChartVersion(
                     pathParams.projectUuid,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -144,8 +144,8 @@ export const useExplorerRoute = () => {
     const unsavedChartVersion = useExplorerContext(
         (context) => context.state.unsavedChartVersion,
     );
-    const queryResultsData = useExplorerContext(
-        (context) => context.queryResults.data,
+    const metricQuery = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery,
     );
     const clearExplore = useExplorerContext(
         (context) => context.actions.clearExplore,
@@ -156,19 +156,19 @@ export const useExplorerRoute = () => {
 
     // Update url params based on pristine state
     useEffect(() => {
-        if (queryResultsData?.metricQuery) {
+        if (metricQuery) {
             history.replace(
                 getExplorerUrlFromCreateSavedChartVersion(
                     pathParams.projectUuid,
                     {
                         ...unsavedChartVersion,
-                        metricQuery: queryResultsData.metricQuery,
+                        metricQuery,
                     },
                 ),
             );
         }
     }, [
-        queryResultsData,
+        metricQuery,
         history,
         pathParams.projectUuid,
         unsavedChartVersion,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11913](https://github.com/lightdash/lightdash/issues/11913)

### Description:

**Steps to test**
1. Click on "Query from tables"
2. Select a table and some fields (don't click "Run Query")
3. Copy the link at the top, when opened it should have the same state

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
