### PR TITLE
feat: allow sorting by popularity and by default

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,4 +1,8 @@
-import { friendlyName, type CatalogField } from '@lightdash/common';
+import {
+    friendlyName,
+    type CatalogField,
+    type CatalogItem,
+} from '@lightdash/common';
 import { Box, Button, HoverCard, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
@@ -89,9 +93,9 @@ const columns: MRT_ColumnDef<CatalogField>[] = [
         Cell: ({ row }) => <Text fw={500}>{row.original.tableName}</Text>,
     },
     {
-        accessorKey: 'usage',
-        header: 'Usage',
-        enableSorting: false,
+        accessorKey: 'chartUsage',
+        header: 'Popularity',
+        enableSorting: true,
         Cell: ({ row }) => <MetricUsageButton row={row} />,
     },
 ];
@@ -149,15 +153,23 @@ export const MetricsTable = () => {
     const [search, setSearch] = useState<string | undefined>(undefined);
     const deferredSearch = useDeferredValue(search);
 
-    const [sorting, setSorting] = useState<MRT_SortingState>([]);
+    // Enable sorting by highest popularity(how many charts use the metric) by default
+    const initialSorting = [
+        {
+            id: 'chartUsage',
+            desc: true,
+        },
+    ];
+
+    const [sorting, setSorting] = useState<MRT_SortingState>(initialSorting);
 
     const { data, fetchNextPage, hasNextPage, isFetching } = useMetricsCatalog({
         projectUuid,
         pageSize: 20,
         search: deferredSearch,
-        // TODO: Handle multiple sorting - for now just use the first one - metric name
+        // TODO: Handle multiple sorting - this needs to be enabled and handled later in the backend
         ...(sorting.length > 0 && {
-            sortBy: sorting[0].id,
+            sortBy: sorting[0].id as keyof CatalogItem,
             sortDirection: sorting[0].desc ? 'desc' : 'asc',
         }),
     });

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -10,7 +10,8 @@ import { lightdashApi } from '../../../api';
 type UseMetricsCatalogOptions = {
     projectUuid?: string;
     search?: string;
-    sortBy?: ApiSort['sort'];
+    // TODO: update with the expected sort options that the backend can handle; also, update to a different type when multiple sorting is enabled
+    sortBy?: ApiSort['sort'] | 'name' | 'chartUsage';
     sortDirection?: ApiSort['order'];
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12104 

### Description:

Can sort by popularity/chart usage and it's sorted DESC by default

demo


https://github.com/user-attachments/assets/60065f91-dee2-47ab-b1f9-77f5732d8138



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
