### PR TITLE
feat: allow tagging and untagging catalog fields

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/CatalogTag.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogTag.tsx
@@ -1,33 +1,54 @@
 import type { CatalogItem } from '@lightdash/common';
-import { Badge } from '@mantine/core';
+import { ActionIcon, Badge, Group } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 
 type Props = {
     tag: Pick<CatalogItem['catalogTags'][number], 'name' | 'color'>;
+    onTagClick?: () => void;
+    onRemove?: () => void;
 };
 
-export const CatalogTag: FC<Props> = ({ tag }) => {
+export const CatalogTag: FC<Props> = ({ tag, onTagClick, onRemove }) => {
     return (
         <Badge
             key={tag.name}
             size="sm"
-            variant="light"
             radius="sm"
+            variant="light"
+            onClick={onTagClick}
             styles={(theme) => ({
                 root: {
                     textTransform: 'none',
-                    fontWeight: 450,
+                    fontWeight: 400,
                     border: `1px solid ${theme.fn.lighten(tag.color, 0.5)}`,
                     backgroundColor: theme.fn.lighten(tag.color, 0.9),
                     color: theme.fn.darken(tag.color, 0.2),
                     cursor: 'pointer',
+                    paddingRight: onRemove ? 2 : 8,
                     '&:hover': {
                         backgroundColor: theme.fn.lighten(tag.color, 0.8),
                     },
                 },
             })}
         >
-            {tag.name}
+            <Group spacing={1}>
+                {tag.name}
+                {onRemove && (
+                    <ActionIcon
+                        variant="transparent"
+                        size={12}
+                        onClick={onRemove}
+                    >
+                        <MantineIcon
+                            color="gray.8"
+                            icon={IconX}
+                            strokeWidth={1.8}
+                        />
+                    </ActionIcon>
+                )}
+            </Group>
         </Badge>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -4,6 +4,7 @@ import { useHover } from '@mantine/hooks';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo } from 'react';
+import { CatalogTag } from './CatalogTag';
 import { MetricChartUsageButton } from './MetricChartUsageButton';
 import { MetricsCatalogTagForm } from './MetricsCatalogTagForm';
 
@@ -69,8 +70,11 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
 
             return (
                 <Group spacing="two" ref={ref} pos="relative" w="100%" h="100%">
-                    {/* TODO: Add tags here  */}
+                    {tags.map((tag) => (
+                        <CatalogTag key={tag.tagUuid} tag={tag} />
+                    ))}
                     <MetricsCatalogTagForm
+                        catalogSearchUuid={row.original.catalogSearchUuid}
                         metricTags={tags}
                         hovered={hovered}
                     />

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -37,6 +37,7 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
         );
         const [opened, setOpened] = useState(false);
         const [search, setSearch] = useState('');
+        console.log('search', search);
         const [tagColor, setTagColor] = useState<string>();
 
         const { data: tags } = useProjectTags(projectUuid);
@@ -49,7 +50,7 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
             if (opened) {
                 setTagColor(getRandomColor(colors));
             } else {
-                setSearch('');
+                // setSearch('');
                 setTagColor(undefined);
             }
         }, [opened, colors]);
@@ -86,10 +87,10 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                             catalogSearchUuid,
                             tagUuid: newTag.tagUuid,
                         });
+                        // Reset search and color after creating a new tag
                         setSearch('');
-                        setOpened(false);
+                        setTagColor(getRandomColor(colors));
                     }
-                    setTagColor(undefined);
                 } catch (error) {
                     // TODO: Add toast on error
                     console.error('Error adding tag:', error);
@@ -102,6 +103,7 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                 tagCatalogItemMutation,
                 tags,
                 tagColor,
+                colors,
             ],
         );
 
@@ -167,7 +169,10 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                         size="xs"
                         mb="xs"
                         radius="md"
