### PR TITLE
feat: stacking error list

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -111,7 +111,10 @@ const TableCalculationModal: FC<Props> = ({
     const handleSubmit = form.onSubmit((data) => {
         const { name, sql } = data;
         if (sql.length === 0)
-            return addToastError({ title: 'SQL cannot be empty' });
+            return addToastError({
+                title: 'SQL cannot be empty',
+                key: 'table-calculation-modal',
+            });
 
         try {
             onSave({
@@ -125,6 +128,7 @@ const TableCalculationModal: FC<Props> = ({
             addToastError({
                 title: 'Error saving',
                 subtitle: e.message,
+                key: 'table-calculation-modal',
             });
         }
     });

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -52,7 +52,7 @@ const TableCalculationModal: FC<Props> = ({
     const theme = useMantineTheme();
     const [isFullscreen, toggleFullscreen] = useToggle(false);
 
-    const { showToastError } = useToaster();
+    const { addToastError } = useToaster();
 
     const tableCalculations = useExplorerContext(
         (context) =>
@@ -111,7 +111,7 @@ const TableCalculationModal: FC<Props> = ({
     const handleSubmit = form.onSubmit((data) => {
         const { name, sql } = data;
         if (sql.length === 0)
-            return showToastError({ title: 'SQL cannot be empty' });
+            return addToastError({ title: 'SQL cannot be empty' });
 
         try {
             onSave({
@@ -122,7 +122,7 @@ const TableCalculationModal: FC<Props> = ({
                 type: data.type,
             });
         } catch (e) {
-            showToastError({
+            addToastError({
                 title: 'Error saving',
                 subtitle: e.message,
             });

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -5,7 +5,6 @@ import {
     Collapse,
     CopyButton,
     Group,
-    ScrollArea,
     Stack,
     Text,
     Title,
@@ -103,59 +102,64 @@ const MultipleToastBody = ({
                 </Button>
             </Group>
 
-            <Collapse in={!listCollapsed} w="100%">
-                <ScrollArea style={{ height: 155, width: '100%' }}>
-                    <Stack spacing="xs" pb="sm">
-                        {toastsData.map((toastData, index) => (
-                            <Group
-                                key={`${toastData.subtitle}-${index}`}
-                                position="apart"
-                                spacing="xxs"
-                                noWrap
-                                sx={(theme) => ({
-                                    width: '100%',
-                                    border: `1px solid ${theme.colors.red[3]}`,
-                                    borderRadius: '4px',
-                                    padding: theme.spacing.xs,
-                                })}
-                            >
-                                {toastData.apiError ? (
-                                    <ApiErrorDisplay
-                                        apiError={toastData.apiError}
-                                    />
-                                ) : (
-                                    <>
-                                        {toastData.title && (
-                                            <Title order={6}>
-                                                {toastData.title}
-                                            </Title>
-                                        )}
-                                        {toastData.subtitle && (
-                                            <MarkdownPreview
-                                                source={toastData.subtitle.toString()}
-                                                linkTarget="_blank"
-                                                style={{
-                                                    backgroundColor:
-                                                        'transparent',
-                                                    color: 'white',
-                                                    fontSize: '12px',
-                                                }}
-                                            />
-                                        )}
-                                    </>
-                                )}
+            <Collapse
+                in={!listCollapsed}
+                style={{
+                    maxHeight: 155,
+                    overflow: 'auto',
+                    display: 'flex',
+                    flexDirection: 'column',
+                }}
+            >
+                <Stack spacing="xs" pb="sm">
+                    {toastsData.map((toastData, index) => (
+                        <Group
+                            key={`${toastData.subtitle}-${index}`}
+                            position="apart"
+                            spacing="xxs"
+                            noWrap
+                            sx={(theme) => ({
+                                width: '100%',
+                                border: `1px solid ${theme.colors.red[3]}`,
+                                borderRadius: '4px',
+                                padding: theme.spacing.xs,
+                            })}
+                        >
+                            {toastData.apiError ? (
+                                <ApiErrorDisplay
+                                    apiError={toastData.apiError}
+                                />
+                            ) : (
+                                <>
+                                    {toastData.title && (
+                                        <Title order={6}>
+                                            {toastData.title}
+                                        </Title>
+                                    )}
+                                    {toastData.subtitle && (
+                                        <MarkdownPreview
+                                            source={toastData.subtitle.toString()}
+                                            linkTarget="_blank"
+                                            style={{
+                                                backgroundColor: 'transparent',
+                                                color: 'white',
+                                                fontSize: '12px',
+                                            }}
+                                        />
+                                    )}
+                                </>
+                            )}
 
-                                <ActionIcon
-                                    variant="transparent"
-                                    size="xs"
-                                    onClick={() => onCloseError?.(toastData)}
-                                >
-                                    <MantineIcon icon={IconX} color="white" />
-                                </ActionIcon>
-                            </Group>
-                        ))}
-                    </Stack>
-                </ScrollArea>
+                            <ActionIcon
+                                variant="transparent"
+                                size="xs"
+                                onClick={() => onCloseError?.(toastData)}
+                            >
+                                <MantineIcon icon={IconX} color="white" />
+                            </ActionIcon>
+                        </Group>
+                    ))}
+                </Stack>
             </Collapse>
         </Stack>
     );

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -64,7 +64,7 @@ const ApiErrorDisplay = ({ apiError }: { apiError: ApiErrorDetail }) => {
             </Group>
         </Stack>
     ) : (
-        apiError.message
+        <>{apiError.message}</>
     );
 };
 

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -2,10 +2,13 @@ import type { ApiErrorDetail } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
+    Collapse,
     CopyButton,
     Group,
+    ScrollArea,
     Stack,
     Text,
+    Title,
     Tooltip,
     type ButtonProps,
 } from '@mantine/core';
@@ -14,15 +17,95 @@ import { type PolymorphicComponentProps } from '@mantine/utils';
 import {
     IconAlertTriangleFilled,
     IconCheck,
+    IconChevronDown,
+    IconChevronUp,
     IconCircleCheckFilled,
     IconCopy,
     IconInfoCircleFilled,
+    IconX,
     type Icon,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import React, { useCallback, useRef, type ReactNode } from 'react';
+import React, { useCallback, useRef, useState, type ReactNode } from 'react';
 import { v4 as uuid } from 'uuid';
 import MantineIcon from '../../components/common/MantineIcon';
+
+const MultipleToastBody = ({
+    toastMessages,
+    title,
+    onCloseError,
+}: {
+    title?: ReactNode;
+    toastMessages: string[];
+    onCloseError?: (key: string) => void;
+}) => {
+    const [listCollapsed, setListCollapsed] = useState(true);
+
+    return (
+        <Stack spacing="xs" align="flex-start">
+            <Group>
+                {title && <Title order={6}>{title}</Title>}
+                <Button
+                    size="xs"
+                    compact
+                    variant="outline"
+                    color="red.1"
+                    rightIcon={
+                        <MantineIcon
+                            color="red.1"
+                            icon={
+                                listCollapsed ? IconChevronUp : IconChevronDown
+                            }
+                        />
+                    }
+                    onClick={() => setListCollapsed(!listCollapsed)}
+                >
+                    <Text>{`${listCollapsed ? 'Show' : 'Hide'} ${
+                        toastMessages.length
+                    }`}</Text>
+                </Button>
+            </Group>
+
+            <Collapse in={!listCollapsed}>
+                <ScrollArea style={{ height: 155 }}>
+                    <Stack spacing="xs" pb="sm">
+                        {toastMessages.map((message, index) => (
+                            <Group
+                                key={`${message}-${index}`}
+                                position="apart"
+                                spacing="xs"
+                                noWrap
+                                sx={(theme) => ({
+                                    width: '100%',
+                                    border: `1px solid ${theme.colors.red[3]}`,
+                                    borderRadius: '4px',
+                                    padding: theme.spacing.sm,
+                                })}
+                            >
+                                <MarkdownPreview
+                                    source={message}
+                                    linkTarget="_blank"
+                                    style={{
+                                        backgroundColor: 'transparent',
+                                        color: 'white',
+                                        fontSize: '12px',
+                                    }}
+                                />
+                                <ActionIcon
+                                    variant="transparent"
+                                    size="xs"
+                                    onClick={() => onCloseError?.(message)}
+                                >
+                                    <MantineIcon icon={IconX} color="white" />
+                                </ActionIcon>
+                            </Group>
+                        ))}
+                    </Stack>
+                </ScrollArea>
+            </Collapse>
+        </Stack>
+    );
+};
 
 type NotificationData = Omit<
     Parameters<typeof notifications.show>[0],
@@ -37,6 +120,7 @@ type NotificationData = Omit<
 
 const useToaster = () => {
     const openedKeys = useRef(new Set<string>());
+    const currentErrors = useRef<Record<string, string[]>>({});
 
     const showToast = useCallback(
         ({
@@ -111,7 +195,10 @@ const useToaster = () => {
                     ) : undefined,
                 onClose: (props: NotificationProps) => {
                     rest.onClose?.(props);
-                    if (props.id) openedKeys.current.delete(props.id);
+                    if (props.id) {
+                        openedKeys.current.delete(props.id);
+                        delete currentErrors.current[props.id];
+                    }
                 },
             };
 
@@ -245,7 +332,100 @@ const useToaster = () => {
         [showToast],
     );
 
+    // This is used to update a multiple toast by key. It is called by
+    // addToastError and removeToastError, which pass different specific functions to
+    // update the error list
+    const updateToastError = useCallback(
+        (
+            {
+                key = 'error-list',
+                title,
+                subtitle,
+                ...restProps
+            }: NotificationData,
+            updateErrors: (
+                key: string,
+                subtitle: NotificationData['subtitle'],
+            ) => void,
+            removeToastError: (data: NotificationData) => void,
+        ) => {
+            if (!subtitle && !title) return;
+
+            const message = subtitle ?? title;
+
+            // Execute the specific error update function (add or remove)
+            updateErrors(key, message);
+
+            const hasMultipleErrors = currentErrors.current[key]?.length > 1;
+
+            const toastBody = hasMultipleErrors ? (
+                <MultipleToastBody
+                    title={title}
+                    toastMessages={currentErrors.current[key]}
+                    onCloseError={(errorMessage) =>
+                        removeToastError({
+                            key,
+                            title,
+                            subtitle: errorMessage,
+                            ...restProps,
+                        })
+                    }
+                />
+            ) : (
+                currentErrors.current[key][0]
+            );
+
+            showToastError({
+                key,
+                subtitle: toastBody,
+                title: hasMultipleErrors ? undefined : title,
+                ...restProps,
+            });
+        },
+        [showToastError],
+    );
+
+    const removeToastError = useCallback(
+        (notificationData: NotificationData) => {
+            updateToastError(
+                notificationData,
+                (key, message) => {
+                    currentErrors.current[key] = currentErrors.current[
+                        key
+                    ].filter((m) => m !== message?.toString());
+
+                    if (currentErrors.current[key].length === 0) {
+                        notifications.hide(key);
+                    }
+                },
+                removeToastError,
+            );
+        },
+        [updateToastError],
+    );
+
+    const addToastError = useCallback(
+        (notificationData: NotificationData) => {
+            console.log('add', notificationData);
+
+            updateToastError(
+                notificationData,
+                (key, message) => {
+                    if (!message) return;
+                    if (currentErrors.current[key]) {
+                        currentErrors.current[key].push(message.toString());
+                    } else {
+                        currentErrors.current[key] = [message.toString()];
+                    }
+                },
+                removeToastError,
+            );
+        },
+        [removeToastError, updateToastError],
+    );
+
     return {
+        addToastError,
         showToastSuccess,
         showToastApiError,
         showToastError,

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -116,7 +116,7 @@ const MultipleToastBody = ({
                                     width: '100%',
                                     border: `1px solid ${theme.colors.red[3]}`,
                                     borderRadius: '4px',
-                                    padding: theme.spacing.sm,
+                                    padding: theme.spacing.xs,
                                 })}
                             >
                                 {toastData.apiError ? (
@@ -224,6 +224,7 @@ const useToaster = () => {
                                     style={{
                                         color: toastColor ? 'white' : undefined,
                                         fontSize: '12px',
+                                        width: '100%',
                                     }}
                                 >
                                     {subtitle}

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -15,7 +15,7 @@ const useQueryError = ({
 }: opts = {}): Dispatch<SetStateAction<ApiError | undefined>> => {
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<ApiError | undefined>();
-    const { showToastError, showToastApiError } = useToaster();
+    const { showToastError, addToastError } = useToaster();
     useEffect(() => {
         (async function doIfError() {
             const { error } = errorResponse || {};
@@ -29,7 +29,7 @@ const useQueryError = ({
                     // we will handle this on pages showing a nice message
 
                     if (forceToastOnForbidden) {
-                        showToastApiError({
+                        addToastError({
                             title: forbiddenToastTitle ?? 'Forbidden',
                             apiError: error,
                         });
@@ -68,7 +68,7 @@ const useQueryError = ({
                         window.location.href = '/login';
                     }
                 } else {
-                    showToastApiError({
+                    addToastError({
                         apiError: error,
                     });
                 }
@@ -80,7 +80,7 @@ const useQueryError = ({
         forceToastOnForbidden,
         queryClient,
         showToastError,
-        showToastApiError,
+        addToastError,
     ]);
     return setErrorResponse;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11198 

### Description:

Makes it possible to add errors to a list instead of each in it's own toast. That list is collapsable and the errors can be dismissed individually. 

Note that there is a new method `addToastError` that will add to the list and I kept the old `showToastError` for now. This way we can keep the existing behavior in some places, but use error lists in others. For now I have only updated a few places where multiple errors were most problematic to use the error list, primarily the API error reporting. 

The collapsed errors now look like:
<img width="470" alt="Screenshot 2024-10-30 at 09 58 29" src="https://github.com/user-attachments/assets/b6472a00-fc7e-462a-963a-a81187ecfe15">


And the expanded list looks like:
<img width="466" alt="Screenshot 2024-10-30 at 09 58 44" src="https://github.com/user-attachments/assets/054263b4-ea56-4253-85dd-3019ddc2aa24">

 One consistent way to test this is to add a table calculation with invalid columns or no sql, then do it again. The first toast will be the same as always, the second one will add to the list.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
