### PR TITLE
feat: open metric preview on click of metric in table

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -176,7 +176,6 @@ export const MetricsTable = () => {
         ),
         state: {
             isLoading: isFetching,
-            showProgressBars: isFetching,
             density: 'xs',
         },
         rowVirtualizerInstanceRef,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -106,7 +106,11 @@ const UseMetricButton = ({
     row: MRT_Row<CatalogFieldWithAnalytics>;
 }) => {
     const [currentTableName, setCurrentTableName] = useState<string>();
-    const { data: explore } = useExplore(currentTableName);
+    const {
+        data: explore,
+        isLoading,
+        isFetching,
+    } = useExplore(currentTableName);
     const history = useHistory();
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
@@ -136,6 +140,7 @@ const UseMetricButton = ({
             onClick={() => {
                 setCurrentTableName(row.original.tableName);
             }}
+            loading={isFetching && isLoading}
         >
             Use Metric
         </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -229,8 +229,8 @@ export const MetricsTable = () => {
                 {isFetching
                     ? 'Loading more...'
                     : hasNextPage
-                    ? 'Scroll for more'
-                    : 'All metrics loaded'}
+                    ? `Scroll for more metrics (${flatData.length} loaded)`
+                    : `All metrics loaded (${flatData.length})`}
             </Text>
         ),
         state: {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -106,11 +106,8 @@ const UseMetricButton = ({
     row: MRT_Row<CatalogFieldWithAnalytics>;
 }) => {
     const [currentTableName, setCurrentTableName] = useState<string>();
-    const {
-        data: explore,
-        isLoading,
-        isFetching,
-    } = useExplore(currentTableName);
+    const { data: explore, isFetching } = useExplore(currentTableName);
+    const [isNavigating, setIsNavigating] = useState(false);
     const history = useHistory();
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
@@ -118,10 +115,12 @@ const UseMetricButton = ({
 
     useEffect(() => {
         if (!!currentTableName && explore && projectUuid) {
+            setIsNavigating(true);
             const unsavedChartVersion = createMetricPreviewUnsavedChartVersion(
                 row.original,
                 explore,
             );
+
             history.push(
                 getExplorerUrlFromCreateSavedChartVersion(
                     projectUuid,
@@ -140,7 +139,7 @@ const UseMetricButton = ({
             onClick={() => {
                 setCurrentTableName(row.original.tableName);
             }}
-            loading={isFetching && isLoading}
+            loading={isFetching || isNavigating}
         >
             Use Metric
         </Button>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,4 +1,7 @@
-import { type CatalogFieldWithAnalytics } from '@lightdash/common';
+import {
+    friendlyName,
+    type CatalogFieldWithAnalytics,
+} from '@lightdash/common';
 import { Box, Button, HoverCard, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
@@ -62,7 +65,9 @@ const columns: MRT_ColumnDef<CatalogFieldWithAnalytics>[] = [
     {
         accessorKey: 'name',
         header: 'Metric Name',
-        Cell: ({ row }) => <Text fw={500}>{row.original.label}</Text>,
+        Cell: ({ row }) => (
+            <Text fw={500}>{friendlyName(row.original.label)}</Text>
+        ),
     },
     {
         accessorKey: 'description',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/12104

### Description:

> [!NOTE]
> I have a subsequent PR that refactors this component into smaller ones

When the user clicks on `use metric`, they are redirected to an explore where they can preview their metric - it gets a date dimension - if it can't find it in the base table, and if there are other joined tables, it will try to find it again. 

demo:


https://github.com/user-attachments/assets/04ac1b8b-9010-4f24-ab21-04c116bb91ff



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
