### PR TITLE
fix: apply correct boolean check when editing virtual view

### DIFF
--- a/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
@@ -10,8 +10,7 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
-import { lazy, Suspense, useState, type FC } from 'react';
-import { ConditionalVisibility } from '../../../components/common/ConditionalVisibility';
+import { lazy, Suspense, useState, useTransition, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useExplorerContext } from '../../../providers/ExplorerProvider';
@@ -31,6 +30,7 @@ export const EditVirtualViewModal: FC<Props> = ({
     explore,
 }) => {
     const hasUnsavedChanges = !!useSearchParams('create_saved_chart_version');
+    const [isPending, startTransition] = useTransition();
 
     const [modalStep, setModalStep] = useState<
         'unsavedChanges' | 'editVirtualView' | undefined
@@ -76,7 +76,7 @@ export const EditVirtualViewModal: FC<Props> = ({
                 },
             })}
         >
-            <ConditionalVisibility isVisible={modalStep === 'unsavedChanges'}>
+            {modalStep === 'unsavedChanges' && (
                 <Stack>
                     <Text fz="sm">
                         Are you sure you want to leave this page? Changes you've
@@ -89,17 +89,19 @@ export const EditVirtualViewModal: FC<Props> = ({
                         <Button
                             color="red"
                             onClick={() => {
-                                clearQuery();
-
-                                setModalStep('editVirtualView');
+                                startTransition(() => {
+                                    clearQuery();
+                                    setModalStep('editVirtualView');
+                                });
                             }}
+                            loading={isPending}
                         >
                             Discard & continue
                         </Button>
                     </Group>
                 </Stack>
-            </ConditionalVisibility>
-            <ConditionalVisibility isVisible={modalStep === 'editVirtualView'}>
+            )}
+            {modalStep === 'editVirtualView' && (
                 <Suspense
                     fallback={
                         <Center h="95vh" w="95vw">
@@ -120,7 +122,7 @@ export const EditVirtualViewModal: FC<Props> = ({
                         }}
                     />
                 </Suspense>
-            </ConditionalVisibility>
+            )}
         </Modal>
     );
 };

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -59,18 +59,10 @@ const SqlRunnerNew = ({
         dispatch(resetChartState());
     });
 
-    useEffect(() => {
-        if (virtualViewState) {
-            // remove wrapping parenthesis if they exist
-            const sql = virtualViewState.sql.replace(/^[()]+|[()]+$/g, '');
-            dispatch(setSql(sql));
-            dispatch(setMode('virtualView'));
-        }
-    }, [dispatch, virtualViewState]);
-
     useMount(() => {
         const shouldFetch = !!isEditMode || !!virtualViewState;
-        const shouldOpenChartOnLoad = !!isEditMode;
+        // If we are editing a virtual view, we don't want to open the chart on load
+        const shouldOpenChartOnLoad = !!isEditMode && !virtualViewState;
 
         if (shouldFetch) {
             dispatch(
@@ -79,6 +71,12 @@ const SqlRunnerNew = ({
                     shouldOpenChartOnLoad,
                 }),
             );
+        }
+        if (virtualViewState) {
+            // remove wrapping parenthesis if they exist
+            const sql = virtualViewState.sql.replace(/^[()]+|[()]+$/g, '');
+            dispatch(setSql(sql));
+            dispatch(setMode('virtualView'));
         }
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Fix boolean check introduced in #11611  - messed this up but it's fixed now and included on-mount-related-code in that `useOnMount`

Fixed a perf issue when switching between modals when editing a virtual view. Suspense loads the chart correctly and caches it after closing the modal and reopening it! 

Before

see chart opening and screen freezing while loading the sql runner component async

https://github.com/user-attachments/assets/0dff6698-4c34-43b9-8a6f-0f0c3f2030ff

After

both issues fixed - opens sql and there's no freeze between modal body states.

https://github.com/user-attachments/assets/febe0521-6349-4160-9f45-ce6a17ba3cd1



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


