### PR TITLE
fix(cli): set preview project in config when preview is updated

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -298,6 +298,7 @@ export const startPreviewHandler = async (
 
     const previewProject = await getPreviewProject(projectName);
     if (previewProject) {
+        await setPreviewProject(previewProject.projectUuid, projectName);
         await LightdashAnalytics.track({
             event: 'start_preview.update',
             properties: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12034 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


To reproduce bug run:
```
# creates preview
CI=true LIGHTDASH_API_KEY=af38f1f28d1d4d5ccc4a5c94781f70e1 LIGHTDASH_PROJECT=3675b69e-8324-4110-bdca-059031aa8da3 LIGHTDASH_URL=http://localhost:3000 node ./packages/cli/dist/index.js start-preview --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles --name 'banana'

# validates preview 
CI=true LIGHTDASH_API_KEY=af38f1f28d1d4d5ccc4a5c94781f70e1 LIGHTDASH_PROJECT=3675b69e-8324-4110-bdca-059031aa8da3 LIGHTDASH_URL=http://localhost:3000 node ./packages/cli/dist/index.js validate --preview --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles

# delete CLI config to mimic a new Github action run
rm ~./.config/lightdash/config.yaml

# updates preview
CI=true LIGHTDASH_API_KEY=af38f1f28d1d4d5ccc4a5c94781f70e1 LIGHTDASH_PROJECT=3675b69e-8324-4110-bdca-059031aa8da3 LIGHTDASH_URL=http://localhost:3000 node ./packages/cli/dist/index.js start-preview --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles --name 'banana'

# validates preview 
CI=true LIGHTDASH_API_KEY=af38f1f28d1d4d5ccc4a5c94781f70e1 LIGHTDASH_PROJECT=3675b69e-8324-4110-bdca-059031aa8da3 LIGHTDASH_URL=http://localhost:3000 node ./packages/cli/dist/index.js validate --preview --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles

```

It now applies the preview project context to the config  when the preview is being updated instead of created. This context will the used by `validate --preview` and not throw an error.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
