### PR TITLE
fix: check for saved chart view access when running pivot query

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7113,6 +7113,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 indexColumn: { ref: 'PivotIndexColum', required: true },
+                savedSqlUuid: { dataType: 'string' },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7898,6 +7898,9 @@
                     },
                     "indexColumn": {
                         "$ref": "#/components/schemas/PivotIndexColum"
+                    },
+                    "savedSqlUuid": {
+                        "type": "string"
                     }
                 },
                 "required": ["valuesColumns", "indexColumn"],
@@ -10652,7 +10655,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1304.1",
+        "version": "0.1309.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -429,24 +429,24 @@ export class SavedSqlService extends BaseService {
             }
         }
 
-        const { hasAccess: hasViewAccess } = savedChart
+        const { hasAccess: savedChartViewAccess } = savedChart
             ? await this.hasSavedChartAccess(user, 'view', savedChart)
             : { hasAccess: false };
 
         if (
             // If it's not a saved chart, check if the user has access to run a pivot query
-            user.ability.cannot(
+            !savedChartViewAccess &&
+            (user.ability.cannot(
                 'create',
                 subject('Job', { organizationUuid, projectUuid }),
             ) ||
-            (user.ability.cannot(
-                'manage',
-                subject('SqlRunner', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            ) &&
-                !hasViewAccess)
+                user.ability.cannot(
+                    'manage',
+                    subject('SqlRunner', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                ))
         ) {
             throw new ForbiddenError();
         }

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -34,6 +34,7 @@ export type SqlRunnerPayload = {
 } & SqlRunnerBody;
 
 type ApiSqlRunnerPivotQueryPayload = {
+    savedSqlUuid?: string;
     indexColumn: PivotIndexColum;
     valuesColumns: {
         reference: string;

--- a/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
+++ b/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
@@ -23,6 +23,7 @@ const schedulePivotSqlJob = async ({
     ...payload
 }: {
     projectUuid: string;
+    savedSqlUuid?: string;
     context?: string;
 } & SqlRunnerPivotQueryBody) =>
     lightdashApi<ApiJobScheduledResponse['results']>({
@@ -32,19 +33,24 @@ const schedulePivotSqlJob = async ({
         method: 'POST',
         body: JSON.stringify(payload),
     });
+
 type PivotQueryFn = (
     args: SqlRunnerPivotQueryBody & {
         projectUuid: string;
+        savedSqlUuid?: string;
         context?: string;
     },
 ) => Promise<Omit<PivotChartData, 'columns'>>;
+
 const pivotQueryFn: PivotQueryFn = async ({
     projectUuid,
+    savedSqlUuid,
     context,
     ...args
 }) => {
     const scheduledJob = await schedulePivotSqlJob({
         projectUuid,
+        savedSqlUuid,
         context,
         ...args,
     });
@@ -121,6 +127,7 @@ const convertSemanticLayerQueryToSqlRunnerPivotQuery = (
 // TEMPORARY
 export const getPivotQueryFunctionForSqlRunner = ({
     projectUuid,
+    savedSqlUuid,
     limit,
     sortBy,
     sql,
@@ -128,6 +135,7 @@ export const getPivotQueryFunctionForSqlRunner = ({
     context,
 }: {
     projectUuid: string;
+    savedSqlUuid?: string;
     limit?: number;
     sql: string;
     sortBy?: VizSortBy[];
@@ -149,6 +157,7 @@ export const getPivotQueryFunctionForSqlRunner = ({
             convertSemanticLayerQueryToSqlRunnerPivotQuery(query, fields);
         const pivotResults = await pivotQueryFn({
             projectUuid,
+            savedSqlUuid,
             sql,
             indexColumn,
             valuesColumns,

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -69,10 +69,12 @@ export const useSavedSqlChartResults = ({
                 getResultsFromStream,
                 context,
             });
+
             const resultsRunner = new SqlRunnerResultsRunnerFrontend({
                 rows: chartResults.results,
                 columns: chartResults.columns,
                 projectUuid: projectUuid!,
+                savedSqlUuid: chart.savedSqlUuid,
                 sql: chart.sql,
                 ...(isVizCartesianChartConfig(chart.config) && {
                     sortBy: chart.config.fieldConfig?.sortBy,

--- a/packages/frontend/src/features/sqlRunner/runners/SqlRunnerResultsRunnerFrontend.ts
+++ b/packages/frontend/src/features/sqlRunner/runners/SqlRunnerResultsRunnerFrontend.ts
@@ -34,6 +34,7 @@ export class SqlRunnerResultsRunnerFrontend extends BaseResultsRunner {
         columns,
         rows,
         projectUuid,
+        savedSqlUuid,
         limit,
         sql,
         sortBy,
@@ -41,6 +42,7 @@ export class SqlRunnerResultsRunnerFrontend extends BaseResultsRunner {
         columns: VizColumn[];
         rows: RawResultRow[];
         projectUuid: string;
+        savedSqlUuid?: string;
         limit?: number;
         sql: string;
         sortBy?: VizSortBy[];
@@ -63,6 +65,7 @@ export class SqlRunnerResultsRunnerFrontend extends BaseResultsRunner {
             columnNames: fields.map((field) => field.name),
             runPivotQuery: getPivotQueryFunctionForSqlRunner({
                 projectUuid,
+                savedSqlUuid,
                 limit,
                 sql,
                 fields,

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -383,6 +383,7 @@ export const {
 
 export const selectSqlRunnerResultsRunner = createSelector(
     [
+        sqlRunnerSlice.selectors.selectSavedSqlChart,
         sqlRunnerSlice.selectors.selectColumns,
         sqlRunnerSlice.selectors.selectRows,
         selectProjectUuid,
@@ -390,7 +391,7 @@ export const selectSqlRunnerResultsRunner = createSelector(
         selectSql,
         (_state, sortBy?: VizSortBy[]) => sortBy,
     ],
-    (columns, rows, projectUuid, limit, sql, sortBy) => {
+    (sqlChart, columns, rows, projectUuid, limit, sql, sortBy) => {
         return new SqlRunnerResultsRunnerFrontend({
             columns: columns || [],
             rows: rows || [],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11995 

### Description:

**Steps to test**
1. Create a chart using the `Sql Runner` & save
2. Create a new user with `editor` role
3. Open the saved chart using the `editor` user

Note: `viewers` & `interactive_viewers` should also be able to see the saved chart, as this should have the same permissions as normal charts

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
