### PR TITLE
fix: scheduled delivery any value filter override

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -282,7 +282,7 @@ const updateFilters = (
             ...(schedulerFilters ?? []),
             {
                 ...schedulerFilter,
-                disabled: filterToCompareAgainst.disabled === true,
+                disabled: false,
             },
         ];
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12350 

### Description:

Dashboard filters with *any value* weren't overridable in Scheduled delivery filters. The Scheduler UI was considering them disabled since they had an empty default value. 

To test this:
1. Add a dashboard filter with no default (any value)
2. Create a scheduled delivery and add the a default value
3. Send now. The filter added to the delivery should be respected

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
