### PR TITLE
feat: open usage chart in modal and let user open chart

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartsUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartsUsageModal.tsx
@@ -1,0 +1,61 @@
+import {
+    Anchor,
+    Group,
+    List,
+    Modal,
+    Stack,
+    Text,
+    type ModalProps,
+} from '@mantine/core';
+import { IconDeviceAnalytics } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useAppSelector } from '../../sqlRunner/store/hooks';
+
+type Props = ModalProps;
+
+export const MetricChartsUsageModal: FC<Props> = ({ opened, onClose }) => {
+    const activeMetric = useAppSelector(
+        (state) => state.metricsCatalog.activeMetric,
+    );
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={
+                <Group spacing="xs">
+                    <MantineIcon
+                        icon={IconDeviceAnalytics}
+                        size="lg"
+                        color="gray.7"
+                    />
+                    <Text fw={500}>Metric Usage</Text>
+                </Group>
+            }
+            styles={(theme) => ({
+                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
+                body: { padding: 0 },
+            })}
+        >
+            <Stack p="md" spacing="xs">
+                <Text>This metric is used in the following charts:</Text>
+                <List pl="sm">
+                    {activeMetric?.analytics?.charts.map((chart) => (
+                        <List.Item key={chart.uuid} fz="sm">
+                            <Anchor
+                                href={`/projects/${projectUuid}/saved/${chart.uuid}`}
+                                target="_blank"
+                            >
+                                {chart.name}
+                            </Anchor>
+                        </List.Item>
+                    ))}
+                </List>
+            </Stack>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -10,7 +10,6 @@ import { MetricsTable } from './MetricsTable';
 export const MetricsCatalogPanel = () => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const params = useParams<{ projectUuid: string }>();
-    console.log({ params });
 
     const dispatch = useAppDispatch();
     const isMetricUsageModalOpen = useAppSelector(

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,8 +1,31 @@
 import { Group, Stack, Title } from '@mantine/core';
+import { useParams } from 'react-router-dom';
+import { useMount } from 'react-use';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
+import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
+import { setActiveMetric, setProjectUuid } from '../store/metricsCatalogSlice';
+import { MetricChartsUsageModal } from './MetricChartsUsageModal';
 import { MetricsTable } from './MetricsTable';
 
 export const MetricsCatalogPanel = () => {
+    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const params = useParams<{ projectUuid: string }>();
+    console.log({ params });
+
+    const dispatch = useAppDispatch();
+    const isMetricUsageModalOpen = useAppSelector(
+        (state) => state.metricsCatalog.modals.chartUsageModal.isOpen,
+    );
+    const onCloseMetricUsageModal = () => {
+        dispatch(setActiveMetric(undefined));
+    };
+
+    useMount(() => {
+        if (!projectUuid && params.projectUuid) {
+            dispatch(setProjectUuid(params.projectUuid));
+        }
+    });
+
     return (
         <Stack>
             <Group position="apart">
@@ -10,6 +33,10 @@ export const MetricsCatalogPanel = () => {
                 <RefreshDbtButton />
             </Group>
             <MetricsTable />
+            <MetricChartsUsageModal
+                opened={isMetricUsageModalOpen}
+                onClose={onCloseMetricUsageModal}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -30,6 +30,12 @@ const MetricUsageButton = ({
             onClick={() =>
                 hasChartsUsage && dispatch(setActiveMetric(row.original))
             }
+            sx={{
+                '&[data-disabled]': {
+                    backgroundColor: 'transparent',
+                    fontWeight: 400,
+                },
+            }}
         >
             {hasChartsUsage
                 ? `${row.original.analytics?.charts.length} uses`

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,15 +1,42 @@
 import { type CatalogFieldWithAnalytics } from '@lightdash/common';
-import { Badge, HoverCard, Text } from '@mantine/core';
+import { Button, HoverCard, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
+    type MRT_Row,
     type MRT_Virtualizer,
 } from 'mantine-react-table';
 import { useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricsCatalog } from '../hooks/useMetricsCatalog';
+import { setActiveMetric } from '../store/metricsCatalogSlice';
+
+const MetricUsageButton = ({
+    row,
+}: {
+    row: MRT_Row<CatalogFieldWithAnalytics>;
+}) => {
+    const hasChartsUsage = row.original.analytics?.charts.length > 0;
+    const dispatch = useAppDispatch();
+    return (
+        <Button
+            size="xs"
+            compact
+            color="indigo"
+            variant="subtle"
+            disabled={!hasChartsUsage}
+            onClick={() =>
+                hasChartsUsage && dispatch(setActiveMetric(row.original))
+            }
+        >
+            {hasChartsUsage
+                ? `${row.original.analytics?.charts.length} uses`
+                : 'No usage'}
+        </Button>
+    );
+};
 
 const columns: MRT_ColumnDef<CatalogFieldWithAnalytics>[] = [
     {
@@ -44,18 +71,16 @@ const columns: MRT_ColumnDef<CatalogFieldWithAnalytics>[] = [
     {
         accessorKey: 'usage',
         header: 'Usage',
-        Cell: ({ row }) => (
-            <Badge fw={500} radius="sm" color="indigo">
-                {row.original.analytics?.charts.length} uses
-            </Badge>
-        ),
+        Cell: ({ row }) => <MetricUsageButton row={row} />,
     },
 ];
 
 const fetchSize = 25;
 
 export const MetricsTable = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
         useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -1,0 +1,46 @@
+import type { CatalogFieldWithAnalytics } from '@lightdash/common';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+type MetricsCatalogState = {
+    modals: {
+        chartUsageModal: {
+            isOpen: boolean;
+        };
+    };
+    activeMetricChartsUsage:
+        | CatalogFieldWithAnalytics['analytics']['charts']
+        | undefined;
+    projectUuid: string | undefined;
+};
+
+const initialState: MetricsCatalogState = {
+    activeMetricChartsUsage: undefined,
+    projectUuid: undefined,
+    modals: {
+        chartUsageModal: {
+            isOpen: false,
+        },
+    },
+};
+
+export const metricsCatalogSlice = createSlice({
+    name: 'metricsCatalog',
+    initialState,
+    reducers: {
+        setProjectUuid: (state, action: PayloadAction<string>) => {
+            state.projectUuid = action.payload;
+        },
+        setActiveMetricChartsUsage: (
+            state,
+            action: PayloadAction<
+                MetricsCatalogState['activeMetricChartsUsage']
+            >,
+        ) => {
+            state.activeMetricChartsUsage = action.payload;
+            state.modals.chartUsageModal.isOpen = !!action.payload;
+        },
+    },
+});
+
+export const { setActiveMetricChartsUsage, setProjectUuid } =
+    metricsCatalogSlice.actions;

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -7,14 +7,12 @@ type MetricsCatalogState = {
             isOpen: boolean;
         };
     };
-    activeMetricChartsUsage:
-        | CatalogFieldWithAnalytics['analytics']['charts']
-        | undefined;
+    activeMetric: CatalogFieldWithAnalytics | undefined;
     projectUuid: string | undefined;
 };
 
 const initialState: MetricsCatalogState = {
-    activeMetricChartsUsage: undefined,
+    activeMetric: undefined,
     projectUuid: undefined,
     modals: {
         chartUsageModal: {
@@ -30,17 +28,14 @@ export const metricsCatalogSlice = createSlice({
         setProjectUuid: (state, action: PayloadAction<string>) => {
             state.projectUuid = action.payload;
         },
-        setActiveMetricChartsUsage: (
+        setActiveMetric: (
             state,
-            action: PayloadAction<
-                MetricsCatalogState['activeMetricChartsUsage']
-            >,
+            action: PayloadAction<CatalogFieldWithAnalytics | undefined>,
         ) => {
-            state.activeMetricChartsUsage = action.payload;
+            state.activeMetric = action.payload;
             state.modals.chartUsageModal.isOpen = !!action.payload;
         },
     },
 });
 
-export const { setActiveMetricChartsUsage, setProjectUuid } =
-    metricsCatalogSlice.actions;
+export const { setActiveMetric, setProjectUuid } = metricsCatalogSlice.actions;

--- a/packages/frontend/src/features/sqlRunner/store/index.ts
+++ b/packages/frontend/src/features/sqlRunner/store/index.ts
@@ -6,6 +6,7 @@ import { barChartConfigSlice } from '../../../components/DataViz/store/barChartS
 import { lineChartConfigSlice } from '../../../components/DataViz/store/lineChartSlice';
 import { pieChartConfigSlice } from '../../../components/DataViz/store/pieChartSlice';
 import { tableVisSlice } from '../../../components/DataViz/store/tableVisSlice';
+import { metricsCatalogSlice } from '../../metricsCatalog/store/metricsCatalogSlice';
 import { semanticViewerSlice } from '../../semanticViewer/store/semanticViewerSlice';
 import { listenerMiddleware } from './listenerMiddleware';
 import { sqlRunnerSlice } from './sqlRunnerSlice';
@@ -20,6 +21,7 @@ export const store = configureStore({
         pieChartConfig: pieChartConfigSlice.reducer,
         tableVisConfig: tableVisSlice.reducer,
         [semanticViewerSlice.name]: semanticViewerSlice.reducer,
+        [metricsCatalogSlice.name]: metricsCatalogSlice.reducer,
     },
     // Add the listener middleware to the store, this is useful for listening to actions and running side effects
     middleware: (getDefaultMiddleware) =>

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -1,17 +1,21 @@
 import { type FC } from 'react';
+import { Provider } from 'react-redux';
 import Page from '../components/common/Page/Page';
 import { MetricsCatalogPanel } from '../features/metricsCatalog';
+import { store } from '../features/sqlRunner/store';
 
 const MetricsCatalog: FC = () => {
     return (
-        <Page
-            withFitContent
-            withPaddedContent
-            withRightSidebar
-            withLargeContent
-        >
-            <MetricsCatalogPanel />
-        </Page>
+        <Provider store={store}>
+            <Page
+                withFitContent
+                withPaddedContent
+                withRightSidebar
+                withLargeContent
+            >
+                <MetricsCatalogPanel />
+            </Page>
+        </Provider>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/12104

### Description:

Adds new slice `metricsCatalog` 
Adds modal, and it's controlled by the setting of active metric name - we might want to do this differently in the future, but it works fine

https://github.com/user-attachments/assets/f045cebd-685d-463c-80ae-8932771919ac



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
