### PR TITLE
fix: use optimistic updates on category changes

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -28,8 +28,8 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
-    const { mutateAsync: updateTag } = useUpdateTag();
-    const { mutateAsync: deleteTag } = useDeleteTag();
+    const { mutate: updateTag } = useUpdateTag();
+    const { mutate: deleteTag } = useDeleteTag();
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(category.name);
     const [editColor, setEditColor] = useState(category.color);
@@ -37,20 +37,43 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     const handleSave = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            await updateTag({
+            console.log('Initiating tag update:', {
                 projectUuid,
                 tagUuid: category.tagUuid,
-                data: { name: editName, color: editColor },
+                currentName: category.name,
+                newName: editName,
+                currentColor: category.color,
+                newColor: editColor,
             });
+            try {
+                updateTag({
+                    projectUuid,
+                    tagUuid: category.tagUuid,
+                    data: { name: editName, color: editColor },
+                });
+                console.log('Tag update completed successfully');
+                setIsEditing(false);
+            } catch (error) {
+                console.error('Tag update failed:', error);
+            }
         }
-        setIsEditing(false);
-    }, [editColor, editName, projectUuid, category.tagUuid, updateTag]);
+    }, [editColor, editName, projectUuid, category, updateTag]);
 
     const onDelete = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            await deleteTag({ projectUuid, tagUuid: category.tagUuid });
+            console.log('Initiating tag deletion:', {
+                projectUuid,
+                tagUuid: category.tagUuid,
+                categoryName: category.name,
+            });
+            try {
+                deleteTag({ projectUuid, tagUuid: category.tagUuid });
+                console.log('Tag deletion completed successfully');
+            } catch (error) {
+                console.error('Tag deletion failed:', error);
+            }
         }
-    }, [deleteTag, projectUuid, category.tagUuid]);
+    }, [deleteTag, projectUuid, category]);
 
     if (isEditing) {
         return (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -125,11 +125,7 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     return (
         <Group spacing={4} position="apart" w="100%">
-            <CatalogCategory
-                category={category}
-                onClick={onClick}
-                onRemove={onDelete}
-            />
+            <CatalogCategory category={category} onClick={onClick} />
             <ActionIcon
                 size="xs"
                 variant="subtle"

--- a/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
@@ -8,7 +8,7 @@ type AddCategoryToCatalogItemParams = {
     tagUuid: string;
 };
 
-const addCategoryToCatalogItem = async ({
+export const addCategoryToCatalogItem = async ({
     projectUuid,
     catalogSearchUuid,
     tagUuid,
@@ -31,8 +31,15 @@ export const useAddCategoryToCatalogItem = () => {
         AddCategoryToCatalogItemParams
     >({
         mutationFn: addCategoryToCatalogItem,
+        onMutate: async (variables) => {
+            console.log('Adding category - Mutation started:', variables);
+        },
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['metrics-catalog']);
+            console.log('Adding category - API call successful');
+            void queryClient.invalidateQueries(['metrics-catalog']);
+        },
+        onError: (error) => {
+            console.error('Adding category - API call failed:', error);
         },
     });
 };
@@ -62,8 +69,15 @@ export const useRemoveCategoryFromCatalogItem = () => {
         RemoveCategoryFromCatalogItemParams
     >({
         mutationFn: removeCategoryFromCatalogItem,
+        onMutate: async (variables) => {
+            console.log('Removing category - Mutation started:', variables);
+        },
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['metrics-catalog']);
+            console.log('Removing category - API call successful');
+            void queryClient.invalidateQueries(['metrics-catalog']);
+        },
+        onError: (error) => {
+            console.error('Removing category - API call failed:', error);
         },
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- Creating a category (which will also category the metric)
1. optimistically update the list of categories in the form 
2. update the tagInput value array
3. as well as the cell array

- uncategorising a metric
1. update the tagInput value array
1. as well as the cell array
1. list of categories in the form **remains the same**

- deleting a **tag** project
1. update the tagInput value array (if category is there)
1. as well as the cell array
1. list of categories in the form updates

- updating a **tag** the project
1. update the tagInput value array (if category is there)
1. as well as the cell array
1. list of categories in the form updates

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
