### PR TITLE
feat: change user 'isActive' definition

### DIFF
--- a/packages/backend/src/database/migrations/20241104104713_reset_users_active_status.ts
+++ b/packages/backend/src/database/migrations/20241104104713_reset_users_active_status.ts
@@ -1,0 +1,44 @@
+import { Knex } from 'knex';
+import { OpenIdIdentitiesTableName } from '../entities/openIdIdentities';
+import { PasswordLoginTableName } from '../entities/passwordLogins';
+import { UserTableName } from '../entities/users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex('users').update({
+        is_active: true,
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const users = await knex(UserTableName)
+        .leftJoin(
+            PasswordLoginTableName,
+            `${UserTableName}.user_id`,
+            `${PasswordLoginTableName}.user_id`,
+        )
+        .leftJoin(
+            OpenIdIdentitiesTableName,
+            `${UserTableName}.user_id`,
+            `${OpenIdIdentitiesTableName}.user_id`,
+        )
+        .select<
+            { user_id: string; user_uuid: string; has_authentication: false }[]
+        >(
+            `${UserTableName}.user_id`,
+            knex.raw(
+                `CASE WHEN COALESCE(password_logins.user_id, openid_identities.user_id, null) IS NOT NULL THEN TRUE ELSE FALSE END as has_authentication`,
+            ),
+        )
+        .distinctOn(`user_id`);
+    const queries: Promise<number>[] = [];
+    users.forEach((user) => {
+        queries.push(
+            knex('users')
+                .update({
+                    is_active: user.has_authentication,
+                })
+                .where('user_id', user.user_id),
+        );
+    });
+    await Promise.all(queries);
+}

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -162,14 +162,19 @@ export class OrganizationMemberProfileModel {
                 userUuids: data.map((m) => m.user_uuid),
             });
 
+        const usersHaveAuthenticationMap = new Map(
+            usersHaveAuthenticationRows.map((row) => [
+                row.user_uuid,
+                row.has_authentication,
+            ]),
+        );
+
         return {
             pagination,
             data: data.map((m) =>
                 OrganizationMemberProfileModel.parseRow(
                     m,
-                    usersHaveAuthenticationRows.find(
-                        (row) => row.user_uuid === m.user_uuid,
-                    )?.has_authentication,
+                    usersHaveAuthenticationMap.get(m.user_uuid) || false,
                 ),
             ),
         };
