### PR TITLE
feat: methods to activate/deactivate user

### DIFF
--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -82,6 +82,14 @@ export class OrganizationMemberProfileModel {
     private static parseRow(
         member: DbOrganizationMemberProfile,
     ): OrganizationMemberProfile {
+        const isInviteExpired =
+            !member.is_active &&
+            !!member.expires_at &&
+            member.expires_at < new Date();
+
+        const isPending =
+            !member.is_active && !isInviteExpired && !!member.expires_at;
+
         return {
             userUuid: member.user_uuid,
             firstName: member.first_name,
@@ -90,9 +98,8 @@ export class OrganizationMemberProfileModel {
             organizationUuid: member.organization_uuid,
             role: member.role,
             isActive: member.is_active,
-            isInviteExpired:
-                !member.is_active &&
-                (!member.expires_at || member.expires_at < new Date()),
+            isInviteExpired,
+            isPending,
         };
     }
 

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -338,6 +338,7 @@ export class UserModel {
             isMarketingOptedIn,
             isTrackingAnonymized,
             isSetupComplete,
+            isActive,
         }: Partial<UpdateUserArgs>,
     ): Promise<LightdashUser> {
         await this.database.transaction(async (trx) => {
@@ -348,6 +349,7 @@ export class UserModel {
                     last_name: lastName,
                     is_setup_complete: isSetupComplete,
                     is_marketing_opted_in: isMarketingOptedIn,
+                    is_active: isActive,
                     is_tracking_anonymized: this.canTrackingBeAnonymized()
                         ? isTrackingAnonymized
                         : false,
@@ -560,6 +562,7 @@ export class UserModel {
 
     async createUser(
         createUser: CreateUserArgs | OpenIdUser,
+        isActive: boolean = true,
     ): Promise<LightdashUser> {
         const user = await this.database.transaction(async (trx) => {
             if (
@@ -581,7 +584,7 @@ export class UserModel {
 
             const newUser = await this.createUserTransaction(trx, {
                 ...createUser,
-                isActive: true,
+                isActive,
             });
             return newUser;
         });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -539,6 +539,7 @@ export type UpdateUserArgs = {
     isMarketingOptedIn: boolean;
     isTrackingAnonymized: boolean;
     isSetupComplete: boolean;
+    isActive: boolean;
 };
 
 export type PasswordResetLink = {

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -38,6 +38,10 @@ export type OrganizationMemberProfile = {
      * Whether the user's invite to the organization has expired
      */
     isInviteExpired?: boolean;
+    /**
+     * Whether the user has a pending invite to the organization
+     */
+    isPending?: boolean;
 };
 
 export type OrganizationMemberProfileWithGroups = OrganizationMemberProfile & {

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -82,7 +82,7 @@ const UserNameDisplay: FC<{
                         </Badge>
                     )}
                 </Stack>
-            ) : (
+            ) : user.isInviteExpired || user.isPending ? (
                 <Stack spacing="xxs">
                     {user.email && <Title order={6}>{user.email}</Title>}
                     <Group spacing="xs">
@@ -110,6 +110,23 @@ const UserNameDisplay: FC<{
                             </Anchor>
                         )}
                     </Group>
+                </Stack>
+            ) : (
+                <Stack spacing="xxs">
+                    <Title order={6} color="gray.6">
+                        {user.firstName} {user.lastName}
+                    </Title>
+                    <Badge
+                        variant="filled"
+                        color="red.4"
+                        radius="xs"
+                        sx={{ textTransform: 'none' }}
+                        px="xxs"
+                    >
+                        <Text fz="xs" fw={400} color="gray.8">
+                            Inactive
+                        </Text>
+                    </Badge>
                 </Stack>
             )}
         </Flex>


### PR DESCRIPTION
### Description:

# What this PR does:
- Modifies the userUpdate method in UserModel to accept isActive argument (used when an external service like SCIM will create a user)
- Adds a visual indicator in the user management window that an account is marked as not active

# What this PR **does not** do:
- Limit or block usage of the blocked account 
- Does not create UI controls for making a user active/inactive

# Example 
This video shows the separation of invite logic working as expected along with the "inactive" state:

https://github.com/user-attachments/assets/b6e01933-2d93-4592-a644-0594a81e814d

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
