### PR TITLE
feat: optimistically update categories

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -28,8 +28,8 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
-    const { mutateAsync: updateTag } = useUpdateTag();
-    const { mutateAsync: deleteTag } = useDeleteTag();
+    const { mutate: updateTag } = useUpdateTag();
+    const { mutate: deleteTag } = useDeleteTag();
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(category.name);
     const [editColor, setEditColor] = useState(category.color);
@@ -37,20 +37,43 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     const handleSave = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            await updateTag({
+            console.log('Initiating tag update:', {
                 projectUuid,
                 tagUuid: category.tagUuid,
-                data: { name: editName, color: editColor },
+                currentName: category.name,
+                newName: editName,
+                currentColor: category.color,
+                newColor: editColor,
             });
+            try {
+                updateTag({
+                    projectUuid,
+                    tagUuid: category.tagUuid,
+                    data: { name: editName, color: editColor },
+                });
+                console.log('Tag update completed successfully');
+                setIsEditing(false);
+            } catch (error) {
+                console.error('Tag update failed:', error);
+            }
         }
-        setIsEditing(false);
-    }, [editColor, editName, projectUuid, category.tagUuid, updateTag]);
+    }, [editColor, editName, projectUuid, category, updateTag]);
 
     const onDelete = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            await deleteTag({ projectUuid, tagUuid: category.tagUuid });
+            console.log('Initiating tag deletion:', {
+                projectUuid,
+                tagUuid: category.tagUuid,
+                categoryName: category.name,
+            });
+            try {
+                deleteTag({ projectUuid, tagUuid: category.tagUuid });
+                console.log('Tag deletion completed successfully');
+            } catch (error) {
+                console.error('Tag deletion failed:', error);
+            }
         }
