### PR TITLE
fix: react default prop and controlled component errors

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -45,7 +45,7 @@ type Props<T> = {
     titleLeftIcon?: ReactNode;
     chartName?: string;
     titleHref?: string;
-    description?: string;
+    description?: string | null;
     tile: T;
     isLoading?: boolean;
     extraMenuItems?: ReactNode;
@@ -64,10 +64,10 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     title,
     titleLeftIcon,
     chartName,
-    description,
+    description = null,
     tile,
-    isLoading,
-    extraMenuItems,
+    isLoading = false,
+    extraMenuItems = null,
     onDelete,
     onEdit,
     children,
@@ -374,13 +374,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             />
         </Card>
     );
-};
-
-TileBase.defaultProps = {
-    isLoading: false,
-    extraMenuItems: null,
-    description: null,
-    hasFilters: false,
 };
 
 export default TileBase;

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -122,7 +122,7 @@ export const CartesianChartStyling = ({
                     <Config.Heading>{`X-axis label`}</Config.Heading>
 
                     <TextInput
-                        value={xAxisLabel}
+                        value={xAxisLabel || ''}
                         radius="md"
                         onChange={(e) =>
                             dispatch(
@@ -162,7 +162,7 @@ export const CartesianChartStyling = ({
                                 />
                             )}
                             <TextInput
-                                value={yAxisLabel}
+                                value={yAxisLabel || ''}
                                 radius="md"
                                 onChange={(e) =>
                                     dispatch(

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -53,7 +53,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
     series,
     getSingleSeries,
     updateSingleSeries,
-    isGrouped,
+    isGrouped = false,
     isSingle,
     isOpen,
     toggleIsOpen,
@@ -264,10 +264,6 @@ const SingleSeriesConfiguration: FC<Props> = ({
             </Collapse>
         </Box>
     );
-};
-
-SingleSeriesConfiguration.defaultProps = {
-    isGrouped: false,
 };
 
 export default SingleSeriesConfiguration;


### PR DESCRIPTION
### Description:

Fixes a couple react errors. 
- React started warning about defaultProps, so I removed them:
```
Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```
- There was a warning about control/uncontrolled components for the axis names in SQL runner



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
