### PR TITLE
feat: add pagination to /dataCatalog/metrics endpoint

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -51,7 +51,7 @@ models:
           dimension:
             type: number
             required_attributes:
-              is_admin: 'true'
+              is_admin: "true"
           metrics:
             average_age:
               type: average
@@ -159,14 +159,14 @@ models:
         meta:
           dimension:
             type: date
-            time_intervals: ['DAY', 'WEEK', 'MONTH', 'YEAR']
+            time_intervals: ["DAY", "WEEK", "MONTH", "YEAR"]
           metrics:
             date_of_first_order:
               type: min
             date_of_most_recent_order:
               type: max
       - name: status
-        description: "{{ doc(\"orders_status\") }}"
+        description: '{{ doc("orders_status") }}'
         meta:
           dimension:
             colors:

--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -6,6 +6,7 @@ import {
     ApiErrorPayload,
     type ApiMetricsCatalogResults,
     type KnexPaginateArgs,
+    type KnexPaginatedData,
 } from '@lightdash/common';
 import {
     Get,
@@ -53,9 +54,10 @@ export class CatalogController extends BaseController {
             filter,
         };
 
-        const results = await this.services
+        const { data: results } = await this.services
             .getCatalogService()
             .getCatalog(req.user!, projectUuid, query);
+
         return {
             status: 'ok',
             results,
@@ -159,7 +161,10 @@ export class CatalogController extends BaseController {
         @Query() search?: ApiCatalogSearch['search'],
         @Query() page?: number,
         @Query() pageSize?: number,
-    ): Promise<{ status: 'ok'; results: ApiMetricsCatalogResults }> {
+    ): Promise<{
+        status: 'ok';
+        results: KnexPaginatedData<ApiMetricsCatalogResults>;
+    }> {
         this.setStatus(200);
 
         const paginateArgs: KnexPaginateArgs | undefined =

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -1,4 +1,4 @@
-import { CatalogType } from '@lightdash/common';
+import { CatalogType, type UserAttributeValueMap } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export type DbCatalog = {
@@ -10,6 +10,7 @@ export type DbCatalog = {
     search_vector: string;
     embedding_vector?: string;
     field_type?: string;
+    required_attributes: Record<string, string | string[]> | null;
 };
 
 export type DbCatalogIn = Pick<
@@ -20,6 +21,7 @@ export type DbCatalogIn = Pick<
     | 'description'
     | 'type'
     | 'field_type'
+    | 'required_attributes'
 >;
 export type DbCatalogRemove = Pick<DbCatalog, 'project_uuid' | 'name'>;
 export type DbCatalogUpdate = Pick<DbCatalog, 'embedding_vector'>;

--- a/packages/backend/src/database/migrations/20241028170155_add-required-attributes-to-catalog-search.ts
+++ b/packages/backend/src/database/migrations/20241028170155_add-required-attributes-to-catalog-search.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const CatalogTableName = 'catalog_search';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table.jsonb('required_attributes').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table.dropColumn('required_attributes');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -467,6 +467,44 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginateArgs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                page: { dataType: 'double', required: true },
+                pageSize: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginatedData_ApiMetricsCatalogResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: { ref: 'ApiMetricsCatalogResults', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateComment: {
         dataType: 'refAlias',
         type: {
@@ -3537,18 +3575,6 @@ const models: TsoaRoute.Models = {
                 lastName: { dataType: 'string', required: true },
                 firstName: { dataType: 'string', required: true },
                 userUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    KnexPaginateArgs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                page: { dataType: 'double', required: true },
-                pageSize: { dataType: 'double', required: true },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10707,7 +10707,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1317.2",
+        "version": "0.1319.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -401,6 +401,46 @@
                 },
                 "type": "array"
             },
+            "KnexPaginateArgs": {
+                "properties": {
+                    "page": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "pageSize": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["page", "pageSize"],
+                "type": "object"
+            },
+            "KnexPaginatedData_ApiMetricsCatalogResults_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/ApiMetricsCatalogResults"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
             "ApiCreateComment": {
                 "properties": {
                     "results": {
@@ -3905,20 +3945,6 @@
                 ],
                 "type": "object",
                 "description": "Profile for a user's membership in an organization"
-            },
-            "KnexPaginateArgs": {
-                "properties": {
-                    "page": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "pageSize": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["page", "pageSize"],
-                "type": "object"
             },
             "KnexPaginatedData_OrganizationMemberProfile-Array_": {
                 "properties": {
@@ -10681,7 +10707,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1316.1",
+        "version": "0.1317.2",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -10969,7 +10995,7 @@
                                 "schema": {
                                     "properties": {
                                         "results": {
-                                            "$ref": "#/components/schemas/ApiMetricsCatalogResults"
+                                            "$ref": "#/components/schemas/KnexPaginatedData_ApiMetricsCatalogResults_"
                                         },
                                         "status": {
                                             "type": "string",

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -119,6 +119,7 @@ export class CatalogModel {
                 }
             })
             .andWhere(function userAttributesFiltering() {
+                console.log({ userAttributes });
                 void this.whereJsonSubsetOf(
                     'required_attributes',
                     userAttributes,

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -119,7 +119,6 @@ export class CatalogModel {
                 }
             })
             .andWhere(function userAttributesFiltering() {
-                console.log({ userAttributes });
                 void this.whereJsonSubsetOf(
                     'required_attributes',
                     userAttributes,

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -13,6 +13,7 @@ export const convertExploresToCatalog = (
             name: explore.name,
             description: baseTable?.description || null,
             type: CatalogType.Table,
+            required_attributes: baseTable.requiredAttributes ?? null,
         };
 
         const dimensionsAndMetrics = [
@@ -29,6 +30,10 @@ export const convertExploresToCatalog = (
             description: field.description || null,
             type: CatalogType.Field,
             field_type: field.fieldType,
+            required_attributes:
+                field.requiredAttributes ??
+                baseTable.requiredAttributes ??
+                null,
         }));
 
         return [...acc, table, ...fields];

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -13,7 +13,7 @@ export const convertExploresToCatalog = (
             name: explore.name,
             description: baseTable?.description || null,
             type: CatalogType.Table,
-            required_attributes: baseTable.requiredAttributes ?? null,
+            required_attributes: baseTable.requiredAttributes ?? {}, // ! Initializing as {} so it is not NULL in the database which means it can't be accessed
         };
 
         const dimensionsAndMetrics = [
@@ -31,9 +31,7 @@ export const convertExploresToCatalog = (
             type: CatalogType.Field,
             field_type: field.fieldType,
             required_attributes:
-                field.requiredAttributes ??
-                baseTable.requiredAttributes ??
-                null,
+                field.requiredAttributes ?? baseTable.requiredAttributes ?? {}, // ! Initializing as {} so it is not NULL in the database which means it can't be accessed
         }));
 
         return [...acc, table, ...fields];

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -37,7 +37,12 @@ export const parseFieldsFromCompiledTable = (
         ...Object.values(table.metrics),
     ].filter((f) => !f.hidden); // Filter out hidden fields from catalog
     return tableFields.map((field) =>
-        parseFieldFromMetricOrDimension(table, field, []),
+        parseFieldFromMetricOrDimension(
+            table,
+            field,
+            [],
+            field.requiredAttributes ?? table.requiredAttributes,
+        ),
     );
 };
 

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -14,7 +14,7 @@ const parseFieldFromMetricOrDimension = (
     table: CompiledTable,
     field: CompiledMetric | CompiledDimension,
     tags: string[],
-    requiredAttributes?: Record<string, string | string[]>,
+    requiredAttributes: Record<string, string | string[]> | undefined,
 ): CatalogField => ({
     name: field.name,
     label: field.label,

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -14,6 +14,7 @@ const parseFieldFromMetricOrDimension = (
     table: CompiledTable,
     field: CompiledMetric | CompiledDimension,
     tags: string[],
+    requiredAttributes?: Record<string, string | string[]>,
 ): CatalogField => ({
     name: field.name,
     label: field.label,
@@ -24,7 +25,7 @@ const parseFieldFromMetricOrDimension = (
     fieldType: field.fieldType,
     basicType: getBasicType(field),
     type: CatalogType.Field,
-    requiredAttributes: field?.requiredAttributes || table.requiredAttributes,
+    requiredAttributes,
     tags,
 });
 
@@ -52,7 +53,7 @@ export const parseCatalog = (
             groupLabel: dbCatalog.explore.groupLabel,
             description: dbCatalog.description || undefined,
             type: CatalogType.Table,
-            requiredAttributes: baseTable.requiredAttributes,
+            requiredAttributes: dbCatalog.required_attributes ?? undefined,
             tags: dbCatalog.explore.tags,
         };
     }
@@ -76,5 +77,6 @@ export const parseCatalog = (
         baseTable,
         findField,
         dbCatalog.explore.tags,
+        dbCatalog.required_attributes ?? undefined,
     );
 };

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -23,7 +23,6 @@ import {
     type KnexPaginateArgs,
     type KnexPaginatedData,
 } from '@lightdash/common';
-import { difference } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import { CatalogModel } from '../../models/CatalogModel/CatalogModel';

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -488,7 +488,7 @@ export class CatalogService<
     async getMetricsCatalog(
         user: SessionUser,
         projectUuid: string,
-        paginateArgs?: KnexPaginateArgs, // TODO: Pagination on `searchCatalog`
+        paginateArgs?: KnexPaginateArgs,
         search?: string,
     ): Promise<KnexPaginatedData<CatalogFieldWithAnalytics[]>> {
         const { organizationUuid } = await this.projectModel.getSummary(
@@ -510,7 +510,6 @@ export class CatalogService<
                 userUuid: user.userUuid,
             });
 
-        // ! Pagination here might not work as expected because there's some filtering being applied after the data is fetched
         const paginatedCatalogMetrics = await this.searchCatalog(
             projectUuid,
             userAttributes,

--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -97,6 +97,7 @@ describe('Lightdash catalog search', () => {
                     "# Customers\n\nThis table has basic information about a customer, as well as some derived\nfacts based on a customer's orders\n",
                 type: 'table',
                 tags: [],
+                requiredAttributes: {},
             });
 
             const field = resp.body.results.find(
@@ -113,6 +114,7 @@ describe('Lightdash catalog search', () => {
                 basicType: 'number',
                 fieldType: 'dimension',
                 tags: [],
+                requiredAttributes: {},
             });
         });
     });
@@ -138,6 +140,7 @@ describe('Lightdash catalog search', () => {
                 basicType: 'string',
                 type: 'field',
                 tags: [],
+                requiredAttributes: {},
             });
         });
     });
@@ -161,6 +164,7 @@ describe('Lightdash catalog search', () => {
                 basicType: 'number',
                 type: 'field',
                 tags: [],
+                requiredAttributes: {},
             });
         });
     });
@@ -180,6 +184,7 @@ describe('Lightdash catalog search', () => {
                     f.tableLabel === 'Users' &&
                     f.type === 'field',
             );
+
             expect(matchingField).to.eql({
                 name: 'customer_id',
                 tableLabel: 'Users',
@@ -190,12 +195,14 @@ describe('Lightdash catalog search', () => {
                 basicType: 'number',
                 fieldType: 'dimension',
                 tags: [],
+                requiredAttributes: {},
             });
 
             // Check for a table
             const matchingTable = resp.body.results.find(
                 (t) => t.name === 'customers',
             );
+
             expect(matchingTable).to.eql({
                 name: 'customers',
                 label: 'Customers',
@@ -203,6 +210,7 @@ describe('Lightdash catalog search', () => {
                     "# Customers\n\nThis table has basic information about a customer, as well as some derived\nfacts based on a customer's orders\n",
                 type: 'table',
                 tags: [],
+                requiredAttributes: {},
             });
         });
     });
@@ -228,6 +236,7 @@ describe('Lightdash catalog search', () => {
                 basicType: 'number',
                 fieldType: 'metric',
                 tags: [],
+                requiredAttributes: {},
             });
         });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12135 

### Description:

- introduces `required_attributes` column to `catalog_search` (`null` by default, and then user has to refresh dbt / compile project for all to be populated for each field and table - this is handled on the db query)
- this also ensures that the filtering around required_attributes (or user attributes) and table access (like model selection, tag selection) is happening on the the db query instead of post-db-query

 
### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


test-frontend