### PR TITLE
fix: set metadata project from the Dataset instead of BigQuery client

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -210,8 +210,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         table: string,
     ): Promise<[string, string, string, TableSchema]> {
         const [metadata] = await dataset.table(table).getMetadata();
+
         return [
-            dataset.bigQuery.projectId,
+            dataset.projectId,
             dataset.id!,
             table,
             isTableSchema(metadata?.schema) ? metadata.schema : { fields: [] },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11867 

### Description:

When we remove `project` from `profiles.yml` the BigQuery client will authenticate using the default project set in the config, the way that this is done is that the `projectId` property of `BigQuery` client is supposed to be interpolated and therefore it is `{{ projectId }}` when there's no explicit project to initialize the client with.

When we create the `Dataset` we already pass an explicit `projectId` which comes from the compiled model so we don't need to try and pick up the `projectId` from `BigQuery` client but can instead pick it from the `dataset`

**Steps to reproduce:**
1. Set your `profiles.yml` to use BigQuery with `oauth`
2. Set your default gcloud project using `gcloud config set project <project_id>`
3. Remove `project` from `profiles.yml` so that it uses the default
4. Login in gcloud using `gcloud auth application-default login`
5. Run `lightdash generate -s <my_model>`

**Before**
![Screenshot 2024-10-14 at 12 35 01](https://github.com/user-attachments/assets/46a2e0ce-6364-4476-914d-d9d51b214770)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
