### PR TITLE
fix: update chart when sql changes

### DIFF
--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -27,6 +27,7 @@ export const barChartConfigSlice = createSlice({
         });
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
+            state.chartData = undefined;
             state.chartDataError = new Error(action.error.message);
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
@@ -35,11 +36,8 @@ export const barChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+            state.fieldConfig = action.payload.config.fieldConfig;
 
-            // Only set the initial config if it's not already set and the fieldConfig is present
-            if (!state.fieldConfig && action.payload.config.fieldConfig) {
-                state.fieldConfig = action.payload.config.fieldConfig;
-            }
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -36,11 +36,11 @@ export const barChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+
             // Only set the initial config if it's not already set and the fieldConfig is present
             if (!state.fieldConfig && action.payload.config.fieldConfig) {
                 state.fieldConfig = action.payload.config.fieldConfig;
             }
-
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -36,7 +36,10 @@ export const barChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
-            state.fieldConfig = action.payload.config.fieldConfig;
+            // Only set the initial config if it's not already set and the fieldConfig is present
+            if (!state.fieldConfig && action.payload.config.fieldConfig) {
+                state.fieldConfig = action.payload.config.fieldConfig;
+            }
 
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -36,11 +36,11 @@ export const lineChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+
             // Only set the initial config if it's not already set and the fieldConfig is present
             if (!state.fieldConfig && action.payload.config.fieldConfig) {
                 state.fieldConfig = action.payload.config.fieldConfig;
             }
-
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -35,11 +35,8 @@ export const lineChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+            state.fieldConfig = action.payload.config.fieldConfig;
 
-            // Only set the initial config if it's not already set and the fieldConfig is present
-            if (!state.fieldConfig && action.payload.config.fieldConfig) {
-                state.fieldConfig = action.payload.config.fieldConfig;
-            }
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -27,6 +27,7 @@ export const lineChartConfigSlice = createSlice({
         });
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
+            state.chartData = undefined;
             state.chartDataError = new Error(action.error.message);
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
@@ -35,7 +36,10 @@ export const lineChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
-            state.fieldConfig = action.payload.config.fieldConfig;
+            // Only set the initial config if it's not already set and the fieldConfig is present
+            if (!state.fieldConfig && action.payload.config.fieldConfig) {
+                state.fieldConfig = action.payload.config.fieldConfig;
+            }
 
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -130,11 +130,8 @@ export const pieChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+            state.fieldConfig = action.payload.config.fieldConfig;
 
-            // Only set the initial config if it's not already set and the fieldConfig is present
-            if (!state.fieldConfig && action.payload.config.fieldConfig) {
-                state.fieldConfig = action.payload.config.fieldConfig;
-            }
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -122,6 +122,7 @@ export const pieChartConfigSlice = createSlice({
         });
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
+            state.chartData = undefined;
             state.chartDataError = new Error(action.error.message);
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
@@ -130,7 +131,10 @@ export const pieChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
-            state.fieldConfig = action.payload.config.fieldConfig;
+            // Only set the initial config if it's not already set and the fieldConfig is present
+            if (!state.fieldConfig && action.payload.config.fieldConfig) {
+                state.fieldConfig = action.payload.config.fieldConfig;
+            }
 
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -131,11 +131,11 @@ export const pieChartConfigSlice = createSlice({
             }
 
             state.options = action.payload.options;
+
             // Only set the initial config if it's not already set and the fieldConfig is present
             if (!state.fieldConfig && action.payload.config.fieldConfig) {
                 state.fieldConfig = action.payload.config.fieldConfig;
             }
-
             if (!state.display && action.payload.config.display) {
                 state.display = action.payload.config.display;
             }

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
@@ -39,6 +39,7 @@ export const addSqlRunnerQueryListener = (
                 selectedChartType,
                 completeConfigByKind,
             );
+
             listenerApi.dispatch(setChartOptionsAndConfig(chartResultOptions));
 
             await listenerApi.dispatch(prepareAndFetchChartData());

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
@@ -39,7 +39,6 @@ export const addSqlRunnerQueryListener = (
                 selectedChartType,
                 completeConfigByKind,
             );
-
             listenerApi.dispatch(setChartOptionsAndConfig(chartResultOptions));
 
             await listenerApi.dispatch(prepareAndFetchChartData());


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11842 

### Description:

Fixes keeping old results around when a new SQL query is run. This does 2 things:

1. Always reset the chart config when a new query is run. We had been trying to keep some of it around, but that wasn't working right anyway, so I think just updating it is fine. It seems like the way the UI is set up, it won't be common for people to work on a chart, change the SQL, then work on the chart again. 
2. Remove the old results from the store when an error occurs. They were sticking around and it was confusing. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
