### PR TITLE
chore: capture unexpected error when compiling all explores

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2467,7 +2467,7 @@ export class ProjectService extends BaseService {
         return rows.map((row) => row[getItemId(field)]);
     }
 
-    async refreshAllTables(
+    private async refreshAllTables(
         user: Pick<SessionUser, 'userUuid'>,
         projectUuid: string,
         requestMethod: RequestMethod,
@@ -2618,6 +2618,14 @@ export class ProjectService extends BaseService {
             });
             return explores;
         } catch (e) {
+            if (!(e instanceof LightdashError)) {
+                Sentry.captureException(e);
+            }
+            this.logger.error(
+                `Failed to compile all explores:${
+                    e instanceof Error ? e.stack : e
+                }`,
+            );
             const errorResponse = errorHandler(e);
             this.analytics.track({
                 event: 'project.error',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

At the moment, when there is an unexpected error while compiling all explores we don't capture the original error message. 
This PR makes sure we capture the original error in Sentry and our logs for debug purposes. The message returned to the user is still the same as we can't expose an internal error message.

Example forcing an error:
<img width="1127" alt="Screenshot 2024-10-24 at 14 16 54" src="https://github.com/user-attachments/assets/17ce48f4-902d-43ea-b9a9-b0d18eef6912">

To reproduce add the following code inside the try catch
```throw new Error('force error');```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
