### PR TITLE
feat: add metrics catalog endpoint

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -4,6 +4,7 @@ import {
     ApiCatalogResults,
     ApiCatalogSearch,
     ApiErrorPayload,
+    type ApiMetricsCatalogResults,
     type KnexPaginateArgs,
 } from '@lightdash/common';
 import {
@@ -158,7 +159,7 @@ export class CatalogController extends BaseController {
         @Query() search?: ApiCatalogSearch['search'],
         @Query() page?: number,
         @Query() pageSize?: number,
-    ): Promise<{ status: 'ok'; results: ApiCatalogResults }> {
+    ): Promise<{ status: 'ok'; results: ApiMetricsCatalogResults }> {
         this.setStatus(200);
 
         const paginateArgs: KnexPaginateArgs | undefined =

--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -4,6 +4,7 @@ import {
     ApiCatalogResults,
     ApiCatalogSearch,
     ApiErrorPayload,
+    type KnexPaginateArgs,
 } from '@lightdash/common';
 import {
     Get,
@@ -133,6 +134,45 @@ export class CatalogController extends BaseController {
         const results = await this.services
             .getCatalogService()
             .getFieldAnalytics(req.user!, projectUuid, table, field);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Get metrics catalog
+     * @param projectUuid
+     * @param query contains filters for the catalog items as well as pagination
+     * - search: string
+     * - page: number
+     * - pageSize: number
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/metrics')
+    @OperationId('getMetricsCatalog')
+    async getMetricsCatalog(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() search?: ApiCatalogSearch['search'],
+        @Query() page?: number,
+        @Query() pageSize?: number,
+    ): Promise<{ status: 'ok'; results: ApiCatalogResults }> {
+        this.setStatus(200);
+
+        const paginateArgs: KnexPaginateArgs | undefined =
+            page && pageSize
+                ? {
+                      page,
+                      pageSize,
+                  }
+                : undefined;
+
+        const results = await this.services
+            .getCatalogService()
+            .getMetricsCatalog(req.user!, projectUuid, paginateArgs, search);
+
         return {
             status: 'ok',
             results,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9927,6 +9927,65 @@ export function RegisterRoutes(app: express.Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    app.get(
+        '/api/v1/projects/:projectUuid/dataCatalog/metrics',
+        ...fetchMiddlewares<RequestHandler>(CatalogController),
+        ...fetchMiddlewares<RequestHandler>(
+            CatalogController.prototype.getMetricsCatalog,
+        ),
+
+        async function CatalogController_getMetricsCatalog(
+            request: any,
+            response: any,
+            next: any,
+        ) {
+            const args = {
+                projectUuid: {
+                    in: 'path',
+                    name: 'projectUuid',
+                    required: true,
+                    dataType: 'string',
+                },
+                req: {
+                    in: 'request',
+                    name: 'req',
+                    required: true,
+                    dataType: 'object',
+                },
+                search: { in: 'query', name: 'search', dataType: 'string' },
+                page: { in: 'query', name: 'page', dataType: 'double' },
+                pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<CatalogController>(
+                    CatalogController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                const promise = controller.getMetricsCatalog.apply(
+                    controller,
+                    validatedArgs as any,
+                );
+                promiseHandler(controller, promise, response, 200, next);
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     app.post(
         '/api/v1/comments/dashboards/:dashboardUuid/:dashboardTileUuid',
         ...fetchMiddlewares<RequestHandler>(CommentsController),

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -441,6 +441,32 @@ const models: TsoaRoute.Models = {
         type: { ref: 'CatalogAnalytics', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CatalogFieldWithAnalytics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CatalogField' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        analytics: { ref: 'CatalogAnalytics', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiMetricsCatalogResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'array',
+            array: { dataType: 'refAlias', ref: 'CatalogFieldWithAnalytics' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateComment: {
         dataType: 'refAlias',
         type: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -379,6 +379,28 @@
             "ApiCatalogAnalyticsResults": {
                 "$ref": "#/components/schemas/CatalogAnalytics"
             },
+            "CatalogFieldWithAnalytics": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CatalogField"
+                    },
+                    {
+                        "properties": {
+                            "analytics": {
+                                "$ref": "#/components/schemas/CatalogAnalytics"
+                            }
+                        },
+                        "required": ["analytics"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiMetricsCatalogResults": {
+                "items": {
+                    "$ref": "#/components/schemas/CatalogFieldWithAnalytics"
+                },
+                "type": "array"
+            },
             "ApiCreateComment": {
                 "properties": {
                     "results": {
@@ -10947,7 +10969,7 @@
                                 "schema": {
                                     "properties": {
                                         "results": {
-                                            "$ref": "#/components/schemas/ApiCatalogResults"
+                                            "$ref": "#/components/schemas/ApiMetricsCatalogResults"
                                         },
                                         "status": {
                                             "type": "string",

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10659,7 +10659,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1315.7",
+        "version": "0.1316.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -10931,6 +10931,83 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/dataCatalog/metrics": {
+            "get": {
+                "operationId": "getMetricsCatalog",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/components/schemas/ApiCatalogResults"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["results", "status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get metrics catalog",
+                "tags": ["Catalog"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -19,6 +19,7 @@ import {
     TablesConfiguration,
     TableSelectionType,
     UserAttributeValueMap,
+    type KnexPaginateArgs,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -494,5 +495,18 @@ export class CatalogService<
             }),
         );
         return { charts: chartAnalytics };
+    }
+
+    async getMetricsCatalog(
+        user: SessionUser,
+        projectUuid: string,
+        _paginateArgs?: KnexPaginateArgs,
+        search?: string,
+    ) {
+        return this.getCatalog(user, projectUuid, {
+            search,
+            filter: CatalogFilter.Metrics,
+            type: CatalogType.Field,
+        });
     }
 }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -60,6 +60,11 @@ export type CatalogTable = Pick<
 export type CatalogItem = CatalogField | CatalogTable;
 export type ApiCatalogResults = CatalogItem[];
 
+export type CatalogFieldWithAnalytics = CatalogField & {
+    analytics: CatalogAnalytics;
+};
+export type ApiMetricsCatalogResults = CatalogFieldWithAnalytics[];
+
 export type CatalogMetadata = {
     name: string;
     description: string | undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12129](https://github.com/lightdash/lightdash/issues/12129)
### Description:

Endpoint: `/api/v1/projects/${UUID}/dataCatalog/metrics`

Example response:
```json
{"status": "ok", "results": [{"name":"unique_payment_count","label":"Unique payment count","description":"count of all payments","tableLabel":"Payments","tableName":"payments","fieldType":"metric","basicType":"number","type":"field","tags":[],"analytics":{"charts":[{"name":"Which customers have not recently ordered an item?","uuid":"0e6a25c8-a026-4420-93ba-a5d07ec9bb4e","spaceUuid":"0d96ca58-19e7-4b86-aa7b-c0d30f0797ef","spaceName":"Jaffle shop","dashboardName":null,"dashboardUuid":null}]}
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-frontend
