### PR TITLE
style: apply small ui/ux improvements (part 3)

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -106,6 +106,7 @@ const columns: MRT_ColumnDef<CatalogField>[] = [
         accessorKey: 'directory',
         header: 'Table',
         enableSorting: false,
+        size: 150,
         Cell: ({ row }) => <Text fw={500}>{row.original.tableName}</Text>,
     },
     {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -48,6 +48,7 @@ const MetricUsageButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
             }
             leftIcon={
                 <MantineIcon
+                    display={hasChartsUsage ? 'block' : 'none'}
                     icon={IconChartBar}
                     color="gray.6"
                     size={12}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -4,6 +4,7 @@ import {
     type CatalogItem,
 } from '@lightdash/common';
 import { Box, Button, HoverCard, Text } from '@mantine/core';
+import { IconChartBar } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
     MantineReactTable,
@@ -22,6 +23,7 @@ import {
     useState,
     type UIEvent,
 } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { useExplore } from '../../../hooks/useExplore';
 import {
     createMetricPreviewUnsavedChartVersion,
@@ -38,11 +40,20 @@ const MetricUsageButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
         <Button
             size="xs"
             compact
-            color="indigo"
-            variant="subtle"
+            color="gray.6"
+            variant="default"
             disabled={!hasChartsUsage}
             onClick={() =>
                 hasChartsUsage && dispatch(setActiveMetric(row.original))
+            }
+            leftIcon={
+                <MantineIcon
+                    icon={IconChartBar}
+                    color="gray.6"
+                    size={12}
+                    strokeWidth={1.2}
+                    fill="gray.2"
+                />
             }
             sx={{
                 '&[data-disabled]': {
@@ -50,8 +61,13 @@ const MetricUsageButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
                     fontWeight: 400,
                 },
             }}
+            styles={{
+                leftIcon: {
+                    marginRight: 4,
+                },
+            }}
         >
-            {hasChartsUsage ? `${row.original.chartUsage} uses` : 'No usage'}
+            {hasChartsUsage ? `${row.original.chartUsage}` : 'No usage'}
         </Button>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -266,7 +266,7 @@ export const MetricsTable = () => {
         state: {
             sorting,
             showProgressBars: isFetching,
-            density: 'xs',
+            density: 'md',
         },
         initialState: {
             showGlobalFilter: true, // Show search input by default

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -69,6 +69,7 @@ const columns: MRT_ColumnDef<CatalogField>[] = [
         accessorKey: 'description',
         header: 'Description',
         enableSorting: false,
+        size: 400,
         Cell: ({ row }) => (
             <HoverCard withinPortal shadow="lg" position="right">
                 <HoverCard.Target>
@@ -95,6 +96,7 @@ const columns: MRT_ColumnDef<CatalogField>[] = [
         accessorKey: 'chartUsage',
         header: 'Popularity',
         enableSorting: true,
+        size: 100,
         Cell: ({ row }) => <MetricUsageButton row={row} />,
     },
 ];

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -245,6 +245,11 @@ export const MetricsTable = () => {
         mantineTableHeadRowProps: {
             sx: {
                 boxShadow: 'none',
+                // Each head row has a divider when resizing columns is enabled
+                'th > div > div:last-child': {
+                    width: '0.5px',
+                    padding: '0px',
+                },
             },
         },
         mantineSearchTextInputProps: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12167

### Description:

AC: 

 

- [ ] Make padding in each cell 16px
- [ ]  Hide the resizable column drag handle
- [ ]  Set a width to description column - make it wider
- [ ]  Change appearance of the contents in the Usage column (basically make it clear that this refers to saved charts)


> [!IMPORTANT]
> I couldn't hide the drag handle, but made the width smaller - is this acceptable?

demo:


https://github.com/user-attachments/assets/4949ed8f-4f53-45a1-8f9f-e03a6da56561




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
