### PR TITLE
fix: comments feature enable by default for self-host

### DIFF
--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useFeatureFlagEnabled as useFeatureFlagEnabledPosthog } from 'posthog-js/react';
 import { type UserWithAbility } from '../../../hooks/user/useUser';
 
 export const useDashboardCommentsCheck = (
@@ -15,9 +15,9 @@ export const useDashboardCommentsCheck = (
         'DashboardComments',
     );
 
-    const isDashboardCommentsEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardComments,
-    );
+    // We want to keep this flag enabled by default, so users on self-hosting can use this feature
+    const isDashboardCommentsEnabled =
+        useFeatureFlagEnabledPosthog(FeatureFlags.DashboardComments) !== false;
 
     return {
         canViewDashboardComments:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Thread: https://lightdash.slack.com/archives/C03MCQ08UKS/p1730729911553919?thread_ts=1730715499.115549&cid=C03MCQ08UKS

If posthog is not used, `useFeatureFlagEnabledPosthog(FeatureFlags.DashboardComments)` returns `undefined`

![Screenshot from 2024-11-04 15-29-08](https://github.com/user-attachments/assets/0791e46c-6e02-4c81-b758-7eb63fc2aa2e)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
