### PR TITLE
test: use correct endpoint for download csv chart in dashboard

### DIFF
--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -86,13 +86,13 @@ describe('Download CSV on Dashboards', () => {
         'Should download a CSV from dashboard',
         { retries: 3, pageLoadTimeout: 1000 },
         () => {
-            const downloadUrl = `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/payments/downloadCsv`;
+            const downloadUrl = `/api/v1/saved/*/downloadCsv`;
             cy.intercept({
                 method: 'POST',
                 url: downloadUrl,
             }).as('apiDownloadCsv');
 
-            // wiat for the dashboard to load
+            // wait for the dashboard to load
             cy.findByText('Loading dashboards').should('not.exist');
 
             cy.contains('a', 'Jaffle dashboard').click();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After this merge: https://github.com/lightdash/lightdash/pull/11873/files#diff-911ad724a0c3e0f6738ce95dbf521028bdeefb7c83eeb0fb188b92ac87e3158a 

The test to download a chart tile csv in a dashboard broke bc the endpoint is slightly different.

<img width="415" alt="Screenshot 2024-10-14 at 17 09 22" src="https://github.com/user-attachments/assets/49a7ab78-1392-47ba-ad00-7aa03fa58d04">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-frontent
test-backend
