### PR TITLE
feat: add sorting to dataCatalog/metrics endpoint

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -5,6 +5,7 @@ import {
     ApiCatalogSearch,
     ApiErrorPayload,
     ApiMetricsCatalog,
+    type ApiSort,
     type KnexPaginateArgs,
 } from '@lightdash/common';
 import {
@@ -160,6 +161,8 @@ export class CatalogController extends BaseController {
         @Query() search?: ApiCatalogSearch['search'],
         @Query() page?: number,
         @Query() pageSize?: number,
+        @Query() sort?: ApiSort['sort'],
+        @Query() order?: ApiSort['order'],
     ): Promise<ApiMetricsCatalog> {
         this.setStatus(200);
 
@@ -171,9 +174,24 @@ export class CatalogController extends BaseController {
                   }
                 : undefined;
 
+        const sortArgs: ApiSort | undefined = sort
+            ? {
+                  sort,
+                  order,
+              }
+            : undefined;
+
         const results = await this.services
             .getCatalogService()
-            .getMetricsCatalog(req.user!, projectUuid, paginateArgs, search);
+            .getMetricsCatalog(
+                req.user!,
+                projectUuid,
+                paginateArgs,
+                {
+                    search,
+                },
+                sortArgs,
+            );
 
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -524,6 +524,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSortDirection: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['asc'] },
+                { dataType: 'enum', enums: ['desc'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateComment: {
         dataType: 'refAlias',
         type: {
@@ -10067,6 +10079,8 @@ export function RegisterRoutes(app: express.Router) {
                 search: { in: 'query', name: 'search', dataType: 'string' },
                 page: { in: 'query', name: 'page', dataType: 'double' },
                 pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+                sort: { in: 'query', name: 'sort', dataType: 'string' },
+                order: { in: 'query', name: 'order', ref: 'ApiSortDirection' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -459,6 +459,10 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiSortDirection": {
+                "type": "string",
+                "enum": ["asc", "desc"]
+            },
             "ApiCreateComment": {
                 "properties": {
                     "results": {
@@ -10763,7 +10767,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1324.0",
+        "version": "0.1327.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -11101,6 +11105,22 @@
                         "schema": {
                             "format": "double",
                             "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "order",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/ApiSortDirection"
                         }
                     }
                 ]

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -8,6 +8,7 @@ import {
     NotFoundError,
     TableSelectionType,
     UnexpectedServerError,
+    type ApiSort,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type TablesConfiguration,
@@ -51,6 +52,7 @@ export class CatalogModel {
         tablesConfiguration,
         userAttributes,
         paginateArgs,
+        sortArgs,
     }: {
         searchQuery?: string;
         projectUuid: string;
@@ -66,6 +68,7 @@ export class CatalogModel {
         tablesConfiguration: TablesConfiguration;
         userAttributes: UserAttributeValueMap;
         paginateArgs?: KnexPaginateArgs;
+        sortArgs?: ApiSort;
     }): Promise<KnexPaginatedData<(CatalogTable | CatalogField)[]>> {
         const searchRankRawSql = searchQuery
             ? searchRankFunction({
@@ -211,6 +214,11 @@ export class CatalogModel {
         catalogItemsQuery = catalogItemsQuery
             .orderBy('search_rank', 'desc')
             .limit(limit ?? 50);
+
+        if (sortArgs) {
+            const { sort, order } = sortArgs;
+            catalogItemsQuery = catalogItemsQuery.orderBy(sort, order);
+        }
 
         const paginatedCatalogItems = await KnexPaginate.paginate(
             catalogItemsQuery.select<(DbCatalog & { explore: Explore })[]>(),

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -19,6 +19,7 @@ import {
     TablesConfiguration,
     TableSelectionType,
     UserAttributeValueMap,
+    type ApiSort,
     type CatalogFieldWithAnalytics,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -190,6 +191,7 @@ export class CatalogService<
         type?: CatalogType,
         filter?: CatalogFilter,
         paginateArgs?: KnexPaginateArgs,
+        sortArgs?: ApiSort,
     ): Promise<KnexPaginatedData<(CatalogTable | CatalogField)[]>> {
         const tablesConfiguration =
             await this.projectModel.getTablesConfiguration(projectUuid);
@@ -214,6 +216,7 @@ export class CatalogService<
                             paginateArgs,
                             tablesConfiguration,
                             userAttributes,
+                            sortArgs,
                         }),
                 ),
         );
@@ -489,7 +492,8 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
         paginateArgs?: KnexPaginateArgs,
-        search?: string,
+        { search }: ApiCatalogSearch = {},
+        sortArgs?: ApiSort,
     ): Promise<KnexPaginatedData<CatalogFieldWithAnalytics[]>> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -517,6 +521,7 @@ export class CatalogService<
             CatalogType.Field,
             CatalogFilter.Metrics,
             paginateArgs,
+            sortArgs,
         );
 
         const { data: catalogMetrics, pagination } = paginatedCatalogMetrics;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -158,6 +158,7 @@ export * from './types/api/comments';
 export * from './types/api/errors';
 export * from './types/api/notifications';
 export * from './types/api/share';
+export * from './types/api/sort';
 export * from './types/api/success';
 export * from './types/api/uuid';
 export * from './types/catalog';

--- a/packages/common/src/types/api/sort.ts
+++ b/packages/common/src/types/api/sort.ts
@@ -1,0 +1,2 @@
+export type ApiSortDirection = 'asc' | 'desc';
+export type ApiSort = { sort: string; order?: ApiSortDirection };

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -35,6 +35,7 @@ export type ApiCatalogSearch = {
     type?: CatalogType;
     filter?: CatalogFilter;
 };
+
 export type CatalogField = Pick<
     Field,
     'name' | 'label' | 'fieldType' | 'tableLabel' | 'description'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12168](https://github.com/lightdash/lightdash/issues/12168)

### Description:

New query params added:
- `sort`: name of the column to sort by
- `order`: either `asc`, `desc` or `undefined`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
