### PR TITLE
feat: force unique group names at the db level

### DIFF
--- a/packages/backend/src/database/migrations/20241108145015_group-names-unique.ts
+++ b/packages/backend/src/database/migrations/20241108145015_group-names-unique.ts
@@ -27,7 +27,7 @@ export async function up(knex: Knex): Promise<void> {
             // eslint-disable-next-line no-await-in-loop
             await knex(GroupsTableName)
                 .where({ group_uuid: rows[i].group_uuid })
-                .update({ name: `${name} ${i}` });
+                .update({ name: `${name} ${i + 1}` });
         }
     }
 

--- a/packages/backend/src/database/migrations/20241108145015_group-names-unique.ts
+++ b/packages/backend/src/database/migrations/20241108145015_group-names-unique.ts
@@ -1,0 +1,44 @@
+import { Knex } from 'knex';
+
+const GroupsTableName = 'groups';
+
+export async function up(knex: Knex): Promise<void> {
+    // Ensure no duplicate names for organization_id by appending suffixes
+    const duplicates = await knex(GroupsTableName)
+        .select('name', 'organization_id')
+        .count('* as duplicate_count')
+        .groupBy('name', 'organization_id')
+        .having(knex.raw('count(*) > ?', [1]));
+
+    for (const duplicate of duplicates) {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { name, organization_id } = duplicate;
+
+        // Get all rows with this name and organization_id to rename them
+        // eslint-disable-next-line no-await-in-loop
+        const rows = await knex(GroupsTableName)
+            .select('group_uuid')
+            .where({ name, organization_id })
+            .orderBy('created_at', 'asc');
+
+        // Rename duplicates with suffixes
+        // eslint-disable-next-line no-plusplus
+        for (let i = 1; i < rows.length; i++) {
+            // eslint-disable-next-line no-await-in-loop
+            await knex(GroupsTableName)
+                .where({ group_uuid: rows[i].group_uuid })
+                .update({ name: `${name} ${i}` });
+        }
+    }
+
+    // Add the unique constraint on name and organization_id
+    await knex.schema.alterTable(GroupsTableName, (table) => {
+        table.unique(['name', 'organization_id']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(GroupsTableName, (table) => {
+        table.dropUnique(['name', 'organization_id']);
+    });
+}

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -1,9 +1,11 @@
 import {
+    AlreadyExistsError,
     CreateGroup,
     Group,
     GroupMember,
     GroupMembership,
     GroupWithMembers,
+    KnexPaginationError,
     NotExistsError,
     NotFoundError,
     ProjectGroupAccess,
@@ -226,31 +228,41 @@ export class GroupsModel {
         createGroup: CreateGroup & { organizationUuid: string },
     ): Promise<GroupWithMembers> {
         const groupUuid = await this.database.transaction(async (trx) => {
-            const results = await trx.raw<{
-                rows: { created_at: Date; group_uuid: string }[];
-            }>(
-                `
+            try {
+                const results = await trx.raw<{
+                    rows: { created_at: Date; group_uuid: string }[];
+                }>(
+                    `
                     INSERT INTO groups (name, organization_id)
                     SELECT ?, organization_id
                     FROM organizations
                     WHERE organization_uuid = ? RETURNING group_uuid, groups.created_at
                 `,
-                [createGroup.name, createGroup.organizationUuid],
-            );
-            const [row] = results.rows;
-            if (row === undefined) {
-                throw new UnexpectedDatabaseError(`Failed to create group`);
-            }
-
-            if (createGroup.members && createGroup.members.length > 0) {
-                await GroupsModel.addGroupMembers(
-                    trx,
-                    row.group_uuid,
-                    createGroup.members.map((m) => m.userUuid),
+                    [createGroup.name.trim(), createGroup.organizationUuid],
                 );
+
+                const [row] = results.rows;
+                if (row === undefined) {
+                    throw new UnexpectedDatabaseError(`Failed to create group`);
+                }
+
+                if (createGroup.members && createGroup.members.length > 0) {
+                    await GroupsModel.addGroupMembers(
+                        trx,
+                        row.group_uuid,
+                        createGroup.members.map((m) => m.userUuid),
+                    );
+                }
+                return row.group_uuid;
+            } catch (error) {
+                // Unique violation in PostgreSQL
+                if (error.code === '23505') {
+                    throw new AlreadyExistsError(`Group name already exists`);
+                }
+                throw error; // Re-throw other errors
             }
-            return row.group_uuid;
         });
+
         return this.getGroupWithMembers(groupUuid);
     }
 
@@ -368,7 +380,6 @@ export class GroupsModel {
         groupUuid: string,
         update: UpdateGroupWithMembers,
     ): Promise<GroupWithMembers> {
-        // TODO: fix include member count
         const existingGroup = await this.getGroupWithMembers(groupUuid, 10000);
         if (existingGroup === undefined) {
             throw new NotFoundError(`No group found`);
@@ -376,10 +387,21 @@ export class GroupsModel {
 
         await this.database.transaction(async (trx) => {
             if (update.name) {
-                await trx('groups')
-                    .update({ name: update.name })
-                    .where('group_uuid', groupUuid);
+                try {
+                    await trx('groups')
+                        .update({ name: update.name.trim() })
+                        .where('group_uuid', groupUuid);
+                } catch (error) {
+                    // Unique violation in PostgreSQL
+                    if (error.code === '23505') {
+                        throw new AlreadyExistsError(
+                            `Group name already exists`,
+                        );
+                    }
+                    throw error; // Re-throw other errors
+                }
             }
+
             if (update.members !== undefined) {
                 const membersToAdd = differenceBy(
                     update.members,

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -5,7 +5,6 @@ import {
     GroupMember,
     GroupMembership,
     GroupWithMembers,
-    KnexPaginationError,
     NotExistsError,
     NotFoundError,
     ProjectGroupAccess,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-commercial/issues/362

### Description:
- Creates a unique constraint on the groups table by (name, organization_id) but first changes any identically named groups in an org to "$NAME", "$NAME 2", "$NAME...
- On group update and delete it checks for a Postgres unique violation error and throws an appropriate Lightdash error

<!-- Even better add a screenshot / gif / loom -->
<img width="1293" alt="Screenshot 2024-11-11 at 10 15 18 AM" src="https://github.com/user-attachments/assets/b419f8f1-800b-4936-9e0a-cbe2f6d43097">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
