### PR TITLE
fix: export to CSV failing for some dashboards

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -1196,7 +1196,8 @@ export class CsvService extends BaseService {
             options,
             overrideDashboardFilters: dashboardFilters,
             dateZoomGranularity,
-        });
+        }).then((urls) => urls.filter((url) => url.path !== '#no-results'));
+
         const zipFile = await writeZipFile(csvFiles);
 
         this.analytics.track({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

issue: export dashboard failed for csv option.

steps to reproduce:

1. open any dashboard.
2. create a chart tile with zero returned data.
3. export dashboard.

then it will throw this issue in the backend:
```
[backend] ArchiverError: file filepath argument must be a non-empty string value
[backend]     at Archiver.file (/usr/app/node_modules/archiver/lib/core.js:707:24)
[backend]     at <anonymous> (/usr/app/packages/backend/src/services/CsvService/CsvService.ts:1185:29)
[backend]     at Array.forEach (<anonymous>)
[backend]     at <anonymous> (/usr/app/packages/backend/src/services/CsvService/CsvService.ts:1184:23)
[backend]     at new Promise (<anonymous>)
[backend]     at writeZipFile (/usr/app/packages/backend/src/services/CsvService/CsvService.ts:1169:13)
[backend]     at CsvService.exportCsvDashboard (/usr/app/packages/backend/src/services/CsvService/CsvService.ts:1202:31)
[backend]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[backend]     at async <anonymous> (/usr/app/packages/backend/src/routers/dashboardRouter.ts:196:29) {
[backend]   code: 'FILEFILEPATHREQUIRED',
[backend]   data: undefined
[backend] }
```

root cause:
when tile is empty the csv file path is empty but not being filter out before creating the .zip file.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
