### PR TITLE
feat: project list no previews for members and below

### DIFF
--- a/docs/docs/references/roles.mdx
+++ b/docs/docs/references/roles.mdx
@@ -33,32 +33,22 @@ accessible by users with organization roles.
 | Create virtual views                                   |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
 | Manage project access and permissions                  |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
 | Delete project                                         |      ✅       |        ❌         |       ❌       |             ❌             |       ❌       |
-| Create project previews                                |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
+| Create a preview from a project                        |      ✅       |        ✅         |       ❌       |             ❌             |       ❌       |
 
 ### Organization Roles
 
 Organization Admins can assign roles to organization members, which gives access to all projects in the organization.
 
-| Action                                     | Organization Admin |   Organization Developer   |    Organization Editor     | Organization Interactive Viewer | Organization Viewer | Organization Member |
-| :----------------------------------------- | :----------------: | :------------------------: | :------------------------: | :-----------------------------: | :-----------------: | :-----------------: |
-| Create Personal access tokens              |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ✅          |
-| View **all** projects                      |         ✅         |             ✅             |             ✅             |               ✅                |         ✅          |         ❌          |
-| Create new projects                        |         ✅         |             ✅             |             ✅             |               ✅                |         ❌          |         ❌          |
-| Create project previews                    |         ✅         | [✅ \*](#project-previews) | [✅ \*](#project-previews) |   [✅ \*](#project-previews)    |         ❌          |         ❌          |
-| Edit **all** projects                      |         ✅         |             ✅             |             ✅             |               ❌                |         ❌          |         ❌          |
-| Admin for **all** projects                 |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
-| Invite users to organization               |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
-| Manage organization access and permissions |         ✅         |             ❌             |             ❌             |               ❌                |         ❌          |         ❌          |
-
-:::info
-
-<a name="project-previews" class="hidden-anchor"></a>
-Previews of projects created by Developers, Editors, or Interactive Viewers will
-include all content, including private spaces. However, since user access is
-also copied to the preview project, users will not have access to the private
-content.
-
-:::
+| Action                                     | Organization Admin | Organization Developer | Organization Editor | Organization Interactive Viewer | Organization Viewer | Organization Member |
+| :----------------------------------------- | :----------------: | :--------------------: | :-----------------: | :-----------------------------: | :-----------------: | :-----------------: |
+| Create Personal access tokens              |         ✅         |           ✅           |         ✅          |               ✅                |         ✅          |         ✅          |
+| View **all** projects                      |         ✅         |           ✅           |         ✅          |               ✅                |         ✅          |         ❌          |
+| Create new projects                        |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
+| Create a preview from a project            |         ✅         |           ✅           |         ❌          |               ❌                |         ❌          |         ❌          |
+| Edit **all** projects                      |         ✅         |           ✅           |         ✅          |               ❌                |         ❌          |         ❌          |
+| Admin for **all** projects                 |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
+| Invite users to organization               |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
+| Manage organization access and permissions |         ✅         |           ❌           |         ❌          |               ❌                |         ❌          |         ❌          |
 
 ### Space Roles
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -322,9 +322,9 @@ export class ProjectService extends BaseService {
                     const upstreamProject = await this.projectModel.get(
                         data.upstreamProjectUuid,
                     );
-                    if (upstreamProject.type === ProjectType.DEFAULT) {
+                    if (upstreamProject.type === ProjectType.PREVIEW) {
                         throw new ForbiddenError(
-                            'Cannot create a preview project from a default project',
+                            'Cannot create a preview project from a preview project',
                         );
                     }
                 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -533,6 +533,10 @@ export class ProjectService extends BaseService {
                 const projectSummary = await this.projectModel.getSummary(
                     data.upstreamProjectUuid,
                 );
+                await this.copyUserAccessOnPreview(
+                    data.upstreamProjectUuid,
+                    projectUuid,
+                );
                 await this.copyContentOnPreview(
                     data.upstreamProjectUuid,
                     projectUuid,
@@ -673,6 +677,65 @@ export class ProjectService extends BaseService {
         return {
             jobUuid: job.jobUuid,
         };
+    }
+
+    /*
+        Copy user permissions from upstream project
+        if the user is a viewer in the org, but an editor in a project
+        we want the user to also be an editor in the preview project
+    */
+    async copyUserAccessOnPreview(
+        upstreamProjectUuid: string,
+        previewProjectUuid: string,
+    ): Promise<void> {
+        this.logger.info(
+            `Copying access from project ${upstreamProjectUuid} to preview project ${previewProjectUuid}`,
+        );
+        await wrapSentryTransaction<void>(
+            'duplicateUserAccess',
+            {
+                previewProjectUuid,
+                upstreamProjectUuid,
+            },
+            async () => {
+                const projectAccesses =
+                    await this.projectModel.getProjectAccess(
+                        upstreamProjectUuid,
+                    );
+                const groupAccesses =
+                    await this.projectModel.getProjectGroupAccesses(
+                        upstreamProjectUuid,
+                    );
+
+                this.logger.info(
+                    `Copying ${projectAccesses.length} user access on ${previewProjectUuid}`,
+                );
+                this.logger.info(
+                    `Copying ${groupAccesses.length} group access on ${previewProjectUuid}`,
+                );
+                const insertProjectAccessPromises = projectAccesses.map(
+                    (projectAccess) =>
+                        this.projectModel.createProjectAccess(
+                            previewProjectUuid,
+                            projectAccess.email,
+                            projectAccess.role,
+                        ),
+                );
+                const insertGroupAccessPromises = groupAccesses.map(
+                    (groupAccess) =>
+                        this.groupsModel.addProjectAccess({
+                            groupUuid: groupAccess.groupUuid,
+                            projectUuid: previewProjectUuid,
+                            role: groupAccess.role,
+                        }),
+                );
+
+                await Promise.all([
+                    ...insertGroupAccessPromises,
+                    ...insertProjectAccessPromises,
+                ]);
+            },
+        );
     }
 
     async setExplores(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -318,37 +318,28 @@ export class ProjectService extends BaseService {
                 throw new ForbiddenError();
 
             case ProjectType.PREVIEW:
-                if (data.upstreamProjectUuid) {
-                    // if the upstream project is provided, user must have access to the upstream project level
-                    if (
-                        user.ability.can(
-                            'create',
-                            subject('Project', {
-                                upstreamProjectUuid: data.upstreamProjectUuid,
-                                type: ProjectType.PREVIEW,
-                            }),
-                        )
-                    ) {
-                        return true;
-                    }
-
-                    throw new ForbiddenError();
-                } else {
-                    // if the upstream project is not provided, user must have permission to create project on an organization level
-                    if (
-                        user.ability.can(
-                            'create',
-                            subject('Project', {
-                                organizationUuid: user.organizationUuid,
-                                type: ProjectType.PREVIEW,
-                            }),
-                        )
-                    ) {
-                        return true;
-                    }
-
-                    throw new ForbiddenError();
+                // if the upstream project is not provided, user must have access to create project ONLY on an organization level
+                // if the upstream project is provided, user must have access to the upstream project level OR on an organization level
+                if (
+                    user.ability.can(
+                        'create',
+                        subject('Project', {
+                            upstreamProjectUuid: data.upstreamProjectUuid,
+                            type: ProjectType.PREVIEW,
+                        }),
+                    ) ||
+                    user.ability.can(
+                        'create',
+                        subject('Project', {
+                            organizationUuid: user.organizationUuid,
+                            type: ProjectType.PREVIEW,
+                        }),
+                    )
+                ) {
+                    return true;
                 }
+
+                throw new ForbiddenError();
 
             default:
                 return assertUnreachable(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -679,65 +679,6 @@ export class ProjectService extends BaseService {
         };
     }
 
-    /*
-        Copy user permissions from upstream project
-        if the user is a viewer in the org, but an editor in a project
-        we want the user to also be an editor in the preview project
-    */
-    async copyUserAccessOnPreview(
-        upstreamProjectUuid: string,
-        previewProjectUuid: string,
-    ): Promise<void> {
-        this.logger.info(
-            `Copying access from project ${upstreamProjectUuid} to preview project ${previewProjectUuid}`,
-        );
-        await wrapSentryTransaction<void>(
-            'duplicateUserAccess',
-            {
-                previewProjectUuid,
-                upstreamProjectUuid,
-            },
-            async () => {
-                const projectAccesses =
-                    await this.projectModel.getProjectAccess(
-                        upstreamProjectUuid,
-                    );
-                const groupAccesses =
-                    await this.projectModel.getProjectGroupAccesses(
-                        upstreamProjectUuid,
-                    );
-
-                this.logger.info(
-                    `Copying ${projectAccesses.length} user access on ${previewProjectUuid}`,
-                );
-                this.logger.info(
-                    `Copying ${groupAccesses.length} group access on ${previewProjectUuid}`,
-                );
-                const insertProjectAccessPromises = projectAccesses.map(
-                    (projectAccess) =>
-                        this.projectModel.createProjectAccess(
-                            previewProjectUuid,
-                            projectAccess.email,
-                            projectAccess.role,
-                        ),
-                );
-                const insertGroupAccessPromises = groupAccesses.map(
-                    (groupAccess) =>
-                        this.groupsModel.addProjectAccess({
-                            groupUuid: groupAccess.groupUuid,
-                            projectUuid: previewProjectUuid,
-                            role: groupAccess.role,
-                        }),
-                );
-
-                await Promise.all([
-                    ...insertGroupAccessPromises,
-                    ...insertProjectAccessPromises,
-                ]);
-            },
-        );
-    }
-
     async setExplores(
         user: SessionUser,
         projectUuid: string,
@@ -4064,6 +4005,65 @@ export class ProjectService extends BaseService {
             true, // Skip permission check
         );
         return previewProject.project.projectUuid;
+    }
+
+    /*
+        Copy user permissions from upstream project
+        if the user is a viewer in the org, but an editor in a project
+        we want the user to also be an editor in the preview project
+    */
+    async copyUserAccessOnPreview(
+        upstreamProjectUuid: string,
+        previewProjectUuid: string,
+    ): Promise<void> {
+        this.logger.info(
+            `Copying access from project ${upstreamProjectUuid} to preview project ${previewProjectUuid}`,
+        );
+        await wrapSentryTransaction<void>(
+            'duplicateUserAccess',
+            {
+                previewProjectUuid,
+                upstreamProjectUuid,
+            },
+            async () => {
+                const projectAccesses =
+                    await this.projectModel.getProjectAccess(
+                        upstreamProjectUuid,
+                    );
+                const groupAccesses =
+                    await this.projectModel.getProjectGroupAccesses(
+                        upstreamProjectUuid,
+                    );
+
+                this.logger.info(
+                    `Copying ${projectAccesses.length} user access on ${previewProjectUuid}`,
+                );
+                this.logger.info(
+                    `Copying ${groupAccesses.length} group access on ${previewProjectUuid}`,
+                );
+                const insertProjectAccessPromises = projectAccesses.map(
+                    (projectAccess) =>
+                        this.projectModel.createProjectAccess(
+                            previewProjectUuid,
+                            projectAccess.email,
+                            projectAccess.role,
+                        ),
+                );
+                const insertGroupAccessPromises = groupAccesses.map(
+                    (groupAccess) =>
+                        this.groupsModel.addProjectAccess({
+                            groupUuid: groupAccess.groupUuid,
+                            projectUuid: previewProjectUuid,
+                            role: groupAccess.role,
+                        }),
+                );
+
+                await Promise.all([
+                    ...insertGroupAccessPromises,
+                    ...insertProjectAccessPromises,
+                ]);
+            },
+        );
     }
 
     async copyContentOnPreview(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -329,21 +329,13 @@ export class ProjectService extends BaseService {
                     }
                 }
 
-                // if the upstream project is provided, user must have access to the upstream project level OR on an organization level
-                // if the upstream project is not provided, user must have access to create project ONLY on an organization level
-                // thus, either of the following conditions must be met
                 if (
-                    user.ability.can(
-                        'create',
-                        subject('Project', {
-                            upstreamProjectUuid: data.upstreamProjectUuid,
-                            type: ProjectType.PREVIEW,
-                        }),
-                    ) ||
+                    // checks if user has permission to create project on an organization level or from an upstream project on a project level
                     user.ability.can(
                         'create',
                         subject('Project', {
                             organizationUuid: user.organizationUuid,
+                            upstreamProjectUuid: data.upstreamProjectUuid,
                             type: ProjectType.PREVIEW,
                         }),
                     )

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -1812,7 +1812,7 @@ describe('Organization member permissions', () => {
             const ability = defineAbilityForOrganizationMember(membership);
 
             describe(`user is '${membership.role}' role`, () => {
-                it('can create a project in organization they belong to', () => {
+                it('checks if users can create project in organization they belong to', () => {
                     expect(
                         ability.can(
                             'create',
@@ -1824,7 +1824,7 @@ describe('Organization member permissions', () => {
                     ).toEqual(canCreateProject);
                 });
 
-                it('cannot create a project in another organization', () => {
+                it('checks that users cannot create a project in another organization', () => {
                     expect(
                         ability.can(
                             'create',
@@ -1836,7 +1836,7 @@ describe('Organization member permissions', () => {
                     ).toEqual(false);
                 });
 
-                it('can create a PREVIEW project in organization they belong to', () => {
+                it('checks if users can create a PREVIEW project in organization they belong to', () => {
                     expect(
                         ability.can(
                             'create',
@@ -1848,7 +1848,7 @@ describe('Organization member permissions', () => {
                     ).toEqual(canCreatePreview);
                 });
 
-                it('cannot create a PREVIEW project in another organization', () => {
+                it('checks that users cannot create a PREVIEW project in another organization', () => {
                     expect(
                         ability.can(
                             'create',

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -49,6 +49,45 @@ describe('Organization member permissions', () => {
                 true,
             );
         });
+
+        it('can create a project in their own organization', () => {
+            const check = {
+                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
+            };
+
+            expect(ability.can('create', subject('Project', check))).toEqual(
+                true,
+            );
+        });
+
+        it('cannot create a project in another organization', () => {
+            const org = { organizationUuid: '789', type: ProjectType.DEFAULT };
+
+            expect(ability.can('create', subject('Project', org))).toEqual(
+                false,
+            );
+        });
+
+        it('can create a project in their own organization with different types', () => {
+            const check1 = {
+                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
+                type: ProjectType.DEFAULT,
+            };
+
+            expect(ability.can('create', subject('Project', check1))).toEqual(
+                true,
+            );
+
+            const check2 = {
+                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
+                type: ProjectType.PREVIEW,
+            };
+
+            expect(ability.can('create', subject('Project', check2))).toEqual(
+                true,
+            );
+        });
+
         it('can manage member profiles', () => {
             expect(ability.can('manage', 'OrganizationMemberProfile')).toEqual(
                 true,
@@ -380,6 +419,16 @@ describe('Organization member permissions', () => {
         });
         it('cannot manage organizations', () => {
             expect(ability.can('manage', 'Organization')).toEqual(false);
+        });
+
+        it('cannot create a project in organization they belong to', () => {
+            const check = {
+                organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
+            };
+
+            expect(ability.can('create', subject('Project', check))).toEqual(
+                false,
+            );
         });
 
         it('can view and manage public & accessable dashboards', () => {
@@ -747,6 +796,7 @@ describe('Organization member permissions', () => {
             expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
         });
     });
+
     describe('when user is an developer', () => {
         beforeEach(() => {
             ability = defineAbilityForOrganizationMember(
@@ -761,7 +811,18 @@ describe('Organization member permissions', () => {
         it('can use the SemanticViewer', () => {
             expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
         });
+
+        it('cannot create a project in organization they belong to', () => {
+            const check = {
+                organizationUuid: ORGANIZATION_DEVELOPER.organizationUuid,
+            };
+
+            expect(ability.can('create', subject('Project', check))).toEqual(
+                false,
+            );
+        });
     });
+
     describe('when user is a member', () => {
         beforeEach(() => {
             ability = defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
@@ -779,6 +840,16 @@ describe('Organization member permissions', () => {
         });
         it('cannot view charts', () => {
             expect(ability.can('view', 'SavedChart')).toEqual(false);
+        });
+
+        it('cannot create a project in organization they belong to', () => {
+            const check = {
+                organizationUuid: ORGANIZATION_MEMBER.organizationUuid,
+            };
+
+            expect(ability.can('create', subject('Project', check))).toEqual(
+                false,
+            );
         });
     });
     describe('when user is a viewer', () => {
@@ -1100,20 +1171,17 @@ describe('Organization member permissions', () => {
                 false,
             );
         });
-        it('cannot create PREVIEW Project', () => {
-            const org = { organizationUuid: '456', type: ProjectType.PREVIEW };
 
-            expect(ability.can('create', subject('Project', org))).toEqual(
+        it('cannot create a project in organization they belong to', () => {
+            const check = {
+                organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
+            };
+
+            expect(ability.can('create', subject('Project', check))).toEqual(
                 false,
             );
         });
-        it('cannot create DEFAULT Project', () => {
-            const org = { organizationUuid: '456', type: ProjectType.DEFAULT };
 
-            expect(ability.can('create', subject('Project', org))).toEqual(
-                false,
-            );
-        });
         it('cannot create any resource, except space when have editor space role', () => {
             expect(
                 ability.can(
@@ -1361,24 +1429,17 @@ describe('Organization member permissions', () => {
             );
         });
 
-        it('can create PREVIEW Project', () => {
-            expect(ability.can('create', subject('Job', {}))).toEqual(true);
+        it('cannot create a project in organization they belong to', () => {
+            const check = {
+                organizationUuid:
+                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+            };
 
-            const org = { organizationUuid: '456', type: ProjectType.PREVIEW };
-
-            expect(ability.can('create', subject('Project', org))).toEqual(
-                true,
-            );
-        });
-        it('cannot create DEFAULT Project', () => {
-            expect(ability.can('create', subject('Job', {}))).toEqual(true);
-
-            const org = { organizationUuid: '456', type: ProjectType.DEFAULT };
-
-            expect(ability.can('create', subject('Project', org))).toEqual(
+            expect(ability.can('create', subject('Project', check))).toEqual(
                 false,
             );
         });
+
         it('cannot create any resource, except space when have editor space role', () => {
             expect(
                 ability.can(
@@ -1636,99 +1697,6 @@ describe('Organization member permissions', () => {
                     subject('Job', { userUuid: 'another-user-uuid' }),
                 ),
             ).toEqual(false);
-        });
-    });
-
-    describe('test project preview permissions', () => {
-        const { organizationUuid } = ORGANIZATION_VIEWER;
-
-        it('developers can not create preview or regular projects', () => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        it('editor can not create preview or regular projects', () => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_EDITOR);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        it('developers can create preview but no regular projects', () => {
-            ability = defineAbilityForOrganizationMember(
-                ORGANIZATION_DEVELOPER,
-            );
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('admins can create preview and regular projects', () => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        organizationUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(true);
         });
     });
 });

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -29,1674 +29,1837 @@ const defineAbilityForOrganizationMember = (
 };
 
 describe('Organization member permissions', () => {
-    let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
-    describe('when user is an organization admin', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
-        });
-        it('can manage organizations', () => {
-            expect(ability.can('manage', 'Organization')).toEqual(true);
-        });
-        it('cannot manage another organization', () => {
-            const org = { organizationUuid: '789' };
-            expect(ability.can('manage', subject('Organization', org))).toEqual(
-                false,
-            );
-        });
-        it('can manage their own organization', () => {
-            const org = { organizationUuid: '456' };
-            expect(ability.can('manage', subject('Organization', org))).toEqual(
-                true,
-            );
+    describe('Member permissions', () => {
+        let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
+        describe('when user is an organization admin', () => {
+            beforeEach(() => {
+                ability =
+                    defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
+            });
+
+            it('can manage organizations', () => {
+                expect(ability.can('manage', 'Organization')).toEqual(true);
+            });
+
+            it('cannot manage another organization', () => {
+                const org = { organizationUuid: '789' };
+                expect(
+                    ability.can('manage', subject('Organization', org)),
+                ).toEqual(false);
+            });
+
+            it('can manage their own organization', () => {
+                const org = { organizationUuid: '456' };
+                expect(
+                    ability.can('manage', subject('Organization', org)),
+                ).toEqual(true);
+            });
+
+            it('can manage member profiles', () => {
+                expect(
+                    ability.can('manage', 'OrganizationMemberProfile'),
+                ).toEqual(true);
+            });
+
+            it('cannot manage other members from another organization', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('OrganizationMemberProfile', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('OrganizationMemberProfile', {
+                            organizationUuid: 'notmine',
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view and manage all kinds of dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view and manage all kinds of saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view and manage all kinds of space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_ADMIN.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
         });
 
-        it('can create a project in their own organization', () => {
-            const check = {
-                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-            };
+        describe('when user is an editor', () => {
+            beforeEach(() => {
+                ability =
+                    defineAbilityForOrganizationMember(ORGANIZATION_EDITOR);
+            });
 
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                true,
-            );
+            it('cannot manage organizations', () => {
+                expect(ability.can('manage', 'Organization')).toEqual(false);
+            });
+
+            it('can view and manage public & accessable dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view and manage public & accessable saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can create a space', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view and manage public & accessable space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_EDITOR.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_EDITOR.userUuid,
+                                    role: SpaceMemberRole.ADMIN,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can manage public dashboards from their own organization', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: '456',
+                            isPrivate: false,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot manage public dashboards from another organization', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: '789',
+                            isPrivate: false,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view member profiles', () => {
+                expect(
+                    ability.can('view', 'OrganizationMemberProfile'),
+                ).toEqual(true);
+            });
+
+            it('can create invite links', () => {
+                expect(ability.can('create', 'InviteLink')).toEqual(false);
+            });
+
+            it('cannot run SQL Queries', () => {
+                expect(ability.can('manage', 'SqlRunner')).toEqual(false);
+            });
+
+            it('can use the SemanticViewer', () => {
+                expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
+            });
         });
 
-        it('cannot create a project in another organization', () => {
-            const org = { organizationUuid: '789', type: ProjectType.DEFAULT };
+        describe('when user is an developer', () => {
+            beforeEach(() => {
+                ability = defineAbilityForOrganizationMember(
+                    ORGANIZATION_DEVELOPER,
+                );
+            });
 
-            expect(ability.can('create', subject('Project', org))).toEqual(
-                false,
-            );
+            it('can run SQL Queries', () => {
+                expect(ability.can('manage', 'SqlRunner')).toEqual(true);
+            });
+
+            it('can use the SemanticViewer', () => {
+                expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
+            });
         });
 
-        it('can create a project in their own organization with different types', () => {
-            const check1 = {
-                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                type: ProjectType.DEFAULT,
-            };
+        describe('when user is a member', () => {
+            beforeEach(() => {
+                ability =
+                    defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
+            });
 
-            expect(ability.can('create', subject('Project', check1))).toEqual(
-                true,
-            );
+            it('can view member profiles', () => {
+                expect(
+                    ability.can('view', 'OrganizationMemberProfile'),
+                ).toEqual(true);
+            });
 
-            const check2 = {
-                organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                type: ProjectType.PREVIEW,
-            };
+            it('can create invitations', () => {
+                expect(ability.can('create', 'InviteLink')).toEqual(false);
+            });
 
-            expect(ability.can('create', subject('Project', check2))).toEqual(
-                true,
-            );
+            it('cannot view organizations', () => {
+                expect(ability.can('view', 'Organization')).toEqual(false);
+            });
+
+            it('cannot view charts', () => {
+                expect(ability.can('view', 'SavedChart')).toEqual(false);
+            });
         });
 
-        it('can manage member profiles', () => {
-            expect(ability.can('manage', 'OrganizationMemberProfile')).toEqual(
-                true,
-            );
+        describe('when user is a viewer', () => {
+            beforeEach(() => {
+                ability =
+                    defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
+            });
+
+            it('can only view public & accessable dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view and manage public & accessable saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view and manage public & accessable space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: ORGANIZATION_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view member profiles', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('OrganizationMemberProfile', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can create invitations', () => {
+                expect(
+                    ability.can('create', subject('InviteLink', {})),
+                ).toEqual(false);
+            });
+
+            it('cannot create a project in organization they belong to', () => {
+                const check = {
+                    organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
+                };
+
+                expect(
+                    ability.can('create', subject('Project', check)),
+                ).toEqual(false);
+            });
+
+            it('cannot create any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot run SQL queries', () => {
+                expect(ability.can('manage', subject('SqlRunner', {}))).toEqual(
+                    false,
+                );
+            });
+
+            it('cannot update any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Project', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('InviteLink', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot delete any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Project', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('InviteLink', {
+                            organizationUuid:
+                                ORGANIZATION_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view their own organization', () => {
+                const org = { organizationUuid: '456' };
+                expect(
+                    ability.can('view', subject('Organization', org)),
+                ).toEqual(true);
+            });
+
+            it('cannot view another organization', () => {
+                const org = { organizationUuid: '789' };
+                expect(
+                    ability.can('view', subject('Organization', org)),
+                ).toEqual(false);
+            });
+
+            it('can view dashboards from their own organization', () => {
+                const org = { organizationUuid: '456', isPrivate: false };
+                expect(ability.can('view', subject('Dashboard', org))).toEqual(
+                    true,
+                );
+            });
+
+            it('cannot view dashboards from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', { organizationUuid: '789' }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view savedCharts from their own organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid: '456',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot view savedCharts from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid: '789',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view projects from their own organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { organizationUuid: '456' }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot view projects from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { organizationUuid: '789' }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view their own jobs', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Job', {
+                            userUuid: ORGANIZATION_VIEWER.userUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot view jobs from another user', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Job', { userUuid: 'another-user-uuid' }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot view the SemanticViewer', () => {
+                expect(ability.can('view', 'SemanticViewer')).toEqual(false);
+            });
         });
-        it('cannot manage other members from another organization', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('OrganizationMemberProfile', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('OrganizationMemberProfile', {
-                        organizationUuid: 'notmine',
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view and manage all kinds of dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage all kinds of saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage all kinds of space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
+
+        describe('when user is an interactive viewer', () => {
+            beforeEach(() => {
+                ability = defineAbilityForOrganizationMember(
+                    ORGANIZATION_INTERACTIVE_VIEWER,
+                );
+            });
+
+            it('can view member profiles', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('OrganizationMemberProfile', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can create invitations', () => {
+                expect(
+                    ability.can('create', subject('InviteLink', {})),
+                ).toEqual(false);
+            });
+
+            it('cannot create any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot run SQL queries', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SqlRunner', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot use the SemanticViewer', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot update any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Project', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'update',
+                        subject('InviteLink', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('cannot delete any resource, except space when have editor space role', () => {
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Space', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Dashboard', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('SavedChart', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Project', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('Organization', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('InviteLink', {
+                            organizationUuid:
+                                ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view their own organization', () => {
+                const org = { organizationUuid: '456' };
+                expect(
+                    ability.can('view', subject('Organization', org)),
+                ).toEqual(true);
+            });
+
+            it('cannot view another organization', () => {
+                const org = { organizationUuid: '789' };
+                expect(
+                    ability.can('view', subject('Organization', org)),
+                ).toEqual(false);
+            });
+
+            it('can view dashboards from their own organization', () => {
+                const org = { organizationUuid: '456', isPrivate: false };
+                expect(ability.can('view', subject('Dashboard', org))).toEqual(
+                    true,
+                );
+            });
+
+            it('cannot view dashboards from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            organizationUuid: '789',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view savedCharts from their own organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid: '456',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot view savedCharts from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid: '789',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view projects from their own organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { organizationUuid: '456' }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot view projects from another organization', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { organizationUuid: '789' }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view their own jobs', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Job', {
+                            userUuid: ORGANIZATION_INTERACTIVE_VIEWER.userUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot view jobs from another user', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Job', { userUuid: 'another-user-uuid' }),
+                    ),
+                ).toEqual(false);
+            });
         });
     });
 
-    describe('when user is an editor', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_EDITOR);
-        });
-        it('cannot manage organizations', () => {
-            expect(ability.can('manage', 'Organization')).toEqual(false);
-        });
+    describe('Project creation permissions', () => {
+        [
+            {
+                membership: ORGANIZATION_ADMIN,
+                canCreateProject: true,
+                canCreatePreview: true,
+            },
+            {
+                membership: ORGANIZATION_DEVELOPER,
+                canCreateProject: false,
+                canCreatePreview: true,
+            },
+            {
+                membership: ORGANIZATION_MEMBER,
+                canCreateProject: false,
+                canCreatePreview: false,
+            },
+            {
+                membership: ORGANIZATION_VIEWER,
+                canCreateProject: false,
+                canCreatePreview: false,
+            },
+            {
+                membership: ORGANIZATION_INTERACTIVE_VIEWER,
+                canCreateProject: false,
+                canCreatePreview: false,
+            },
+            {
+                membership: ORGANIZATION_EDITOR,
+                canCreateProject: false,
+                canCreatePreview: false,
+            },
+        ].forEach(({ membership, canCreateProject, canCreatePreview }) => {
+            const ability = defineAbilityForOrganizationMember(membership);
 
-        it('cannot create a project in organization they belong to', () => {
-            const check = {
-                organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-            };
+            describe(`user is '${membership.role}' role`, () => {
+                it('can create a project in organization they belong to', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                organizationUuid: membership.organizationUuid,
+                                type: ProjectType.DEFAULT,
+                            }),
+                        ),
+                    ).toEqual(canCreateProject);
+                });
 
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                false,
-            );
-        });
+                it('cannot create a project in another organization', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                organizationUuid: '789',
+                                type: ProjectType.DEFAULT,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
 
-        it('can view and manage public & accessable dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage public & accessable saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can create a space', () => {
-            expect(
-                ability.can(
-                    'create',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage public & accessable space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_EDITOR.userUuid,
-                                role: SpaceMemberRole.ADMIN,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
+                it('can create a PREVIEW project in organization they belong to', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                organizationUuid: membership.organizationUuid,
+                                type: ProjectType.PREVIEW,
+                            }),
+                        ),
+                    ).toEqual(canCreatePreview);
+                });
 
-        it('can manage public dashboards from their own organization', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: '456',
-                        isPrivate: false,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot manage public dashboards from another organization', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: '789',
-                        isPrivate: false,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view member profiles', () => {
-            expect(ability.can('view', 'OrganizationMemberProfile')).toEqual(
-                true,
-            );
-        });
-        it('can create invite links', () => {
-            expect(ability.can('create', 'InviteLink')).toEqual(false);
-        });
-        it('cannot run SQL Queries', () => {
-            expect(ability.can('manage', 'SqlRunner')).toEqual(false);
-        });
-        it('can use the SemanticViewer', () => {
-            expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
-        });
-    });
-
-    describe('when user is an developer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(
-                ORGANIZATION_DEVELOPER,
-            );
-        });
-
-        it('can run SQL Queries', () => {
-            expect(ability.can('manage', 'SqlRunner')).toEqual(true);
-        });
-
-        it('can use the SemanticViewer', () => {
-            expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
-        });
-
-        it('cannot create a project in organization they belong to', () => {
-            const check = {
-                organizationUuid: ORGANIZATION_DEVELOPER.organizationUuid,
-            };
-
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                false,
-            );
-        });
-    });
-
-    describe('when user is a member', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
-        });
-        it('can view member profiles', () => {
-            expect(ability.can('view', 'OrganizationMemberProfile')).toEqual(
-                true,
-            );
-        });
-        it('can create invitations', () => {
-            expect(ability.can('create', 'InviteLink')).toEqual(false);
-        });
-        it('cannot view organizations', () => {
-            expect(ability.can('view', 'Organization')).toEqual(false);
-        });
-        it('cannot view charts', () => {
-            expect(ability.can('view', 'SavedChart')).toEqual(false);
-        });
-
-        it('cannot create a project in organization they belong to', () => {
-            const check = {
-                organizationUuid: ORGANIZATION_MEMBER.organizationUuid,
-            };
-
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                false,
-            );
-        });
-    });
-    describe('when user is a viewer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
-        });
-        it('can only view public & accessable dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view and manage public & accessable saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view and manage public & accessable space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: ORGANIZATION_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view member profiles', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('OrganizationMemberProfile', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can create invitations', () => {
-            expect(ability.can('create', subject('InviteLink', {}))).toEqual(
-                false,
-            );
-        });
-
-        it('cannot create a project in organization they belong to', () => {
-            const check = {
-                organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-            };
-
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                false,
-            );
-        });
-
-        it('cannot create any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'create',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Organization', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot run SQL queries', () => {
-            expect(ability.can('manage', subject('SqlRunner', {}))).toEqual(
-                false,
-            );
-        });
-        it('cannot update any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'update',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Project', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Organization', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('InviteLink', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot delete any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Space', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Dashboard', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('SavedChart', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Project', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Organization', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('InviteLink', {
-                        organizationUuid: ORGANIZATION_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view their own organization', () => {
-            const org = { organizationUuid: '456' };
-            expect(ability.can('view', subject('Organization', org))).toEqual(
-                true,
-            );
-        });
-        it('cannot view another organization', () => {
-            const org = { organizationUuid: '789' };
-            expect(ability.can('view', subject('Organization', org))).toEqual(
-                false,
-            );
-        });
-
-        it('can view dashboards from their own organization', () => {
-            const org = { organizationUuid: '456', isPrivate: false };
-            expect(ability.can('view', subject('Dashboard', org))).toEqual(
-                true,
-            );
-        });
-        it('cannot view dashboards from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', { organizationUuid: '789' }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view savedCharts from their own organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: '456',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('cannot view savedCharts from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: '789',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view projects from their own organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { organizationUuid: '456' }),
-                ),
-            ).toEqual(true);
-        });
-        it('cannot view projects from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { organizationUuid: '789' }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view their own jobs', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Job', { userUuid: ORGANIZATION_VIEWER.userUuid }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot view jobs from another user', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Job', { userUuid: 'another-user-uuid' }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot view the SemanticViewer', () => {
-            expect(ability.can('view', 'SemanticViewer')).toEqual(false);
-        });
-    });
-    describe('when user is an interactive viewer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForOrganizationMember(
-                ORGANIZATION_INTERACTIVE_VIEWER,
-            );
-        });
-        it('can view member profiles', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('OrganizationMemberProfile', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can create invitations', () => {
-            expect(ability.can('create', subject('InviteLink', {}))).toEqual(
-                false,
-            );
-        });
-
-        it('cannot create a project in organization they belong to', () => {
-            const check = {
-                organizationUuid:
-                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-            };
-
-            expect(ability.can('create', subject('Project', check))).toEqual(
-                false,
-            );
-        });
-
-        it('cannot create any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'create',
-                    subject('Space', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Dashboard', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('SavedChart', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Organization', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot run SQL queries', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SqlRunner', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot use the SemanticViewer', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SemanticViewer', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot update any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'update',
-                    subject('Space', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Dashboard', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('SavedChart', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Project', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('Organization', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'update',
-                    subject('InviteLink', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot delete any resource, except space when have editor space role', () => {
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Space', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Dashboard', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('SavedChart', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Project', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('Organization', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'delete',
-                    subject('InviteLink', {
-                        organizationUuid:
-                            ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view their own organization', () => {
-            const org = { organizationUuid: '456' };
-            expect(ability.can('view', subject('Organization', org))).toEqual(
-                true,
-            );
-        });
-        it('cannot view another organization', () => {
-            const org = { organizationUuid: '789' };
-            expect(ability.can('view', subject('Organization', org))).toEqual(
-                false,
-            );
-        });
-
-        it('can view dashboards from their own organization', () => {
-            const org = { organizationUuid: '456', isPrivate: false };
-            expect(ability.can('view', subject('Dashboard', org))).toEqual(
-                true,
-            );
-        });
-        it('cannot view dashboards from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid: '789',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view savedCharts from their own organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: '456',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('cannot view savedCharts from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        organizationUuid: '789',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view projects from their own organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { organizationUuid: '456' }),
-                ),
-            ).toEqual(true);
-        });
-        it('cannot view projects from another organization', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { organizationUuid: '789' }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view their own jobs', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Job', {
-                        userUuid: ORGANIZATION_INTERACTIVE_VIEWER.userUuid,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('cannot view jobs from another user', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Job', { userUuid: 'another-user-uuid' }),
-                ),
-            ).toEqual(false);
+                it('cannot create a PREVIEW project in another organization', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                organizationUuid: '789',
+                                type: ProjectType.PREVIEW,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
     });
 });

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -176,10 +176,6 @@ export const organizationMemberAbilities: Record<
     },
     developer(member, { can }) {
         organizationMemberAbilities.editor(member, { can });
-        can('create', 'Project', {
-            organizationUuid: member.organizationUuid,
-            type: ProjectType.PREVIEW,
-        });
         can('manage', 'VirtualView', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -213,6 +213,10 @@ export const organizationMemberAbilities: Record<
         can('manage', 'CompileProject', {
             organizationUuid: member.organizationUuid,
         });
+        can('create', 'Project', {
+            organizationUuid: member.organizationUuid,
+            type: ProjectType.PREVIEW,
+        });
     },
     admin(member, { can }) {
         organizationMemberAbilities.developer(member, { can });
@@ -223,6 +227,9 @@ export const organizationMemberAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'SavedChart', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('create', 'Project', {
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'Project', {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -76,10 +76,6 @@ export const organizationMemberAbilities: Record<
     },
     interactive_viewer(member, { can }) {
         organizationMemberAbilities.viewer(member, { can });
-        can('create', 'Project', {
-            organizationUuid: member.organizationUuid,
-            type: ProjectType.PREVIEW,
-        });
         can('create', 'Job');
         can('view', 'Job', { userUuid: member.userUuid });
         can('view', 'UnderlyingData', {
@@ -180,6 +176,10 @@ export const organizationMemberAbilities: Record<
     },
     developer(member, { can }) {
         organizationMemberAbilities.editor(member, { can });
+        can('create', 'Project', {
+            organizationUuid: member.organizationUuid,
+            type: ProjectType.PREVIEW,
+        });
         can('manage', 'VirtualView', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -227,6 +227,7 @@ export const organizationMemberAbilities: Record<
         });
         can('create', 'Project', {
             organizationUuid: member.organizationUuid,
+            type: { $in: [ProjectType.DEFAULT, ProjectType.PREVIEW] },
         });
         can('manage', 'Project', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -1318,7 +1318,7 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.PREVIEW,
                     }),
                 ),
@@ -1327,7 +1327,7 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.DEFAULT,
                     }),
                 ),
@@ -1340,7 +1340,7 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.PREVIEW,
                     }),
                 ),
@@ -1349,7 +1349,7 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.DEFAULT,
                     }),
                 ),
@@ -1362,7 +1362,7 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.PREVIEW,
                     }),
                 ),
@@ -1371,19 +1371,22 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.DEFAULT,
                     }),
                 ),
             ).toEqual(false);
         });
-        it('admins can create preview and regular projects', () => {
+
+        // only organization admins can create regular projects
+        // we no longer support project admins creating regular projects as it doesn't make sense
+        it('admins can create preview but no regular projects', () => {
             ability = defineAbilityForProjectMember(PROJECT_ADMIN);
             expect(
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.PREVIEW,
                     }),
                 ),
@@ -1392,11 +1395,11 @@ describe('Project member permissions', () => {
                 ability.can(
                     'create',
                     subject('Project', {
-                        projectUuid,
+                        upstreamProjectUuid: projectUuid,
                         type: ProjectType.DEFAULT,
                     }),
                 ),
-            ).toEqual(true);
+            ).toEqual(false);
         });
     });
 });

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -27,1379 +27,1387 @@ const defineAbilityForProjectMember = (
 };
 
 describe('Project member permissions', () => {
-    let ability = defineAbilityForProjectMember(PROJECT_ADMIN);
-    describe('when user is an project admin', () => {
-        beforeEach(() => {
-            ability = defineAbilityForProjectMember(PROJECT_ADMIN);
+    describe('Member permissions', () => {
+        let ability = defineAbilityForProjectMember(PROJECT_ADMIN);
+        describe('when user is an project admin', () => {
+            beforeEach(() => {
+                ability = defineAbilityForProjectMember(PROJECT_ADMIN);
+            });
+
+            it('can view and manage all kinds of dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can view and manage all kinds of saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can view and manage all kinds of space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_ADMIN.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can manage other types of public resources', () => {
+                expect(
+                    ability.can('manage', subject('Project', { projectUuid })),
+                ).toEqual(true);
+                expect(
+                    ability.can('manage', subject('Job', { projectUuid })),
+                ).toEqual(true);
+            });
+
+            it('cannot view resources from another projectUuid', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { projectUuid: '5678' }),
+                    ),
+                ).toEqual(false);
+            });
         });
 
-        it('can view and manage all kinds of dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage all kinds of saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage all kinds of space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_ADMIN.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
+        describe('when user is an editor', () => {
+            beforeEach(() => {
+                ability = defineAbilityForProjectMember(PROJECT_EDITOR);
+            });
+
+            it('can view and manage public & accessible dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can view and manage public & accessable saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can create a space', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Space', {
+                            projectUuid: PROJECT_EDITOR.projectUuid,
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can view and manage public & accessable space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_EDITOR.userUuid,
+                                    role: SpaceMemberRole.ADMIN,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view other public resources', () => {
+                expect(
+                    ability.can('view', subject('Project', { projectUuid })),
+                ).toEqual(true);
+            });
+            it('can manage other public resources', () => {
+                expect(
+                    ability.can('manage', subject('Job', { projectUuid })),
+                ).toEqual(true);
+            });
+            it('cannot manage projects', () => {
+                expect(
+                    ability.can('manage', subject('Project', { projectUuid })),
+                ).toEqual(false);
+            });
+            it('can download CSV', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can change csv results', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ChangeCsvResults', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('cannot use SQL runner', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SqlRunner', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can use the SemanticViewer', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
         });
 
-        it('can manage other types of public resources', () => {
-            expect(
-                ability.can('manage', subject('Project', { projectUuid })),
-            ).toEqual(true);
-            expect(
-                ability.can('manage', subject('Job', { projectUuid })),
-            ).toEqual(true);
+        describe('when user is an developer', () => {
+            beforeEach(() => {
+                ability = defineAbilityForProjectMember(PROJECT_DEVELOPER);
+            });
+
+            it('can use SQL runner', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SqlRunner', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can use the SemanticViewer', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+        });
+        describe('when user is a viewer', () => {
+            beforeEach(() => {
+                ability = defineAbilityForProjectMember(PROJECT_VIEWER);
+            });
+
+            it('can only view public & accessable dashboards', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+            it('can view and manage public & accessable saved charts', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+            it('can view and manage public & accessable space', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', {
+                            projectUuid,
+                            isPrivate: true,
+                            access: [
+                                {
+                                    userUuid: PROJECT_VIEWER.userUuid,
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toEqual(false);
+            });
+
+            it('can view other public resources', () => {
+                expect(
+                    ability.can('view', subject('Project', { projectUuid })),
+                ).toEqual(true);
+            });
+            it('cannot view resources from another project', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { projectUuid: '5678' }),
+                    ),
+                ).toEqual(false);
+            });
+            it('cannot manage resources', () => {
+                expect(
+                    ability.can('manage', subject('Project', { projectUuid })),
+                ).toEqual(false);
+                expect(
+                    ability.can('manage', subject('Job', { projectUuid })),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SqlRunner', { projectUuid }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
+            it('can download CSV', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+            it('cannot change csv results', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ChangeCsvResults', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
+            it('cannot Explore', () => {
+                expect(
+                    ability.can('manage', subject('Explore', { projectUuid })),
+                ).toEqual(false);
+            });
+            it('cannot view underlying data', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('UnderlyingData', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
         });
 
-        it('cannot view resources from another projectUuid', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', { projectUuid: '5678', isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { projectUuid: '5678' }),
-                ),
-            ).toEqual(false);
+        describe('when user is a interactive viewer', () => {
+            beforeEach(() => {
+                ability = defineAbilityForProjectMember(
+                    PROJECT_INTERACTIVE_VIEWER,
+                );
+            });
+
+            it('can view public resources', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', { projectUuid, isPrivate: false }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', { projectUuid, isPrivate: false }),
+                    ),
+                ).toEqual(true);
+                expect(
+                    ability.can('view', subject('Project', { projectUuid })),
+                ).toEqual(true);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SemanticViewer', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can not view private resources', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+            });
+            it('cannot view resources from another project', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('SavedChart', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Space', {
+                            projectUuid: '5678',
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Project', { projectUuid: '5678' }),
+                    ),
+                ).toEqual(false);
+            });
+            it('cannot manage resources', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid,
+                            isPrivate: false,
+                        }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', { projectUuid, isPrivate: false }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', { projectUuid, isPrivate: false }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Space', { projectUuid, isPrivate: true }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can('manage', subject('Project', { projectUuid })),
+                ).toEqual(false);
+                expect(
+                    ability.can('manage', subject('Job', { projectUuid })),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SqlRunner', { projectUuid }),
+                    ),
+                ).toEqual(false);
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
+            it('can download CSV', () => {
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+            it('can Explore', () => {
+                expect(
+                    ability.can('manage', subject('Explore', { projectUuid })),
+                ).toEqual(true);
+            });
+            it('can view underlying data', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('UnderlyingData', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
         });
     });
 
-    describe('when user is an editor', () => {
-        beforeEach(() => {
-            ability = defineAbilityForProjectMember(PROJECT_EDITOR);
-        });
+    [
+        {
+            membership: PROJECT_ADMIN,
+            canCreatePreview: true,
+        },
+        {
+            membership: PROJECT_DEVELOPER,
+            canCreatePreview: true,
+        },
+        {
+            membership: PROJECT_EDITOR,
+            canCreatePreview: false,
+        },
+        {
+            membership: PROJECT_INTERACTIVE_VIEWER,
+            canCreatePreview: false,
+        },
+        {
+            membership: PROJECT_VIEWER,
+            canCreatePreview: false,
+        },
+    ].forEach(({ membership, canCreatePreview }) => {
+        describe('test project preview permissions', () => {
+            const ability = defineAbilityForProjectMember(membership);
 
-        it('can view and manage public & accessible dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage public & accessable saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can create a space', () => {
-            expect(
-                ability.can(
-                    'create',
-                    subject('Space', {
-                        projectUuid: PROJECT_EDITOR.projectUuid,
-                    }),
-                ),
-            ).toEqual(true);
-        });
-        it('can view and manage public & accessable space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_EDITOR.userUuid,
-                                role: SpaceMemberRole.ADMIN,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-        });
+            it('checks if user can create PREVIEW projects', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Project', {
+                            upstreamProjectUuid: projectUuid,
+                            type: ProjectType.PREVIEW,
+                        }),
+                    ),
+                ).toEqual(canCreatePreview);
+            });
 
-        it('can view other public resources', () => {
-            expect(
-                ability.can('view', subject('Project', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('can manage other public resources', () => {
-            expect(
-                ability.can('manage', subject('Job', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('cannot manage projects', () => {
-            expect(
-                ability.can('manage', subject('Project', { projectUuid })),
-            ).toEqual(false);
-        });
-        it('can download CSV', () => {
-            expect(
-                ability.can('manage', subject('ExportCsv', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('can change csv results', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('ChangeCsvResults', { projectUuid }),
-                ),
-            ).toEqual(true);
-        });
-
-        it('cannot use SQL runner', () => {
-            expect(
-                ability.can('manage', subject('SqlRunner', { projectUuid })),
-            ).toEqual(false);
-        });
-
-        it('can use the SemanticViewer', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SemanticViewer', { projectUuid }),
-                ),
-            ).toEqual(true);
-        });
-    });
-
-    describe('when user is an developer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForProjectMember(PROJECT_DEVELOPER);
-        });
-
-        it('can use SQL runner', () => {
-            expect(
-                ability.can('manage', subject('SqlRunner', { projectUuid })),
-            ).toEqual(true);
-        });
-
-        it('can use the SemanticViewer', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SemanticViewer', { projectUuid }),
-                ),
-            ).toEqual(true);
-        });
-    });
-    describe('when user is a viewer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForProjectMember(PROJECT_VIEWER);
-        });
-
-        it('can only view public & accessable dashboards', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view and manage public & accessable saved charts', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-        it('can view and manage public & accessable space', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.VIEWER,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', {
-                        projectUuid,
-                        isPrivate: true,
-                        access: [
-                            {
-                                userUuid: PROJECT_VIEWER.userUuid,
-                                role: SpaceMemberRole.EDITOR,
-                            },
-                        ],
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        it('can view other public resources', () => {
-            expect(
-                ability.can('view', subject('Project', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('cannot view resources from another project', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', { projectUuid: '5678', isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { projectUuid: '5678' }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot manage resources', () => {
-            expect(
-                ability.can('manage', subject('Project', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can('manage', subject('Job', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can('manage', subject('SqlRunner', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SemanticViewer', { projectUuid }),
-                ),
-            ).toEqual(false);
-        });
-        it('can download CSV', () => {
-            expect(
-                ability.can('manage', subject('ExportCsv', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('cannot change csv results', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('ChangeCsvResults', { projectUuid }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot Explore', () => {
-            expect(
-                ability.can('manage', subject('Explore', { projectUuid })),
-            ).toEqual(false);
-        });
-        it('cannot view underlying data', () => {
-            expect(
-                ability.can('view', subject('UnderlyingData', { projectUuid })),
-            ).toEqual(false);
-        });
-    });
-
-    describe('when user is a interactive viewer', () => {
-        beforeEach(() => {
-            ability = defineAbilityForProjectMember(PROJECT_INTERACTIVE_VIEWER);
-        });
-
-        it('can view public resources', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can('view', subject('Project', { projectUuid })),
-            ).toEqual(true);
-            expect(
-                ability.can('view', subject('SemanticViewer', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('can not view private resources', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot view resources from another project', () => {
-            expect(
-                ability.can(
-                    'view',
-                    subject('SavedChart', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Dashboard', {
-                        projectUuid: '5678',
-                        isPrivate: false,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Space', { projectUuid: '5678', isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', { projectUuid: '5678' }),
-                ),
-            ).toEqual(false);
-        });
-        it('cannot manage resources', () => {
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', { projectUuid, isPrivate: false }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SavedChart', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Dashboard', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('Space', { projectUuid, isPrivate: true }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can('manage', subject('Project', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can('manage', subject('Job', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can('manage', subject('SqlRunner', { projectUuid })),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'manage',
-                    subject('SemanticViewer', { projectUuid }),
-                ),
-            ).toEqual(false);
-        });
-        it('can download CSV', () => {
-            expect(
-                ability.can('manage', subject('ExportCsv', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('can Explore', () => {
-            expect(
-                ability.can('manage', subject('Explore', { projectUuid })),
-            ).toEqual(true);
-        });
-        it('can view underlying data', () => {
-            expect(
-                ability.can('view', subject('UnderlyingData', { projectUuid })),
-            ).toEqual(true);
-        });
-    });
-
-    describe('test project preview permissions', () => {
-        it('viewers can not create preview or regular projects', () => {
-            ability = defineAbilityForProjectMember(PROJECT_VIEWER);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        it('editor can not create preview or regular projects', () => {
-            ability = defineAbilityForProjectMember(PROJECT_EDITOR);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(false);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        it('developers can create preview but no regular projects', () => {
-            ability = defineAbilityForProjectMember(PROJECT_DEVELOPER);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
-        });
-
-        // only organization admins can create regular projects
-        // we no longer support project admins creating regular projects as it doesn't make sense
-        it('admins can create preview but no regular projects', () => {
-            ability = defineAbilityForProjectMember(PROJECT_ADMIN);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.PREVIEW,
-                    }),
-                ),
-            ).toEqual(true);
-            expect(
-                ability.can(
-                    'create',
-                    subject('Project', {
-                        upstreamProjectUuid: projectUuid,
-                        type: ProjectType.DEFAULT,
-                    }),
-                ),
-            ).toEqual(false);
+            it('checks that users cannot create regular projects', () => {
+                expect(
+                    ability.can(
+                        'create',
+                        subject('Project', {
+                            upstreamProjectUuid: projectUuid,
+                            type: ProjectType.DEFAULT,
+                        }),
+                    ),
+                ).toEqual(false);
+            });
         });
     });
 });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -187,11 +187,13 @@ export const projectMemberAbilities: Record<
                 },
             },
         });
+
         can('manage', 'CompileProject', {
             projectUuid: member.projectUuid,
         });
+
         can('create', 'Project', {
-            projectUuid: member.projectUuid,
+            upstreamProjectUuid: member.projectUuid,
             type: ProjectType.PREVIEW,
         });
     },

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -29,6 +29,7 @@ describe('Lightdash API organization permission tests', () => {
             );
         });
     });
+
     it('Should get forbidden error (403) from GET project endpoints from another organization', () => {
         const projectUuid = SEED_PROJECT.project_uuid; // Same project_uuid that belongs to another organization
         const endpoints = [
@@ -50,6 +51,22 @@ describe('Lightdash API organization permission tests', () => {
             }).then((resp) => {
                 expect(resp.status).to.eq(403);
             });
+        });
+    });
+
+    it('Should get a forbidden error (403) from PATCH project', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const endpoint = `${apiUrl}/projects/${projectUuid}`;
+
+        cy.request({
+            url: endpoint,
+            headers: { 'Content-type': 'application/json' },
+            method: 'PATCH',
+            body: {},
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(403);
         });
     });
 
@@ -98,21 +115,6 @@ describe('Lightdash API organization permission tests', () => {
         });
     });
 
-    it('Should get forbidden error (403) from PATCH project', () => {
-        const projectUuid = SEED_PROJECT.project_uuid;
-
-        const endpoint = `${apiUrl}/projects/${projectUuid}`;
-
-        cy.request({
-            url: endpoint,
-            headers: { 'Content-type': 'application/json' },
-            method: 'PATCH',
-            body: {},
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(403);
-        });
-    });
     it('Should get forbidden error (403) from GET savedChart endpoints from another organization', () => {
         cy.login(); // Make request as first user to get the chartUuid
 
@@ -176,6 +178,7 @@ describe('Lightdash API organization permission tests', () => {
             },
         );
     });
+
     it('Should get forbidden error (403) from PATCH dashboard', () => {
         cy.login(); // Make request as first user to get the chartUuid
 
@@ -210,141 +213,169 @@ describe('Lightdash API organization permission tests', () => {
     });
 });
 
-describe('Lightdash API tests for viewer org user', () => {
-    let email;
+describe('Lightdash API tests for organization on different roles', () => {
+    [
+        'admin',
+        'developer',
+        'editor',
+        'interactive_viewer',
+        'viewer',
+        'member',
+    ].forEach((role) => {
+        describe(`org user with '${role}' role`, () => {
+            let email;
 
-    before(() => {
-        cy.loginWithPermissions('viewer', []).then((e) => {
-            email = e;
-        });
-    });
-    beforeEach(() => {
-        cy.loginWithEmail(email);
-    });
-    it('Should identify user', () => {
-        cy.request(`${apiUrl}/user`).then((resp) => {
-            expect(resp.status).to.eq(200);
-            expect(resp.body.results).to.have.property('email', email);
-            expect(resp.body.results).to.have.property('role', 'viewer');
-        });
-    });
-
-    it('Should get success response (200) from GET public endpoints', () => {
-        const endpoints = ['/livez', '/health', '/flash'];
-        endpoints.forEach((endpoint) => {
-            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
-                expect(resp.status).to.eq(200);
-                expect(resp.body).to.have.property('status', 'ok');
+            before(() => {
+                cy.loginWithPermissions(role, []).then((e) => {
+                    email = e;
+                });
             });
-        });
-    });
 
-    it('Should get success response (200) from GET org', () => {
-        const endpoint = `${apiUrl}/org/`;
+            beforeEach(() => {
+                cy.loginWithEmail(email);
+            });
 
-        cy.request({
-            url: endpoint,
-            headers: { 'Content-type': 'application/json' },
-            method: 'GET',
-        }).then((resp) => {
-            expect(resp.status).to.eq(200);
-        });
-    });
+            it('Should identify user', () => {
+                cy.request(`${apiUrl}/user`).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                    expect(resp.body.results).to.have.property('email', email);
+                    expect(resp.body.results).to.have.property('role', role);
+                });
+            });
 
-    it('Should get a forbidden error (403) from POST project', () => {
-        const endpoint = `${apiUrl}/org/projects/`;
+            it('Should get success response (200) from GET public endpoints', () => {
+                const endpoints = ['/livez', '/health', '/flash'];
+                endpoints.forEach((endpoint) => {
+                    cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body).to.have.property('status', 'ok');
+                    });
+                });
+            });
 
-        cy.request({
-            url: endpoint,
-            headers: { 'Content-type': 'application/json' },
-            method: 'POST',
-            body: {
-                type: 'DEFAULT',
-            },
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(403);
-        });
-    });
+            it('Should get success response (200) from GET org', () => {
+                const endpoint = `${apiUrl}/org/`;
 
-    it('Should get success response (200) from GET userRouter endpoints', () => {
-        const endpoints = [`/user`, `/user/identities`];
-        endpoints.forEach((endpoint) => {
-            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
-                expect(resp.status).to.eq(200);
-                expect(resp.body).to.have.property('status', 'ok');
+                cy.request({
+                    url: endpoint,
+                    headers: { 'Content-type': 'application/json' },
+                    method: 'GET',
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                });
+            });
+
+            it('Should get success response (200) from GET userRouter endpoints', () => {
+                const endpoints = [`/user`, `/user/identities`];
+                endpoints.forEach((endpoint) => {
+                    cy.request(`${apiUrl}${endpoint}`).then((resp) => {
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body).to.have.property('status', 'ok');
+                    });
+                });
             });
         });
     });
 });
 
-describe('Lightdash API tests for interactive_viewer org user', () => {
-    let email;
+describe('lightdash API tests for project creation permissions', () => {
+    [
+        {
+            role: 'admin',
+            canCreateProject: true,
+            canCreatePreview: true,
+        },
+        {
+            role: 'developer',
+            canCreateProject: false,
+            canCreatePreview: true,
+        },
+        {
+            role: 'editor',
+            canCreateProject: false,
+            canCreatePreview: false,
+        },
+        {
+            role: 'interactive_viewer',
+            canCreateProject: false,
+            canCreatePreview: false,
+        },
+        {
+            role: 'viewer',
+            canCreateProject: false,
+            canCreatePreview: false,
+        },
+        {
+            role: 'member',
+            canCreateProject: false,
+            canCreatePreview: false,
+        },
+    ].forEach(({ role, canCreatePreview, canCreateProject }) => {
+        describe(`org user with '${role}' role`, () => {
+            let email;
 
-    before(() => {
-        cy.loginWithPermissions('interactive_viewer', []).then((e) => {
-            email = e;
-        });
-    });
-    beforeEach(() => {
-        cy.loginWithEmail(email);
-    });
-    it('Should identify user', () => {
-        cy.request(`${apiUrl}/user`).then((resp) => {
-            expect(resp.status).to.eq(200);
-            expect(resp.body.results).to.have.property('email', email);
-            expect(resp.body.results).to.have.property(
-                'role',
-                'interactive_viewer',
-            );
-        });
-    });
-
-    it('Should get success response (200) from GET public endpoints', () => {
-        const endpoints = ['/livez', '/health', '/flash'];
-        endpoints.forEach((endpoint) => {
-            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
-                expect(resp.status).to.eq(200);
-                expect(resp.body).to.have.property('status', 'ok');
+            before(() => {
+                cy.loginWithPermissions(role, []).then((e) => {
+                    email = e;
+                });
             });
-        });
-    });
 
-    it('Should get success response (200) from GET org', () => {
-        const endpoint = `${apiUrl}/org/`;
-
-        cy.request({
-            url: endpoint,
-            headers: { 'Content-type': 'application/json' },
-            method: 'GET',
-        }).then((resp) => {
-            expect(resp.status).to.eq(200);
-        });
-    });
-
-    it('Should get a forbidden error (403) from POST project', () => {
-        const endpoint = `${apiUrl}/org/projects/`;
-
-        cy.request({
-            url: endpoint,
-            headers: { 'Content-type': 'application/json' },
-            method: 'POST',
-            body: {
-                type: 'DEFAULT',
-            },
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(403);
-        });
-    });
-
-    it('Should get success response (200) from GET userRouter endpoints', () => {
-        const endpoints = [`/user`, `/user/identities`];
-        endpoints.forEach((endpoint) => {
-            cy.request(`${apiUrl}${endpoint}`).then((resp) => {
-                expect(resp.status).to.eq(200);
-                expect(resp.body).to.have.property('status', 'ok');
+            beforeEach(() => {
+                cy.loginWithEmail(email);
             });
+
+            it('should get a parameter error when sending POST to project with DEFAULT and an UPSTREAM', () => {
+                const endpoint = `${apiUrl}/org/projects/`;
+
+                cy.request({
+                    url: endpoint,
+                    headers: { 'Content-type': 'application/json' },
+                    method: 'POST',
+                    body: {
+                        type: 'DEFAULT',
+                        upstreamProjectUuid: 'uuid',
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(400);
+                });
+            });
+
+            if (!canCreateProject) {
+                it('Should get a forbidden error (403) from POST project', () => {
+                    const endpoint = `${apiUrl}/org/projects/`;
+
+                    cy.request({
+                        url: endpoint,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'POST',
+                        body: {
+                            type: 'DEFAULT',
+                        },
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        expect(resp.status).to.eq(403);
+                    });
+                });
+            }
+
+            if (!canCreatePreview) {
+                it('Should get a forbidden error (403) from POST preview project', () => {
+                    const endpoint = `${apiUrl}/org/projects/`;
+
+                    cy.request({
+                        url: endpoint,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'POST',
+                        body: {
+                            type: 'PREVIEW',
+                        },
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        expect(resp.status).to.eq(403);
+                    });
+                });
+            }
         });
     });
 });

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -251,14 +251,16 @@ describe('Lightdash API tests for viewer org user', () => {
         });
     });
 
-    it('Should get a forbidden (403) from POST project', () => {
+    it('Should get a forbidden error (403) from POST project', () => {
         const endpoint = `${apiUrl}/org/projects/`;
 
         cy.request({
             url: endpoint,
             headers: { 'Content-type': 'application/json' },
             method: 'POST',
-            body: {},
+            body: {
+                type: 'DEFAULT',
+            },
             failOnStatusCode: false,
         }).then((resp) => {
             expect(resp.status).to.eq(403);
@@ -327,7 +329,9 @@ describe('Lightdash API tests for interactive_viewer org user', () => {
             url: endpoint,
             headers: { 'Content-type': 'application/json' },
             method: 'POST',
-            body: {},
+            body: {
+                type: 'DEFAULT',
+            },
             failOnStatusCode: false,
         }).then((resp) => {
             expect(resp.status).to.eq(403);

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -264,10 +264,10 @@ const ProjectSwitcher = () => {
                 switch (project.type) {
                     case ProjectType.DEFAULT:
                         return true;
-                    // check if user has permission to create preview project on an organization level (developer, admin)
-                    // or check if user has permission to create preview project on a project level
-                    // - they should have permission (developer, admin) to the upstream project
                     case ProjectType.PREVIEW:
+                        // check if user has permission to create preview project on an organization level (developer, admin)
+                        // or check if user has permission to create preview project on a project level
+                        // - they should have permission (developer, admin) to the upstream project
                         return (
                             orgRoleCanCreatePreviews ||
                             user.data?.ability.can(
@@ -345,6 +345,7 @@ const ProjectSwitcher = () => {
                     ))}
 
                     {activeProject &&
+                    activeProject.type === ProjectType.DEFAULT &&
                     (orgRoleCanCreatePreviews ||
                         user.data?.ability.can(
                             'create',

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -168,6 +168,7 @@ const ProjectSwitcher = () => {
     const { showToastSuccess } = useToaster();
     const history = useHistory();
 
+    const { user } = useApp();
     const { isInitialLoading: isLoadingProjects, data: projects } =
         useProjects();
     const { isLoading: isLoadingActiveProjectUuid, activeProjectUuid } =
@@ -242,11 +243,23 @@ const ProjectSwitcher = () => {
 
     const inactiveProjects = useMemo(() => {
         if (!activeProjectUuid || !projects) return [];
-        return projects.filter((p) => p.projectUuid !== activeProjectUuid);
-    }, [activeProjectUuid, projects]);
+        return projects
+            .filter((p) => p.projectUuid !== activeProjectUuid)
+            .filter((project) => {
+                return (
+                    project.type === ProjectType.DEFAULT ||
+                    user.data?.ability.can(
+                        'create',
+                        subject('Project', {
+                            organizationUuid: user.data?.organizationUuid,
+                            type: project.type,
+                        }),
+                    )
+                );
+            });
+    }, [activeProjectUuid, projects, user.data]);
 
     const [isCreatePreviewOpen, setIsCreatePreview] = useState(false);
-    const { user } = useApp();
 
     if (
         isLoadingProjects ||

--- a/packages/frontend/src/hooks/useProjectPreview.ts
+++ b/packages/frontend/src/hooks/useProjectPreview.ts
@@ -45,7 +45,7 @@ export const useCreatePreviewMutation = () => {
             },
             onError: ({ error }) => {
                 showToastApiError({
-                    title: `Failed to create project`,
+                    title: `Failed to create preview project`,
                     apiError: error,
                 });
             },


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/8307

### Description:

test-frontend
test-backend
test-cli

internal discussion: https://lightdash.slack.com/archives/C07TP0EN8PP/p1730197569059179

developer:

![CleanShot 2024-10-29 at 19 49 18@2x](https://github.com/user-attachments/assets/0cba162e-5101-483d-bf47-290e48053987)

member:

![CleanShot 2024-10-29 at 19 49 44@2x](https://github.com/user-attachments/assets/b0f49c74-9a30-4364-a49d-decd2d3f3dce)

member able to access preview via url:

![CleanShot 2024-10-29 at 19 50 20@2x](https://github.com/user-attachments/assets/9a4fad02-1130-440c-853e-8b14bd0d029a)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
