### PR TITLE
fix: remove number metric total calculation on pivot

### DIFF
--- a/packages/frontend/src/hooks/useColumnTotals.ts
+++ b/packages/frontend/src/hooks/useColumnTotals.ts
@@ -31,15 +31,14 @@ export const isSummable = (item: Item | undefined) => {
     if (isCustomDimension(item)) {
         return false;
     }
-    const numericTypes: string[] = [
-        DimensionType.NUMBER,
-        MetricType.NUMBER,
-        MetricType.COUNT,
-        MetricType.SUM,
-    ];
+    const numericTypes: string[] = [MetricType.COUNT, MetricType.SUM];
+    const isNumberDimension =
+        isDimension(item) && item.type === DimensionType.NUMBER;
+    const isNumbericType =
+        numericTypes.includes(item.type) || isNumberDimension;
     const isPercent = item.format === 'percent';
     const isDatePart = isDimension(item) && item.timeInterval;
-    return numericTypes.includes(item.type) && !isPercent && !isDatePart;
+    return isNumbericType && !isPercent && !isDatePart;
 };
 
 const getResultColumnTotals = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12047
Related: https://github.com/lightdash/lightdash/issues/9981

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
### Why we have decided to not support number metrics on totals 

https://github.com/lightdash/lightdash/issues/9981#issuecomment-2443881249

For context, we don't calculate totals on pivot tables for metric type `number`, because the `sum` of numbers is not a correct total. 

Let's take this example: 

I have a metric which is a type:number calculated from `sums`

```
      - name: amount
        description: Total amount (AUD) of the individual payment
        meta:
          metrics:
            total_revenue:
              type: sum
              description: Sum of all payments
            total_cost:
                type: number
                sql: ${total_revenue} - 10
            total_percent_profit: 
                type: number
                sql: 100 * ${total_revenue}/${total_cost}
```

WHen I calculate totals in a non-pivot table, the result is correct, we calculate this on a special backend endpoint, by grouping the right columns.

![image](https://github.com/user-attachments/assets/d4cb8a4c-cef9-4b67-a7e2-3079bec76925)

When I pivot the table, the frontend is `aggregating` all the rows, to calculate the total, (because we allowed NUMBER on `isSummable` function) , the total result is wrong.

![image](https://github.com/user-attachments/assets/8592655a-fccc-44aa-bd9c-8bcced03f6a7)

FOr this use case, we could `manually` calculate the total, by running the `100 * ${total_revenue}/${total_cost}` operation on the `total of the individual metrics`, like: 

> 100 * (994.16 /	854.16) = 116

However, the main issue is that in the `frontend`, this total_revenue and total_cost might not be present in the result of the query, so we'll have to move this calculation to the backend somehow, per dimension pivot, which is not an easy thing to do. 

So we decided to temporarily remove this total calculation from number types 

<!-- Even better add a screenshot / gif / loom -->

### Description

before:
![Screenshot from 2024-10-29 11-49-33](https://github.com/user-attachments/assets/7d1aac6e-83ef-49b4-baa8-c4662f6ee153)

after:

![image](https://github.com/user-attachments/assets/0534e3a9-6cff-41b4-b495-fa78ff96705f)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
