### PR TITLE
style: use font `Inter` in MetricsCatalog

### DIFF
--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -1,20 +1,32 @@
+import { MantineProvider } from '@mantine/core';
 import { type FC } from 'react';
 import { Provider } from 'react-redux';
 import Page from '../components/common/Page/Page';
 import { MetricsCatalogPanel } from '../features/metricsCatalog';
 import { store } from '../features/sqlRunner/store';
+import { getMantineThemeOverride } from '../mantineTheme';
 
 const MetricsCatalog: FC = () => {
     return (
         <Provider store={store}>
-            <Page
-                withFitContent
-                withPaddedContent
-                withRightSidebar
-                withLargeContent
+            <MantineProvider
+                theme={{
+                    // TODO: Introduce Inter as a font in the theme globally
+                    ...getMantineThemeOverride(),
+                    fontFamily: `Inter, ${
+                        getMantineThemeOverride().fontFamily
+                    }`,
+                }}
             >
-                <MetricsCatalogPanel />
-            </Page>
+                <Page
+                    withFitContent
+                    withPaddedContent
+                    withRightSidebar
+                    withLargeContent
+                >
+                    <MetricsCatalogPanel />
+                </Page>
+            </MantineProvider>
         </Provider>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12194

### Description:


overrides the main font family to `inter` just in Metrics Catalog for now 
Added a TODO to address this override and enable it globally if no issues are found.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
