### PR TITLE
feat: updated_at added to users table

### DIFF
--- a/packages/backend/src/database/entities/users.ts
+++ b/packages/backend/src/database/entities/users.ts
@@ -10,6 +10,7 @@ export type DbUser = {
     is_tracking_anonymized: boolean;
     is_setup_complete: boolean;
     is_active: boolean;
+    updated_at: Date;
 };
 
 export type DbUserIn = Pick<
@@ -31,6 +32,7 @@ export type DbUserUpdate = Partial<
         | 'is_tracking_anonymized'
         | 'is_setup_complete'
         | 'is_active'
+        | 'updated_at'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20241028143602_add_updated_at_to_users_table.ts
+++ b/packages/backend/src/database/migrations/20241028143602_add_updated_at_to_users_table.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const USERS_TABLE_NAME = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(USERS_TABLE_NAME, (tableBuilder) => {
+        tableBuilder
+            .timestamp('updated_at')
+            .defaultTo(knex.fn.now())
+            .notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(USERS_TABLE_NAME, (tableBuilder) => {
+        tableBuilder.dropColumn('updated_at');
+    });
+}

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -345,7 +345,7 @@ export class UserModel {
         await this.database.transaction(async (trx) => {
             const [user] = await trx(UserTableName)
                 .where('user_uuid', userUuid)
-                .update<Partial<DbUserUpdate>>({
+                .update<DbUserUpdate>({
                     first_name: firstName,
                     last_name: lastName,
                     is_setup_complete: isSetupComplete,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Commercial PR: https://github.com/lightdash/lightdash-commercial/pull/327 

### Description:
- This adds updated_at to the users table. Used for SCIM to show the oldest updated users first
- this also adds logic to update update_at when a user is updated, joins an org, or activates

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
