### PR TITLE
chore: add CUD virtual views & query_executed analytics events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -208,6 +208,7 @@ type MetricQueryExecutionProperties = {
     numCustomSqlDimensions: number;
     dateZoomGranularity: string | null;
     timezone?: string;
+    virtualViewId?: string;
 };
 
 type SqlExecutionProperties = {

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1056,6 +1056,38 @@ export type SemanticLayerView = BaseTrack & {
     };
 };
 
+export type VirtualViewCreatedEvent = BaseTrack & {
+    event: 'virtual_view.created';
+    userId: string;
+    properties: {
+        virtualViewId: string;
+        name: string;
+        projectId: string;
+        organizationId: string;
+    };
+};
+
+export type VirtualViewUpdatedEvent = BaseTrack & {
+    event: 'virtual_view.updated';
+    userId: string;
+    properties: {
+        virtualViewId: string;
+        name: string;
+        projectId: string;
+        organizationId: string;
+    };
+};
+
+export type VirtualViewDeletedEvent = BaseTrack & {
+    event: 'virtual_view.deleted';
+    userId: string;
+    properties: {
+        virtualViewId: string;
+        projectId: string;
+        organizationId: string;
+    };
+};
+
 type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -1128,7 +1160,10 @@ type TypedEvent =
     | UpdateSqlChartEvent
     | DeleteSqlChartEvent
     | CreateSqlChartVersionEvent
-    | CommentsEvent;
+    | CommentsEvent
+    | VirtualViewCreatedEvent
+    | VirtualViewUpdatedEvent
+    | VirtualViewDeletedEvent;
 
 type WrapTypedEvent = SemanticLayerView;
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1057,36 +1057,26 @@ export type SemanticLayerView = BaseTrack & {
     };
 };
 
-export type VirtualViewCreatedEvent = BaseTrack & {
+export type BaseVirtualViewEvent = BaseTrack & {
+    userId: string;
+    properties: {
+        virtualViewId: string;
+        projectId: string;
+        organizationId: string;
+        name?: string;
+    };
+};
+
+export type VirtualViewCreatedEvent = BaseVirtualViewEvent & {
     event: 'virtual_view.created';
-    userId: string;
-    properties: {
-        virtualViewId: string;
-        name: string;
-        projectId: string;
-        organizationId: string;
-    };
 };
 
-export type VirtualViewUpdatedEvent = BaseTrack & {
+export type VirtualViewUpdatedEvent = BaseVirtualViewEvent & {
     event: 'virtual_view.updated';
-    userId: string;
-    properties: {
-        virtualViewId: string;
-        name: string;
-        projectId: string;
-        organizationId: string;
-    };
 };
 
-export type VirtualViewDeletedEvent = BaseTrack & {
+export type VirtualViewDeletedEvent = BaseVirtualViewEvent & {
     event: 'virtual_view.deleted';
-    userId: string;
-    properties: {
-        virtualViewId: string;
-        projectId: string;
-        organizationId: string;
-    };
 };
 
 type TypedEvent =

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2038,7 +2038,7 @@ export class ProjectModel {
         projectUuid: string,
         { name, sql, columns }: CreateVirtualViewPayload,
         warehouseClient: WarehouseClient,
-    ): Promise<Pick<Explore, 'name'>> {
+    ): Promise<Explore> {
         const virtualView = createVirtualView(
             name,
             sql,
@@ -2077,7 +2077,7 @@ export class ProjectModel {
             })
             .returning('*');
 
-        return { name };
+        return virtualView;
     }
 
     async updateVirtualView(
@@ -2139,7 +2139,7 @@ export class ProjectModel {
             })
             .returning('*');
 
-        return { name: translatedToExplore.name };
+        return translatedToExplore;
     }
 
     async deleteVirtualView(projectUuid: string, name: string) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1918,6 +1918,9 @@ export class ProjectService extends BaseService {
                                 ? { dashboardId: queryTags.dashboard_uuid }
                                 : {}),
                             chartId: chartUuid,
+                            ...(explore.type === ExploreType.VIRTUAL
+                                ? { virtualViewId: explore.name }
+                                : {}),
                         },
                     });
                     this.logger.debug(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -43,6 +43,7 @@ import {
     findFieldByIdInExplore,
     ForbiddenError,
     formatRows,
+    friendlyName,
     getAggregatedField,
     getDashboardFilterRulesForTables,
     getDateDimension,
@@ -4421,7 +4422,19 @@ export class ProjectService extends BaseService {
             payload,
             warehouseClient,
         );
-        return virtualView;
+
+        this.analytics.track({
+            event: 'virtual_view.created',
+            userId: user.userUuid,
+            properties: {
+                virtualViewId: virtualView.name,
+                name: virtualView.label,
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+            },
+        });
+
+        return { name: virtualView.name };
     }
 
     async updateSemanticLayerConnection(
@@ -4500,7 +4513,18 @@ export class ProjectService extends BaseService {
             warehouseClient,
         );
 
-        return updatedExplore;
+        this.analytics.track({
+            event: 'virtual_view.updated',
+            userId: user.userUuid,
+            properties: {
+                virtualViewId: updatedExplore.name,
+                name: updatedExplore.label,
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+            },
+        });
+
+        return { name: updatedExplore.name };
     }
 
     async deleteVirtualView(
@@ -4520,6 +4544,16 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
-        return this.projectModel.deleteVirtualView(projectUuid, name);
+        await this.projectModel.deleteVirtualView(projectUuid, name);
+
+        this.analytics.track({
+            event: 'virtual_view.deleted',
+            userId: user.userUuid,
+            properties: {
+                virtualViewId: name,
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+            },
+        });
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11960 

### Description:

> [!NOTE]
> I'm doing the `saved_chart_created` and `saved_chart_updated` on a separate PR since it demands a wider change

**virtual_view_created - this event should be triggered when a virtual view is first created.**

<img width="1892" alt="Screenshot 2024-10-17 at 10 25 36" src="https://github.com/user-attachments/assets/ea7b442a-63b8-4238-931b-6925e91ee194">

**virtual_view_updated - this event should be triggered when a virtual view is updated.**

<img width="1873" alt="Screenshot 2024-10-17 at 10 26 27" src="https://github.com/user-attachments/assets/29404e8d-690f-4f0e-b24d-277e670382ab">

**virtual_view_deleted - this event should be triggered when a virtual view is deleted.**

<img width="1838" alt="Screenshot 2024-10-17 at 10 27 21" src="https://github.com/user-attachments/assets/7d994f99-0695-47d1-a42c-f4f3eedffe96">

**query_executed --> add a parameter called virtual_view_id which is empty if the query was executed from a regular explore or the SQL runner, but is non-empty if the query was executed from a virtual view.**

<img width="1835" alt="Screenshot 2024-10-17 at 10 36 49" src="https://github.com/user-attachments/assets/cd96ed6c-1cb4-45b0-a12c-832d07fb521e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

