### PR TITLE
chore: add catalog-category-related events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1107,6 +1107,16 @@ export type WriteBackEvent = BaseTrack & {
     };
 };
 
+type CreateTagEvent = BaseTrack & {
+    event: 'category.created';
+    userId: string;
+    properties: {
+        name: string;
+        projectId: string;
+        organizationId: string;
+    };
+};
+
 type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -1183,7 +1193,8 @@ type TypedEvent =
     | VirtualViewEvent
     | GithubInstallEvent
     | WriteBackEvent
-    | SchedulerTimezoneUpdateEvent;
+    | SchedulerTimezoneUpdateEvent
+    | CreateTagEvent;
 
 type WrapTypedEvent = SemanticLayerView;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4832,6 +4832,16 @@ export class ProjectService extends BaseService {
             created_by_user_uuid: user.userUuid,
         });
 
+        this.analytics.track({
+            event: 'category.created',
+            userId: user.userUuid,
+            properties: {
+                name,
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+            },
+        });
+
         return { tagUuid: createdTagUuid.tag_uuid };
     }
 

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -20,6 +20,9 @@ export const ExploreMetricButton = ({ row }: Props) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
+    const organizationUuid = useAppSelector(
+        (state) => state.metricsCatalog.organizationUuid,
+    );
     const [currentTableName, setCurrentTableName] = useState<string>();
     const { track } = useTracking();
     const { isFetching } = useExplore(currentTableName, {
@@ -51,6 +54,8 @@ export const ExploreMetricButton = ({ row }: Props) => {
         track({
             name: EventName.METRICS_CATALOG_EXPLORE_CLICKED,
             properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
                 metricName: row.original.name,
                 tableName: row.original.tableName,
             },

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
@@ -5,7 +5,7 @@ import { type MRT_Row } from 'mantine-react-table';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
-import { useAppDispatch } from '../../sqlRunner/store/hooks';
+import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { setActiveMetric } from '../store/metricsCatalogSlice';
 
 export const MetricChartUsageButton = ({
@@ -14,6 +14,12 @@ export const MetricChartUsageButton = ({
     row: MRT_Row<CatalogField>;
 }) => {
     const hasChartsUsage = row.original.chartUsage ?? 0 > 0;
+    const organizationUuid = useAppSelector(
+        (state) => state.metricsCatalog.organizationUuid,
+    );
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
     const dispatch = useAppDispatch();
     const { track } = useTracking();
 
@@ -25,6 +31,8 @@ export const MetricChartUsageButton = ({
                     metricName: row.original.name,
                     chartCount: row.original.chartUsage ?? 0,
                     tableName: row.original.tableName,
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
                 },
             });
             dispatch(setActiveMetric(row.original));

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -24,6 +24,9 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
+    const organizationUuid = useAppSelector(
+        (state) => state.metricsCatalog.organizationUuid,
+    );
 
     const { data: analytics, isLoading } = useMetricChartAnalytics({
         projectUuid,
@@ -71,6 +74,9 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
                                         track({
                                             name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
                                             properties: {
+                                                organizationId:
+                                                    organizationUuid,
+                                                projectId: projectUuid,
                                                 metricName: activeMetric?.name,
                                                 tableName:
                                                     activeMetric?.tableName,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,15 +1,27 @@
 import { Group, Stack, Title } from '@mantine/core';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useMount } from 'react-use';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
+import { useProject } from '../../../hooks/useProject';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
-import { setActiveMetric, setProjectUuid } from '../store/metricsCatalogSlice';
+import {
+    setActiveMetric,
+    setOrganizationUuid,
+    setProjectUuid,
+} from '../store/metricsCatalogSlice';
 import { MetricChartUsageModal } from './MetricChartUsageModal';
 import { MetricsTable } from './MetricsTable';
 
 export const MetricsCatalogPanel = () => {
-    const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
+    const organizationUuid = useAppSelector(
+        (state) => state.metricsCatalog.organizationUuid,
+    );
     const params = useParams<{ projectUuid: string }>();
+    const { data: project } = useProject(projectUuid);
 
     const dispatch = useAppDispatch();
     const isMetricUsageModalOpen = useAppSelector(
@@ -24,6 +36,12 @@ export const MetricsCatalogPanel = () => {
             dispatch(setProjectUuid(params.projectUuid));
         }
     });
+
+    useEffect(() => {
+        if (!organizationUuid && project?.organizationUuid) {
+            dispatch(setOrganizationUuid(project.organizationUuid));
+        }
+    }, [project, dispatch, organizationUuid]);
 
     return (
         <Stack>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -47,6 +47,9 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
         const projectUuid = useAppSelector(
             (state) => state.metricsCatalog.projectUuid,
         );
+        const organizationUuid = useAppSelector(
+            (state) => state.metricsCatalog.organizationUuid,
+        );
         const [opened, setOpened] = useState(false);
         const [search, setSearch] = useState('');
         const [tagColor, setTagColor] = useState<string>();
@@ -106,6 +109,8 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                     track({
                         name: EventName.METRICS_CATALOG_TAG_ADDED,
                         properties: {
+                            organizationId: organizationUuid,
+                            projectId: projectUuid,
                             tagName,
                             isNewTag: !existingTag,
                         },
@@ -117,13 +122,14 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
             },
             [
                 projectUuid,
-                catalogSearchUuid,
-                createTagMutation,
-                tagCatalogItemMutation,
                 tags,
-                tagColor,
-                colors,
                 track,
+                organizationUuid,
+                tagCatalogItemMutation,
+                catalogSearchUuid,
+                tagColor,
+                createTagMutation,
+                colors,
             ],
         );
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -21,6 +21,8 @@ import {
 } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { TagInput } from '../../../components/common/TagInput/TagInput';
+import { useTracking } from '../../../providers/TrackingProvider';
+import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import {
     useCreateTag,
@@ -40,6 +42,7 @@ type Props = {
 
 export const MetricsCatalogTagForm: FC<Props> = memo(
     ({ catalogSearchUuid, metricTags, hovered }) => {
+        const { track } = useTracking();
         const { colors } = useMantineTheme();
         const projectUuid = useAppSelector(
             (state) => state.metricsCatalog.projectUuid,
@@ -99,6 +102,14 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                         setSearch('');
                         setTagColor(getRandomColor(colors));
                     }
+
+                    track({
+                        name: EventName.METRICS_CATALOG_TAG_ADDED,
+                        properties: {
+                            tagName,
+                            isNewTag: !existingTag,
+                        },
+                    });
                 } catch (error) {
                     // TODO: Add toast on error
                     console.error('Error adding tag:', error);
@@ -112,6 +123,7 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                 tags,
                 tagColor,
                 colors,
+                track,
             ],
         );
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogTagForm.tsx
@@ -107,7 +107,7 @@ export const MetricsCatalogTagForm: FC<Props> = memo(
                     }
 
                     track({
-                        name: EventName.METRICS_CATALOG_TAG_ADDED,
+                        name: EventName.METRICS_CATALOG_TAG_CLICKED,
                         properties: {
                             organizationId: organizationUuid,
                             projectId: projectUuid,

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -9,12 +9,14 @@ type MetricsCatalogState = {
     };
     activeMetric: CatalogField | undefined;
     projectUuid: string | undefined;
+    organizationUuid: string | undefined;
     tagFilters: CatalogField['catalogTags'][number]['tagUuid'][];
 };
 
 const initialState: MetricsCatalogState = {
     activeMetric: undefined,
     projectUuid: undefined,
+    organizationUuid: undefined,
     tagFilters: [],
     modals: {
         chartUsageModal: {
@@ -29,6 +31,9 @@ export const metricsCatalogSlice = createSlice({
     reducers: {
         setProjectUuid: (state, action: PayloadAction<string>) => {
             state.projectUuid = action.payload;
+        },
+        setOrganizationUuid: (state, action: PayloadAction<string>) => {
+            state.organizationUuid = action.payload;
         },
         setActiveMetric: (
             state,
@@ -56,4 +61,5 @@ export const {
     setProjectUuid,
     setTagFilters,
     clearTagFilters,
+    setOrganizationUuid,
 } = metricsCatalogSlice.actions;

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -62,7 +62,7 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_CHART_USAGE_CLICKED
         | EventName.METRICS_CATALOG_EXPLORE_CLICKED
         | EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED
-        | EventName.METRICS_CATALOG_TAG_ADDED
+        | EventName.METRICS_CATALOG_TAG_CLICKED
         | EventName.METRICS_CATALOG_TAG_FILTER_APPLIED;
     properties?: {};
 };
@@ -207,8 +207,8 @@ type MetricsCatalogChartUsageChartClickedEvent = {
     };
 };
 
-type MetricsCatalogTagAddedEvent = {
-    name: EventName.METRICS_CATALOG_TAG_ADDED;
+type MetricsCatalogTagClickedEvent = {
+    name: EventName.METRICS_CATALOG_TAG_CLICKED;
     properties: {
         organizationId: string;
         projectId: string;
@@ -241,7 +241,7 @@ export type EventData =
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent
     | MetricsCatalogChartUsageChartClickedEvent
-    | MetricsCatalogTagAddedEvent
+    | MetricsCatalogTagClickedEvent
     | MetricsCatalogTagFilterAppliedEvent;
 
 type IdentifyData = {

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -62,7 +62,8 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_CHART_USAGE_CLICKED
         | EventName.METRICS_CATALOG_EXPLORE_CLICKED
         | EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED
-        | EventName.METRICS_CATALOG_TAG_ADDED;
+        | EventName.METRICS_CATALOG_TAG_ADDED
+        | EventName.METRICS_CATALOG_TAG_FILTER_APPLIED;
     properties?: {};
 };
 
@@ -177,6 +178,8 @@ export type DashboardAutoRefreshUpdateEvent = {
 type MetricsCatalogChartUsageClickedEvent = {
     name: EventName.METRICS_CATALOG_CHART_USAGE_CLICKED;
     properties: {
+        organizationId: string;
+        projectId: string;
         metricName: string;
         chartCount: number;
         tableName: string;
@@ -186,6 +189,8 @@ type MetricsCatalogChartUsageClickedEvent = {
 type MetricsCatalogExploreClickedEvent = {
     name: EventName.METRICS_CATALOG_EXPLORE_CLICKED;
     properties: {
+        organizationId: string;
+        projectId: string;
         metricName: string;
         tableName: string;
     };
@@ -194,6 +199,8 @@ type MetricsCatalogExploreClickedEvent = {
 type MetricsCatalogChartUsageChartClickedEvent = {
     name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED;
     properties: {
+        organizationId: string;
+        projectId: string;
         metricName: string;
         tableName: string;
         chartId: string;
@@ -203,9 +210,18 @@ type MetricsCatalogChartUsageChartClickedEvent = {
 type MetricsCatalogTagAddedEvent = {
     name: EventName.METRICS_CATALOG_TAG_ADDED;
     properties: {
-        metricName: string;
+        organizationId: string;
+        projectId: string;
         tagName: string;
         isNewTag: boolean;
+    };
+};
+
+type MetricsCatalogTagFilterAppliedEvent = {
+    name: EventName.METRICS_CATALOG_TAG_FILTER_APPLIED;
+    properties: {
+        organizationId: string;
+        projectId: string;
     };
 };
 
@@ -225,7 +241,8 @@ export type EventData =
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent
     | MetricsCatalogChartUsageChartClickedEvent
-    | MetricsCatalogTagAddedEvent;
+    | MetricsCatalogTagAddedEvent
+    | MetricsCatalogTagFilterAppliedEvent;
 
 type IdentifyData = {
     id: string;

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -61,7 +61,8 @@ type GenericEvent = {
         | EventName.DASHBOARD_AUTO_REFRESH_UPDATED
         | EventName.METRICS_CATALOG_CHART_USAGE_CLICKED
         | EventName.METRICS_CATALOG_EXPLORE_CLICKED
-        | EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED;
+        | EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED
+        | EventName.METRICS_CATALOG_TAG_ADDED;
     properties?: {};
 };
 
@@ -199,6 +200,15 @@ type MetricsCatalogChartUsageChartClickedEvent = {
     };
 };
 
+type MetricsCatalogTagAddedEvent = {
+    name: EventName.METRICS_CATALOG_TAG_ADDED;
+    properties: {
+        metricName: string;
+        tagName: string;
+        isNewTag: boolean;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | FormClickedEvent
@@ -214,7 +224,8 @@ export type EventData =
     | DashboardAutoRefreshUpdateEvent
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent
-    | MetricsCatalogChartUsageChartClickedEvent;
+    | MetricsCatalogChartUsageChartClickedEvent
+    | MetricsCatalogTagAddedEvent;
 
 type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -113,8 +113,12 @@ export enum EventName {
     COMMENTS_CLICKED = 'comments.clicked',
     NOTIFICATIONS_COMMENTS_ITEM_CLICKED = 'notifications_comments_item.clicked',
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
+
+    // Metrics Catalog
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',
     METRICS_CATALOG_CHART_USAGE_CHART_CLICKED = 'metrics_catalog_chart_usage_chart.clicked',
     METRICS_CATALOG_EXPLORE_CLICKED = 'metrics_catalog_explore.clicked',
+    // TODO: Rename from tag to category
     METRICS_CATALOG_TAG_ADDED = 'metrics_catalog_category_added',
+    METRICS_CATALOG_TAG_FILTER_APPLIED = 'metrics_catalog_category_filter_applied',
 }

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -119,6 +119,6 @@ export enum EventName {
     METRICS_CATALOG_CHART_USAGE_CHART_CLICKED = 'metrics_catalog_chart_usage_chart.clicked',
     METRICS_CATALOG_EXPLORE_CLICKED = 'metrics_catalog_explore.clicked',
     // TODO: Rename from tag to category
-    METRICS_CATALOG_TAG_ADDED = 'metrics_catalog_category_added',
-    METRICS_CATALOG_TAG_FILTER_APPLIED = 'metrics_catalog_category_filter_applied',
+    METRICS_CATALOG_TAG_CLICKED = 'metrics_catalog_category.clicked',
+    METRICS_CATALOG_TAG_FILTER_APPLIED = 'metrics_catalog_category_filter.applied',
 }

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -116,4 +116,5 @@ export enum EventName {
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',
     METRICS_CATALOG_CHART_USAGE_CHART_CLICKED = 'metrics_catalog_chart_usage_chart.clicked',
     METRICS_CATALOG_EXPLORE_CLICKED = 'metrics_catalog_explore.clicked',
+    METRICS_CATALOG_TAG_ADDED = 'metrics_catalog_category_added',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7265,7 +7265,7 @@
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.18", "@types/react-dom@^18.3.0":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.3.0":
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
   integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
@@ -7310,7 +7310,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.48", "@types/react@^18.3.5":
+"@types/react@*", "@types/react@^18.3.5":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12260

### Description:

> [!NOTE]
> Added as well project id and org id to all metrics-catalog-related events

 ### User creates tag (server with tag name)

<img width="1877" alt="image" src="https://github.com/user-attachments/assets/bc9b38eb-0d9f-4358-8ee5-89202fe84e8b">

 ### User tags metrics (ui click)

<img width="1895" alt="image" src="https://github.com/user-attachments/assets/b040a860-5c5d-4abd-923d-10fb6ec2ca27">


 ### User filters by tag (ui search)

<img width="1911" alt="image" src="https://github.com/user-attachments/assets/ecf6937b-910b-4621-9467-e09525b3f281">




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
