### PR TITLE
feat: show catalog metrics in table

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/tracks.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/tracks.yml
@@ -74,9 +74,20 @@ models:
         meta:
           dimension:
             type: string
-          metrics: 
+          metrics:
             unique_event_count:
               type: count_distinct
+              description: |
+                **Unique Event Count** provides a distinct count of tracked events in the system.
+
+                - Counts each unique event type only once
+                - Useful for analyzing event diversity
+                - *Note*: This differs from `event_count` which includes duplicates
+
+                ### Common Use Cases
+                * Measuring feature adoption
+                * Analyzing user engagement patterns
+                * Tracking product usage variety
             event_count:
               type: count
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -69,6 +69,7 @@
         "immer": "^10.1.1",
         "jspdf": "^2.5.1",
         "lodash": "^4.17.21",
+        "mantine-react-table": "^1.3.4",
         "monaco-editor": "^0.44.0",
         "monaco-sql-languages": "^0.12.2",
         "polished": "^4.2.2",

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,9 +1,15 @@
-import { Box } from '@mantine/core';
+import { Group, Stack, Title } from '@mantine/core';
+import RefreshDbtButton from '../../../components/RefreshDbtButton';
+import { MetricsTable } from './MetricsTable';
 
 export const MetricsCatalogPanel = () => {
     return (
-        <Box>
+        <Stack>
+            <Group position="apart">
+                <Title order={4}>Metrics Catalog</Title>
+                <RefreshDbtButton />
+            </Group>
             <MetricsTable />
-        </Box>
+        </Stack>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,3 +1,9 @@
+import { Box } from '@mantine/core';
+
 export const MetricsCatalogPanel = () => {
-    return <div>MetricsCatalogPanel</div>;
+    return (
+        <Box>
+            <MetricsTable />
+        </Box>
+    );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,0 +1,229 @@
+import { Anchor, Button, Text, Tooltip } from '@mantine/core';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_ColumnFiltersState,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from 'mantine-react-table';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type UIEvent,
+} from 'react';
+
+type MetricData = {
+    metricName: string;
+    friendlyName: string;
+    description: string;
+    directory: string;
+    tableName: string;
+    groupName: string;
+    usage: number;
+    metricId: string; // for linking to explore view
+};
+
+type MetricApiResponse = {
+    data: Array<MetricData>;
+    meta: {
+        totalRowCount: number;
+    };
+};
+
+const generateMockData = (start: number, size: number): MetricApiResponse => {
+    const mockMetrics: MetricData[] = Array.from({ length: size }).map(
+        (_, index) => ({
+            metricId: `metric-${start + index}`,
+            metricName: `daily_active_users_${start + index}`,
+            friendlyName: `Daily Active Users ${start + index}`,
+            description: `# Daily Active Users\n\nThis metric tracks the number of unique users who performed any action in the last 24 hours.\n\n## Calculation\nCount of distinct user_ids where last_seen > now() - interval '1 day'`,
+            directory: `user_metrics`,
+            tableName: 'User Analytics',
+            groupName: 'Engagement Metrics',
+            usage: Math.floor(Math.random() * 100),
+        }),
+    );
+
+    return {
+        data: mockMetrics,
+        meta: {
+            totalRowCount: 1000, // Total mock records
+        },
+    };
+};
+
+const columns: MRT_ColumnDef<MetricData>[] = [
+    {
+        accessorKey: 'friendlyName',
+        header: 'Metric Name',
+        Cell: ({ row }) => (
+            <Anchor
+                href={`/explore?metric=${row.original.metricId}`}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+                {row.original.friendlyName}
+            </Anchor>
+        ),
+    },
+    {
+        accessorKey: 'description',
+        header: 'Description',
+        Cell: ({ row }) => (
+            <Tooltip
+                multiline
+                variant="xs"
+                withinPortal
+                label={<MarkdownPreview source={row.original.description} />}
+            >
+                <Text lineClamp={2}>{row.original.description}</Text>
+            </Tooltip>
+        ),
+    },
+    {
+        accessorKey: 'directory',
+        header: 'Directory',
+        Cell: ({ row }) => (
+            <Text>
+                {row.original.groupName
+                    ? `${row.original.tableName} / ${row.original.groupName}`
+                    : row.original.tableName}
+            </Text>
+        ),
+    },
+    {
+        accessorKey: 'usage',
+        header: 'Usage',
+        Cell: ({ row }) => (
+            <Tooltip
+                label="Click to view saved charts"
+                withinPortal
+                variant="xs"
+            >
+                <Button
+                    variant="subtle"
+                    // onClick={() => showSavedCharts(row.original.metricId)}
+                >
+                    {row.original.usage} uses
+                </Button>
+            </Tooltip>
+        ),
+    },
+];
+
+const fetchSize = 25;
+
+export const MetricsTable = () => {
+    const tableContainerRef = useRef<HTMLDivElement>(null); //we can get access to the underlying TableContainer element and react to its scroll events
+    const rowVirtualizerInstanceRef =
+        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null); //we can get access to the underlying Virtualizer instance and call its scrollToIndex method
+
+    const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>(
+        [],
+    );
+    const [globalFilter, setGlobalFilter] = useState<string>();
+    const [sorting, setSorting] = useState<MRT_SortingState>([]);
+
+    const { data, fetchNextPage, isError, isFetching, isLoading } =
+        useInfiniteQuery<MetricApiResponse>({
+            queryKey: ['table-data', columnFilters, globalFilter, sorting],
+            queryFn: async ({ pageParam = 0 }) => {
+                // Simulate network delay
+                await new Promise((resolve) => setTimeout(resolve, 500));
+                return generateMockData(pageParam * fetchSize, fetchSize);
+            },
+            getNextPageParam: (_lastGroup, groups) => groups.length,
+            keepPreviousData: true,
+            refetchOnWindowFocus: false,
+        });
+
+    const flatData = useMemo(
+        () => data?.pages.flatMap((page) => page.data) ?? [],
+        [data],
+    );
+
+    const totalDBRowCount = data?.pages?.[0]?.meta?.totalRowCount ?? 0;
+    const totalFetched = flatData.length;
+
+    //called on scroll and possibly on mount to fetch more data as the user scrolls and reaches bottom of table
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (containerRefElement) {
+                const { scrollHeight, scrollTop, clientHeight } =
+                    containerRefElement;
+                //once the user has scrolled within 400px of the bottom of the table, fetch more data if we can
+                if (
+                    scrollHeight - scrollTop - clientHeight < 400 &&
+                    !isFetching &&
+                    totalFetched < totalDBRowCount
+                ) {
+                    void fetchNextPage();
+                }
+            }
+        },
+        [fetchNextPage, isFetching, totalFetched, totalDBRowCount],
+    );
+
+    //scroll to top of table when sorting or filters change
+    useEffect(() => {
+        if (rowVirtualizerInstanceRef.current) {
+            try {
+                rowVirtualizerInstanceRef.current.scrollToIndex(0);
+            } catch (e) {
+                console.error(e);
+            }
+        }
+    }, [sorting, columnFilters, globalFilter]);
+
+    //a check on mount to see if the table is already scrolled to the bottom and immediately needs to fetch more data
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const table = useMantineReactTable({
+        columns,
+        data: flatData,
+        enablePagination: false,
+        enableColumnResizing: true,
+        enableRowNumbers: true,
+        enableRowVirtualization: true, //optional, but recommended if it is likely going to be more than 100 rows
+        manualFiltering: true,
+        manualSorting: true,
+        mantineTableContainerProps: {
+            ref: tableContainerRef, //get access to the table container element
+            sx: { maxHeight: '600px' }, //give the table a max height
+            onScroll: (
+                event: UIEvent<HTMLDivElement>, //add an event listener to the table container element
+            ) => fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineToolbarAlertBannerProps: {
+            color: 'red',
+            children: 'Error loading data',
+        },
+        onColumnFiltersChange: setColumnFilters,
+        onGlobalFilterChange: setGlobalFilter,
+        onSortingChange: setSorting,
+        renderBottomToolbarCustomActions: () => (
+            <Text>
+                Fetched {totalFetched} of {totalDBRowCount} total rows.
+            </Text>
+        ),
+        state: {
+            columnFilters,
+            globalFilter,
+            isLoading,
+            showAlertBanner: isError,
+            showProgressBars: isFetching,
+            sorting,
+        },
+        rowVirtualizerInstanceRef, //get access to the virtualizer instance
+        rowVirtualizerProps: { overscan: 10 },
+    });
+
+    return <MantineReactTable table={table} />;
+};

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -1,0 +1,48 @@
+import { type ApiMetricsCatalogResults } from '@lightdash/common';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+type UseMetricsCatalogOptions = {
+    projectUuid: string;
+    search?: string;
+    pageSize?: number;
+    enabled?: boolean;
+};
+
+const DEFAULT_PAGE_SIZE = 25;
+
+const getMetricsCatalog = async ({
+    projectUuid,
+}: // search,
+// pageParam = 0, // Changed from page to pageParam
+// pageSize,
+UseMetricsCatalogOptions & { pageParam?: number }) =>
+    lightdashApi<ApiMetricsCatalogResults>({
+        method: 'GET',
+        url: `/projects/${projectUuid}/dataCatalog/metrics`,
+        body: undefined,
+        // TODO: Add query parameters for pagination
+        // params: {
+        //     offset: pageParam * pageSize,
+        //     limit: pageSize,
+        //     search
+        // }
+    });
+
+export const useMetricsCatalog = ({
+    projectUuid,
+    search,
+    pageSize = DEFAULT_PAGE_SIZE,
+    enabled = true,
+}: UseMetricsCatalogOptions) => {
+    return useInfiniteQuery({
+        queryKey: ['metrics-catalog', projectUuid, search, pageSize],
+        queryFn: ({ pageParam }) =>
+            getMetricsCatalog({ projectUuid, search, pageSize, pageParam }),
+        getNextPageParam: (_lastPage, allPages) => {
+            // TODO: Implement proper next page calculation based on API response
+            return allPages.length;
+        },
+        enabled: enabled && !!projectUuid,
+    });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6075,6 +6075,13 @@
   resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.47.0.tgz#c41c680d1947e3ab2d60af3febc4132287c60596"
   integrity sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA==
 
+"@tanstack/match-sorter-utils@8.8.4":
+  version "8.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz#0b2864d8b7bac06a9f84cb903d405852cc40a457"
+  integrity sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==
+  dependencies:
+    remove-accents "0.4.2"
+
 "@tanstack/match-sorter-utils@^8.7.0":
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.11.3.tgz#904bf4916bac1338751491de0685151126e5c29b"
@@ -6104,12 +6111,26 @@
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
 
+"@tanstack/react-table@8.10.6":
+  version "8.10.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.10.6.tgz#a8c03cc06ac890bce4404739b9356059c4259dd4"
+  integrity sha512-D0VEfkIYnIKdy6SHiBNEaMc4SxO+MV7ojaPhRu8jP933/gbMi367+Wul2LxkdovJ5cq6awm0L1+jgxdS/unzIg==
+  dependencies:
+    "@tanstack/table-core" "8.10.6"
+
 "@tanstack/react-table@^8.15.3":
   version "8.15.3"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.15.3.tgz#9933222642d5d5bdaea5a78cf6c5d42aa86a1c22"
   integrity sha512-aocQ4WpWiAh7R+yxNp+DGQYXeVACh5lv2kk96DjYgFiHDCB0cOFoYMT/pM6eDOzeMXR9AvPoLeumTgq8/0qX+w==
   dependencies:
     "@tanstack/table-core" "8.15.3"
+
+"@tanstack/react-virtual@3.0.0-beta.63":
+  version "3.0.0-beta.63"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.63.tgz#a68d31b7454c99f40667ec3d85d696a4dd058ef9"
+  integrity sha512-n4aaZs3g9U2oZjFp8dAeT1C2g4rr/3lbCo2qWbD9NquajKnGx7R+EfLBAHJ6pVMmfsTMZ0XCBwkIs7U74R/s0A==
+  dependencies:
+    "@tanstack/virtual-core" "3.0.0-beta.63"
 
 "@tanstack/react-virtual@^3.10.7":
   version "3.10.7"
@@ -6118,10 +6139,20 @@
   dependencies:
     "@tanstack/virtual-core" "3.10.7"
 
+"@tanstack/table-core@8.10.6":
+  version "8.10.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.10.6.tgz#c79d145dfc3dc9947a2b1cdac82cd4ec4cef822a"
+  integrity sha512-9t8brthhAmCBIjzk7fCDa/kPKoLQTtA31l9Ir76jYxciTlHU61r/6gYm69XF9cbg9n88gVL5y7rNpeJ2dc1AFA==
+
 "@tanstack/table-core@8.15.3":
   version "8.15.3"
   resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.15.3.tgz#1a11cef82a458e90694bedfb40dcff610e69460e"
   integrity sha512-wOgV0HfEvuMOv8RlqdR9MdNNqq0uyvQtP39QOvGlggHvIObOE4exS+D5LGO8LZ3LUXxId2IlUKcHDHaGujWhUg==
+
+"@tanstack/virtual-core@3.0.0-beta.63":
+  version "3.0.0-beta.63"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.63.tgz#fa6ffc8b5b9bfef19006ea330f00456381c30361"
+  integrity sha512-KhhfRYSoQpl0y+2axEw+PJZd/e/9p87PDpPompxcXnweNpt9ZHCT/HuNx7MKM9PVY/xzg9xJSWxwnSCrO+d6PQ==
 
 "@tanstack/virtual-core@3.10.7":
   version "3.10.7"
@@ -15276,6 +15307,15 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+mantine-react-table@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/mantine-react-table/-/mantine-react-table-1.3.4.tgz#0fdaba69e344b1c59a1616f9288a8e381472f83c"
+  integrity sha512-rD0CaeC4RCU7k/ZKvfj5ijFFMd4clGpeg/EwMcogYFioZjj8aNfD78osTNNYr90AnOAFGnd7ZnderLK89+W1ZQ==
+  dependencies:
+    "@tanstack/match-sorter-utils" "8.8.4"
+    "@tanstack/react-table" "8.10.6"
+    "@tanstack/react-virtual" "3.0.0-beta.63"
 
 markdown-it@^14.0.0:
   version "14.0.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/12104

### Description:

Adds package: `mantine-react-table`
Adds simple `useMetricsCatalog` hook 
Displays a very simple table (used this PR as a base: https://github.com/lightdash/lightdash/pull/12124)

> [!NOTE]
> This doesn't include work on infinite scroll/querying -  awaiting BE work

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/cc511673-9394-49b3-8ed8-440a46cad109">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
