### PR TITLE
Introducing Lightdash Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ With Lightdash, we offer a free self-hosted service (it's all just open source!)
 Have a question about a feature? Or maybe fancy some light reading? Head on over to
 our [Lightdash documentation](https://docs.lightdash.com/) to check out our tutorials, reference docs, FAQs and more.
 
+You can also [Ask Lightdash Guru](https://gurubase.io/g/lightdash), it is a Lightdash-focused AI to answer your questions.
+
 ## Reporting bugs and feature requests
 
 Want to report a bug or request a feature? Open an [issue](https://github.com/lightdash/lightdash/issues/new/choose).


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Lightdash Guru](https://gurubase.io/g/lightdash) to Gurubase. Lightdash Guru uses the data from this repo and data from the [docs](http://docs.lightdash.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Lightdash Guru", which highlights that Lightdash now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Lightdash Guru in Gurubase, just let me know that's totally fine.
