### PR TITLE
fix: send now filters weren't working for images, some filters 

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -282,10 +282,7 @@ const updateFilters = (
             ...(schedulerFilters ?? []),
             {
                 ...schedulerFilter,
-                disabled: !(
-                    filterToCompareAgainst.disabled &&
-                    filterToCompareAgainst.disabled === true
-                ),
+                disabled: filterToCompareAgainst.disabled === true,
             },
         ];
     }

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -27,7 +27,7 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 const MinimalDashboard: FC = () => {
     const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
     const schedulerUuid = useSearchParams('schedulerUuid');
-    const sendNowchedulerFilters = useSearchParams('sendNowchedulerFilters');
+    const sendNowSchedulerFilters = useSearchParams('sendNowSchedulerFilters');
     const schedulerTabs = useSearchParams('selectedTabs');
     const dateZoom = useDateZoomGranularitySearch();
 
@@ -42,18 +42,18 @@ const MinimalDashboard: FC = () => {
         isError: isSchedulerError,
         error: schedulerError,
     } = useScheduler(schedulerUuid!, {
-        enabled: !!schedulerUuid && !sendNowchedulerFilters,
+        enabled: !!schedulerUuid && !sendNowSchedulerFilters,
     });
 
     const schedulerFilters = useMemo(() => {
         if (schedulerUuid && scheduler && isDashboardScheduler(scheduler)) {
             return scheduler.filters;
         }
-        if (sendNowchedulerFilters) {
-            return JSON.parse(sendNowchedulerFilters);
+        if (sendNowSchedulerFilters) {
+            return JSON.parse(sendNowSchedulerFilters);
         }
         return undefined;
-    }, [scheduler, schedulerUuid, sendNowchedulerFilters]);
+    }, [scheduler, schedulerUuid, sendNowSchedulerFilters]);
 
     const selectedTabs = useMemo(() => {
         if (schedulerTabs) {


### PR DESCRIPTION
…isabled on creation

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12204 

### Description:

The SD filters were being set as disabled. This fixes that by using the existing fitler setting for disabled.

Also, send now wasn't using the Scheduled delivery filters because of a typo in URL parsing. This was adding to confusing about whether SD filters worked at all. Also fixed here. 

To repro the issue:

Add a fitler to a dashboard for something like 'date is after...'
Set up a scheduled delivery with a filter for a different 'date is after...'
Send now. You will get data filtered by the dashboard filter.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
