### PR TITLE
fix: open threshold edit modal on click of link

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -55,6 +55,7 @@ import {
 import { ChartSchedulersModal } from '../../../features/scheduler';
 import {
     getSchedulerUuidFromUrlParams,
+    getThresholdUuidFromUrlParams,
     isSchedulerTypeSync,
 } from '../../../features/scheduler/utils';
 import { SyncModal as GoogleSheetsSyncModal } from '../../../features/sync/components';
@@ -270,11 +271,22 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
             } else {
                 scheduledDeliveriesModalHandlers.open();
             }
+        } else {
+            const thresholdUuidFromUrlParams =
+                getThresholdUuidFromUrlParams(search);
+            if (thresholdUuidFromUrlParams) {
+                if (isSync) {
+                    syncWithGoogleSheetsModalHandlers.open();
+                } else {
+                    thresholdAlertsModalHandlers.open();
+                }
+            }
         }
     }, [
         search,
         syncWithGoogleSheetsModalHandlers,
         scheduledDeliveriesModalHandlers,
+        thresholdAlertsModalHandlers,
     ]);
 
     useEffect(() => {

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -275,11 +275,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
             const thresholdUuidFromUrlParams =
                 getThresholdUuidFromUrlParams(search);
             if (thresholdUuidFromUrlParams) {
-                if (isSync) {
-                    syncWithGoogleSheetsModalHandlers.open();
-                } else {
-                    thresholdAlertsModalHandlers.open();
-                }
+                thresholdAlertsModalHandlers.open();
             }
         }
     }, [

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -19,7 +19,10 @@ import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { useScheduler, useSendNowScheduler } from '../hooks/useScheduler';
 import { useSchedulersUpdateMutation } from '../hooks/useSchedulersUpdateMutation';
-import { getSchedulerUuidFromUrlParams } from '../utils';
+import {
+    getSchedulerUuidFromUrlParams,
+    getThresholdUuidFromUrlParams,
+} from '../utils';
 import SchedulerForm from './SchedulerForm';
 import SchedulersModalFooter from './SchedulerModalFooter';
 import SchedulersList from './SchedulersList';
@@ -291,6 +294,21 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
                 pathname,
                 search: newParams.toString(),
             });
+        } else {
+            const ThresholdUuidFromUrlParams =
+                getThresholdUuidFromUrlParams(search);
+            if (ThresholdUuidFromUrlParams) {
+                setState(States.EDIT);
+                setSchedulerUuid(ThresholdUuidFromUrlParams);
+
+                // remove from url param after modal is open
+                const newParams = new URLSearchParams(search);
+                newParams.delete('threshold_uuid');
+                history.replace({
+                    pathname,
+                    search: newParams.toString(),
+                });
+            }
         }
     }, [history, pathname, search]);
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalContent.tsx
@@ -295,11 +295,11 @@ const SchedulerModalContent: FC<Omit<Props, 'name'>> = ({
                 search: newParams.toString(),
             });
         } else {
-            const ThresholdUuidFromUrlParams =
+            const thresholdUuidFromUrlParams =
                 getThresholdUuidFromUrlParams(search);
-            if (ThresholdUuidFromUrlParams) {
+            if (thresholdUuidFromUrlParams) {
                 setState(States.EDIT);
-                setSchedulerUuid(ThresholdUuidFromUrlParams);
+                setSchedulerUuid(thresholdUuidFromUrlParams);
 
                 // remove from url param after modal is open
                 const newParams = new URLSearchParams(search);

--- a/packages/frontend/src/features/scheduler/utils/index.ts
+++ b/packages/frontend/src/features/scheduler/utils/index.ts
@@ -5,6 +5,13 @@ export const getSchedulerUuidFromUrlParams = (
     return searchParams.get('scheduler_uuid');
 };
 
+export const getThresholdUuidFromUrlParams = (
+    search: string,
+): string | null => {
+    const searchParams = new URLSearchParams(search);
+    return searchParams.get('threshold_uuid');
+};
+
 export const isSchedulerTypeSync = (search: string): string | null => {
     const searchParams = new URLSearchParams(search);
     return searchParams.get('isSync');


### PR DESCRIPTION
Closes: #9075 

Description:
Checked Schedule Delivery model is getting open when we pass scheduler_uuid as query parameter in the URL
and replicated the same for threshold_uuid. please check the below video

https://github.com/user-attachments/assets/7fb3ba24-f2d7-414a-a0d4-07da54ca0e17

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
