### PR TITLE
feat: select exposure type in `lightdash generate-exposures`

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -13,6 +13,7 @@ import {
     CalculateTotalFromQuery,
     CreateProjectMember,
     DbtExposure,
+    DbtExposureType,
     isDuplicateDashboardParams,
     ParameterError,
     RequestMethod,
@@ -365,11 +366,12 @@ export class ProjectController extends BaseController {
     async GetDbtExposures(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() exposureType?: DbtExposureType,
     ): Promise<{ status: 'ok'; results: Record<string, DbtExposure> }> {
         this.setStatus(200);
         const exposures = await this.services
             .getProjectService()
-            .getDbtExposures(req.user!, projectUuid);
+            .getDbtExposures(req.user!, projectUuid, exposureType);
         return {
             status: 'ok',
             results: exposures,

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -13,6 +13,7 @@ type GenerateExposuresHandlerOptions = {
     projectDir: string;
     verbose: boolean;
     output?: string;
+    exposureType?: string;
 };
 
 export const generateExposuresHandler = async (
@@ -49,10 +50,14 @@ export const generateExposuresHandler = async (
     try {
         const absoluteProjectPath = path.resolve(options.projectDir);
 
+        const queryParams = options.exposureType
+            ? { exposureType: options.exposureType }
+            : undefined;
         const exposures = await lightdashApi<Record<string, DbtExposure>>({
             method: 'GET',
             url: `/api/v1/projects/${config.context.project}/dbt-exposures`,
             body: undefined,
+            queryParams,
         });
 
         console.info(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -661,6 +661,10 @@ ${styles.bold('Examples:')}
         'The path where the output exposures YAML file will be written',
         undefined,
     )
+    .option(
+        '--exposure-type <type>',
+        'The type of exposures to generate. This must be one of "application", "analysis", or "dashboard"',
+    )
     .action(generateExposuresHandler);
 
 const errorHandler = (err: Error) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/8620

### Description:

The `lightdash generate-exposures` commands currently returns dbt Exposrusres of the exposure types of `application`, `analysis` and `dashboard`. Resulting dbt Exposures contains every saved charts. However, we somtime want to select only dbt Exposures of Lightdash dashboards. This change enables us to specify the dbt Exposure type in the `lightdash generate-exposures` command.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
