### PR TITLE
chore: optimize group members list

### DIFF
--- a/packages/backend/src/database/entities/groupMemberships.ts
+++ b/packages/backend/src/database/entities/groupMemberships.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-type DbGroupMembership = {
+export type DbGroupMembership = {
     group_uuid: string;
     user_id: number;
     organization_id: number;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Remove loop to get group members that is not efficient and can cause the database pool to max out.

We can now find members with pagination and for multiple groups.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
