### PR TITLE
feat: create `/metrics` route with placeholder

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -24,6 +24,7 @@ import Home from './pages/Home';
 import Invite from './pages/Invite';
 import JoinOrganization from './pages/JoinOrganization';
 import Login from './pages/Login';
+import MetricsCatalog from './pages/MetricsCatalog';
 import MinimalDashboard from './pages/MinimalDashboard';
 import MinimalSavedExplorer from './pages/MinimalSavedExplorer';
 import PasswordRecovery from './pages/PasswordRecovery';
@@ -347,6 +348,15 @@ const Routes: FC = () => {
                                         <NavBar />
                                         <TrackPage name={PageName.CATALOG}>
                                             <Catalog />
+                                        </TrackPage>
+                                    </Route>
+
+                                    <Route path="/projects/:projectUuid/metrics">
+                                        <NavBar />
+                                        <TrackPage
+                                            name={PageName.METRICS_CATALOG}
+                                        >
+                                            <MetricsCatalog />
                                         </TrackPage>
                                     </Route>
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,0 +1,3 @@
+export const MetricsCatalogPanel = () => {
+    return <div>MetricsCatalogPanel</div>;
+};

--- a/packages/frontend/src/features/metricsCatalog/index.ts
+++ b/packages/frontend/src/features/metricsCatalog/index.ts
@@ -1,0 +1,1 @@
+export * from './components/MetricsCatalogPanel';

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -1,0 +1,18 @@
+import { type FC } from 'react';
+import Page from '../components/common/Page/Page';
+import { MetricsCatalogPanel } from '../features/metricsCatalog';
+
+const MetricsCatalog: FC = () => {
+    return (
+        <Page
+            withFitContent
+            withPaddedContent
+            withRightSidebar
+            withLargeContent
+        >
+            <MetricsCatalogPanel />
+        </Page>
+    );
+};
+
+export default MetricsCatalog;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -48,6 +48,7 @@ export enum PageName {
     VERIFY_EMAIL = 'verify_email',
     JOIN_ORGANIZATION = 'join_organization',
     CATALOG = 'catalog',
+    METRICS_CATALOG = 'metrics_catalog',
 }
 
 export enum CategoryName {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12104

### Description:

small placeholder in new route

<img width="865" alt="Screenshot 2024-10-28 at 09 48 10" src="https://github.com/user-attachments/assets/3972c4c3-590e-4937-b850-e74faa1d203e">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
