### PR TITLE
chore: focus on mount of sql editor

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -265,6 +265,9 @@ export const SqlEditor: FC<{
                     onSubmit(currentSql ?? '');
                 },
             );
+
+            // When creating a new sql query, focus the editor so the user can start typing immediately
+            editorObj.focus();
         },
         [onSubmit],
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11325

### Description:

> [!NOTE]
> We only _worry_ about a new sql query, bc when the user wants to edit a sql chart, the tab that is enabled on page load is the Chart/vis, not the sql editor.

Before

https://github.com/user-attachments/assets/670d5628-d788-4b98-bcef-fb7cedc896ec



After


https://github.com/user-attachments/assets/a35a97c8-d3f6-429d-86a5-0e9511e859f9



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