-    }, [deleteTag, projectUuid, category.tagUuid]);
+    }, [deleteTag, projectUuid, category]);
 
     if (isEditing) {
         return (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -37,21 +37,12 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     const handleSave = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            console.log('Initiating tag update:', {
-                projectUuid,
-                tagUuid: category.tagUuid,
-                currentName: category.name,
-                newName: editName,
-                currentColor: category.color,
-                newColor: editColor,
-            });
             try {
                 updateTag({
                     projectUuid,
                     tagUuid: category.tagUuid,
                     data: { name: editName, color: editColor },
                 });
-                console.log('Tag update completed successfully');
                 setIsEditing(false);
             } catch (error) {
                 console.error('Tag update failed:', error);
@@ -61,14 +52,8 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     const onDelete = useCallback(async () => {
         if (category.tagUuid && projectUuid) {
-            console.log('Initiating tag deletion:', {
-                projectUuid,
-                tagUuid: category.tagUuid,
-                categoryName: category.name,
-            });
             try {
                 deleteTag({ projectUuid, tagUuid: category.tagUuid });
-                console.log('Tag deletion completed successfully');
             } catch (error) {
                 console.error('Tag deletion failed:', error);
             }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -125,11 +125,7 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
     return (
         <Group spacing={4} position="apart" w="100%">
-            <CatalogCategory
-                category={category}
-                onClick={onClick}
-                onRemove={onDelete}
-            />
+            <CatalogCategory category={category} onClick={onClick} />
             <ActionIcon
                 size="xs"
                 variant="subtle"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -74,6 +74,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
 
         useEffect(() => {
             if (opened) {
+                // Generate new color when popover opens
                 setTagColor(getRandomColor(colors));
             } else {
                 setTagColor(undefined);
@@ -108,6 +109,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                             catalogSearchUuid,
                         });
 
+                        // Reset search and color after creating a new tag
                         setSearch('');
                         setTagColor(getRandomColor(colors));
                     }
@@ -122,6 +124,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                         },
                     });
                 } catch (error) {
+                    // TODO: Add toast on error
                     console.error('Error adding tag:', error);
                 }
             },
@@ -155,6 +158,8 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
             [projectUuid, untagCatalogItemMutation, catalogSearchUuid],
         );
 
+        // Filter existing categories that are already applied to this metric
+        // Returns categories whose names match the search term (case insensitive)
         const filteredExistingCategories = useMemo(
             () =>
                 filter(metricCategories, (category) =>
@@ -163,6 +168,9 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
             [metricCategories, search],
         );
 
+        // Filter available categories that can be applied to this metric
+        // 1. Get categories that aren't already applied to this metric
+        // 2. Filter remaining categories to match search term (case insensitive)
         const filteredAvailableCategories = useMemo(
             () =>
                 filter(
@@ -273,6 +281,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                             spacing={4}
                             w="100%"
                             mah={140}
+                            // For the scrollbar to not overlap the button
                             pr="sm"
                             sx={{
                                 overflow: 'auto',

--- a/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
@@ -8,7 +8,7 @@ type AddCategoryToCatalogItemParams = {
     tagUuid: string;
 };
 
-const addCategoryToCatalogItem = async ({
+export const addCategoryToCatalogItem = async ({
     projectUuid,
     catalogSearchUuid,
     tagUuid,
@@ -31,8 +31,15 @@ export const useAddCategoryToCatalogItem = () => {
         AddCategoryToCatalogItemParams
     >({
         mutationFn: addCategoryToCatalogItem,
+        onMutate: async (variables) => {
+            console.log('Adding category - Mutation started:', variables);
+        },
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['metrics-catalog']);
+            console.log('Adding category - API call successful');
+            void queryClient.invalidateQueries(['metrics-catalog']);
+        },
+        onError: (error) => {
+            console.error('Adding category - API call failed:', error);
         },
     });
 };
@@ -62,8 +69,15 @@ export const useRemoveCategoryFromCatalogItem = () => {
         RemoveCategoryFromCatalogItemParams
     >({
         mutationFn: removeCategoryFromCatalogItem,
+        onMutate: async (variables) => {
+            console.log('Removing category - Mutation started:', variables);
+        },
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['metrics-catalog']);
+            console.log('Removing category - API call successful');
+            void queryClient.invalidateQueries(['metrics-catalog']);
+        },
+        onError: (error) => {
+            console.error('Removing category - API call failed:', error);
         },
     });
 };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useCatalogCategories.tsx
@@ -4,7 +4,11 @@ import {
     type ApiSuccessEmpty,
     type Tag,
 } from '@lightdash/common';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQueryClient,
+    type InfiniteData,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type AddCategoryToCatalogItemParams = {
@@ -34,7 +38,9 @@ export const useAddCategoryToCatalogItem = () => {
         ApiSuccessEmpty['results'],
         ApiError,
         AddCategoryToCatalogItemParams,
-        { previousCatalog: unknown }
+        {
+            previousCatalog: unknown;
+        }
     >({
         mutationFn: addCategoryToCatalogItem,
         onMutate: async ({ catalogSearchUuid, tagUuid, projectUuid }) => {
@@ -57,19 +63,21 @@ export const useAddCategoryToCatalogItem = () => {
             ]);
 
             // Update all matching queries
-            queryClient.setQueriesData(
+            queryClient.setQueriesData<
+                InfiniteData<ApiMetricsCatalog['results']>
+            >(
                 {
                     queryKey: ['metrics-catalog', projectUuid],
                     exact: false,
                 },
-                (old: any) => {
+                (old) => {
                     if (!old?.pages) return old;
 
                     return {
                         ...old,
-                        pages: old.pages.map((page: any) => ({
+                        pages: old.pages.map((page) => ({
                             ...page,
-                            data: page.data.map((item: any) =>
+                            data: page.data.map((item) =>
                                 item.catalogSearchUuid === catalogSearchUuid
                                     ? {
                                           ...item,
@@ -98,10 +106,9 @@ export const useAddCategoryToCatalogItem = () => {
                 Object.entries(context.previousCatalog).forEach(
                     ([queryKeyStr, data]) => {
                         const queryKey = JSON.parse(queryKeyStr);
-                        queryClient.setQueryData<ApiMetricsCatalog['results']>(
-                            queryKey,
-                            data,
-                        );
+                        queryClient.setQueryData<
+                            InfiniteData<ApiMetricsCatalog['results']>
+                        >(queryKey, data);
                     },
                 );
             }
@@ -138,7 +145,9 @@ export const useRemoveCategoryFromCatalogItem = () => {
         ApiSuccessEmpty['results'],
         ApiError,
         RemoveCategoryFromCatalogItemParams,
-        { previousCatalog: unknown }
+        {
+            previousCatalog: unknown;
+        }
     >({
         mutationFn: removeCategoryFromCatalogItem,
         onMutate: async ({ catalogSearchUuid, tagUuid, projectUuid }) => {
@@ -154,24 +163,26 @@ export const useRemoveCategoryFromCatalogItem = () => {
             ]);
 
             // Update all matching queries
-            queryClient.setQueriesData(
+            queryClient.setQueriesData<
+                InfiniteData<ApiMetricsCatalog['results']>
+            >(
                 {
                     queryKey: ['metrics-catalog', projectUuid],
                     exact: false,
                 },
-                (old: any) => {
+                (old) => {
                     if (!old?.pages) return old;
 
                     return {
                         ...old,
-                        pages: old.pages.map((page: any) => ({
+                        pages: old.pages.map((page) => ({
                             ...page,
-                            data: page.data.map((item: any) =>
+                            data: page.data.map((item) =>
                                 item.catalogSearchUuid === catalogSearchUuid
                                     ? {
                                           ...item,
                                           categories: item.categories.filter(
-                                              (category: any) =>
+                                              (category) =>
                                                   category.tagUuid !== tagUuid,
                                           ),
                                       }
@@ -189,10 +200,9 @@ export const useRemoveCategoryFromCatalogItem = () => {
                 Object.entries(context.previousCatalog).forEach(
                     ([queryKeyStr, data]) => {
                         const queryKey = JSON.parse(queryKeyStr);
-                        queryClient.setQueryData<ApiMetricsCatalog['results']>(
-                            queryKey,
-                            data,
-                        );
+                        queryClient.setQueryData<
+                            InfiniteData<ApiMetricsCatalog['results']>
+                        >(queryKey, data);
                     },
                 );
             }

--- a/packages/frontend/src/features/metricsCatalog/hooks/useProjectTags.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useProjectTags.tsx
@@ -40,7 +40,9 @@ export const useCreateTag = () => {
             data: Pick<Tag, 'name' | 'color'>;
             catalogSearchUuid?: string;
         },
-        { previousCatalog: InfiniteData<ApiMetricsCatalog['results']> }
+        {
+            previousCatalog: unknown;
+        }
     >({
         mutationFn: async ({ projectUuid, data, catalogSearchUuid }) => {
             const newTag = await createTag(projectUuid, data);
@@ -132,10 +134,9 @@ export const useCreateTag = () => {
                 Object.entries(context.previousCatalog).forEach(
                     ([queryKeyStr, data]) => {
                         const queryKey = JSON.parse(queryKeyStr);
-                        queryClient.setQueryData<ApiMetricsCatalog['results']>(
-                            queryKey,
-                            data,
-                        );
+                        queryClient.setQueryData<
+                            InfiniteData<ApiMetricsCatalog['results']>
+                        >(queryKey, data);
                     },
                 );
             }
@@ -194,7 +195,9 @@ export const useUpdateTag = () => {
             tagUuid: string;
             data: Pick<Tag, 'name' | 'color'>;
         },
-        { previousCatalog: InfiniteData<ApiMetricsCatalog['results']> }
+        {
+            previousCatalog: unknown;
+        }
     >({
         mutationFn: ({ projectUuid, tagUuid, data }) => {
             return updateTag(projectUuid, tagUuid, data);
@@ -289,7 +292,9 @@ export const useDeleteTag = () => {
         ApiSuccessEmpty,
         ApiError,
         { projectUuid: string; tagUuid: string },
-        { previousCatalog: InfiniteData<ApiMetricsCatalog['results']> }
+        {
+            previousCatalog: unknown;
+        }
     >({
         mutationFn: ({ projectUuid, tagUuid }) => {
             return deleteTag(projectUuid, tagUuid);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12308 

### Description:

Adds optimistic updates to `metrics-catalog` and `project-tags` queries. 

#### Test plan

- Creating a category (which will also category the metric)
1. optimistically update the list of categories in the form 
2. update the tagInput value array
3. as well as the cell array

- uncategorising a metric
1. update the tagInput value array
1. as well as the cell array
1. list of categories in the form **remains the same**

- deleting a **tag** project
1. update the tagInput value array (if category is there)
1. as well as the cell array
1. list of categories in the form updates

- updating a **tag** the project
1. update the tagInput value array (if category is there)
1. as well as the cell array
1. list of categories in the form updates

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
