### PR TITLE
chore: introduce shared emoji picker and metric icon

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,6 +67,7 @@
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "echarts-for-react": "^3.0.2",
+        "emoji-picker-react": "^4.12.0",
         "fuse.js": "^6.5.3",
         "immer": "^10.1.1",
         "jspdf": "^2.5.1",

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -12,7 +12,7 @@ import {
 import { useClickOutside } from '@mantine/hooks';
 import EmojiPicker, { EmojiStyle } from 'emoji-picker-react';
 import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
-import { forwardRef, useCallback, useState, type FC } from 'react';
+import { forwardRef, useCallback, useEffect, useState, type FC } from 'react';
 import MetricIconPlaceholder from '../../../svgs/metrics-catalog-metric-icon.svg?react';
 
 const SharedEmojiPicker = forwardRef(
@@ -74,6 +74,21 @@ export const MetricsCatalogColumnName: FC<Props> = ({ row, table }) => {
     } | null>(null);
     const [iconRef, setIconRef] = useState<HTMLButtonElement | null>(null);
     const [pickerRef, setPickerRef] = useState<HTMLDivElement | null>(null);
+
+    useEffect(
+        function lockScroll() {
+            const tableContainer = table.refs.tableContainerRef.current;
+            if (tableContainer && isPickerOpen) {
+                tableContainer.style.overflow = 'hidden';
+            }
+            return () => {
+                if (tableContainer) {
+                    tableContainer.style.overflow = 'auto';
+                }
+            };
+        },
+        [isPickerOpen, table.refs.tableContainerRef],
+    );
 
     const handleClosePicker = useCallback(() => {
         setIsPickerOpen(false);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -15,6 +15,8 @@ import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
 import { forwardRef, useCallback, useEffect, useState, type FC } from 'react';
 import MetricIconPlaceholder from '../../../svgs/metrics-catalog-metric-icon.svg?react';
 
+const PICKER_HEIGHT = 400;
+
 const SharedEmojiPicker = forwardRef(
     (
         {
@@ -44,6 +46,7 @@ const SharedEmojiPicker = forwardRef(
 
                         {/* TODO: display loader on emoji picker loading */}
                         <EmojiPicker
+                            height={PICKER_HEIGHT}
                             style={{
                                 pointerEvents: 'none',
                                 opacity: 0.5,
@@ -102,8 +105,19 @@ export const MetricsCatalogColumnName: FC<Props> = ({ row, table }) => {
             return handleClosePicker();
         }
         const rect = e.currentTarget.getBoundingClientRect();
+
+        // Get viewport height and picker approximate height (400px is typical for emoji picker)
+        const viewportHeight = window.innerHeight;
+        const pickerHeight = PICKER_HEIGHT;
+
+        // Check if there's enough space below
+        const spaceBelow = viewportHeight - rect.bottom;
+        const shouldShowAbove = spaceBelow < pickerHeight;
+
         setPickerPosition({
-            top: rect.bottom + 5,
+            top: shouldShowAbove
+                ? rect.top - pickerHeight - 5
+                : rect.bottom + 5,
             left: rect.left,
         });
         setIsPickerOpen(true);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -7,6 +7,7 @@ import {
     Highlight,
     Paper,
     Portal,
+    Text,
 } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import EmojiPicker, { EmojiStyle } from 'emoji-picker-react';
@@ -36,9 +37,17 @@ const SharedEmojiPicker = forwardRef(
                         zIndex: getDefaultZIndex('overlay'),
                     }}
                 >
-                    <Paper shadow="md">
+                    <Paper shadow="md" pos="relative">
+                        <Text fw={500} size="sm" ta="center">
+                            Coming soon
+                        </Text>
+
                         {/* TODO: display loader on emoji picker loading */}
                         <EmojiPicker
+                            style={{
+                                pointerEvents: 'none',
+                                opacity: 0.5,
+                            }}
                             // TODO: Add onEmojiClick
                             previewConfig={undefined}
                             lazyLoadEmojis

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -1,0 +1,110 @@
+import { type CatalogField } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    getDefaultZIndex,
+    Group,
+    Highlight,
+    Paper,
+    Portal,
+} from '@mantine/core';
+import { useClickOutside } from '@mantine/hooks';
+import EmojiPicker, { EmojiStyle } from 'emoji-picker-react';
+import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
+import { forwardRef, useCallback, useState, type FC } from 'react';
+import MetricIconPlaceholder from '../../../svgs/metrics-catalog-metric-icon.svg?react';
+
+const SharedEmojiPicker = forwardRef(
+    (
+        {
+            position,
+        }: {
+            position: { top: number; left: number } | null;
+        },
+        ref: React.ForwardedRef<HTMLDivElement>,
+    ) => {
+        if (!position) return null;
+
+        return (
+            <Portal>
+                <Box
+                    ref={ref}
+                    pos="fixed"
+                    top={position.top}
+                    left={position.left}
+                    sx={{
+                        zIndex: getDefaultZIndex('overlay'),
+                    }}
+                >
+                    <Paper shadow="md">
+                        {/* TODO: display loader on emoji picker loading */}
+                        <EmojiPicker
+                            // TODO: Add onEmojiClick
+                            previewConfig={undefined}
+                            lazyLoadEmojis
+                            emojiStyle={EmojiStyle.NATIVE}
+                            searchDisabled
+                        />
+                    </Paper>
+                </Box>
+            </Portal>
+        );
+    },
+);
+
+type Props = {
+    row: MRT_Row<CatalogField>;
+    table: MRT_TableInstance<CatalogField>;
+};
+
+export const MetricsCatalogColumnName: FC<Props> = ({ row, table }) => {
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+    const [pickerPosition, setPickerPosition] = useState<{
+        top: number;
+        left: number;
+    } | null>(null);
+    const [iconRef, setIconRef] = useState<HTMLButtonElement | null>(null);
+    const [pickerRef, setPickerRef] = useState<HTMLDivElement | null>(null);
+
+    const handleClosePicker = useCallback(() => {
+        setIsPickerOpen(false);
+        setPickerPosition(null);
+    }, []);
+
+    useClickOutside(handleClosePicker, null, [iconRef, pickerRef]);
+
+    const handleIconClick = (e: React.MouseEvent) => {
+        if (isPickerOpen) {
+            return handleClosePicker();
+        }
+        const rect = e.currentTarget.getBoundingClientRect();
+        setPickerPosition({
+            top: rect.bottom + 5,
+            left: rect.left,
+        });
+        setIsPickerOpen(true);
+    };
+
+    return (
+        <>
+            <Group noWrap spacing="xs">
+                <ActionIcon
+                    ref={setIconRef}
+                    variant="default"
+                    w={25}
+                    h={25}
+                    radius="sm"
+                    p="two"
+                    sx={{ flexShrink: 0 }}
+                    onClick={handleIconClick}
+                >
+                    <MetricIconPlaceholder width="100%" height="100%" />
+                </ActionIcon>
+                <Highlight highlight={table.getState().globalFilter || ''}>
+                    {row.original.label}
+                </Highlight>
+            </Group>
+            <SharedEmojiPicker position={pickerPosition} ref={setPickerRef} />
+        </>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -116,6 +116,7 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             );
 
             return (
+                // This is a hack to make the whole cell clickable and avoid race conditions with click outside events
                 <Box
                     pos="absolute"
                     p="md"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,13 +1,13 @@
 import { type CatalogField } from '@lightdash/common';
-import { Box, Group, Highlight, HoverCard, Paper, Text } from '@mantine/core';
+import { Box, Group, Highlight, HoverCard, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo } from 'react';
-import MetricIconPlaceholder from '../../../svgs/metrics-catalog-metric-icon.svg?react';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { CatalogCategory } from './CatalogCategory';
 import { MetricChartUsageButton } from './MetricChartUsageButton';
 import { MetricsCatalogCategoryForm } from './MetricsCatalogCategoryForm';
+import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
 
 export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
     {
@@ -15,25 +15,7 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         header: 'Metric Name',
         enableSorting: true,
         enableEditing: false,
-        Cell: ({ row, table }) => (
-            <Group noWrap spacing="xs">
-                <Paper
-                    w={25}
-                    h={25}
-                    withBorder
-                    radius="sm"
-                    p="two"
-                    sx={{
-                        flexShrink: 0,
-                    }}
-                >
-                    <MetricIconPlaceholder width="100%" height="100%" />
-                </Paper>
-                <Highlight highlight={table.getState().globalFilter || ''}>
-                    {row.original.label}
-                </Highlight>
-            </Group>
-        ),
+        Cell: MetricsCatalogColumnName,
     },
     {
         accessorKey: 'description',
@@ -134,7 +116,6 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             );
 
             return (
-                // This is a hack to make the whole cell clickable and avoid race conditions with click outside events
                 <Box
                     pos="absolute"
                     p="md"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,8 +1,9 @@
 import { type CatalogField } from '@lightdash/common';
-import { Box, Group, Highlight, HoverCard, Text } from '@mantine/core';
+import { Box, Group, Highlight, HoverCard, Paper, Text } from '@mantine/core';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo } from 'react';
+import MetricIconPlaceholder from '../../../svgs/metrics-catalog-metric-icon.svg?react';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { CatalogCategory } from './CatalogCategory';
 import { MetricChartUsageButton } from './MetricChartUsageButton';
@@ -15,9 +16,23 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         enableSorting: true,
         enableEditing: false,
         Cell: ({ row, table }) => (
-            <Highlight highlight={table.getState().globalFilter || ''}>
-                {row.original.label}
-            </Highlight>
+            <Group noWrap spacing="xs">
+                <Paper
+                    w={25}
+                    h={25}
+                    withBorder
+                    radius="sm"
+                    p="two"
+                    sx={{
+                        flexShrink: 0,
+                    }}
+                >
+                    <MetricIconPlaceholder width="100%" height="100%" />
+                </Paper>
+                <Highlight highlight={table.getState().globalFilter || ''}>
+                    {row.original.label}
+                </Highlight>
+            </Group>
         ),
     },
     {

--- a/packages/frontend/src/svgs/metrics-catalog-metric-icon.svg
+++ b/packages/frontend/src/svgs/metrics-catalog-metric-icon.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.12499 2.25L4.87499 15.75M13.125 2.25L10.875 15.75M15.375 6H2.625M14.625 12H1.875" stroke="#845EF7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10783,6 +10783,13 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
+emoji-picker-react@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/emoji-picker-react/-/emoji-picker-react-4.12.0.tgz#4cc310ad4b8a39844a2d5edcc92967683d6b5138"
+  integrity sha512-q2c8UcZH0eRIMj41bj0k1akTjk69tsu+E7EzkW7giN66iltF6H9LQvQvw6ugscsxdC+1lmt3WZpQkkY65J95tg==
+  dependencies:
+    flairup "1.0.0"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -12105,6 +12112,11 @@ finity@^0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/finity/-/finity-0.5.4.tgz"
   integrity sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA==
+
+flairup@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/flairup/-/flairup-1.0.0.tgz#d3af0052ad02734c12d2446608a869498adb351b"
+  integrity sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==
 
 flat-cache@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Close: #12344 

### Description:

Adds `emoji-picker-react`
Creates shared emoji picker (one for all cells with `Portal`) 

DEMO: 


https://github.com/user-attachments/assets/92e49064-65be-48b4-afb8-9aac07694ba0



> [!NOTE]
> If we had a popover with the picker for each cell, that would lead to a very slow ux because the emoji picker would be mounted on every open. If we kept the popover mounted, it would lead to a nr_of_cells X pickers on the UI which is a no-no. So keeping a shared instance and moving the position as requested is an easier experience. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
