### PR TITLE
fix: filter metric on sidebar icon

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -3,6 +3,7 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    isFilterableField,
     isMetric,
     isTableCalculation,
     isTimeInterval,
@@ -11,6 +12,7 @@ import {
     type Item,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Group,
     Highlight,
     HoverCard,
@@ -24,6 +26,8 @@ import { type FC } from 'react';
 import { useToggle } from 'react-use';
 import { getItemBgColor } from '../../../../../hooks/useColumns';
 import { useFilters } from '../../../../../hooks/useFilters';
+import { useTracking } from '../../../../../providers/TrackingProvider';
+import { EventName } from '../../../../../types/Events';
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useItemDetail } from '../ItemDetailContext';
@@ -48,6 +52,9 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
     } = useTableTreeContext();
     const { isFilteredField } = useFilters();
     const { showItemDetail } = useItemDetail();
+
+    const { addFilter } = useFilters();
+    const { track } = useTracking();
 
     const [isHover, toggleHover] = useToggle(false);
     const [isMenuOpen, toggleMenu] = useToggle(false);
@@ -200,13 +207,32 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                         </HoverCard.Dropdown>
                     </HoverCard>
 
-                    {isFiltered ? (
-                        <Tooltip withinPortal label="This field is filtered">
-                            <MantineIcon
-                                icon={IconFilter}
-                                color="gray.7"
-                                style={{ flexShrink: 0 }}
-                            />
+                    {(isFiltered || isHover) &&
+                    !isAdditionalMetric(item) &&
+                    isFilterableField(item) ? (
+                        <Tooltip
+                            withinPortal
+                            label={
+                                isFiltered
+                                    ? 'This field is filtered'
+                                    : `Click here to filter by ${item.name}`
+                            }
+                        >
+                            <ActionIcon
+                                onClick={(e) => {
+                                    track({
+                                        name: EventName.ADD_FILTER_CLICKED,
+                                    });
+                                    addFilter(item, undefined);
+                                    e.stopPropagation(); // Do not toggle the field on filter click
+                                }}
+                            >
+                                <MantineIcon
+                                    icon={IconFilter}
+                                    color="gray.7"
+                                    style={{ flexShrink: 0 }}
+                                />
+                            </ActionIcon>
                         </Tooltip>
                     ) : null}
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -215,7 +215,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                             label={
                                 isFiltered
                                     ? 'This field is filtered'
-                                    : `Click here to filter by ${item.name}`
+                                    : `Click here to add filter`
                             }
                         >
                             <ActionIcon
@@ -223,7 +223,7 @@ const TreeSingleNode: FC<Props> = ({ node }) => {
                                     track({
                                         name: EventName.ADD_FILTER_CLICKED,
                                     });
-                                    addFilter(item, undefined);
+                                    if (!isFiltered) addFilter(item, undefined);
                                     e.stopPropagation(); // Do not toggle the field on filter click
                                 }}
                             >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #12289


### Extra requirements

- we keep add metric in ... menu
-  if there’s already a filter applied, then clicking on the filter doesn’t do anything


### Description:
<!-- Add a description of the changes proposed in the pull request. -->
![image](https://github.com/user-attachments/assets/cc7ff57f-f784-49dc-bce3-44d508806f17)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
