### PR TITLE
chore: get chart usage from api response

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -459,19 +459,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CatalogFieldWithAnalytics: {
         dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'CatalogField' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        analytics: { ref: 'CatalogAnalytics', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
+        type: { ref: 'CatalogField', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiMetricsCatalogResults: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -457,16 +457,11 @@ const models: TsoaRoute.Models = {
         type: { ref: 'CatalogAnalytics', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CatalogFieldWithAnalytics: {
-        dataType: 'refAlias',
-        type: { ref: 'CatalogField', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiMetricsCatalogResults: {
         dataType: 'refAlias',
         type: {
             dataType: 'array',
-            array: { dataType: 'refAlias', ref: 'CatalogFieldWithAnalytics' },
+            array: { dataType: 'refAlias', ref: 'CatalogField' },
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -387,12 +387,9 @@
             "ApiCatalogAnalyticsResults": {
                 "$ref": "#/components/schemas/CatalogAnalytics"
             },
-            "CatalogFieldWithAnalytics": {
-                "$ref": "#/components/schemas/CatalogField"
-            },
             "ApiMetricsCatalogResults": {
                 "items": {
-                    "$ref": "#/components/schemas/CatalogFieldWithAnalytics"
+                    "$ref": "#/components/schemas/CatalogField"
                 },
                 "type": "array"
             },
@@ -10763,7 +10760,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1328.0",
+        "version": "0.1330.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -388,20 +388,7 @@
                 "$ref": "#/components/schemas/CatalogAnalytics"
             },
             "CatalogFieldWithAnalytics": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/CatalogField"
-                    },
-                    {
-                        "properties": {
-                            "analytics": {
-                                "$ref": "#/components/schemas/CatalogAnalytics"
-                            }
-                        },
-                        "required": ["analytics"],
-                        "type": "object"
-                    }
-                ]
+                "$ref": "#/components/schemas/CatalogField"
             },
             "ApiMetricsCatalogResults": {
                 "items": {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -21,7 +21,6 @@ import {
     UserAttributeValueMap,
     type ApiSort,
     type CatalogFieldMap,
-    type CatalogFieldWithAnalytics,
     type ChartUsageUpdate,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -479,7 +478,7 @@ export class CatalogService<
         paginateArgs?: KnexPaginateArgs,
         { search }: ApiCatalogSearch = {},
         sortArgs?: ApiSort,
-    ): Promise<KnexPaginatedData<CatalogFieldWithAnalytics[]>> {
+    ): Promise<KnexPaginatedData<CatalogField[]>> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -11,6 +11,7 @@ import {
     Explore,
     ExploreError,
     ForbiddenError,
+    getItemId,
     hasIntersection,
     InlineErrorType,
     isExploreError,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -11,7 +11,6 @@ import {
     Explore,
     ExploreError,
     ForbiddenError,
-    getItemId,
     hasIntersection,
     InlineErrorType,
     isExploreError,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -499,7 +499,7 @@ export class CatalogService<
                 userUuid: user.userUuid,
             });
 
-        const paginatedCatalogMetrics = await this.searchCatalog(
+        const paginatedCatalog = await this.searchCatalog(
             projectUuid,
             userAttributes,
             search,
@@ -509,22 +509,15 @@ export class CatalogService<
             sortArgs,
         );
 
-        const { data: catalogMetrics, pagination } = paginatedCatalogMetrics;
-        const data = catalogMetrics
-            .filter(
-                (item): item is CatalogField => item.type === CatalogType.Field, // This is for type narrowing the values returned from `searchCatalog`
-            )
-            // TODO: to be removed after chart_usage
-            .map<CatalogFieldWithAnalytics>((metric) => ({
-                ...metric,
-                analytics: {
-                    charts: [],
-                },
-            }));
+        const { data: catalogMetrics, pagination } = paginatedCatalog;
+
+        const paginatedCatalogMetrics = catalogMetrics.filter(
+            (item): item is CatalogField => item.type === CatalogType.Field, // This is for type narrowing the values returned from `searchCatalog`
+        );
 
         return {
             pagination,
-            data,
+            data: paginatedCatalogMetrics,
         };
     }
 

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -64,9 +64,7 @@ export type CatalogTable = Pick<
 export type CatalogItem = CatalogField | CatalogTable;
 export type ApiCatalogResults = CatalogItem[];
 
-export type CatalogFieldWithAnalytics = CatalogField & {
-    analytics: CatalogAnalytics;
-};
+export type CatalogFieldWithAnalytics = CatalogField;
 export type ApiMetricsCatalogResults = CatalogFieldWithAnalytics[];
 
 export type ApiMetricsCatalog = {

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -64,8 +64,7 @@ export type CatalogTable = Pick<
 export type CatalogItem = CatalogField | CatalogTable;
 export type ApiCatalogResults = CatalogItem[];
 
-export type CatalogFieldWithAnalytics = CatalogField;
-export type ApiMetricsCatalogResults = CatalogFieldWithAnalytics[];
+export type ApiMetricsCatalogResults = CatalogField[];
 
 export type ApiMetricsCatalog = {
     status: 'ok';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartsUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartsUsageModal.tsx
@@ -1,26 +1,17 @@
-import {
-    Anchor,
-    Group,
-    List,
-    Modal,
-    Stack,
-    Text,
-    type ModalProps,
-} from '@mantine/core';
+import { Group, Modal, Stack, Text, type ModalProps } from '@mantine/core';
 import { IconDeviceAnalytics } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useAppSelector } from '../../sqlRunner/store/hooks';
 
 type Props = ModalProps;
 
 export const MetricChartsUsageModal: FC<Props> = ({ opened, onClose }) => {
-    const activeMetric = useAppSelector(
-        (state) => state.metricsCatalog.activeMetric,
-    );
-    const projectUuid = useAppSelector(
-        (state) => state.metricsCatalog.projectUuid,
-    );
+    // const activeMetric = useAppSelector(
+    //     (state) => state.metricsCatalog.activeMetric,
+    // );
+    // const projectUuid = useAppSelector(
+    //     (state) => state.metricsCatalog.projectUuid,
+    // );
 
     return (
         <Modal
@@ -43,7 +34,8 @@ export const MetricChartsUsageModal: FC<Props> = ({ opened, onClose }) => {
         >
             <Stack p="md" spacing="xs">
                 <Text>This metric is used in the following charts:</Text>
-                <List pl="sm">
+                {/* TODO: Add charts usage endpoint query data here */}
+                {/* <List pl="sm">
                     {activeMetric?.analytics?.charts.map((chart) => (
                         <List.Item key={chart.uuid} fz="sm">
                             <Anchor
@@ -54,7 +46,7 @@ export const MetricChartsUsageModal: FC<Props> = ({ opened, onClose }) => {
                             </Anchor>
                         </List.Item>
                     ))}
-                </List>
+                </List> */}
             </Stack>
         </Modal>
     );

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,7 +1,4 @@
-import {
-    friendlyName,
-    type CatalogFieldWithAnalytics,
-} from '@lightdash/common';
+import { friendlyName, type CatalogField } from '@lightdash/common';
 import { Box, Button, HoverCard, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
@@ -31,11 +28,7 @@ import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricsCatalog } from '../hooks/useMetricsCatalog';
 import { setActiveMetric } from '../store/metricsCatalogSlice';
 
-const MetricUsageButton = ({
-    row,
-}: {
-    row: MRT_Row<CatalogFieldWithAnalytics>;
-}) => {
+const MetricUsageButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
     const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
     const dispatch = useAppDispatch();
     return (
@@ -60,7 +53,7 @@ const MetricUsageButton = ({
     );
 };
 
-const columns: MRT_ColumnDef<CatalogFieldWithAnalytics>[] = [
+const columns: MRT_ColumnDef<CatalogField>[] = [
     {
         accessorKey: 'name',
         header: 'Metric Name',
@@ -103,11 +96,7 @@ const columns: MRT_ColumnDef<CatalogFieldWithAnalytics>[] = [
     },
 ];
 
-const UseMetricButton = ({
-    row,
-}: {
-    row: MRT_Row<CatalogFieldWithAnalytics>;
-}) => {
+const UseMetricButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
     const [currentTableName, setCurrentTableName] = useState<string>();
     const { data: explore, isFetching } = useExplore(currentTableName);
     const [isNavigating, setIsNavigating] = useState(false);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -36,7 +36,7 @@ const MetricUsageButton = ({
 }: {
     row: MRT_Row<CatalogFieldWithAnalytics>;
 }) => {
-    const hasChartsUsage = row.original.analytics?.charts.length > 0;
+    const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
     const dispatch = useAppDispatch();
     return (
         <Button
@@ -55,9 +55,7 @@ const MetricUsageButton = ({
                 },
             }}
         >
-            {hasChartsUsage
-                ? `${row.original.analytics?.charts.length} uses`
-                : 'No usage'}
+            {hasChartsUsage ? `${row.original.chartUsage} uses` : 'No usage'}
         </Button>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -1,4 +1,4 @@
-import type { CatalogFieldWithAnalytics } from '@lightdash/common';
+import type { CatalogField } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 type MetricsCatalogState = {
@@ -7,7 +7,7 @@ type MetricsCatalogState = {
             isOpen: boolean;
         };
     };
-    activeMetric: CatalogFieldWithAnalytics | undefined;
+    activeMetric: CatalogField | undefined;
     projectUuid: string | undefined;
 };
 
@@ -30,7 +30,7 @@ export const metricsCatalogSlice = createSlice({
         },
         setActiveMetric: (
             state,
-            action: PayloadAction<CatalogFieldWithAnalytics | undefined>,
+            action: PayloadAction<CatalogField | undefined>,
         ) => {
             state.activeMetric = action.payload;
             state.modals.chartUsageModal.isOpen = !!action.payload;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12104

### Description:

<img width="221" alt="image" src="https://github.com/user-attachments/assets/37a85777-9d00-4f15-8dfb-b6eb03a66c7e">

> [!NOTE]
> Will get the charts per field endpoint working on a separate PR

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
