### PR TITLE
feat: allow to filter by catalog tags

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -48,13 +48,13 @@ export class CatalogController extends BaseController {
     async getCatalog(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-        @Query() search?: ApiCatalogSearch['search'],
+        @Query() search?: ApiCatalogSearch['searchQuery'],
         @Query() type?: ApiCatalogSearch['type'],
         @Query() filter?: ApiCatalogSearch['filter'],
     ): Promise<{ status: 'ok'; results: ApiCatalogResults }> {
         this.setStatus(200);
         const query: ApiCatalogSearch = {
-            search,
+            searchQuery: search,
             type,
             filter,
         };
@@ -170,11 +170,12 @@ export class CatalogController extends BaseController {
     async getMetricsCatalog(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-        @Query() search?: ApiCatalogSearch['search'],
+        @Query() search?: ApiCatalogSearch['searchQuery'],
         @Query() page?: number,
         @Query() pageSize?: number,
         @Query() sort?: ApiSort['sort'],
         @Query() order?: ApiSort['order'],
+        @Query() catalogTags?: ApiCatalogSearch['catalogTags'],
     ): Promise<ApiMetricsCatalog> {
         this.setStatus(200);
 
@@ -200,7 +201,8 @@ export class CatalogController extends BaseController {
                 projectUuid,
                 paginateArgs,
                 {
-                    search,
+                    searchQuery: search,
+                    catalogTags,
                 },
                 sortArgs,
             );

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -4,7 +4,6 @@ import {
     type CatalogItem,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import { TagsTableName } from './tags';
 
 export type DbCatalog = {
     catalog_search_uuid: string;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10235,6 +10235,12 @@ export function RegisterRoutes(app: express.Router) {
                 pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
                 sort: { in: 'query', name: 'sort', dataType: 'string' },
                 order: { in: 'query', name: 'order', ref: 'ApiSortDirection' },
+                catalogTags: {
+                    in: 'query',
+                    name: 'catalogTags',
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10934,7 +10934,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1344.0",
+        "version": "0.1345.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11289,6 +11289,17 @@
                         "schema": {
                             "$ref": "#/components/schemas/ApiSortDirection"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "catalogTags",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     }
                 ]
             }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -37,9 +37,10 @@ export type CatalogSelection = {
 };
 
 export type ApiCatalogSearch = {
-    search?: string;
+    searchQuery?: string;
     type?: CatalogType;
     filter?: CatalogFilter;
+    catalogTags?: string[];
 };
 
 export type CatalogField = Pick<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12261 

### Description:

- Adds `catalogTags` query parameter to allow filtering by tag uuids in `/metrics` endpoint
- Supports array values by passing N times, e.g. `catalogTags=3715c854-a5e6-4ad3-996b-81d4b2372ef1&catalogTags=d963896a-8180-4a37-bf6f-a27877b883d8`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
