### PR TITLE
fix: increase notification time for chart added to dashboard

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -263,6 +263,7 @@ export const useUpdateDashboard = (
                                   ),
                           }
                         : undefined,
+                    autoClose: 10000,
                 });
             },
             onError: ({ error }) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12004 

### Description:

Increase time for 'open dashboard' toast from 5 seconds to 10 seconds.  To see it: add a chart to a dashboard from the explores page.

This one
<img width="543" alt="Screenshot 2024-10-24 at 13 54 54" src="https://github.com/user-attachments/assets/1843502c-edd7-416d-b0b7-9339d54e94b0">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
