### PR TITLE
fix: add group members in a single insert

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -1,4 +1,5 @@
 import {
+    ApiCreateGroupResponse,
     ApiErrorPayload,
     ApiGroupListResponse,
     ApiGroupResponse,
@@ -326,7 +327,7 @@ export class OrganizationController extends BaseController {
     async createGroup(
         @Request() req: express.Request,
         @Body() body: CreateGroup,
-    ): Promise<ApiGroupResponse> {
+    ): Promise<ApiCreateGroupResponse> {
         const group = await this.services
             .getOrganizationService()
             .addGroupToOrganization(req.user!, body);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3853,6 +3853,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateGroupResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'GroupWithMembers', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Group.name_': {
         dataType: 'refAlias',
         type: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4191,6 +4191,20 @@
             "UpdateAllowedEmailDomains": {
                 "$ref": "#/components/schemas/Omit_AllowedEmailDomains.organizationUuid_"
             },
+            "ApiCreateGroupResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/GroupWithMembers"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_Group.name_": {
                 "properties": {
                     "name": {
@@ -13166,7 +13180,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupResponse"
+                                    "$ref": "#/components/schemas/ApiCreateGroupResponse"
                                 }
                             }
                         }

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -318,7 +318,7 @@ export class GroupsModel {
                 group.organization_id,
             )
             .whereIn('user_uuid', memberUuids)
-            .select('user_id', 'user_uuid');
+            .select('users.user_id', 'user_uuid');
 
         if (users.length === 0) {
             return [];

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -41,6 +41,63 @@ export class GroupsModel {
         this.database = args.database;
     }
 
+    static async addGroupMembers(
+        trx: Knex,
+        groupUuid: string,
+        memberUuids: string[],
+    ): Promise<GroupMembership[]> {
+        // Check if the group exists
+        const group = await trx('groups')
+            .where('group_uuid', groupUuid)
+            .first('group_uuid', 'organization_id');
+        if (group === undefined) {
+            throw new NotFoundError(`No group found`);
+        }
+
+        // Check what members exist and are part of the organization
+        const users = await trx('users')
+            .innerJoin(
+                'organization_memberships',
+                'users.user_id',
+                'organization_memberships.user_id',
+            )
+            .where(
+                'organization_memberships.organization_id',
+                group.organization_id,
+            )
+            .whereIn('user_uuid', memberUuids)
+            .select('users.user_id', 'user_uuid');
+
+        if (users.length === 0) {
+            return [];
+        }
+
+        const membershipsToAdd = users.map((user) => ({
+            group_uuid: groupUuid,
+            user_id: user.user_id,
+            organization_id: group.organization_id,
+        }));
+
+        // Add members to the group
+        const membershipsAdded = await trx('group_memberships')
+            .insert(membershipsToAdd)
+            .onConflict()
+            .ignore()
+            .returning('*');
+
+        // Return the added memberships
+        return membershipsAdded.reduce<GroupMembership[]>((acc, membership) => {
+            const user = users.find((u) => u.user_id === membership.user_id);
+            if (user) {
+                acc.push({
+                    groupUuid: membership.group_uuid,
+                    userUuid: user.user_uuid,
+                });
+            }
+            return acc;
+        }, []);
+    }
+
     async find(
         filters: { organizationUuid: string; searchQuery?: string },
         paginateArgs?: KnexPaginateArgs,
@@ -157,31 +214,33 @@ export class GroupsModel {
     async createGroup(
         createGroup: CreateGroup & { organizationUuid: string },
     ): Promise<GroupWithMembers> {
-        const results = await this.database.raw<{
-            rows: { created_at: Date; group_uuid: string }[];
-        }>(
-            `
-                INSERT INTO groups (name, organization_id)
-                SELECT ?, organization_id
-                FROM organizations
-                WHERE organization_uuid = ?
-                RETURNING group_uuid, groups.created_at
-            `,
-            [createGroup.name, createGroup.organizationUuid],
-        );
-        const [row] = results.rows;
-        if (row === undefined) {
-            throw new UnexpectedDatabaseError(`Failed to create group`);
-        }
-
-        if (createGroup.members && createGroup.members.length > 0) {
-            await this.addGroupMembers(
-                row.group_uuid,
-                createGroup.members.map((m) => m.userUuid),
+        const groupUuid = await this.database.transaction(async (trx) => {
+            const results = await trx.raw<{
+                rows: { created_at: Date; group_uuid: string }[];
+            }>(
+                `
+                    INSERT INTO groups (name, organization_id)
+                    SELECT ?, organization_id
+                    FROM organizations
+                    WHERE organization_uuid = ? RETURNING group_uuid, groups.created_at
+                `,
+                [createGroup.name, createGroup.organizationUuid],
             );
-        }
+            const [row] = results.rows;
+            if (row === undefined) {
+                throw new UnexpectedDatabaseError(`Failed to create group`);
+            }
 
-        return this.getGroupWithMembers(row.group_uuid);
+            if (createGroup.members && createGroup.members.length > 0) {
+                await GroupsModel.addGroupMembers(
+                    trx,
+                    row.group_uuid,
+                    createGroup.members.map((m) => m.userUuid),
+                );
+            }
+            return row.group_uuid;
+        });
+        return this.getGroupWithMembers(groupUuid);
     }
 
     async getGroup(groupUuid: string): Promise<Group> {
@@ -273,81 +332,15 @@ export class GroupsModel {
         await this.database('groups').where('group_uuid', groupUuid).del();
     }
 
-    async maybeAddGroupMember(
-        member: GroupMembership,
-    ): Promise<GroupMembership | undefined> {
-        // This will return undefined if
-        // - the group uuid doesn't exist
-        // - the user uuid doesn't exist
-        // - the user is already a member of the group
-        // - the user is not a member of the group's parent organization
-        try {
-            const members = await this.addGroupMembers(member.groupUuid, [
-                member.userUuid,
-            ]);
-            return members[0];
-        } catch (e) {
-            if (e instanceof NotFoundError) {
-                return undefined;
-            }
-            throw e;
-        }
-    }
-
     async addGroupMembers(
         groupUuid: string,
         memberUuids: string[],
     ): Promise<GroupMembership[]> {
-        // Check if the group exists
-        const group = await this.database('groups')
-            .where('group_uuid', groupUuid)
-            .first('group_uuid', 'organization_id');
-        if (group === undefined) {
-            throw new NotFoundError(`No group found`);
-        }
-
-        // Check what members exist and are part of the organization
-        const users = await this.database('users')
-            .innerJoin(
-                'organization_memberships',
-                'users.user_id',
-                'organization_memberships.user_id',
-            )
-            .where(
-                'organization_memberships.organization_id',
-                group.organization_id,
-            )
-            .whereIn('user_uuid', memberUuids)
-            .select('users.user_id', 'user_uuid');
-
-        if (users.length === 0) {
-            return [];
-        }
-
-        const membershipsToAdd = users.map((user) => ({
-            group_uuid: groupUuid,
-            user_id: user.user_id,
-            organization_id: group.organization_id,
-        }));
-
-        // Add members to the group
-        const membershipsAdded = await this.database('group_memberships')
-            .insert(membershipsToAdd)
-            .onConflict()
-            .ignore()
-            .returning('*');
-
-        // Return the added memberships
-        return membershipsAdded.reduce<GroupMembership[]>((acc, membership) => {
-            const user = users.find((u) => u.user_id === membership.user_id);
-            if (user) {
-                acc.push({
-                    groupUuid: membership.group_uuid,
-                    userUuid: user.user_uuid,
-                });
-            }
-            return acc;
-        }, []);
+        return GroupsModel.addGroupMembers(
+            this.database,
+            groupUuid,
+            memberUuids,
+        );
     }
 
     async removeGroupMember(member: GroupMembership): Promise<boolean> {

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -50,7 +50,9 @@ export class GroupsService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        const groupMembership = await this.groupsModel.addGroupMember(member);
+        const groupMembership = await this.groupsModel.maybeAddGroupMember(
+            member,
+        );
         if (groupMembership) {
             const updatedGroup = await this.groupsModel.getGroupWithMembers(
                 member.groupUuid,

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -50,8 +50,9 @@ export class GroupsService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        const groupMembership = await this.groupsModel.maybeAddGroupMember(
-            member,
+        const [groupMembership] = await this.groupsModel.addGroupMembers(
+            member.groupUuid,
+            [member.userUuid],
         );
         if (groupMembership) {
             const updatedGroup = await this.groupsModel.getGroupWithMembers(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -495,27 +495,11 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const group = await this.groupsModel.createGroup({
+        const groupWithMembers = await this.groupsModel.createGroup({
             organizationUuid: actor.organizationUuid,
             ...createGroup,
         });
 
-        if (createGroup.members === undefined) {
-            return group;
-        }
-
-        await Promise.all(
-            createGroup.members.map((member) =>
-                this.groupsModel.addGroupMember({
-                    groupUuid: group.uuid,
-                    userUuid: member.userUuid,
-                }),
-            ),
-        );
-
-        const groupWithMembers = await this.groupsModel.getGroupWithMembers(
-            group.uuid,
-        );
         this.analytics.track({
             userId: actor.userUuid,
             event: 'group.created',

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -482,7 +482,7 @@ export class OrganizationService extends BaseService {
     async addGroupToOrganization(
         actor: SessionUser,
         createGroup: CreateGroup,
-    ): Promise<Group | GroupWithMembers> {
+    ): Promise<GroupWithMembers> {
         if (
             actor.organizationUuid === undefined ||
             actor.ability.cannot(

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -87,6 +87,11 @@ export type ApiGroupResponse = {
     results: Group | GroupWithMembers;
 };
 
+export type ApiCreateGroupResponse = {
+    status: 'ok';
+    results: GroupWithMembers;
+};
+
 export type ApiGroupListResponse = {
     status: 'ok';
     results: KnexPaginatedData<Group[] | GroupWithMembers[]>;

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -110,7 +110,7 @@ export const useInfiniteOrganizationGroups = (
 };
 
 const createGroupQuery = async (data: CreateGroup) =>
-    lightdashApi<Group>({
+    lightdashApi<GroupWithMembers>({
         url: `/org/groups`,
         method: 'POST',
         body: JSON.stringify(data),
@@ -119,7 +119,7 @@ const createGroupQuery = async (data: CreateGroup) =>
 export const useGroupCreateMutation = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
-    return useMutation<Group, ApiError, CreateGroup>(
+    return useMutation<GroupWithMembers, ApiError, CreateGroup>(
         (data) => createGroupQuery(data),
         {
             mutationKey: ['create_group'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Remove loop that adds members on group creation. Prevent issues with database pool max out.
Should have no impact on existing behaviour.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
