### PR TITLE
feat: custom dimensions custom range float values

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -150,7 +150,7 @@ export const CustomBinDimensionModal: FC<{
     }, [setFieldValue, item, isEditing]);
 
     const handleOnSubmit = form.onSubmit((unparsedValues) => {
-        // manitne form does not produce zod parsed values
+        // mantine form does not produce zod parsed values
         // so, number({ coerce: true }) does not work
         // that's why we need to parse the values manually
         const values = formSchema.parse(unparsedValues);

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -149,7 +149,12 @@ export const CustomBinDimensionModal: FC<{
         }
     }, [setFieldValue, item, isEditing]);
 
-    const handleOnSubmit = form.onSubmit((values) => {
+    const handleOnSubmit = form.onSubmit((unparsedValues) => {
+        // manitne form does not produce zod parsed values
+        // so, number({ coerce: true }) does not work
+        // that's why we need to parse the values manually
+        const values = formSchema.parse(unparsedValues);
+
         if (item) {
             const sanitizedId = sanitizeId(
                 values.customDimensionLabel,

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -97,10 +97,12 @@ export const CustomBinDimensionModal: FC<{
                 binWidth: z.number().positive(),
             }),
             customRange: z.array(
-                z.object({
-                    from: z.number({ coerce: true }).or(z.undefined()),
-                    to: z.number({ coerce: true }).or(z.undefined()),
-                }),
+                z
+                    .object({
+                        from: z.number({ coerce: true }).optional(),
+                        to: z.number({ coerce: true }).optional(),
+                    })
+                    .transform((o) => ({ from: o.from, to: o.to })),
             ),
         }),
     });


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/11859

### Description:

mantine 7 offers the option to have floats in the number input. but mantine 6 does not. changed to text input instead of number input and I also added a zod schema

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
