### PR TITLE
refactor: split metrics table components into multiple

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,0 +1,72 @@
+import { type CatalogField } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { type MRT_Row } from 'mantine-react-table';
+import { useState } from 'react';
+import { useExplore } from '../../../hooks/useExplore';
+import {
+    createMetricPreviewUnsavedChartVersion,
+    getExplorerUrlFromCreateSavedChartVersion,
+} from '../../../hooks/useExplorerRoute';
+import { useTracking } from '../../../providers/TrackingProvider';
+import { EventName } from '../../../types/Events';
+import { useAppSelector } from '../../sqlRunner/store/hooks';
+
+type Props = {
+    row: MRT_Row<CatalogField>;
+};
+
+export const ExploreMetricButton = ({ row }: Props) => {
+    const [isGeneratingPreviewUrl, setIsGeneratingPreviewUrl] = useState(false);
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
+    const [currentTableName, setCurrentTableName] = useState<string>();
+    const { track } = useTracking();
+    const { isFetching } = useExplore(currentTableName, {
+        onSuccess(explore) {
+            if (!!currentTableName && explore && projectUuid) {
+                setIsGeneratingPreviewUrl(true);
+                const unsavedChartVersion =
+                    createMetricPreviewUnsavedChartVersion(
+                        row.original,
+                        explore,
+                    );
+
+                const { pathname, search } =
+                    getExplorerUrlFromCreateSavedChartVersion(
+                        projectUuid,
+                        unsavedChartVersion,
+                    );
+                const url = new URL(pathname, window.location.origin);
+                url.search = new URLSearchParams(search).toString();
+
+                window.open(url.href, '_blank');
+                setIsGeneratingPreviewUrl(false);
+                setCurrentTableName(undefined);
+            }
+        },
+    });
+
+    const handleExploreClick = () => {
+        track({
+            name: EventName.METRICS_CATALOG_EXPLORE_CLICKED,
+            properties: {
+                metricName: row.original.name,
+                tableName: row.original.tableName,
+            },
+        });
+        setCurrentTableName(row.original.tableName);
+    };
+
+    return (
+        <Button
+            size="xs"
+            compact
+            variant="subtle"
+            onClick={handleExploreClick}
+            loading={isFetching || isGeneratingPreviewUrl}
+        >
+            Explore
+        </Button>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
@@ -1,0 +1,67 @@
+import { type CatalogField } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconChartBar } from '@tabler/icons-react';
+import { type MRT_Row } from 'mantine-react-table';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useTracking } from '../../../providers/TrackingProvider';
+import { EventName } from '../../../types/Events';
+import { useAppDispatch } from '../../sqlRunner/store/hooks';
+import { setActiveMetric } from '../store/metricsCatalogSlice';
+
+export const MetricChartUsageButton = ({
+    row,
+}: {
+    row: MRT_Row<CatalogField>;
+}) => {
+    const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
+    const dispatch = useAppDispatch();
+    const { track } = useTracking();
+
+    const handleChartUsageClick = () => {
+        if (hasChartsUsage) {
+            track({
+                name: EventName.METRICS_CATALOG_CHART_USAGE_CLICKED,
+                properties: {
+                    metricName: row.original.name,
+                    chartCount: row.original.chartUsage ?? 0,
+                    tableName: row.original.tableName,
+                },
+            });
+            dispatch(setActiveMetric(row.original));
+        }
+    };
+
+    return (
+        <Button
+            size="xs"
+            compact
+            color="gray.6"
+            variant="default"
+            disabled={!hasChartsUsage}
+            onClick={handleChartUsageClick}
+            leftIcon={
+                <MantineIcon
+                    display={hasChartsUsage ? 'block' : 'none'}
+                    icon={IconChartBar}
+                    color="gray.6"
+                    size={12}
+                    strokeWidth={1.2}
+                    fill="gray.2"
+                />
+            }
+            sx={{
+                '&[data-disabled]': {
+                    backgroundColor: 'transparent',
+                    fontWeight: 400,
+                },
+            }}
+            styles={{
+                leftIcon: {
+                    marginRight: 4,
+                },
+            }}
+        >
+            {hasChartsUsage ? `${row.original.chartUsage}` : 'No usage'}
+        </Button>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -16,7 +16,7 @@ import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricChartAnalytics } from '../hooks/useMetricChartAnalytics';
 type Props = ModalProps;
 
-export const MetricChartsUsageModal: FC<Props> = ({ opened, onClose }) => {
+export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     const { track } = useTracking();
     const activeMetric = useAppSelector(
         (state) => state.metricsCatalog.activeMetric,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,0 +1,64 @@
+import { type CatalogField } from '@lightdash/common';
+import { Highlight, HoverCard, Text } from '@mantine/core';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { type MRT_ColumnDef } from 'mantine-react-table';
+import { MetricChartUsageButton } from './MetricChartUsageButton';
+
+export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
+    {
+        accessorKey: 'name',
+        header: 'Metric Name',
+        enableSorting: true,
+        Cell: ({ row, table }) => (
+            <Highlight highlight={table.getState().globalFilter || ''}>
+                {row.original.label}
+            </Highlight>
+        ),
+    },
+    {
+        accessorKey: 'description',
+        header: 'Description',
+        enableSorting: false,
+        size: 400,
+        Cell: ({ table, row }) => (
+            <HoverCard
+                withinPortal
+                shadow="lg"
+                position="right"
+                disabled={!row.original.description}
+            >
+                <HoverCard.Target>
+                    <Text lineClamp={2}>
+                        <Highlight
+                            highlight={table.getState().globalFilter || ''}
+                        >
+                            {row.original.description ?? ''}
+                        </Highlight>
+                    </Text>
+                </HoverCard.Target>
+                <HoverCard.Dropdown>
+                    <MarkdownPreview
+                        source={row.original.description}
+                        style={{
+                            fontSize: '12px',
+                        }}
+                    />
+                </HoverCard.Dropdown>
+            </HoverCard>
+        ),
+    },
+    {
+        accessorKey: 'directory',
+        header: 'Table',
+        enableSorting: false,
+        size: 150,
+        Cell: ({ row }) => <Text fw={500}>{row.original.tableName}</Text>,
+    },
+    {
+        accessorKey: 'chartUsage',
+        header: 'Popularity',
+        enableSorting: true,
+        size: 100,
+        Cell: ({ row }) => <MetricChartUsageButton row={row} />,
+    },
+];

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -4,7 +4,7 @@ import { useMount } from 'react-use';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { setActiveMetric, setProjectUuid } from '../store/metricsCatalogSlice';
-import { MetricChartsUsageModal } from './MetricChartsUsageModal';
+import { MetricChartUsageModal } from './MetricChartUsageModal';
 import { MetricsTable } from './MetricsTable';
 
 export const MetricsCatalogPanel = () => {
@@ -32,7 +32,7 @@ export const MetricsCatalogPanel = () => {
                 <RefreshDbtButton />
             </Group>
             <MetricsTable />
-            <MetricChartsUsageModal
+            <MetricChartUsageModal
                 opened={isMetricUsageModalOpen}
                 onClose={onCloseMetricUsageModal}
             />

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,12 +1,8 @@
-import { type CatalogField, type CatalogItem } from '@lightdash/common';
-import { Box, Button, Highlight, HoverCard, Text } from '@mantine/core';
-import { IconChartBar } from '@tabler/icons-react';
-import MarkdownPreview from '@uiw/react-markdown-preview';
+import { type CatalogItem } from '@lightdash/common';
+import { Box, Text } from '@mantine/core';
 import {
     MantineReactTable,
     useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_Row,
     type MRT_SortingState,
     type MRT_Virtualizer,
 } from 'mantine-react-table';
@@ -19,126 +15,10 @@ import {
     useState,
     type UIEvent,
 } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
-import { useTracking } from '../../../providers/TrackingProvider';
-import { EventName } from '../../../types/Events';
-import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
+import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricsCatalog } from '../hooks/useMetricsCatalog';
-import { setActiveMetric } from '../store/metricsCatalogSlice';
 import { ExploreMetricButton } from './ExploreMetricButton';
-
-const MetricUsageButton = ({ row }: { row: MRT_Row<CatalogField> }) => {
-    const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
-    const dispatch = useAppDispatch();
-    const { track } = useTracking();
-
-    const handleChartUsageClick = () => {
-        if (hasChartsUsage) {
-            track({
-                name: EventName.METRICS_CATALOG_CHART_USAGE_CLICKED,
-                properties: {
-                    metricName: row.original.name,
-                    chartCount: row.original.chartUsage ?? 0,
-                    tableName: row.original.tableName,
-                },
-            });
-            dispatch(setActiveMetric(row.original));
-        }
-    };
-
-    return (
-        <Button
-            size="xs"
-            compact
-            color="gray.6"
-            variant="default"
-            disabled={!hasChartsUsage}
-            onClick={handleChartUsageClick}
-            leftIcon={
-                <MantineIcon
-                    display={hasChartsUsage ? 'block' : 'none'}
-                    icon={IconChartBar}
-                    color="gray.6"
-                    size={12}
-                    strokeWidth={1.2}
-                    fill="gray.2"
-                />
-            }
-            sx={{
-                '&[data-disabled]': {
-                    backgroundColor: 'transparent',
-                    fontWeight: 400,
-                },
-            }}
-            styles={{
-                leftIcon: {
-                    marginRight: 4,
-                },
-            }}
-        >
-            {hasChartsUsage ? `${row.original.chartUsage}` : 'No usage'}
-        </Button>
-    );
-};
-
-const columns: MRT_ColumnDef<CatalogField>[] = [
-    {
-        accessorKey: 'name',
-        header: 'Metric Name',
-        enableSorting: true,
-        Cell: ({ row, table }) => (
-            <Highlight highlight={table.getState().globalFilter || ''}>
-                {row.original.label}
-            </Highlight>
-        ),
-    },
-    {
-        accessorKey: 'description',
-        header: 'Description',
-        enableSorting: false,
-        size: 400,
-        Cell: ({ table, row }) => (
-            <HoverCard
-                withinPortal
-                shadow="lg"
-                position="right"
-                disabled={!row.original.description}
-            >
-                <HoverCard.Target>
-                    <Text lineClamp={2}>
-                        <Highlight
-                            highlight={table.getState().globalFilter || ''}
-                        >
-                            {row.original.description ?? ''}
-                        </Highlight>
-                    </Text>
-                </HoverCard.Target>
-                <HoverCard.Dropdown>
-                    <MarkdownPreview
-                        source={row.original.description}
-                        style={{
-                            fontSize: '12px',
-                        }}
-                    />
-                </HoverCard.Dropdown>
-            </HoverCard>
-        ),
-    },
-    {
-        accessorKey: 'directory',
-        header: 'Table',
-        enableSorting: false,
-        size: 150,
-        Cell: ({ row }) => <Text fw={500}>{row.original.tableName}</Text>,
-    },
-    {
-        accessorKey: 'chartUsage',
-        header: 'Popularity',
-        enableSorting: true,
-        size: 100,
-        Cell: ({ row }) => <MetricUsageButton row={row} />,
-    },
-];
+import { MetricsCatalogColumns } from './MetricsCatalogColumns';
 
 export const MetricsTable = () => {
     const projectUuid = useAppSelector(
@@ -202,7 +82,7 @@ export const MetricsTable = () => {
     }, [fetchMoreOnBottomReached]);
 
     const table = useMantineReactTable({
-        columns,
+        columns: MetricsCatalogColumns,
         data: flatData,
         enableColumnResizing: true,
         enableRowNumbers: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #10330

### Description:

**NOTE**
`MetricsCatalogColumns` returns an array but each element's `Cell` is basically a component so I'm keeping it PascalCased 


<img width="287" alt="image" src="https://github.com/user-attachments/assets/177498ec-8768-4d8a-ad04-55e6a3f15e0c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
