### PR TITLE
feat: project list ordering

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -57,6 +57,7 @@ import {
     DbDashboard,
     DbDashboardTabs,
 } from '../../database/entities/dashboards';
+import { GroupMembershipTableName } from '../../database/entities/groupMemberships';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import {
     DbOrganization,
@@ -197,7 +198,9 @@ export class ProjectModel {
                 void q
                     .select(
                         'projects.project_uuid',
-                        this.database.raw(`COUNT(*) as member_count`),
+                        this.database.raw(
+                            `COUNT(distinct ${GroupMembershipTableName}.user_id) as member_count`,
+                        ),
                     )
                     .from(ProjectGroupAccessTableName)
                     .groupBy('projects.project_uuid')
@@ -206,13 +209,20 @@ export class ProjectModel {
                         'projects.project_uuid',
                         `${ProjectGroupAccessTableName}.project_uuid`,
                     )
+                    .leftJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${ProjectGroupAccessTableName}.group_uuid`,
+                    )
                     .where('projects.organization_id', organizationId);
             })
             .with('agg_project_membership_counts', (q) => {
                 void q
                     .select(
                         'projects.project_uuid',
-                        this.database.raw(`COUNT(*) as member_count`),
+                        this.database.raw(
+                            `COUNT(distinct ${ProjectMembershipsTableName}.user_id) as member_count`,
+                        ),
                     )
                     .from(ProjectMembershipsTableName)
                     .groupBy('projects.project_uuid')

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -25,6 +25,12 @@ import { useProjects } from '../../hooks/useProjects';
 import { useApp } from '../../providers/AppProvider';
 import { Can } from '../common/Authorization';
 
+const MENU_TEXT_PROPS = {
+    c: 'gray.2',
+    fz: 'xs',
+    fw: 500,
+};
+
 const CreatePreviewModal = ({
     isOpened,
     onClose,
@@ -104,15 +110,14 @@ const InactiveProjectItem: FC<{
                 >
                     <Text
                         ref={truncatedRef}
-                        c="gray.2"
-                        fz="xs"
-                        fw={500}
+                        {...MENU_TEXT_PROPS}
                         truncate
                         maw={350}
                     >
                         {item.name}
                     </Text>
                 </Tooltip>
+
                 {item.type === ProjectType.PREVIEW && (
                     <Badge
                         color="yellow.1"
@@ -239,6 +244,7 @@ const ProjectSwitcher = () => {
         if (!activeProjectUuid || !projects) return [];
         return projects.filter((p) => p.projectUuid !== activeProjectUuid);
     }, [activeProjectUuid, projects]);
+
     const [isCreatePreviewOpen, setIsCreatePreview] = useState(false);
     const { user } = useApp();
 
@@ -296,6 +302,7 @@ const ProjectSwitcher = () => {
                             handleProjectChange={handleProjectChange}
                         />
                     ))}
+
                     {activeProject && (
                         <Can
                             I="create"
@@ -313,7 +320,7 @@ const ProjectSwitcher = () => {
                                     e.stopPropagation();
                                 }}
                             >
-                                <Text fz="xs" fw={500}>
+                                <Text {...MENU_TEXT_PROPS}>
                                     + Create preview
                                 </Text>
                             </Menu.Item>
@@ -321,6 +328,7 @@ const ProjectSwitcher = () => {
                     )}
                 </Menu.Dropdown>
             </Menu>
+
             {activeProject && (
                 <CreatePreviewModal
                     isOpened={isCreatePreviewOpen}


### PR DESCRIPTION
Closes: #12003

### OG description from the ticket:

- production projects should be at the top, listed by the most users who have viewer+ access to them (i.e. project with 900 users is at the top, project with 400 users is below that)
- preview projects should be below the production projects, listed in order of most recently created (most recent at the top)

### Description:

first task mentions users who have viewer+ access. Since we are optimizing for a large number of project lists, querying permissions for all users is going to be very resource-intensive (though I'm open to suggestions if you think this is achievable).

I decieded to order by three components:

- if project is default it goes first, preview goes last
- then we order by direct project members + group inherited members (descending)
- and in the last we order by created_at (descending)

second sort is the most controversial, but let me clarify:
- organization-inherited users do not matter because they are the same for all projects.
- project members and groups might have overlapping users, but this isn't a major issue, as duplication also contributes to the "popularity" of the project.

![CleanShot 2024-10-28 at 22 42 01@2x](https://github.com/user-attachments/assets/6964b479-d15a-4654-b1d8-44962a8c770d)

![CleanShot 2024-10-28 at 22 42 37@2x](https://github.com/user-attachments/assets/929014e5-18b4-42ed-8c83-504ceef497e5)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
