### PR TITLE
fix: added check and throw error in group update if newMembers does not match expected

### DIFF
--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -415,6 +415,13 @@ export class GroupsModel {
                         )
                         .andWhere('groups.group_uuid', groupUuid);
 
+                    // Check if there are no valid users to add and throw an error if so
+                    if (newMembers.length === 0) {
+                        throw new Error(
+                            `No valid users found for the provided user UUIDs`,
+                        );
+                    }
+
                     await trx('group_memberships')
                         .insert(newMembers)
                         .onConflict()

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -415,11 +415,9 @@ export class GroupsModel {
                         )
                         .andWhere('groups.group_uuid', groupUuid);
 
-                    // Check if there are no valid users to add and throw an error if so
-                    if (newMembers.length === 0) {
-                        throw new Error(
-                            `No valid users found for the provided user UUIDs`,
-                        );
+                    // Check if the initial and resulting counts match
+                    if (newMembers.length !== membersToAdd.length) {
+                        throw new Error(`Some provided user UUIDs are invalid`);
                     }
 
                     await trx('group_memberships')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-commercial/issues/373

### Description:
- Adds check in group update if newMembers matches membersToAdd, throws error if not. Previously the error thrown by having an empty array for newMembers was not helpful

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