-                        onSearchChange={(value) => setSearch(value)}
+                        onSearchChange={(value) => {
+                            setSearch(value);
+                        }}
+                        searchValue={search}
                         addOnBlur={false}
                         onBlur={(e) => {
                             e.stopPropagation();

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -37,7 +37,6 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
         );
         const [opened, setOpened] = useState(false);
         const [search, setSearch] = useState('');
-        console.log('search', search);
         const [tagColor, setTagColor] = useState<string>();
 
         const { data: tags } = useProjectTags(projectUuid);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -27,11 +27,10 @@ type Props = {
     catalogSearchUuid: string;
     metricTags: CatalogField['catalogTags'];
     hovered: boolean;
-    leftAligned?: boolean;
 };
 
 export const MetricsCatalogTagForm: FC<Props> = memo(
-    ({ catalogSearchUuid, metricTags, hovered, leftAligned }) => {
+    ({ catalogSearchUuid, metricTags, hovered }) => {
         const { colors } = useMantineTheme();
         const projectUuid = useAppSelector(
             (state) => state.metricsCatalog.projectUuid,
@@ -142,6 +141,10 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                                 icon={IconPlus}
                             />
                         }
+                        fz={10}
+                        right={0}
+                        bottom={0}
+                        left="auto"
                         styles={(theme) => ({
                             leftIcon: {
                                 marginRight: 4,
@@ -150,20 +153,6 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                                 border: `dashed 1px ${theme.colors.gray[4]}`,
                                 visibility:
                                     hovered || opened ? 'visible' : 'hidden',
-                                fontSize: '10px',
-                                ...(leftAligned
-                                    ? {
-                                          left: 0,
-                                          right: 'auto',
-                                          top: '50%',
-                                          transform: 'translateY(-50%)',
-                                          bottom: 'auto',
-                                      }
-                                    : {
-                                          right: 0,
-                                          left: 'auto',
-                                          bottom: 0,
-                                      }),
                             },
                         })}
                         onClick={() => setOpened((prev) => !prev)}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -1,31 +1,37 @@
 import { type CatalogField } from '@lightdash/common';
 import {
-    ActionIcon,
+    Box,
     Button,
     Group,
     Popover,
     Stack,
     Text,
-    TextInput,
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { IconPlus, IconRefresh, IconTrash } from '@tabler/icons-react';
-import { memo, useEffect, useState, type FC } from 'react';
+import { IconPlus, IconRefresh } from '@tabler/icons-react';
+import { memo, useCallback, useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { TagInput } from '../../../components/common/TagInput/TagInput';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
-import { useCreateTag, useProjectTags } from '../hooks/useCatalogTags';
+import {
+    useCreateTag,
+    useProjectTags,
+    useTagCatalogItem,
+    useUntagCatalogItem,
+} from '../hooks/useCatalogTags';
 import { getRandomColor } from '../utils/getRandomTagColor';
 import { CatalogTag } from './CatalogTag';
 
 type Props = {
+    catalogSearchUuid: string;
     metricTags: CatalogField['catalogTags'];
     hovered: boolean;
     leftAligned?: boolean;
 };
 
 export const MetricsCatalogTagForm: FC<Props> = memo(
-    ({ metricTags, hovered, leftAligned }) => {
+    ({ catalogSearchUuid, metricTags, hovered, leftAligned }) => {
         const { colors } = useMantineTheme();
         const projectUuid = useAppSelector(
             (state) => state.metricsCatalog.projectUuid,
@@ -36,46 +42,82 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
 
         const { data: tags } = useProjectTags(projectUuid);
         const createTagMutation = useCreateTag();
+        const tagCatalogItemMutation = useTagCatalogItem();
+        const untagCatalogItemMutation = useUntagCatalogItem();
 
-        useEffect(
-            function generateNewColorOnPopoverOpen() {
-                if (opened) {
-                    setTagColor(getRandomColor(colors));
-                } else {
-                    setSearch('');
-                    setTagColor(undefined);
-                }
-            },
-            [opened, colors],
-        );
-
-        const handleAddTag = async (tagName: string) => {
-            if (!projectUuid) return;
-
-            try {
-                const existingTag = tags?.find((tag) => tag.name === tagName);
-
-                if (existingTag) {
-                    // TODO: implement tag update
-                } else {
-                    await createTagMutation.mutateAsync({
-                        projectUuid,
-                        data: {
-                            name: tagName,
-                            color: tagColor ?? getRandomColor(colors),
-                        },
-                    });
-
-                    // TODO: After creating tag, tag field with the uuid from the previous mutation
-                    setOpened(false);
-                }
+        // Generate new color when popover opens
+        useEffect(() => {
+            if (opened) {
+                setTagColor(getRandomColor(colors));
+            } else {
                 setSearch('');
                 setTagColor(undefined);
-            } catch (error) {
-                // TODO: show toast error
-                console.error('Error adding tag:', error);
             }
-        };
+        }, [opened, colors]);
+
+        const handleAddTag = useCallback(
+            async (tagName: string) => {
+                if (!projectUuid) return;
+
+                try {
+                    const existingTag = tags?.find(
+                        (tag) => tag.name === tagName,
+                    );
+
+                    if (existingTag) {
+                        await tagCatalogItemMutation.mutateAsync({
+                            projectUuid,
+                            catalogSearchUuid,
+                            tagUuid: existingTag.tagUuid,
+                        });
+                        setSearch('');
+                    } else {
+                        if (!tagColor) return;
+
+                        const newTag = await createTagMutation.mutateAsync({
+                            projectUuid,
+                            data: {
+                                name: tagName,
+                                color: tagColor,
+                            },
+                        });
+
+                        await tagCatalogItemMutation.mutateAsync({
+                            projectUuid,
+                            catalogSearchUuid,
+                            tagUuid: newTag.tagUuid,
+                        });
+                        setSearch('');
+                        setOpened(false);
+                    }
+                    setTagColor(undefined);
+                } catch (error) {
+                    // TODO: Add toast on error
+                    console.error('Error adding tag:', error);
+                }
+            },
+            [
+                projectUuid,
+                catalogSearchUuid,
+                createTagMutation,
+                tagCatalogItemMutation,
+                tags,
+                tagColor,
+            ],
+        );
+
+        const handleUntag = useCallback(
+            async (tagUuid: string) => {
+                if (!projectUuid) return;
+
+                await untagCatalogItemMutation.mutateAsync({
+                    projectUuid,
+                    catalogSearchUuid,
+                    tagUuid,
+                });
+            },
+            [projectUuid, catalogSearchUuid, untagCatalogItemMutation],
+        );
 
         return (
             <Popover
@@ -130,14 +172,41 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                     </Button>
                 </Popover.Target>
                 <Popover.Dropdown p="xs">
-                    <TextInput
-                        radius="md"
-                        size="xs"
+                    <TagInput
+                        value={metricTags.map((tag) => tag.name)}
                         placeholder="Search"
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
+                        size="xs"
+                        mb="xs"
+                        radius="md"
+                        onSearchChange={(value) => setSearch(value)}
+                        addOnBlur={false}
+                        onBlur={(e) => {
+                            e.stopPropagation();
+                        }}
+                        valueComponent={({ value, onRemove }) => (
+                            <Box mx={2}>
+                                <CatalogTag
+                                    tag={{
+                                        name: value,
+                                        color:
+                                            metricTags.find(
+                                                (tag) => tag.name === value,
+                                            )?.color ?? getRandomColor(colors),
+                                    }}
+                                    onRemove={() => {
+                                        onRemove(value);
+                                        const tagUuid = metricTags.find(
+                                            (tag) => tag.name === value,
+                                        )?.tagUuid;
+                                        if (tagUuid) {
+                                            void handleUntag(tagUuid);
+                                        }
+                                    }}
+                                />
+                            </Box>
+                        )}
                     />
-                    <Text size="xs" fw={500} color="dimmed">
+                    <Text size="xs" fw={500} color="dimmed" mb="xs">
                         Select a tag or create a new one
                     </Text>
                     <Stack spacing="xs" align="flex-start">
@@ -171,23 +240,11 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                                     >
                                         <CatalogTag
                                             tag={tag}
-                                            // TODO: implement tag click (tagging field)
+                                            onTagClick={() =>
+                                                handleAddTag(tag.name)
+                                            }
                                         />
-                                        {/* Only show on hover */}
-                                        <ActionIcon
-                                            size="xs"
-                                            variant="subtle"
-                                            onClick={() => {
-                                                // TODO: implement tag deletion
-                                                return;
-                                            }}
-                                        >
-                                            <MantineIcon
-                                                icon={IconTrash}
-                                                color="gray.6"
-                                                size={14}
-                                            />
-                                        </ActionIcon>
+                                        {/* TODO: Implement tag deletion from project */}
                                     </Group>
                                 ))}
                         </Stack>

--- a/packages/frontend/src/features/metricsCatalog/hooks/useCatalogTags.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useCatalogTags.tsx
@@ -2,6 +2,7 @@ import {
     type ApiCreateTagResponse,
     type ApiError,
     type ApiGetTagsResponse,
+    type ApiSuccessEmpty,
     type Tag,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -51,5 +52,69 @@ export const useProjectTags = (projectUuid: string | undefined) => {
         queryKey: ['project-tags', projectUuid],
         queryFn: () => getTags(projectUuid!),
         enabled: !!projectUuid,
+    });
+};
+
+type TagCatalogItemParams = {
+    projectUuid: string;
+    catalogSearchUuid: string;
+    tagUuid: string;
+};
+
+const tagCatalogItem = async ({
+    projectUuid,
+    catalogSearchUuid,
+    tagUuid,
+}: TagCatalogItemParams) => {
+    return lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/projects/${projectUuid}/dataCatalog/${catalogSearchUuid}/tags`,
+        method: 'POST',
+        body: JSON.stringify({ tagUuid }),
+    });
+};
+
+/**
+ * Tag a catalog item
+ */
+export const useTagCatalogItem = () => {
+    const queryClient = useQueryClient();
+    return useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        TagCatalogItemParams
+    >({
+        mutationFn: tagCatalogItem,
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(['metrics-catalog']);
+        },
+    });
+};
+
+const untagCatalogItem = async ({
+    projectUuid,
+    catalogSearchUuid,
+    tagUuid,
+}: TagCatalogItemParams) => {
+    return lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/projects/${projectUuid}/dataCatalog/${catalogSearchUuid}/tags/${tagUuid}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+};
+
+/**
+ * Untag a catalog item
+ */
+export const useUntagCatalogItem = () => {
+    const queryClient = useQueryClient();
+    return useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        TagCatalogItemParams
+    >({
+        mutationFn: untagCatalogItem,
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(['metrics-catalog']);
+        },
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/10330

### Description:

Can tag a metric catalog item
Can untag it
Can see the tags for each field
Uses `TagInput` component to render the tags

https://github.com/user-attachments/assets/716da4e7-d191-4a3c-9477-fdeee27cdc4a



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
