### PR TITLE
fix: view underlying data with a null date

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
@@ -89,7 +89,6 @@ id,user_id,order_date,status
 88,91,2018-03-27,shipped
 89,21,2018-03-28,placed
 90,66,2018-03-30,shipped
-100,85,null,placed
 91,47,2018-03-31,placed
 92,84,2018-04-02,placed
 93,66,2018-04-03,placed

--- a/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
@@ -99,4 +99,3 @@ id,user_id,order_date,status
 98,41,2018-04-07,placed
 99,85,2018-04-09,placed
 100,85,null,placed
-

--- a/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
@@ -89,6 +89,7 @@ id,user_id,order_date,status
 88,91,2018-03-27,shipped
 89,21,2018-03-28,placed
 90,66,2018-03-30,shipped
+100,85,null,placed
 91,47,2018-03-31,placed
 92,84,2018-04-02,placed
 93,66,2018-04-03,placed
@@ -98,4 +99,3 @@ id,user_id,order_date,status
 97,89,2018-04-07,placed
 98,41,2018-04-07,placed
 99,85,2018-04-09,placed
-100,85,null,placed

--- a/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_orders.csv
@@ -98,3 +98,5 @@ id,user_id,order_date,status
 97,89,2018-04-07,placed
 98,41,2018-04-07,placed
 99,85,2018-04-09,placed
+100,85,null,placed
+

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1085,7 +1085,7 @@ function formatRawValue(
         (field.type === DimensionType.DATE ||
             field.type === DimensionType.TIMESTAMP);
 
-    if (isTimestamp) {
+    if (isTimestamp && value !== null) {
         // We want to return the datetime in UTC to avoid timezone issues in the frontend like in chart tooltips
         return dayjs(value).utc(true).format();
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12201 

### Description:

This fixes an issue where clicking 'view underlying data' with a null date caused an error in the dialog (see video). The fix is small and a seems a little unrelated from the bug, but it makes our date handling more correct. The fix is to return null when a date field is null; before were were trying to parse null as a date and returning 'Invalid date' as a date. The underlying data dialog was then trying to use 'Invalid date' as a filter value, causing the error. 

This fix will change the way null dates are returned from runQuery. I don't know if there are other places that were relying on the old (broken) behavior. This is definitely more correct though. 

To test:
- use the orders model and choose oder date day as one of the fields
- filter such that orders date day isNull (in this branch there will be a null value)
- view underlying data
- this throws an error in main, it should be fixed in this branch

Repro WITH the bug (main)
![Kapture 2024-11-01 at 14 46 30](https://github.com/user-attachments/assets/d9ebd61b-e445-4ced-b44b-391599f06b54)

Behavior with this fix
![Kapture 2024-11-01 at 14 44 41](https://github.com/user-attachments/assets/3ec97442-637e-4951-b815-606f4e751c4d)


test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
