### PR TITLE
fix: compare sqls on change to edit virtual view

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -66,6 +66,17 @@ const normalizeSQL = (
     }
 };
 
+export const compareSqlQueries = (
+    previousSql: string,
+    currentSql: string,
+    warehouseConnectionType: WarehouseTypes | undefined,
+): boolean => {
+    return (
+        normalizeSQL(previousSql, warehouseConnectionType) !==
+        normalizeSQL(currentSql, warehouseConnectionType)
+    );
+};
+
 export const DEFAULT_NAME = 'Untitled SQL Query';
 
 export interface SqlRunnerState {
@@ -282,7 +293,11 @@ export const sqlRunnerSlice = createSlice({
                 state.successfulSqlQueries.current || '',
                 state.warehouseConnectionType,
             );
-            state.hasUnrunChanges = normalizedNewSql !== normalizedCurrentSql;
+            state.hasUnrunChanges = compareSqlQueries(
+                normalizedNewSql,
+                normalizedCurrentSql,
+                state.warehouseConnectionType,
+            );
         },
         setSqlLimit: (state, action: PayloadAction<number>) => {
             state.limit = action.payload;

--- a/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
@@ -41,6 +41,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useValidationWithResults } from '../../../hooks/validation/useValidation';
 import { useSqlQueryRun } from '../../sqlRunner/hooks/useSqlQueryRun';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
+import { compareSqlQueries } from '../../sqlRunner/store/sqlRunnerSlice';
 import { useUpdateVirtualView } from '../hooks/useVirtualView';
 import { compareColumns, type ColumnDiff } from '../utils/compareColumns';
 
@@ -337,8 +338,17 @@ export const HeaderVirtualView: FC<{
     const history = useHistory();
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
-    const hasUnrunChanges = useAppSelector(
-        (state) => state.sqlRunner.hasUnrunChanges,
+    const warehouseConnectionType = useAppSelector(
+        (state) => state.sqlRunner.warehouseConnectionType,
+    );
+    const hasUnrunChanges = useMemo(
+        () =>
+            compareSqlQueries(
+                virtualViewState.sql,
+                sql,
+                warehouseConnectionType,
+            ),
+        [sql, virtualViewState.sql, warehouseConnectionType],
     );
 
     const { mutateAsync: getValidation, isPolling: isRunningValidation } =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Found this issue when the user types a SQL query, runs it, but can't save its edit. 
Only they can type the sql and click save. 

reuses a compare sql function. 

**before**

https://github.com/user-attachments/assets/35ee226e-dde9-4cd9-9882-f97d9e56d2d3

**after**


https://github.com/user-attachments/assets/8ac2574f-9fbb-483e-aadc-7da76bfe7a3e




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
