### PR TITLE
feat(api): include charts saved in dashboards in charts summary list by default

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -103,7 +103,7 @@ export class ProjectController extends BaseController {
      * List all charts summaries in a project
      * @param projectUuid The uuid of the project to get charts for
      * @param req express request
-     * @param includeChartSavedInDashboards Whether to include charts that are saved in dashboards
+     * @param excludeChartsSavedInDashboard Whether to exclude charts that are saved in dashboards
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -112,7 +112,7 @@ export class ProjectController extends BaseController {
     async getChartSummariesInProject(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-        @Query() includeChartSavedInDashboards?: boolean,
+        @Query() excludeChartsSavedInDashboard?: boolean,
     ): Promise<ApiChartSummaryListResponse> {
         this.setStatus(200);
         return {
@@ -122,7 +122,7 @@ export class ProjectController extends BaseController {
                 .getChartSummaries(
                     req.user!,
                     projectUuid,
-                    includeChartSavedInDashboards,
+                    excludeChartsSavedInDashboard,
                 ),
         };
     }

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -103,6 +103,7 @@ export class ProjectController extends BaseController {
      * List all charts summaries in a project
      * @param projectUuid The uuid of the project to get charts for
      * @param req express request
+     * @param includeChartSavedInDashboards Whether to include charts that are saved in dashboards
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -111,13 +112,18 @@ export class ProjectController extends BaseController {
     async getChartSummariesInProject(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() includeChartSavedInDashboards?: boolean,
     ): Promise<ApiChartSummaryListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getChartSummaries(req.user!, projectUuid),
+                .getChartSummaries(
+                    req.user!,
+                    projectUuid,
+                    includeChartSavedInDashboards,
+                ),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12990,6 +12990,11 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'object',
                 },
+                includeChartSavedInDashboards: {
+                    in: 'query',
+                    name: 'includeChartSavedInDashboards',
+                    dataType: 'boolean',
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12990,9 +12990,9 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'object',
                 },
-                includeChartSavedInDashboards: {
+                excludeChartsSavedInDashboard: {
                     in: 'query',
-                    name: 'includeChartSavedInDashboards',
+                    name: 'excludeChartsSavedInDashboard',
                     dataType: 'boolean',
                 },
             };

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10681,7 +10681,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1316.1",
+        "version": "0.1319.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -13384,9 +13384,9 @@
                         }
                     },
                     {
-                        "description": "Whether to include charts that are saved in dashboards",
+                        "description": "Whether to exclude charts that are saved in dashboards",
                         "in": "query",
-                        "name": "includeChartSavedInDashboards",
+                        "name": "excludeChartsSavedInDashboard",
                         "required": false,
                         "schema": {
                             "type": "boolean"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13382,6 +13382,15 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Whether to include charts that are saved in dashboards",
+                        "in": "query",
+                        "name": "includeChartSavedInDashboards",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ]
             }

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -35,7 +35,11 @@ import {
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../config/parseConfig';
-import { DashboardsTableName } from '../database/entities/dashboards';
+import {
+    DashboardsTableName,
+    DashboardTileChartTableName,
+    DashboardVersionsTableName,
+} from '../database/entities/dashboards';
 import { OrganizationTableName } from '../database/entities/organizations';
 import {
     PinnedChartTableName,
@@ -1108,6 +1112,7 @@ export class SavedChartModel {
         spaceUuids?: string[];
         slug?: string;
         exploreName?: string;
+        includeChartSavedInDashboards?: boolean;
     }): Promise<(ChartSummary & { updatedAt: Date })[]> {
         return Sentry.startSpan(
             {
@@ -1122,10 +1127,62 @@ export class SavedChartModel {
                         filters.projectUuid,
                     );
                 }
-                if (filters.spaceUuids) {
+
+                if (filters.includeChartSavedInDashboards) {
+                    // Join only the charts from the latest dashboard version
                     void query
-                        .whereNotNull(`${SavedChartsTableName}.space_id`)
-                        .whereIn('spaces.space_uuid', filters.spaceUuids);
+                        .leftJoin(
+                            DashboardVersionsTableName,
+                            `${DashboardVersionsTableName}.dashboard_id`,
+                            '=',
+                            `${DashboardsTableName}.dashboard_id`,
+                        )
+                        .leftJoin(
+                            DashboardTileChartTableName,
+                            function chartsJoin() {
+                                this.on(
+                                    `${DashboardTileChartTableName}.dashboard_version_id`,
+                                    '=',
+                                    `${DashboardVersionsTableName}.dashboard_version_id`,
+                                );
+                                this.andOn(
+                                    `${DashboardTileChartTableName}.saved_chart_id`,
+                                    '=',
+                                    `${SavedChartsTableName}.saved_query_id`,
+                                );
+                            },
+                        );
+
+                    // Get charts not saved in a dashboard OR the charts saved a dashboard AND used in the latest dashboard version
+                    void query.where((whereBuilder) => {
+                        void whereBuilder
+                            .whereNull(`${DashboardsTableName}.dashboard_id`)
+                            .orWhere((orWhereBuilder) => {
+                                void orWhereBuilder
+                                    .whereNotNull(
+                                        `${DashboardTileChartTableName}.saved_chart_id`,
+                                    )
+                                    .andWhere(
+                                        `${DashboardVersionsTableName}.created_at`,
+                                        '=',
+                                        this.database
+                                            .from(DashboardVersionsTableName)
+                                            .max('created_at')
+                                            .where(
+                                                `${DashboardVersionsTableName}.dashboard_id`,
+                                                this.database.ref(
+                                                    `${DashboardsTableName}.dashboard_id`,
+                                                ),
+                                            ),
+                                    );
+                            });
+                    });
+                } else {
+                    void query.whereNotNull(`${SavedChartsTableName}.space_id`); // Note: charts saved in dashboards have saved_queries.space_id = null
+                }
+
+                if (filters.spaceUuids) {
+                    void query.whereIn('spaces.space_uuid', filters.spaceUuids);
                 }
                 if (filters.slug) {
                     void query.where('saved_queries.slug', filters.slug);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3731,7 +3731,7 @@ export class ProjectService extends BaseService {
     async getChartSummaries(
         user: SessionUser,
         projectUuid: string,
-        includeChartSavedInDashboards: boolean = false,
+        excludeChartsSavedInDashboard: boolean = false,
     ): Promise<ChartSummary[]> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -3766,7 +3766,7 @@ export class ProjectService extends BaseService {
         return this.savedChartModel.find({
             projectUuid,
             spaceUuids: allowedSpaceUuids,
-            includeChartSavedInDashboards,
+            excludeChartsSavedInDashboard,
         });
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3731,6 +3731,7 @@ export class ProjectService extends BaseService {
     async getChartSummaries(
         user: SessionUser,
         projectUuid: string,
+        includeChartSavedInDashboards: boolean = false,
     ): Promise<ChartSummary[]> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -3765,6 +3766,7 @@ export class ProjectService extends BaseService {
         return this.savedChartModel.find({
             projectUuid,
             spaceUuids: allowedSpaceUuids,
+            includeChartSavedInDashboards,
         });
     }
 

--- a/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
+++ b/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
@@ -6,18 +6,22 @@ describe('Lightdash chart summaries endpoints', () => {
     beforeEach(() => {
         cy.login();
     });
-    it('Should list charts in spaces', () => {
+    it('List should not include charts saved in dashboards', () => {
         cy.request(chartSummariesEndpointPath).then((resp) => {
             expect(resp.status).to.eq(200);
-            expect(resp.body.results).to.have.length(9);
+            expect(resp.body.results.map((chart) => chart.name)).to.not.include(
+                '[Saved in dashboard] How much revenue do we have per payment method?',
+            );
         });
     });
-    it('Should list charts in spaces and dashboards', () => {
+    it('List should include charts saved in dashboards', () => {
         cy.request(
             `${chartSummariesEndpointPath}?includeChartSavedInDashboards=true`,
         ).then((resp) => {
             expect(resp.status).to.eq(200);
-            expect(resp.body.results).to.have.length(10);
+            expect(resp.body.results.map((chart) => chart.name)).to.include(
+                '[Saved in dashboard] How much revenue do we have per payment method?',
+            );
         });
     });
 });

--- a/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
+++ b/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
@@ -1,0 +1,23 @@
+import { SEED_PROJECT } from '@lightdash/common';
+
+const chartSummariesEndpointPath = `/api/v1/projects/${SEED_PROJECT.project_uuid}/chart-summaries`;
+
+describe('Lightdash chart summaries endpoints', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+    it('Should list charts in spaces', () => {
+        cy.request(chartSummariesEndpointPath).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.have.length(9);
+        });
+    });
+    it('Should list charts in spaces and dashboards', () => {
+        cy.request(
+            `${chartSummariesEndpointPath}?includeChartSavedInDashboards=true`,
+        ).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.have.length(10);
+        });
+    });
+});

--- a/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
+++ b/packages/e2e/cypress/e2e/api/chartSummaries.cy.ts
@@ -6,20 +6,20 @@ describe('Lightdash chart summaries endpoints', () => {
     beforeEach(() => {
         cy.login();
     });
-    it('List should not include charts saved in dashboards', () => {
+    it('List should include charts saved in dashboards', () => {
         cy.request(chartSummariesEndpointPath).then((resp) => {
             expect(resp.status).to.eq(200);
-            expect(resp.body.results.map((chart) => chart.name)).to.not.include(
+            expect(resp.body.results.map((chart) => chart.name)).to.include(
                 '[Saved in dashboard] How much revenue do we have per payment method?',
             );
         });
     });
-    it('List should include charts saved in dashboards', () => {
+    it('List should exclude charts saved in dashboards', () => {
         cy.request(
-            `${chartSummariesEndpointPath}?includeChartSavedInDashboards=true`,
+            `${chartSummariesEndpointPath}?excludeChartsSavedInDashboard=true`,
         ).then((resp) => {
             expect(resp.status).to.eq(200);
-            expect(resp.body.results.map((chart) => chart.name)).to.include(
+            expect(resp.body.results.map((chart) => chart.name)).to.not.include(
                 '[Saved in dashboard] How much revenue do we have per payment method?',
             );
         });

--- a/packages/frontend/src/hooks/useChartSummaries.ts
+++ b/packages/frontend/src/hooks/useChartSummaries.ts
@@ -4,7 +4,7 @@ import { lightdashApi } from '../api';
 
 const getChartSummariesInProject = async (projectUuid: string) => {
     return lightdashApi<ChartSummary[]>({
-        url: `/projects/${projectUuid}/chart-summaries`,
+        url: `/projects/${projectUuid}/chart-summaries?excludeChartsSavedInDashboard=true`,
         method: 'GET',
         body: undefined,
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12113](https://github.com/lightdash/lightdash/issues/12113)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- updated SQL to make sure we only list charts that are used in the latest version of the dashboards
- added a new dashboard in seed data
- added API test
- added a new URL param `excludeChartsSavedInDashboard` to exclude charts saved in dashboards

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
