### PR TITLE
fix: time-based filters in scheduled deliveries 

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -278,6 +278,7 @@ export const applyDimensionOverrides = (
         if (override) {
             return {
                 ...override,
+                disabled: dimension.disabled,
                 tileTargets: dimension.tileTargets,
             };
         }

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -282,7 +282,7 @@ const updateFilters = (
             ...(schedulerFilters ?? []),
             {
                 ...schedulerFilter,
-                disabled: filterToCompareAgainst.disabled === true,
+                disabled: Boolean(filterToCompareAgainst.disabled),
             },
         ];
     }

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -282,10 +282,7 @@ const updateFilters = (
             ...(schedulerFilters ?? []),
             {
                 ...schedulerFilter,
-                disabled: !(
-                    filterToCompareAgainst.disabled &&
-                    filterToCompareAgainst.disabled === true
-                ),
+                disabled: filterToCompareAgainst.disabled === true,
             },
         ];
     }


### PR DESCRIPTION


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12204 

### Description:

Fixes an issue where some filters on scheduled deliveries not overriding dashboard filters. The SD filters were being set as disabled. This fixes that by using the DB setting for disabled. 

To repro the issue:
1. Add a fitler to a dashboard for something like 'date is after...'
2. Set up a scheduled delivery with a filter for a different 'date is after...'
3. Send now. You will get data filtered by the dashboard filter. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
