### PR TITLE
feat: Show HTTP method in `lightdashApi`

### DIFF
--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -44,7 +44,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         ...proxyAuthorizationHeader,
     };
     const fullUrl = new URL(url, config.context.serverUrl).href;
-    GlobalState.debug(`> Making HTTP query to: ${fullUrl}`);
+    GlobalState.debug(`> Making HTTP ${method} request to: ${fullUrl}`);
 
     return fetch(fullUrl, { method, headers, body })
         .then((r) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: NA

### Description:

When I seldom encountered errors when executing a `lightdash stop-preview` command today. Resulting logs of a command didn't provide meaningful information about the error. First, I want to show the HTTP method to call a Lightdash API. Then, I want to improve the error message `Something went wrong.` after identifying which endpoint raise the error.

```
$ lightdash stop-preview
...
> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/health
> HTTP request returned status: 200
> HTTP request returned status: ok
> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/org/projects/
> HTTP request returned status: 200
> HTTP request returned status: ok
> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/user
> HTTP request returned status: 200
> HTTP request returned status: ok
> Making HTTP query to: https://xxx.lightdash.cloud/api/v1/org/projects/xxxxx
> HTTP request returned status: 500
Something went wrong.
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
