### PR TITLE
fix: allow stacking in ungrouped bar charts

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -346,39 +346,37 @@ export const Layout: FC<Props> = ({ items }) => {
                                 );
                             })}
                     </Stack>
-                    {pivotDimensions &&
-                        pivotDimensions.length > 0 &&
-                        canBeStacked && (
-                            <Tooltip
-                                variant="xs"
-                                label="x-axis must be non-numeric to enable stacking"
-                                withinPortal
-                                position="top-start"
-                                disabled={!isXAxisFieldNumeric}
-                            >
-                                <Group spacing="xs">
-                                    <Config.Label>Stacking</Config.Label>
-                                    <SegmentedControl
-                                        disabled={isXAxisFieldNumeric}
-                                        value={
-                                            !isXAxisFieldNumeric && isStacked
-                                                ? 'stack'
-                                                : 'noStacking'
-                                        }
-                                        onChange={(value) =>
-                                            setStacking(value === 'stack')
-                                        }
-                                        data={[
-                                            {
-                                                label: 'None',
-                                                value: 'noStacking',
-                                            },
-                                            { label: 'Stack', value: 'stack' },
-                                        ]}
-                                    />
-                                </Group>
-                            </Tooltip>
-                        )}
+                    {canBeStacked && (
+                        <Tooltip
+                            variant="xs"
+                            label="x-axis must be non-numeric to enable stacking"
+                            withinPortal
+                            position="top-start"
+                            disabled={!isXAxisFieldNumeric}
+                        >
+                            <Group spacing="xs">
+                                <Config.Label>Stacking</Config.Label>
+                                <SegmentedControl
+                                    disabled={isXAxisFieldNumeric}
+                                    value={
+                                        !isXAxisFieldNumeric && isStacked
+                                            ? 'stack'
+                                            : 'noStacking'
+                                    }
+                                    onChange={(value) =>
+                                        setStacking(value === 'stack')
+                                    }
+                                    data={[
+                                        {
+                                            label: 'None',
+                                            value: 'noStacking',
+                                        },
+                                        { label: 'Stack', value: 'stack' },
+                                    ]}
+                                />
+                            </Group>
+                        </Tooltip>
+                    )}
                 </Config.Section>
             </Config>
         </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8701 

### Description:

Allow stacking in ungrouped bar charts. It seems like mostly we were hiding the control for this. It seems to work well with the control available. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
