### PR TITLE
fix: improve query for removing specific explore from cached_explores

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2156,9 +2156,13 @@ export class ProjectModel {
             .update({
                 explores: this.database.raw(
                     `
-                    COALESCE(
-                        jsonb_agg(value) FILTER (WHERE value->>'name' != ?),
-                        '[]'::jsonb
+                    (
+                        SELECT COALESCE(
+                            jsonb_agg(explore_obj),
+                            '[]'::jsonb
+                        )
+                        FROM jsonb_array_elements(explores) AS explore_obj
+                        WHERE explore_obj->>'name' != ?
                     )
                 `,
                     [name],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11904](https://github.com/lightdash/lightdash/issues/11904)

### Description:

Now removes the explore correctly - query was incorrect.

To test: 
- create virtual view
- delete it
- should return back to `/tables` with the virtual view deleted

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
