### PR TITLE
style: apply new designs to field configuration (x, y)

### DIFF
--- a/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
@@ -103,7 +103,7 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
 
         // Add a new series
-        cy.contains('Add').click();
+        cy.get('button[data-testid="add-y-axis-field"]').click();
         cy.get('.echarts-for-react')
             .find('text')
             .contains('Customer id sum')
@@ -122,10 +122,7 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
 
         // Verify that the chart is not displayed when the configuration is incomplete
-        cy.get('input[placeholder="Select X axis"]')
-            .siblings()
-            .find('button.mantine-CloseButton-root')
-            .click();
+        cy.get('button[data-testid="remove-x-axis-field"]').click();
         cy.contains('Incomplete chart configuration').should('be.visible');
         cy.contains("You're missing an X axis").should('be.visible');
     });

--- a/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
@@ -13,14 +13,23 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
             radius="md"
             {...props}
             icon={<TableFieldIcon fieldType={fieldType} />}
-            styles={{
+            styles={(theme) => ({
                 input: {
                     fontWeight: 500,
+                    borderColor: theme.colors.gray[2],
+                    borderRadius: theme.radius.md,
+                    boxShadow: '0px 1px 2px 0px rgba(228, 229, 231, 0.24)',
                 },
                 item: {
                     '&[data-selected="true"]': {
                         fontWeight: 500,
                     },
+                },
+            })}
+            rightSectionWidth="min-content"
+            rightSectionProps={{
+                style: {
+                    padding: 6,
                 },
             }}
         />

--- a/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
@@ -15,6 +15,7 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
             icon={<TableFieldIcon fieldType={fieldType} />}
             styles={(theme) => ({
                 input: {
+                    height: '32px',
                     fontWeight: 500,
                     borderColor: theme.colors.gray[2],
                     borderRadius: theme.radius.md,

--- a/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
@@ -28,11 +28,6 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
                 },
             })}
             rightSectionWidth="min-content"
-            rightSectionProps={{
-                style: {
-                    padding: 6,
-                },
-            }}
         />
     );
 };

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -173,12 +173,10 @@ const XFieldAxisConfig = ({
                             onChangeSortBy={(value) =>
                                 field.reference &&
                                 dispatch(
-                                    actions.setSortBy([
-                                        {
-                                            reference: field.reference,
-                                            direction: value,
-                                        },
-                                    ]),
+                                    actions.setSortBy({
+                                        reference: field.reference,
+                                        direction: value,
+                                    }),
                                 )
                             }
                         />
@@ -294,7 +292,7 @@ export const CartesianChartFieldConfiguration = ({
     );
 
     return (
-        <Stack spacing="md" mt="sm">
+        <Stack spacing="xl" mt="sm">
             <Config>
                 <Config.Section>
                     <Config.Heading>{`X-axis`}</Config.Heading>

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -188,6 +188,7 @@ const XFieldAxisConfig = ({
                     color="gray.6"
                     variant="subtle"
                     onClick={() => dispatch(actions.removeXAxisField())}
+                    data-testid="remove-x-axis-field"
                 >
                     <MantineIcon icon={IconMinus} />
                 </ActionIcon>
@@ -318,6 +319,7 @@ export const CartesianChartFieldConfiguration = ({
                                 onClick={() =>
                                     dispatch(actions.addYAxisField())
                                 }
+                                data-testid="add-y-axis-field"
                             >
                                 <MantineIcon icon={IconPlus} />
                             </ActionIcon>

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -3,7 +3,14 @@ import {
     VizAggregationOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
+import {
+    Box,
+    Group,
+    Select,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine/core';
 import {
     IconAsterisk,
     IconMathFunction,
@@ -89,28 +96,30 @@ export const DataVizAggregationConfig: FC<Props> = ({
     }));
 
     return (
-        <Select
-            withinPortal
-            data={selectOptions}
-            itemComponent={AggregationItem}
-            value={aggregation ?? aggregationOptionsWithNone?.[0]}
-            onChange={(value: VizAggregationOptions | null) =>
-                value && onChangeAggregation(value)
-            }
-            classNames={{
-                item: classes.item,
-                dropdown: classes.dropdown,
-                input: classes.input,
-                rightSection: classes.rightSection,
-            }}
-            styles={{
-                input: {
-                    width:
-                        aggregation === VizAggregationOptions.ANY
-                            ? '70px'
-                            : '50px',
-                },
-            }}
-        />
+        <Tooltip label="Aggregation type" variant="xs" withinPortal>
+            <Select
+                withinPortal
+                data={selectOptions}
+                itemComponent={AggregationItem}
+                value={aggregation ?? aggregationOptionsWithNone?.[0]}
+                onChange={(value: VizAggregationOptions | null) =>
+                    value && onChangeAggregation(value)
+                }
+                classNames={{
+                    item: classes.item,
+                    dropdown: classes.dropdown,
+                    input: classes.input,
+                    rightSection: classes.rightSection,
+                }}
+                styles={{
+                    input: {
+                        width:
+                            aggregation === VizAggregationOptions.ANY
+                                ? '70px'
+                                : '50px',
+                    },
+                }}
+            />
+        </Tooltip>
     );
 };

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -74,23 +74,45 @@ export const DataVizAggregationConfig: FC<Props> = ({
 }) => {
     const aggregationOptionsWithNone = options ?? [];
 
+    const selectOptions = aggregationOptionsWithNone.map((option) => ({
+        value: option,
+        label:
+            option === VizAggregationOptions.ANY
+                ? 'Any value'
+                : capitalize(option),
+    }));
+
     return (
         <Select
-            radius="md"
-            data={aggregationOptionsWithNone.map((option) => ({
-                value: option,
-                label: capitalize(option),
-            }))}
+            withinPortal
+            fz="13px"
+            data={selectOptions}
             itemComponent={AggregationItem}
-            icon={aggregation && <AggregationIcon aggregation={aggregation} />}
             value={aggregation ?? aggregationOptionsWithNone?.[0]}
             onChange={(value: VizAggregationOptions | null) =>
                 value && onChangeAggregation(value)
             }
             styles={(theme) => ({
                 input: {
-                    width: '110px',
+                    width: '70px',
+                    height: '20px',
+                    minHeight: '20px',
+                    padding: 0,
+                    textAlign: 'center',
+                    backgroundColor: theme.fn.lighten(
+                        theme.colors.indigo[0],
+                        0.5,
+                    ),
+                    color: theme.colors.indigo[4],
                     fontWeight: 500,
+                    border: 'none',
+                    borderRadius: theme.radius.sm,
+                },
+                rightSection: {
+                    display: 'none',
+                },
+                dropdown: {
+                    minWidth: 'fit-content',
                 },
                 item: {
                     '&[data-selected="true"]': {

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -3,7 +3,7 @@ import {
     VizAggregationOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group, Select, Text } from '@mantine/core';
+import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
 import {
     IconAsterisk,
     IconMathFunction,
@@ -16,6 +16,7 @@ import {
 import { capitalize } from 'lodash';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import { usePillSelectStyles } from '../hooks/usePillSelectStyles';
 
 // TODO: this should be a typed enum (VizAggregationOptions) and exhaustive switch case
 const AggregationIcon: FC<{ aggregation: string | undefined }> = ({
@@ -72,6 +73,11 @@ export const DataVizAggregationConfig: FC<Props> = ({
     onChangeAggregation,
     aggregation,
 }) => {
+    const { colors } = useMantineTheme();
+    const { classes } = usePillSelectStyles({
+        backgroundColor: colors.indigo[0],
+        textColor: colors.indigo[4],
+    });
     const aggregationOptionsWithNone = options ?? [];
 
     const selectOptions = aggregationOptionsWithNone.map((option) => ({
@@ -91,52 +97,20 @@ export const DataVizAggregationConfig: FC<Props> = ({
             onChange={(value: VizAggregationOptions | null) =>
                 value && onChangeAggregation(value)
             }
-            styles={(theme) => ({
+            classNames={{
+                item: classes.item,
+                dropdown: classes.dropdown,
+                input: classes.input,
+                rightSection: classes.rightSection,
+            }}
+            styles={{
                 input: {
                     width:
                         aggregation === VizAggregationOptions.ANY
                             ? '70px'
                             : '50px',
-                    height: '24px',
-                    minHeight: '24px',
-                    padding: 0,
-                    textAlign: 'center',
-                    backgroundColor: theme.fn.lighten(
-                        theme.colors.indigo[0],
-                        0.5,
-                    ),
-                    color: theme.colors.indigo[4],
-                    fontWeight: 500,
-                    border: 'none',
-                    borderRadius: theme.radius.sm,
-                    fontSize: '13px',
-                    '&:hover': {
-                        backgroundColor: theme.fn.lighten(
-                            theme.colors.indigo[0],
-                            0.1,
-                        ),
-                    },
                 },
-                rightSection: {
-                    display: 'none',
-                },
-                dropdown: {
-                    minWidth: 'fit-content',
-                },
-                item: {
-                    '&[data-selected="true"]': {
-                        color: theme.colors.gray[7],
-                        fontWeight: 500,
-                        backgroundColor: theme.colors.gray[2],
-                    },
-                    '&[data-selected="true"]:hover': {
-                        backgroundColor: theme.colors.gray[3],
-                    },
-                    '&:hover': {
-                        backgroundColor: theme.colors.gray[1],
-                    },
-                },
-            })}
+            }}
         />
     );
 };

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -85,7 +85,6 @@ export const DataVizAggregationConfig: FC<Props> = ({
     return (
         <Select
             withinPortal
-            fz="13px"
             data={selectOptions}
             itemComponent={AggregationItem}
             value={aggregation ?? aggregationOptionsWithNone?.[0]}
@@ -94,9 +93,12 @@ export const DataVizAggregationConfig: FC<Props> = ({
             }
             styles={(theme) => ({
                 input: {
-                    width: '70px',
-                    height: '20px',
-                    minHeight: '20px',
+                    width:
+                        aggregation === VizAggregationOptions.ANY
+                            ? '70px'
+                            : '50px',
+                    height: '24px',
+                    minHeight: '24px',
                     padding: 0,
                     textAlign: 'center',
                     backgroundColor: theme.fn.lighten(
@@ -107,6 +109,13 @@ export const DataVizAggregationConfig: FC<Props> = ({
                     fontWeight: 500,
                     border: 'none',
                     borderRadius: theme.radius.sm,
+                    fontSize: '13px',
+                    '&:hover': {
+                        backgroundColor: theme.fn.lighten(
+                            theme.colors.indigo[0],
+                            0.1,
+                        ),
+                    },
                 },
                 rightSection: {
                     display: 'none',

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,0 +1,70 @@
+import { SortByDirection, type VizSortBy } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+
+const SortIcon: FC<{ sortByDirection: SortByDirection }> = ({
+    sortByDirection,
+}) => {
+    let icon;
+    switch (sortByDirection) {
+        case SortByDirection.ASC:
+            icon = IconArrowRight;
+            break;
+        case SortByDirection.DESC:
+            icon = IconArrowLeft;
+            break;
+    }
+
+    return <MantineIcon color="gray.6" icon={icon} />;
+};
+
+type Props = {
+    sortBy: VizSortBy['direction'] | undefined;
+    onChangeSortBy: (value: VizSortBy['direction']) => void;
+};
+
+export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
+    const currentSortDirection = sortBy || SortByDirection.ASC;
+    const isAscending = currentSortDirection === SortByDirection.ASC;
+
+    const toggleSort = () => {
+        const newDirection = isAscending
+            ? SortByDirection.DESC
+            : SortByDirection.ASC;
+        onChangeSortBy(newDirection);
+    };
+
+    return (
+        <>
+            <Button
+                onClick={toggleSort}
+                rightIcon={
+                    isAscending ? (
+                        <SortIcon sortByDirection={SortByDirection.ASC} />
+                    ) : null
+                }
+                leftIcon={
+                    !isAscending ? (
+                        <SortIcon sortByDirection={SortByDirection.DESC} />
+                    ) : null
+                }
+                w="100%"
+                h="20px"
+                mih="20px"
+                px="xxs"
+                radius="md"
+                color="gray.0"
+                c="gray.6"
+                fw={500}
+                fz={13}
+                sx={(theme) => ({
+                    borderRadius: theme.radius.sm,
+                })}
+            >
+                {isAscending ? 'Ascending' : 'Descending'}
+            </Button>
+        </>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -68,7 +68,6 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     return (
         <Select
             withinPortal
-            fz="13px"
             data={selectOptions}
             itemComponent={SortItem}
             value={sortBy ?? selectOptions[0].value}

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,5 +1,5 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
+import { Box, Select, Text, useMantineTheme } from '@mantine/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -26,6 +26,17 @@ type Props = {
     onChangeSortBy: (value: VizSortBy['direction'] | undefined) => void;
 };
 
+const getSortLabel = (label: SortByDirection | undefined) => {
+    switch (label) {
+        case SortByDirection.ASC:
+            return 'Sort ascending';
+        case SortByDirection.DESC:
+            return 'Sort descending';
+        default:
+            return 'No sorting';
+    }
+};
+
 const SortItem = forwardRef<
     HTMLDivElement,
     ComponentPropsWithoutRef<'div'> & {
@@ -35,16 +46,13 @@ const SortItem = forwardRef<
     }
 >(({ value, label, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap spacing="xs">
-            {value && <SortIcon sortByDirection={value} />}
-            <Text>{label}</Text>
-        </Group>
+        <Text>{getSortLabel(value)}</Text>
     </Box>
 ));
 
 export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     const { colors } = useMantineTheme();
-    const { classes } = usePillSelectStyles({
+    const { classes, cx } = usePillSelectStyles({
         backgroundColor: colors.gray[2],
         textColor: colors.gray[7],
         hoverColor: colors.gray[3],
@@ -53,7 +61,7 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     const selectOptions = [
         {
             value: 'none',
-            label: 'No sort',
+            label: 'No sorting',
         },
         {
             value: SortByDirection.ASC,
@@ -74,27 +82,16 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
             onChange={(value: SortByDirection | 'none') =>
                 onChangeSortBy(value === 'none' ? undefined : value)
             }
-            icon={
-                sortBy ? (
-                    <MantineIcon
-                        color="gray.6"
-                        icon={
-                            sortBy === SortByDirection.ASC
-                                ? IconArrowRight
-                                : IconArrowLeft
-                        }
-                    />
-                ) : null
-            }
+            icon={sortBy ? <SortIcon sortByDirection={sortBy} /> : null}
             classNames={{
                 item: classes.item,
                 dropdown: classes.dropdown,
-                input: classes.input,
+                input: cx(classes.input, !sortBy && classes.inputUnsetValue),
                 rightSection: classes.rightSection,
             }}
             styles={{
                 input: {
-                    width: sortBy ? '110px' : '60px',
+                    width: '105px',
                 },
             }}
         />

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,10 +1,10 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Box, Group, Select, Text } from '@mantine/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
-const SortIcon: FC<{ sortByDirection: SortByDirection }> = ({
+const SortIcon: FC<{ sortByDirection: VizSortBy['direction'] }> = ({
     sortByDirection,
 }) => {
     let icon;
@@ -17,54 +17,118 @@ const SortIcon: FC<{ sortByDirection: SortByDirection }> = ({
             break;
     }
 
-    return <MantineIcon color="gray.6" icon={icon} />;
+    return icon ? <MantineIcon color="gray.6" icon={icon} /> : null;
 };
 
 type Props = {
     sortBy: VizSortBy['direction'] | undefined;
-    onChangeSortBy: (value: VizSortBy['direction']) => void;
+    onChangeSortBy: (value: VizSortBy['direction'] | undefined) => void;
 };
 
-export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
-    const currentSortDirection = sortBy || SortByDirection.ASC;
-    const isAscending = currentSortDirection === SortByDirection.ASC;
+const SortItem = forwardRef<
+    HTMLDivElement,
+    ComponentPropsWithoutRef<'div'> & {
+        label: string;
+        value: SortByDirection | undefined;
+        selected: boolean;
+    }
+>(({ value, label, ...others }, ref) => (
+    <Box ref={ref} {...others}>
+        <Group noWrap spacing="xs">
+            {value && <SortIcon sortByDirection={value} />}
+            <Text>{label}</Text>
+        </Group>
+    </Box>
+));
 
-    const toggleSort = () => {
-        const newDirection = isAscending
-            ? SortByDirection.DESC
-            : SortByDirection.ASC;
-        onChangeSortBy(newDirection);
-    };
+export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
+    console.log({ sortBy });
+
+    const selectOptions = [
+        {
+            value: 'none',
+            label: 'No sort',
+        },
+        {
+            value: SortByDirection.ASC,
+            label: 'Ascending',
+        },
+        {
+            value: SortByDirection.DESC,
+            label: 'Descending',
+        },
+    ];
 
     return (
-        <>
-            <Button
-                onClick={toggleSort}
-                rightIcon={
-                    isAscending ? (
-                        <SortIcon sortByDirection={SortByDirection.ASC} />
-                    ) : null
-                }
-                leftIcon={
-                    !isAscending ? (
-                        <SortIcon sortByDirection={SortByDirection.DESC} />
-                    ) : null
-                }
-                w="100%"
-                h="20px"
-                mih="20px"
-                px="xxs"
-                radius="md"
-                color="gray.0"
-                c="gray.6"
-                fw={500}
-                fz={13}
-                sx={(theme) => ({
+        <Select
+            withinPortal
+            fz="13px"
+            data={selectOptions}
+            itemComponent={SortItem}
+            value={sortBy ?? selectOptions[0].value}
+            onChange={(value: SortByDirection | 'none') =>
+                onChangeSortBy(value === 'none' ? undefined : value)
+            }
+            icon={
+                sortBy ? (
+                    <MantineIcon
+                        color="gray.6"
+                        icon={
+                            sortBy === SortByDirection.ASC
+                                ? IconArrowRight
+                                : IconArrowLeft
+                        }
+                    />
+                ) : null
+            }
+            styles={(theme) => ({
+                input: {
+                    width: sortBy ? '110px' : '50px',
+                    height: '24px',
+                    minHeight: '24px',
+                    padding: 0,
+                    textAlign: 'right',
+                    backgroundColor: theme.fn.lighten(
+                        theme.colors.gray[2],
+                        0.5,
+                    ),
+                    paddingLeft: '4px',
+                    color: theme.colors.gray[7],
+                    fontWeight: 500,
+                    border: 'none',
                     borderRadius: theme.radius.sm,
-                })}
-            >
-                {isAscending ? 'Ascending' : 'Descending'}
-            </Button>
-        </>
+                    '&[data-with-icon]': {
+                        padding: theme.spacing.sm,
+                    },
+                    fontSize: '13px',
+                    '&:hover': {
+                        backgroundColor: theme.fn.lighten(
+                            theme.colors.gray[2],
+                            0.1,
+                        ),
+                    },
+                },
+
+                rightSection: {
+                    display: 'none',
+                },
+                dropdown: {
+                    minWidth: 'fit-content',
+                },
+                item: {
+                    '&[data-selected="true"]': {
+                        color: theme.colors.gray[7],
+                        fontWeight: 500,
+                        backgroundColor: theme.colors.gray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.gray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[1],
+                    },
+                },
+            })}
+        />
     );
 };

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,8 +1,9 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Box, Group, Select, Text } from '@mantine/core';
+import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import { usePillSelectStyles } from '../hooks/usePillSelectStyles';
 
 const SortIcon: FC<{ sortByDirection: VizSortBy['direction'] }> = ({
     sortByDirection,
@@ -42,7 +43,12 @@ const SortItem = forwardRef<
 ));
 
 export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
-    console.log({ sortBy });
+    const { colors } = useMantineTheme();
+    const { classes } = usePillSelectStyles({
+        backgroundColor: colors.gray[2],
+        textColor: colors.gray[7],
+        hoverColor: colors.gray[3],
+    });
 
     const selectOptions = [
         {
@@ -81,54 +87,17 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
                     />
                 ) : null
             }
-            styles={(theme) => ({
+            classNames={{
+                item: classes.item,
+                dropdown: classes.dropdown,
+                input: classes.input,
+                rightSection: classes.rightSection,
+            }}
+            styles={{
                 input: {
-                    width: sortBy ? '110px' : '50px',
-                    height: '24px',
-                    minHeight: '24px',
-                    padding: 0,
-                    textAlign: 'right',
-                    backgroundColor: theme.fn.lighten(
-                        theme.colors.gray[2],
-                        0.5,
-                    ),
-                    paddingLeft: '4px',
-                    color: theme.colors.gray[7],
-                    fontWeight: 500,
-                    border: 'none',
-                    borderRadius: theme.radius.sm,
-                    '&[data-with-icon]': {
-                        padding: theme.spacing.sm,
-                    },
-                    fontSize: '13px',
-                    '&:hover': {
-                        backgroundColor: theme.fn.lighten(
-                            theme.colors.gray[2],
-                            0.1,
-                        ),
-                    },
+                    width: sortBy ? '110px' : '60px',
                 },
-
-                rightSection: {
-                    display: 'none',
-                },
-                dropdown: {
-                    minWidth: 'fit-content',
-                },
-                item: {
-                    '&[data-selected="true"]': {
-                        color: theme.colors.gray[7],
-                        fontWeight: 500,
-                        backgroundColor: theme.colors.gray[2],
-                    },
-                    '&[data-selected="true"]:hover': {
-                        backgroundColor: theme.colors.gray[3],
-                    },
-                    '&:hover': {
-                        backgroundColor: theme.colors.gray[1],
-                    },
-                },
-            })}
+            }}
         />
     );
 };

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,5 +1,5 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Box, Select, Text, useMantineTheme } from '@mantine/core';
+import { Box, Select, Text, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -74,26 +74,31 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     ];
 
     return (
-        <Select
-            withinPortal
-            data={selectOptions}
-            itemComponent={SortItem}
-            value={sortBy ?? selectOptions[0].value}
-            onChange={(value: SortByDirection | 'none') =>
-                onChangeSortBy(value === 'none' ? undefined : value)
-            }
-            icon={sortBy ? <SortIcon sortByDirection={sortBy} /> : null}
-            classNames={{
-                item: classes.item,
-                dropdown: classes.dropdown,
-                input: cx(classes.input, !sortBy && classes.inputUnsetValue),
-                rightSection: classes.rightSection,
-            }}
-            styles={{
-                input: {
-                    width: '105px',
-                },
-            }}
-        />
+        <Tooltip label="Sort by" variant="xs" withinPortal>
+            <Select
+                withinPortal
+                data={selectOptions}
+                itemComponent={SortItem}
+                value={sortBy ?? selectOptions[0].value}
+                onChange={(value: SortByDirection | 'none') =>
+                    onChangeSortBy(value === 'none' ? undefined : value)
+                }
+                icon={sortBy ? <SortIcon sortByDirection={sortBy} /> : null}
+                classNames={{
+                    item: classes.item,
+                    dropdown: classes.dropdown,
+                    input: cx(
+                        classes.input,
+                        !sortBy && classes.inputUnsetValue,
+                    ),
+                    rightSection: classes.rightSection,
+                }}
+                styles={{
+                    input: {
+                        width: '105px',
+                    },
+                }}
+            />
+        </Tooltip>
     );
 };

--- a/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
+++ b/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
@@ -34,6 +34,9 @@ export const usePillSelectStyles = createStyles(
             },
             marginRight: '6px',
         },
+        inputUnsetValue: {
+            color: theme.fn.lighten(textColor, 0.5),
+        },
         rightSection: {
             display: 'none',
         },

--- a/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
+++ b/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
@@ -32,6 +32,7 @@ export const usePillSelectStyles = createStyles(
                 padding: 0,
                 paddingLeft: '16px',
             },
+            marginRight: '6px',
         },
         rightSection: {
             display: 'none',

--- a/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
+++ b/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
@@ -1,0 +1,57 @@
+import { createStyles } from '@mantine/core';
+
+export const usePillSelectStyles = createStyles(
+    (
+        theme,
+        {
+            backgroundColor = theme.colors.gray[2],
+            textColor = theme.colors.gray[7],
+            hoverColor,
+        }: {
+            backgroundColor?: string;
+            textColor?: string;
+            hoverColor?: string;
+        } = {},
+    ) => ({
+        input: {
+            height: '24px',
+            minHeight: '24px',
+            padding: 0,
+            textAlign: 'center',
+            fontWeight: 500,
+            border: 'none',
+            borderRadius: theme.radius.sm,
+            fontSize: '13px',
+            backgroundColor: theme.fn.lighten(backgroundColor, 0.5),
+            color: textColor,
+            '&:hover': {
+                backgroundColor:
+                    hoverColor || theme.fn.lighten(backgroundColor, 0.1),
+            },
+            '&[data-with-icon]': {
+                padding: 0,
+                paddingLeft: '16px',
+            },
+        },
+        rightSection: {
+            display: 'none',
+        },
+        dropdown: {
+            minWidth: 'fit-content',
+        },
+        item: {
+            '&[data-selected="true"]': {
+                color: textColor,
+                fontWeight: 500,
+                backgroundColor: theme.fn.lighten(backgroundColor, 0.5),
+            },
+            '&[data-selected="true"]:hover': {
+                backgroundColor:
+                    hoverColor || theme.fn.lighten(backgroundColor, 0.3),
+            },
+            '&:hover': {
+                backgroundColor: theme.fn.lighten(backgroundColor, 0.7),
+            },
+        },
+    }),
+);

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -5,7 +5,7 @@ import {
     isFormat,
     VIZ_DEFAULT_AGGREGATION,
     type CartesianChartDisplay,
-    type PivotChartLayout,
+    type SortByDirection,
     type VizAggregationOptions,
     type VizCartesianChartConfig,
     type VizCartesianChartOptions,
@@ -284,10 +284,23 @@ export const cartesianChartConfigSlice = createSlice({
 
         setSortBy: (
             { fieldConfig },
-            action: PayloadAction<PivotChartLayout['sortBy']>,
+            action: PayloadAction<{
+                reference: string;
+                direction: SortByDirection | undefined;
+            }>,
         ) => {
             if (!fieldConfig) return;
-            fieldConfig.sortBy = action.payload;
+
+            if (action.payload.direction) {
+                fieldConfig.sortBy = [
+                    {
+                        reference: action.payload.reference,
+                        direction: action.payload.direction,
+                    },
+                ];
+            } else {
+                fieldConfig.sortBy = undefined;
+            }
         },
 
         setStacked: ({ display }, action: PayloadAction<boolean>) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/11470

### Description:

See main ticket and request figma link

<img width="1059" alt="Screenshot 2024-10-23 at 16 34 56" src="https://github.com/user-attachments/assets/362d5ca5-8212-4a27-8051-b5d3ccb171bb">

THis PR: 
- Introduces `usePillSelectStyles` - allows us to create PillSelect's with Mantine hooks
- Allows the user to update the sort and aggregation inside the fieldReferenceSelect
- Replaces the `+ add ` button with an action icon
- Replaces the `clearable` prop with a different approach (with the - action icon)
- Refactors the `setSortBy` action. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
