### PR TITLE
fix: snowflake unencrypted key authentication

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -133,22 +133,31 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
     constructor(credentials: CreateSnowflakeCredentials) {
         super(credentials);
 
-        let decodedPrivateKey: string | undefined;
-        if (credentials.privateKey && credentials.privateKeyPass) {
-            // Get the private key from the file as an object and
-            // extract the private key from the object as a PEM-encoded string.
-            decodedPrivateKey = crypto
-                .createPrivateKey({
-                    key: credentials.privateKey,
-                    format: 'pem',
-                    passphrase: credentials.privateKeyPass,
-                })
-                .export({
-                    format: 'pem',
-                    type: 'pkcs8',
-                })
-                .toString('utf-8');
+        let privateKey: string | undefined;
+        if (credentials.privateKey) {
+            if (
+                typeof credentials.privateKeyPass === 'string' &&
+                credentials.privateKeyPass.length > 0
+            ) {
+                // Get the private key from the file as an object and
+                // extract the private key from the object as a PEM-encoded string.
+                privateKey = crypto
+                    .createPrivateKey({
+                        key: credentials.privateKey,
+                        format: 'pem',
+                        passphrase: credentials.privateKeyPass,
+                    })
+                    .export({
+                        format: 'pem',
+                        type: 'pkcs8',
+                    })
+                    .toString();
+            } else {
+                privateKey = credentials.privateKey;
+            }
         }
+
+        console.log({ privateKey });
 
         if (typeof credentials.quotedIdentifiersIgnoreCase !== 'undefined') {
             this.quotedIdentifiersIgnoreCase =
@@ -161,9 +170,9 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 password: credentials.password,
                 authenticator: 'SNOWFLAKE',
             };
-        } else if (decodedPrivateKey) {
+        } else if (privateKey) {
             authenticationOptions = {
-                privateKey: decodedPrivateKey,
+                privateKey,
                 authenticator: 'SNOWFLAKE_JWT',
             };
         }


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/11954

### Description:

bug was introduced here: https://github.com/lightdash/lightdash/commit/e8915222f2fb1f65ee1f2f71040719c8b97835c8#diff-749d13d2e4158294b62b12b5c584291f9d81ce75138402d5bcb13b331692c2afR137

it did not account for a key authentication without a passphrase



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
