### PR TITLE
fix: amend button label when updating project settings

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -155,7 +155,7 @@ const configureSnowflakeWarehouse = (
 
 const testCompile = (): Cypress.Chainable<string> => {
     // Compile
-    cy.findByText('Test & compile project').click();
+    cy.findByText('Test & deploy project').click();
     cy.contains('Step 1/3', { timeout: 60000 });
     cy.contains('Step 2/3', { timeout: 60000 });
     cy.contains('Successfully synced dbt project!', { timeout: 60000 });

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -290,7 +290,7 @@ export const UpdateProjectConnection: FC<{
                 <Button type="submit" loading={isSaving} disabled={isDisabled}>
                     {data?.dbtConnection?.type === DbtProjectType.NONE
                         ? 'Save and test'
-                        : 'Test & compile project'}
+                        : 'Test & deploy project'}
                 </Button>
             </Card>
         </FormContainer>

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -387,7 +387,7 @@ export const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                     type="submit"
                     loading={isSavingProject}
                 >
-                    Test & compile project
+                    Test & deploy project
                 </Button>
             </ProjectFormProvider>
         </FormContainer>


### PR DESCRIPTION
### Description:

Amend the button label when updating project settings so it is obvious that the project will be deployed. 

<img width="865" alt="Screenshot 2024-10-24 at 14 39 39" src="https://github.com/user-attachments/assets/4e3c7dd8-1cb4-43bd-93bf-351ec55b650e">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
