### PR TITLE
chore: modern-ish backend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "prettier": "2.7.1",
         "prettier-plugin-organize-imports": "^3.1.1",
         "ts-jest": "^29.1.1",
-        "tslib": "^2.6.2",
+        "tslib": "^2.8.0",
         "tsx": "4.11.0",
         "typescript": "^4.9.5"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     },
     "dependencies": {
         "concurrently": "^8.2.0",
-        "npm-run-all2": "^6.0.6"
+        "npm-run-all2": "^6.0.6",
+        "tslib": "^2.6.2"
     },
     "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -42,7 +43,6 @@
         "prettier": "2.7.1",
         "prettier-plugin-organize-imports": "^3.1.1",
         "ts-jest": "^29.1.1",
-        "tslib": "^2.8.0",
         "tsx": "4.11.0",
         "typescript": "^4.9.5"
     },

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -3,14 +3,16 @@
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig.json to read more about this file */
         "resolveJsonModule": true,
-
         "composite": true,
         /* Basic Options */
         // "incremental": true,                         /* Enable incremental compilation */
-        "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-        "lib": ["esnext", "dom"],
-        "allowJs": true /* Allow javascript files to be compiled. */,
+        "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "lib": [
+            "ESNext",
+            "DOM"
+        ],
+        "allowJs": false /* Allow javascript files to be compiled. */,
         // "checkJs": true,                             /* Report errors in .js files. */
         // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
         // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
@@ -23,10 +25,9 @@
         // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
         // "removeComments": true,                      /* Do not emit comments to output. */
         // "noEmit": true,                              /* Do not emit outputs. */
-        // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+        "importHelpers": true, /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
         /* Strict Type-Checking Options */
         "strict": true /* Enable all strict type-checking options. */,
         "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
@@ -36,7 +37,6 @@
         // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
         // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
         // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-
         /* Additional Checks */
         // "noUnusedLocals": true,                      /* Report errors on unused locals. */
         // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
@@ -44,9 +44,8 @@
         // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
         // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
         // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-
         /* Module Resolution Options */
-        // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "moduleResolution": "Node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
         // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -55,27 +54,27 @@
         //            "./node_modules/@types"
         //        ] /* List of folders to include type definitions from. */,
         // "types": [],                                 /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        // "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
         // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
         // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-
         /* Source Map Options */
         // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
         // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
         // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
         // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
         /* Experimental Options */
         "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
         // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-
         /* Advanced Options */
         "skipLibCheck": true /* Skip type checking of declaration files. */,
         "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
         "useUnknownInCatchVariables": false
     },
-    "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.json"],
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.json"
+    ],
     "references": [
         {
             "path": "../common"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,11 +5,11 @@
         /* Basic Options */
         // "incremental": true,                         /* Enable incremental compilation */
         "target": "ES2022" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
         "lib": [
-            "esnext"
+            "ESNext"
         ],
-        // "allowJs": true,                             /* Allow javascript files to be compiled. */
+        "allowJs": false, /* Allow javascript files to be compiled. */
         // "checkJs": true,                             /* Report errors in .js files. */
         // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
         // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
@@ -22,7 +22,7 @@
         // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
         // "removeComments": true,                      /* Do not emit comments to output. */
         // "noEmit": true,                              /* Do not emit outputs. */
-        // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+        "importHelpers": true, /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
         /* Strict Type-Checking Options */
@@ -42,7 +42,7 @@
         // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
         // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
         /* Module Resolution Options */
-        "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "moduleResolution": "Node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
         // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -4,12 +4,12 @@
         /* Visit https://aka.ms/tsconfig.json to read more about this file */
         /* Basic Options */
         // "incremental": true,                         /* Enable incremental compilation */
-        "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
         "lib": [
-            "esnext"
+            "ESNext"
         ],
-        // "allowJs": true,                             /* Allow javascript files to be compiled. */
+        "allowJs": false, /* Allow javascript files to be compiled. */
         // "checkJs": true,                             /* Report errors in .js files. */
         // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
         // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
@@ -22,7 +22,7 @@
         // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
         // "removeComments": true,                      /* Do not emit comments to output. */
         // "noEmit": true,                              /* Do not emit outputs. */
-        // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+        "importHelpers": true, /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
         /* Strict Type-Checking Options */
@@ -42,13 +42,13 @@
         // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
         // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
         /* Module Resolution Options */
-        // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "moduleResolution": "Node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
         // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                             /* List of folders to include type definitions from. */
         // "types": [],                                 /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        // "allowSyntheticDefaultImports": false, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
         "resolveJsonModule": true,
         // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */

--- a/packages/warehouses/tsconfig.json
+++ b/packages/warehouses/tsconfig.json
@@ -2,13 +2,14 @@
     "extends": "./../../tsconfig.json",
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
         /* Basic Options */
         // "incremental": true,                         /* Enable incremental compilation */
-        "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-        "lib": ["esnext"],
-        // "allowJs": true,                             /* Allow javascript files to be compiled. */
+        "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "lib": [
+            "ESNext"
+        ],
+        "allowJs": false, /* Allow javascript files to be compiled. */
         // "checkJs": true,                             /* Report errors in .js files. */
         // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
         // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
@@ -24,7 +25,6 @@
         // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
         /* Strict Type-Checking Options */
         "strict": true /* Enable all strict type-checking options. */,
         "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
@@ -34,7 +34,6 @@
         // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
         // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
         // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-
         /* Additional Checks */
         // "noUnusedLocals": true,                      /* Report errors on unused locals. */
         // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
@@ -42,36 +41,35 @@
         // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
         // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
         // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-
         /* Module Resolution Options */
-        // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "moduleResolution": "Node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
         // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                             /* List of folders to include type definitions from. */
         // "types": [],                                 /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        // "allowSyntheticDefaultImports": false, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
         "resolveJsonModule": true,
         // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
         // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-
         /* Source Map Options */
         // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
         // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
         // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
         // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
         /* Experimental Options */
         // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-
         /* Advanced Options */
         "skipLibCheck": true /* Skip type checking of declaration files. */,
         "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
         "useUnknownInCatchVariables": false
     },
-    "include": ["src/**/*.ts", "src/**/*.json"],
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.json"
+    ],
     "references": [
         {
             "path": "../common"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20521,6 +20521,11 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.5.3, tslib@^2.6.1, tslib@^2.6
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
+tslib@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
+  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
+
 tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20521,11 +20521,6 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.5.3, tslib@^2.6.1, tslib@^2.6
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
-  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
-
 tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz"


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- smaller build
- synchronized config between backend/warehouses/common/cli
- modern-ish builds (supported by node 20)
- it supposed to have a performance impact since it's now using fewer polyfills and native async/await!


tsconfig values:

```json
{
  "target": "ES2020",
  "module": "CommonJS",
  "lib": [
    "ESNext"
  ],
  "allowJs": false,
  "importHelpers": true,
  "moduleResolution": "Node",
  "esModuleInterop": true,
}
```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
