### PR TITLE
feat: block deactivated users from accessing Lightdash

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -140,7 +140,15 @@ export class SchedulerModel {
     }
 
     async getAllSchedulers(): Promise<SchedulerAndTargets[]> {
-        const schedulers = this.database(SchedulerTableName).select();
+        const schedulers = this.database(SchedulerTableName)
+            .select()
+            .join(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SchedulerTableName}.created_by`,
+            )
+            .where(`${SchedulerTableName}.enabled`, true)
+            .where(`${UserTableName}.is_active`, true);
         return this.getSchedulersWithTargets(await schedulers);
     }
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -8,6 +8,7 @@ import {
     CreateInviteLink,
     CreatePasswordResetLink,
     CreateUserArgs,
+    DeactivatedAccountError,
     DeleteOpenIdentity,
     EmailStatusExpiring,
     ExpiredError,
@@ -545,6 +546,10 @@ export class UserService extends BaseService {
         );
         // Identity already exists. Update the identity attributes and login the user
         if (openIdSession) {
+            if (!openIdSession.isActive) {
+                throw new DeactivatedAccountError();
+            }
+
             const organization = this.loginToOrganization(
                 openIdSession?.userUuid,
                 openIdUser.openId.issuerType,
@@ -952,6 +957,9 @@ export class UserService extends BaseService {
                 email,
                 password,
             );
+            if (!user.isActive) {
+                throw new DeactivatedAccountError();
+            }
             const userOrganization = this.loginToOrganization(
                 user.userUuid,
                 LocalIssuerTypes.EMAIL,
@@ -1162,6 +1170,9 @@ export class UserService extends BaseService {
             throw new AuthorizationError();
         }
         const { user, personalAccessToken } = results;
+        if (!user.isActive) {
+            throw new DeactivatedAccountError();
+        }
         const organization = this.loginToOrganization(
             user.userUuid,
             LocalIssuerTypes.API_TOKEN,

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -35,6 +35,20 @@ export class ForbiddenError extends LightdashError {
     }
 }
 
+export class DeactivatedAccountError extends LightdashError {
+    constructor(
+        message = 'Your account has been deactivated. Please contact your organization administrator.',
+        data: { [key: string]: any } = {},
+    ) {
+        super({
+            message,
+            name: 'DeactivatedAccountError',
+            statusCode: 403,
+            data,
+        });
+    }
+}
+
 export class AuthorizationError extends LightdashError {
     constructor(
         message = "You don't have authorization to perform this action",

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -18,7 +18,16 @@ const defaultHeaders = {
 };
 
 const handleError = (err: any): ApiError => {
-    if (err.error?.statusCode && err.error?.name) return err;
+    if (err.error?.statusCode && err.error?.name) {
+        if (
+            err.error?.name === 'DeactivatedAccountError' &&
+            window.location.pathname !== '/login'
+        ) {
+            // redirect to login page when account is deactivated
+            window.location.href = '/login';
+        }
+        return err;
+    }
     return {
         status: 'error',
         error: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash-commercial/issues/324

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

We want user accounts marked with isActive = false to not have access to Lightdash. The experience should be:

- if they aren’t signed in: they see an error trying to sign in
- if they are signed in: on the next action they are signed out and redirected to /login

Note: we need to change the value in the DB to test.

Fail with password

https://github.com/user-attachments/assets/e54afa0f-9007-42e3-8db2-851f23beb1d7

Fail with oauth

https://github.com/user-attachments/assets/767316e1-3725-40c8-b4f4-4b30b6166af5

Session destroyed & redirect to /login page ( the error message might show for a brief moment depending on the error handling in the page. Depriotized this as it is an edge case and haven't found of a solution that covers all places )

https://github.com/user-attachments/assets/ab6f57f4-80dc-4d9b-833f-c2921bb600aa




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
