### PR TITLE
fix: warn user when leaving dashboard to create chart within dashboard on unsaved changes

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -517,9 +517,7 @@ const Dashboard: FC = () => {
                 if (
                     !prompt.pathname.includes(
                         `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
-                    ) &&
-                    // Allow user to add a new table
-                    !sessionStorage.getItem('unsavedDashboardTiles')
+                    )
                 ) {
                     // Set the blocked navigation location to navigate on confirming from user
                     setBlockedNavigationLocation(prompt.pathname);


### PR DESCRIPTION
…d on unsaved changes

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12055

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This behaviour was intentional, but I agree it doesn't make much sense. 

I'm throwing a warning if you're trying to leave the dashboard to create a chart with unsaved changes. 

<!-- Even better add a screenshot / gif / loom -->
[Screencast from 24-10-24 16:49:49.webm](https://github.com/user-attachments/assets/50b8a4e7-4a46-4dcc-bbf6-c055a248c752)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
