### PR TITLE
fix: fix additional_dimensions allowing time_intervals

### DIFF
--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -383,6 +383,79 @@
                                                     "maxItems": 2
                                                 }
                                             }
+                                        },
+                                        "additional_dimensions": {
+                                            "type": "object",
+                                            "patternProperties": {
+                                                "^[a-z0-9_]+$": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "string",
+                                                                "number",
+                                                                "timestamp",
+                                                                "date",
+                                                                "boolean"
+                                                            ]
+                                                        },
+                                                        "label": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                        },
+                                                        "sql": {
+                                                            "type": "string",
+                                                            "minLength": 1
+                                                        },
+                                                        "time_intervals": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "RAW",
+                                                                            "DAY",
+                                                                            "WEEK",
+                                                                            "MONTH",
+                                                                            "QUARTER",
+                                                                            "YEAR",
+                                                                            "HOUR",
+                                                                            "MINUTE",
+                                                                            "SECOND",
+                                                                            "MILLISECOND",
+                                                                            "WEEK_NUM",
+                                                                            "MONTH_NUM",
+                                                                            "MONTH_NAME",
+                                                                            "DAY_OF_WEEK_NAME",
+                                                                            "QUARTER_NAME",
+                                                                            "DAY_OF_WEEK_INDEX",
+                                                                            "DAY_OF_MONTH_NUM",
+                                                                            "DAY_OF_YEAR_NUM",
+                                                                            "QUARTER_NUM",
+                                                                            "YEAR_NUM",
+                                                                            "HOUR_OF_DAY_NUM",
+                                                                            "MINUTE_OF_HOUR_NUM"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "default",
+                                                                        "OFF"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -99,7 +99,7 @@ type DbtColumnLightdashConfig = {
     metrics?: { [metricName: string]: DbtColumnLightdashMetric };
 };
 
-type DbtColumnLightdashDimension = {
+export type DbtColumnLightdashDimension = {
     name?: string;
     label?: string;
     type?: DimensionType;
@@ -119,7 +119,7 @@ type DbtColumnLightdashDimension = {
 
 type DbtColumnLightdashAdditionalDimension = Omit<
     DbtColumnLightdashDimension,
-    'name' | 'time_intervals'
+    'name'
 >;
 
 export type DbtColumnLightdashMetric = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11716 

### Description:

After this PR `additional_dimensions` now support `time_intervals`!
It follows the same logic of `dimensions` where:
- if `time_intervals` is not specified, it uses the default
- if `time_intervals` is specified, it uses those intervals
- if `time_intervals` are "OFF", the value is raw

```yaml
      - name: event
        description: ""
        meta:
          dimension:
            type: string
            groups: ["events"]
          additional_dimensions:
            timestamp_est:
              type: timestamp
              group_label: "Timestamp test"
              sql: ${TABLE}.timestamp_ltz
              time_intervals: ["YEAR"]
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
