### PR TITLE
fix: fix invalid slack message blocks when dashboard tile is empty

### DIFF
--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -338,23 +338,33 @@ export const getDashboardCsvResultsBlocks = ({
                 action_id: 'button-action',
             },
         },
-        ...csvUrls.map<KnownBlock>((csvUrl, index) => ({
-            type: 'section',
-            text: {
-                type: 'mrkdwn',
-                text: `:black_small_square: ${csvUrl.filename}`,
-            },
-            accessory: {
-                type: 'button',
-                text: {
-                    type: 'plain_text',
-                    text: 'Download results',
-                    emoji: true,
-                },
-                url: csvUrl.path,
-                action_id: `download-results-${index}`,
-            },
-        })),
+        ...csvUrls.map<KnownBlock>((csvUrl, index) =>
+            csvUrl.path !== '#no-results'
+                ? {
+                      type: 'section',
+                      text: {
+                          type: 'mrkdwn',
+                          text: `:black_small_square: ${csvUrl.filename}`,
+                      },
+                      accessory: {
+                          type: 'button',
+                          text: {
+                              type: 'plain_text',
+                              text: 'Download results',
+                              emoji: true,
+                          },
+                          url: csvUrl.path,
+                          action_id: `download-results-${index}`,
+                      },
+                  }
+                : {
+                      type: 'section',
+                      text: {
+                          type: 'mrkdwn',
+                          text: '*_This query returned no results_*',
+                      },
+                  },
+        ),
         footerMarkdown
             ? {
                   type: 'context',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Issue: when dashboard tile is empty, csvUrl is assigned with value '#no-results', then when generating the slack message blocks, this value is passed directly to `url` field, which would result in invalid message block error.

```
accessory: {
    ...
        url: csvUrl.path,
    ...
},
```

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
