### PR TITLE
style: use group apart instead of pos rel/abs

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -8,7 +8,7 @@ import {
     isCustomBinDimension,
     isCustomSqlDimension,
 } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Skeleton, Stack, Text } from '@mantine/core';
+import { ActionIcon, Group, Menu, Skeleton, Stack, Text } from '@mantine/core';
 import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
 import { memo, useMemo, useState, useTransition, type FC } from 'react';
 import { useParams } from 'react-router-dom';
@@ -146,7 +146,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     return (
         <>
-            <Box pos="relative">
+            <Group position="apart">
                 <PageBreadcrumbs
                     size="md"
                     items={[
@@ -167,12 +167,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                 {canManageVirtualViews && explore.type === ExploreType.VIRTUAL && (
                     <Menu withArrow offset={-2}>
                         <Menu.Target>
-                            <ActionIcon
-                                variant="transparent"
-                                pos="absolute"
-                                top="0"
-                                right="0"
-                            >
+                            <ActionIcon variant="transparent">
                                 <MantineIcon icon={IconDots} />
                             </ActionIcon>
                         </Menu.Target>
@@ -203,7 +198,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                         </Menu.Dropdown>
                     </Menu>
                 )}
-            </Box>
+            </Group>
 
             <ItemDetailProvider>
                 <ExploreTree


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11909 

### Description:

before
![image](https://github.com/user-attachments/assets/d8a72501-6397-43f8-a3c3-357d84644ece)

after
<img width="392" alt="Screenshot 2024-10-14 at 12 23 56" src="https://github.com/user-attachments/assets/adbb30a1-0958-4951-b669-2cec7957dcc3">

All good still for non-saved chart/exploring mode

<img width="213" alt="Screenshot 2024-10-14 at 12 24 04" src="https://github.com/user-attachments/assets/f95b2e85-4874-475c-94c4-abf23dee0e96">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