@@ -285,15 +290,19 @@ export class OrganizationMemberProfileModel {
             await UserModel.findIfUsersHaveAuthentication(this.database, {
                 userUuids: updatedMembers.map((m) => m.user_uuid),
             });
+        const usersHaveAuthenticationMap = new Map(
+            usersHaveAuthenticationRows.map((row) => [
+                row.user_uuid,
+                row.has_authentication,
+            ]),
+        );
 
         return {
             pagination,
             data: updatedMembers.map((m) => ({
                 ...OrganizationMemberProfileModel.parseRow(
                     m,
-                    usersHaveAuthenticationRows.find(
-                        (row) => row.user_uuid === m.user_uuid,
-                    )?.has_authentication,
+                    usersHaveAuthenticationMap.get(m.user_uuid) || false,
                 ),
                 groups: m.groups,
             })),
@@ -314,13 +323,17 @@ export class OrganizationMemberProfileModel {
             await UserModel.findIfUsersHaveAuthentication(this.database, {
                 userUuids: members.map((m) => m.user_uuid),
             });
+        const usersHaveAuthenticationMap = new Map(
+            usersHaveAuthenticationRows.map((row) => [
+                row.user_uuid,
+                row.has_authentication,
+            ]),
+        );
 
         return members.map((m) =>
             OrganizationMemberProfileModel.parseRow(
                 m,
-                usersHaveAuthenticationRows.find(
-                    (row) => row.user_uuid === m.user_uuid,
-                )?.has_authentication,
+                usersHaveAuthenticationMap.get(m.user_uuid) || false,
             ),
         );
     }

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -138,18 +138,6 @@ export class UserModel {
             .merge();
     }
 
-    /**
-     *  select
-     *  "users"."user_uuid",
-     *  CASE WHEN COALESCE(password_logins.user_id, openid_identities.user_id, null) IS NOT NULL THEN TRUE ELSE FALSE END as has_authentication
-     *  from "users"
-     *  left join "password_logins" on "users"."user_id" = "password_logins"."user_id"
-     *  left join "openid_identities" on "users"."user_id" = "openid_identities"."user_id"
-     *  where "users"."user_uuid" in ($1)
-     *  group by "users"."user_uuid"
-     *  - column "password_logins.user_id" must appear in the GROUP BY clause or be used in an aggregate function
-     */
-
     static findIfUsersHaveAuthentication(
         trx: Knex,
         filters: { userUuids: string[] },

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -85,7 +85,7 @@ export const mapDbUserDetailsToLightdashUser = (
     isSetupComplete: user.is_setup_complete,
     role: user.role,
     isActive: user.is_active,
-    hasAuthentication,
+    isPending: !hasAuthentication,
 });
 
 const userDetailsQueryBuilder = (

--- a/packages/backend/src/services/UserService.mock.ts
+++ b/packages/backend/src/services/UserService.mock.ts
@@ -89,7 +89,7 @@ export const newUser: SessionUser = {
     userId: 0,
     role: inviteUser.role,
     ability: new Ability([]),
-    isActive: false,
+    isActive: true,
     abilityRules: [],
 };
 
@@ -106,5 +106,5 @@ export const userWithoutOrg: LightdashUser = {
     isTrackingAnonymized: false,
     isMarketingOptedIn: false,
     isSetupComplete: false,
-    isActive: false,
+    isActive: true,
 };

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -479,7 +479,7 @@ describe('UserService', () => {
             (userModel.findUserByEmail as jest.Mock).mockImplementationOnce(
                 async () => ({
                     ...userWithoutOrg,
-                    isActive: false,
+                    isPending: true,
                     organizationUuid: sessionUser.organizationUuid,
                 }),
             );

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -366,7 +366,7 @@ export class UserService extends BaseService {
                 throw new ParameterError(
                     'Email is already used by a user in another organization',
                 );
-            } else if (existingUserWithEmail.isActive) {
+            } else if (existingUserWithEmail.hasAuthentication) {
                 throw new ParameterError(
                     'Email is already used by a user in your organization',
                 );
@@ -1014,7 +1014,13 @@ export class UserService extends BaseService {
         const updatedUser = await this.userModel.updateUser(
             user.userUuid,
             user.email,
-            data,
+            {
+                firstName: data.firstName,
+                lastName: data.lastName,
+                email: data.email,
+                isMarketingOptedIn: data.isMarketingOptedIn,
+                isTrackingAnonymized: data.isTrackingAnonymized,
+            },
         );
         this.identifyUser(updatedUser);
         this.analytics.track({

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -366,7 +366,7 @@ export class UserService extends BaseService {
                 throw new ParameterError(
                     'Email is already used by a user in another organization',
                 );
-            } else if (existingUserWithEmail.hasAuthentication) {
+            } else if (!existingUserWithEmail.isPending) {
                 throw new ParameterError(
                     'Email is already used by a user in your organization',
                 );

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -31,7 +31,7 @@ export type OrganizationMemberProfile = {
      */
     role: OrganizationMemberRole;
     /**
-     * Whether the user has accepted their invite to the organization
+     * Whether the user can login
      */
     isActive: boolean;
     /**
@@ -39,7 +39,7 @@ export type OrganizationMemberProfile = {
      */
     isInviteExpired?: boolean;
     /**
-     * Whether the user has a pending invite to the organization
+     * Whether the user doesn't have an authentication method (password or openId)
      */
     isPending?: boolean;
 };

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -16,6 +16,7 @@ export interface LightdashUser {
     isSetupComplete: boolean;
     role?: OrganizationMemberRole;
     isActive: boolean;
+    hasAuthentication: boolean;
 }
 
 export type LightdashUserWithOrg = Required<LightdashUser>;

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -15,8 +15,14 @@ export interface LightdashUser {
     isMarketingOptedIn: boolean;
     isSetupComplete: boolean;
     role?: OrganizationMemberRole;
+    /**
+     * Whether the user can login
+     */
     isActive: boolean;
-    hasAuthentication: boolean;
+    /**
+     * Whether the user doesn't have an authentication method (password or openId)
+     */
+    isPending?: boolean;
 }
 
 export type LightdashUserWithOrg = Required<LightdashUser>;

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -62,28 +62,27 @@ const UserNameDisplay: FC<{
 }> = ({ user, showInviteLink, hasEmail, onGetLink }) => {
     return (
         <Flex justify="space-between" align="center">
-            {user.isActive ? (
-                <Stack spacing="xxs">
-                    <Title order={6}>
-                        {user.firstName} {user.lastName}
+            {!user.isActive ? (
+                <Stack spacing="xxs" align="flex-start">
+                    <Title order={6} color="gray.6">
+                        {user.firstName
+                            ? `${user.firstName} ${user.lastName}`
+                            : user.email}
                     </Title>
-
-                    {user.email && (
-                        <Badge
-                            variant="filled"
-                            color="gray.2"
-                            radius="xs"
-                            sx={{ textTransform: 'none' }}
-                            px="xxs"
-                        >
-                            <Text fz="xs" fw={400} color="gray.8">
-                                {user.email}
-                            </Text>
-                        </Badge>
-                    )}
+                    <Badge
+                        variant="filled"
+                        color="red.4"
+                        radius="xs"
+                        sx={{ textTransform: 'none' }}
+                        px="xxs"
+                    >
+                        <Text fz="xs" fw={400} color="gray.8">
+                            Inactive
+                        </Text>
+                    </Badge>
                 </Stack>
-            ) : user.isInviteExpired || user.isPending ? (
-                <Stack spacing="xxs">
+            ) : user.isPending ? (
+                <Stack spacing="xxs" align="flex-start">
                     {user.email && <Title order={6}>{user.email}</Title>}
                     <Group spacing="xs">
                         <Badge
@@ -112,21 +111,24 @@ const UserNameDisplay: FC<{
                     </Group>
                 </Stack>
             ) : (
-                <Stack spacing="xxs">
-                    <Title order={6} color="gray.6">
+                <Stack spacing="xxs" align="flex-start">
+                    <Title order={6}>
                         {user.firstName} {user.lastName}
                     </Title>
-                    <Badge
-                        variant="filled"
-                        color="red.4"
-                        radius="xs"
-                        sx={{ textTransform: 'none' }}
-                        px="xxs"
-                    >
-                        <Text fz="xs" fw={400} color="gray.8">
-                            Inactive
-                        </Text>
-                    </Badge>
+
+                    {user.email && (
+                        <Badge
+                            variant="filled"
+                            color="gray.2"
+                            radius="xs"
+                            sx={{ textTransform: 'none' }}
+                            px="xxs"
+                        >
+                            <Text fz="xs" fw={400} color="gray.8">
+                                {user.email}
+                            </Text>
+                        </Badge>
+                    )}
                 </Stack>
             )}
         </Flex>

--- a/packages/frontend/src/features/comments/components/CommentForm.tsx
+++ b/packages/frontend/src/features/comments/components/CommentForm.tsx
@@ -48,7 +48,7 @@ export const CommentForm: FC<Props> = ({
     const userNames: SuggestionsItem[] | undefined = useMemo(() => {
         if (!listUsers || !space?.access) return undefined;
         return listUsers.reduce<SuggestionsItem[]>((acc, user) => {
-            if (!user.isActive) return acc;
+            if (user.isPending) return acc;
 
             return [
                 ...acc,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash-commercial/issues/324<!-- reference the related issue e.g. #150 -->

### Description:

We want user accounts marked with isActive = false to not have access to Lightdash. 

At the moment, is_active is being used to track what users were invited but haven't logged in yet aka don't have an authentication method.

The variable/value is used in these places:

https://github.com/lightdash/lightdash/blob/547ad8083fc47a848b33110ea6a09f440c7b160f/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx#L65

https://github.com/lightdash/lightdash/blob/1dd45b035b9485c6f646f68a4a4a5520eca15010/packages/frontend/src/features/comments/components/CommentForm.tsx#L51

https://github.com/lightdash/lightdash/blob/fa0c44aff40c8a86a5dd1ae0dda91a58be09c8a1/packages/backend/src/services/UserService.ts#L369

https://github.com/lightdash/lightdash/blob/f87a352b7f19b1af9fce1fa414bb84e49d6de185/packages/backend/src/models/OrganizationMemberProfileModel.ts#L86

First, we need to adjust our logic to not rely on isActive to determine if a user is pending (aka hasn't accepted the invite ).
We would have to update the logic to check if the user already has an authentication method.

What I changed:
- add migration so `is_active` is `true` for all users
- update models to fetch if the user has authentication methods and based on that determine their `isPending` status.
- update logic that depending on `isActive` to now use `isPending` 
- misc of fixes (check PR comments)

(note that you can only set a user to be inactive by changing the DB)
<img width="902" alt="Screenshot 2024-11-04 at 13 21 29" src="https://github.com/user-attachments/assets/4dc07e0f-cfb9-4281-b295-1e7e43cb41f1">

### Test:
✅ authenticate with user
✅ invite user
✅ accept invite 
✅ tested migration rollback and forward with pending users

## Next PRs

In the second PR, we can update the code to block non active users from using Lightdash.

In the third PR, have a way for admins to activate/deactivate users in the UI.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
