### PR TITLE
feat: reorderable dashboard filters

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,6 +27,8 @@
     "dependencies": {
         "@casl/ability": "^5.4.4",
         "@casl/react": "^3.0.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
         "@emotion/react": "^11.10.6",
         "@hello-pangea/dnd": "^16.5.0",
         "@hookform/error-message": "^2.0.0",

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -1,5 +1,18 @@
+import {
+    DndContext,
+    DragOverlay,
+    MouseSensor,
+    TouchSensor,
+    useDraggable,
+    useDroppable,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+    type DragStartEvent,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
 import { Group, Skeleton } from '@mantine/core';
-import { type FC } from 'react';
+import { type FC, type ReactNode } from 'react';
 import { useDashboardContext } from '../../../providers/DashboardProvider';
 import Filter from '../Filter';
 import InvalidFilter from '../InvalidFilter';
@@ -10,6 +23,55 @@ interface ActiveFiltersProps {
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
 }
+
+const DraggableItem: FC<{
+    id: string;
+    children: ReactNode;
+    disabled?: boolean;
+}> = ({ id, children, disabled }) => {
+    const { attributes, listeners, setNodeRef, transform } = useDraggable({
+        id,
+        disabled,
+    });
+    const style = transform
+        ? {
+              transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+              opacity: 0.8,
+          }
+        : undefined;
+    return (
+        <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+            {children}
+        </div>
+    );
+};
+
+const DroppableArea: FC<{ id: string; children: ReactNode }> = ({
+    id,
+    children,
+}) => {
+    const { active, isOver, over, setNodeRef } = useDroppable({ id });
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const placeHolderStyle = { boxShadow: 'unset' };
+    if (isOver && active && over && active.id !== over.id) {
+        const oldIndex = dashboardFilters.dimensions.findIndex(
+            (item) => item.id === active.id,
+        );
+        const newIndex = dashboardFilters.dimensions.findIndex(
+            (item) => item.id === over.id,
+        );
+        if (newIndex < oldIndex) {
+            placeHolderStyle.boxShadow = '-8px 0px #6495ed';
+        } else if (newIndex > oldIndex) {
+            placeHolderStyle.boxShadow = '8px 0px #6495ed';
+        }
+    }
+    return (
+        <div ref={setNodeRef} style={{ ...placeHolderStyle }}>
+            {children}
+        </div>
+    );
+};
 
 const ActiveFilters: FC<ActiveFiltersProps> = ({
     isEditMode,
@@ -36,6 +98,20 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     const updateDimensionDashboardFilter = useDashboardContext(
         (c) => c.updateDimensionDashboardFilter,
     );
+    const setDashboardFilters = useDashboardContext(
+        (c) => c.setDashboardFilters,
+    );
+    const setHaveFiltersChanged = useDashboardContext(
+        (c) => c.setHaveFiltersChanged,
+    );
+
+    const mouseSensor = useSensor(MouseSensor, {
+        activationConstraint: { distance: 10 },
+    });
+    const touchSensor = useSensor(TouchSensor, {
+        activationConstraint: { delay: 250, tolerance: 5 },
+    });
+    const dragSensors = useSensors(mouseSensor, touchSensor);
 
     if (isLoadingDashboardFilters || isFetchingDashboardFilters) {
         return (
@@ -51,42 +127,91 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
 
     if (!allFilterableFieldsMap) return null;
 
+    const handleDragStart = (_event: DragStartEvent) => onPopoverClose();
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!active || !over || active.id === over.id) return;
+        const oldIndex = dashboardFilters.dimensions.findIndex(
+            (item) => item.id === active.id,
+        );
+        const newIndex = dashboardFilters.dimensions.findIndex(
+            (item) => item.id === over.id,
+        );
+        const newDimensions = arrayMove(
+            dashboardFilters.dimensions,
+            oldIndex,
+            newIndex,
+        );
+        setDashboardFilters({
+            ...dashboardFilters,
+            dimensions: newDimensions,
+        });
+        setHaveFiltersChanged(true);
+    };
+
     return (
         <>
-            {dashboardFilters.dimensions.map((item, index) => {
-                const field = allFilterableFieldsMap[item.target.fieldId];
-                return field ? (
-                    <Filter
-                        key={item.id}
-                        isEditMode={isEditMode}
-                        field={field}
-                        filterRule={item}
-                        openPopoverId={openPopoverId}
-                        onPopoverOpen={onPopoverOpen}
-                        onPopoverClose={onPopoverClose}
-                        onRemove={() =>
-                            removeDimensionDashboardFilter(index, false)
-                        }
-                        onUpdate={(value) =>
-                            updateDimensionDashboardFilter(
-                                value,
-                                index,
-                                false,
-                                isEditMode,
-                            )
-                        }
-                    />
-                ) : (
-                    <InvalidFilter
-                        key={item.id}
-                        isEditMode={isEditMode}
-                        filterRule={item}
-                        onRemove={() =>
-                            removeDimensionDashboardFilter(index, false)
-                        }
-                    />
-                );
-            })}
+            <DndContext
+                sensors={dragSensors}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+            >
+                <>
+                    {dashboardFilters.dimensions.map((item, index) => {
+                        const field =
+                            allFilterableFieldsMap[item.target.fieldId];
+                        return (
+                            <DroppableArea key={item.id} id={item.id}>
+                                <DraggableItem
+                                    key={item.id}
+                                    id={item.id}
+                                    disabled={!isEditMode}
+                                >
+                                    {field ? (
+                                        <Filter
+                                            key={item.id}
+                                            isEditMode={isEditMode}
+                                            field={field}
+                                            filterRule={item}
+                                            openPopoverId={openPopoverId}
+                                            onPopoverOpen={onPopoverOpen}
+                                            onPopoverClose={onPopoverClose}
+                                            onRemove={() =>
+                                                removeDimensionDashboardFilter(
+                                                    index,
+                                                    false,
+                                                )
+                                            }
+                                            onUpdate={(value) =>
+                                                updateDimensionDashboardFilter(
+                                                    value,
+                                                    index,
+                                                    false,
+                                                    isEditMode,
+                                                )
+                                            }
+                                        />
+                                    ) : (
+                                        <InvalidFilter
+                                            key={item.id}
+                                            isEditMode={isEditMode}
+                                            filterRule={item}
+                                            onRemove={() =>
+                                                removeDimensionDashboardFilter(
+                                                    index,
+                                                    false,
+                                                )
+                                            }
+                                        />
+                                    )}
+                                </DraggableItem>
+                            </DroppableArea>
+                        );
+                    })}
+                </>
+                <DragOverlay />
+            </DndContext>
 
             {dashboardTemporaryFilters.dimensions.map((item, index) => {
                 const field = allFilterableFieldsMap[item.target.fieldId];

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -224,7 +224,14 @@ const Filter: FC<Props> = ({
                             }
                             bg="white"
                             leftIcon={
-                                isDraggable && <IconGripVertical size={12} />
+                                isDraggable && (
+                                    <MantineIcon
+                                        icon={IconGripVertical}
+                                        color="gray"
+                                        cursor="grab"
+                                        size="sm"
+                                    />
+                                )
                             }
                             rightIcon={
                                 (isEditMode || isTemporary) && (

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -12,7 +12,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useDisclosure, useId } from '@mantine/hooks';
-import { IconFilter } from '@tabler/icons-react';
+import { IconFilter, IconGripVertical } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import { useDashboardContext } from '../../providers/DashboardProvider';
 import {
@@ -74,6 +74,8 @@ const Filter: FC<Props> = ({
 
     const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
         useDisclosure();
+
+    const isDraggable = isEditMode && !isTemporary;
 
     const defaultFilterRule = useMemo(() => {
         if (!filterableFieldsByTileUuid || !field || !filterRule) return;
@@ -221,6 +223,9 @@ const Filter: FC<Props> = ({
                                     : 'default'
                             }
                             bg="white"
+                            leftIcon={
+                                isDraggable && <IconGripVertical size={12} />
+                            }
                             rightIcon={
                                 (isEditMode || isTemporary) && (
                                     <CloseButton size="sm" onClick={onRemove} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,6 +2382,37 @@
     gonzales-pe "^4.3.0"
     node-source-walk "^7.0.0"
 
+"@dnd-kit/accessibility@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz#1054e19be276b5f1154ced7947fc0cb5d99192e0"
+  integrity sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.1.0.tgz#e81a3d10d9eca5d3b01cbf054171273a3fe01def"
+  integrity sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.0"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-8.0.0.tgz#086b7ac6723d4618a4ccb6f0227406d8a8862a96"
+  integrity sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.10.6":
   version "11.10.6"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz"


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/6705

### Description:
When editing a dashboard, filters may be reordered by dragging. Blue indicator denotes drop location.
![image](https://github.com/user-attachments/assets/9db9ceed-ae30-4508-bbe4-9a985eca6c55)

Please note:
1. Using `dnd-kit` as it supports dragging of components that wrap to multiple lines.
2. The blue "drop zone" indicator only occupies the existing space between filters because trying to expand it causes glitches when filters wrap on multiple lines. This is also the reason the 6-dot drag handle appears on all filters when in edit mode rather than only on mouseover.
3. While dragging, filter is slightly translucent to help see what's under it. Lmk if you'd like to change that.
4. A dragged filter appears under filters to its right. I looked into fixing this, and the code changes are considerable. Since this is sort of nice to have, I did not continue working on that, but will if you'd like. Lmk.
5. Fyi there is a bug unrelated to this PR where temporary filters disappear on save, although they are saved. Steps to repro: add temporary filter, enter edit mode, save. Temp filter disappears. Reload page to see it was saved, and it displays as a non-temporary filter.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
