### PR TITLE
fix: metrics catalog scroll bars

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -3,6 +3,7 @@ import {
     Group,
     List,
     Modal,
+    ScrollArea,
     Stack,
     Text,
     type ModalProps,
@@ -52,6 +53,7 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
                 header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
                 body: { padding: 0 },
             })}
+            scrollAreaComponent={ScrollArea.Autosize}
         >
             <Stack p="md" spacing="xs">
                 <Text>This metric is used in the following charts:</Text>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -3,7 +3,6 @@ import {
     Group,
     List,
     Modal,
-    ScrollArea,
     Stack,
     Text,
     type ModalProps,
@@ -36,64 +35,82 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     });
 
     return (
-        <Modal
+        <Modal.Root
             opened={opened}
             onClose={onClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconDeviceAnalytics}
-                        size="lg"
-                        color="gray.7"
-                    />
-                    <Text fw={500}>Metric Usage</Text>
-                </Group>
-            }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
-                body: { padding: 0 },
-            })}
-            scrollAreaComponent={ScrollArea.Autosize}
+            yOffset={200}
+            scrollAreaComponent={undefined}
+            size="lg"
         >
-            <Stack p="md" spacing="xs">
-                <Text>This metric is used in the following charts:</Text>
-                {isLoading ? (
-                    <Text size="sm" color="dimmed">
-                        Loading...
-                    </Text>
-                ) : analytics?.charts.length === 0 ? (
-                    <Text size="sm" color="dimmed">
-                        No charts found using this metric
-                    </Text>
-                ) : (
-                    <List pl="sm">
-                        {analytics?.charts.map((chart) => (
-                            <List.Item key={chart.uuid} fz="sm">
-                                <Anchor
-                                    href={`/projects/${projectUuid}/saved/${chart.uuid}`}
-                                    target="_blank"
-                                    onClick={() => {
-                                        track({
-                                            name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
-                                            properties: {
-                                                organizationId:
-                                                    organizationUuid,
-                                                projectId: projectUuid,
-                                                metricName: activeMetric?.name,
-                                                tableName:
-                                                    activeMetric?.tableName,
-                                                chartId: chart.uuid,
-                                            },
-                                        });
-                                    }}
-                                >
-                                    {chart.name}
-                                </Anchor>
-                            </List.Item>
-                        ))}
-                    </List>
-                )}
-            </Stack>
-        </Modal>
+            <Modal.Overlay />
+            <Modal.Content sx={{ overflow: 'hidden' }}>
+                <Modal.Header
+                    sx={(theme) => ({
+                        borderBottom: `1px solid ${theme.colors.gray[4]}`,
+                    })}
+                >
+                    <Group spacing="xs">
+                        <MantineIcon
+                            icon={IconDeviceAnalytics}
+                            size="lg"
+                            color="gray.7"
+                        />
+                        <Text fw={500}>Metric Usage</Text>
+                    </Group>
+                    <Modal.CloseButton />
+                </Modal.Header>
+                <Modal.Body
+                    p={0}
+                    mah={300}
+                    h="100%"
+                    sx={{
+                        overflowY: 'auto',
+                    }}
+                >
+                    <Stack spacing="xs" p="md">
+                        <Text>
+                            This metric is used in the following charts:
+                        </Text>
+                        {isLoading ? (
+                            <Text size="sm" color="dimmed">
+                                Loading...
+                            </Text>
+                        ) : analytics?.charts.length === 0 ? (
+                            <Text size="sm" color="dimmed">
+                                No charts found using this metric
+                            </Text>
+                        ) : (
+                            <List pl="sm">
+                                {analytics?.charts.map((chart) => (
+                                    <List.Item key={chart.uuid} fz="sm">
+                                        <Anchor
+                                            href={`/projects/${projectUuid}/saved/${chart.uuid}`}
+                                            target="_blank"
+                                            onClick={() => {
+                                                track({
+                                                    name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
+                                                    properties: {
+                                                        organizationId:
+                                                            organizationUuid,
+                                                        projectId: projectUuid,
+                                                        metricName:
+                                                            activeMetric?.name,
+                                                        tableName:
+                                                            activeMetric?.tableName,
+                                                        chartId: chart.uuid,
+                                                    },
+                                                });
+                                            }}
+                                        >
+                                            {chart.name}
+                                        </Anchor>
+                                    </List.Item>
+                                ))}
+                            </List>
+                        )}
+                    </Stack>
+                </Modal.Body>
+            </Modal.Content>
+        </Modal.Root>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -25,7 +25,7 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         header: 'Description',
         enableSorting: false,
         enableEditing: false,
-        size: 400,
+        size: 200,
         Cell: ({ table, row }) => (
             <HoverCard
                 withinPortal
@@ -58,7 +58,7 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         header: 'Table',
         enableSorting: false,
         enableEditing: false,
-        size: 150,
+        size: 100,
         Cell: ({ row }) => <Text fw={500}>{row.original.tableName}</Text>,
     },
     {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -29,7 +29,7 @@ export const MetricsTable = () => {
         (state) => state.metricsCatalog.categoryFilters,
     );
 
-    const tableBodyRef = useRef<HTMLTableSectionElement>(null);
+    const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
         useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
 
@@ -84,13 +84,8 @@ export const MetricsTable = () => {
 
     // Check if we need to fetch more data on mount
     useEffect(() => {
-        fetchMoreOnBottomReached(tableBodyRef.current);
+        fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
-
-    const shouldPadHeader = useMemo(
-        () => hasNextPage || (data?.pages.length ?? 0) > 1,
-        [hasNextPage, data?.pages.length],
-    );
 
     const table = useMantineReactTable({
         columns: MetricsCatalogColumns,
@@ -118,13 +113,18 @@ export const MetricsTable = () => {
         mantinePaperProps: {
             shadow: undefined,
         },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            sx: { maxHeight: '600px', minHeight: '600px' },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
         mantineTableProps: {
             highlightOnHover: true,
             withColumnBorders: true,
         },
         mantineTableHeadRowProps: {
             sx: {
-                paddingRight: shouldPadHeader ? '15px' : '0px', // Add padding to the right of the header to account for the scrollbar
                 boxShadow: 'none',
                 // Each head row has a divider when resizing columns is enabled
                 'th > div > div:last-child': {
@@ -132,23 +132,6 @@ export const MetricsTable = () => {
                     padding: '0px',
                 },
             },
-        },
-        mantineTableContainerProps: {
-            sx: {
-                overflowY: 'hidden', // Hide the vertical scrollbar on the container so it doesn't overlap the header
-                overflowX: 'auto',
-            },
-        },
-        mantineTableBodyProps: {
-            ref: tableBodyRef,
-            sx: {
-                maxHeight: '600px',
-                minHeight: '600px',
-                overflowY: 'auto',
-                overflowX: 'hidden', // Hide the horizontal scrollbar on the body because of the column resizing
-            },
-            onScroll: (event: UIEvent<HTMLDivElement>) =>
-                fetchMoreOnBottomReached(event.target as HTMLDivElement),
         },
         mantineTopToolbarProps: {
             sx: {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -29,7 +29,7 @@ export const MetricsTable = () => {
         (state) => state.metricsCatalog.categoryFilters,
     );
 
-    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const tableBodyRef = useRef<HTMLTableSectionElement>(null);
     const rowVirtualizerInstanceRef =
         useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
 
@@ -84,8 +84,13 @@ export const MetricsTable = () => {
 
     // Check if we need to fetch more data on mount
     useEffect(() => {
-        fetchMoreOnBottomReached(tableContainerRef.current);
+        fetchMoreOnBottomReached(tableBodyRef.current);
     }, [fetchMoreOnBottomReached]);
+
+    const shouldPadHeader = useMemo(
+        () => hasNextPage || (data?.pages.length ?? 0) > 1,
+        [hasNextPage, data?.pages.length],
+    );
 
     const table = useMantineReactTable({
         columns: MetricsCatalogColumns,
@@ -113,18 +118,13 @@ export const MetricsTable = () => {
         mantinePaperProps: {
             shadow: undefined,
         },
-        mantineTableContainerProps: {
-            ref: tableContainerRef,
-            sx: { maxHeight: '600px', minHeight: '600px' },
-            onScroll: (event: UIEvent<HTMLDivElement>) =>
-                fetchMoreOnBottomReached(event.target as HTMLDivElement),
-        },
         mantineTableProps: {
             highlightOnHover: true,
             withColumnBorders: true,
         },
         mantineTableHeadRowProps: {
             sx: {
+                paddingRight: shouldPadHeader ? '15px' : '0px',
                 boxShadow: 'none',
                 // Each head row has a divider when resizing columns is enabled
                 'th > div > div:last-child': {
@@ -132,6 +132,23 @@ export const MetricsTable = () => {
                     padding: '0px',
                 },
             },
+        },
+        mantineTableContainerProps: {
+            sx: {
+                overflowY: 'hidden',
+                overflowX: 'auto',
+            },
+        },
+        mantineTableBodyProps: {
+            ref: tableBodyRef,
+            sx: {
+                maxHeight: '600px',
+                minHeight: '600px',
+                overflowY: 'auto',
+                overflowX: 'hidden',
+            },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
         },
         mantineTopToolbarProps: {
             sx: {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -124,7 +124,7 @@ export const MetricsTable = () => {
         },
         mantineTableHeadRowProps: {
             sx: {
-                paddingRight: shouldPadHeader ? '15px' : '0px',
+                paddingRight: shouldPadHeader ? '15px' : '0px', // Add padding to the right of the header to account for the scrollbar
                 boxShadow: 'none',
                 // Each head row has a divider when resizing columns is enabled
                 'th > div > div:last-child': {
@@ -135,7 +135,7 @@ export const MetricsTable = () => {
         },
         mantineTableContainerProps: {
             sx: {
-                overflowY: 'hidden',
+                overflowY: 'hidden', // Hide the vertical scrollbar on the container so it doesn't overlap the header
                 overflowX: 'auto',
             },
         },
@@ -145,7 +145,7 @@ export const MetricsTable = () => {
                 maxHeight: '600px',
                 minHeight: '600px',
                 overflowY: 'auto',
-                overflowX: 'hidden',
+                overflowX: 'hidden', // Hide the horizontal scrollbar on the body because of the column resizing
             },
             onScroll: (event: UIEvent<HTMLDivElement>) =>
                 fetchMoreOnBottomReached(event.target as HTMLDivElement),

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -18,12 +18,7 @@ const MetricsCatalog: FC = () => {
                     }`,
                 }}
             >
-                <Page
-                    withFitContent
-                    withPaddedContent
-                    withRightSidebar
-                    withLargeContent
-                >
+                <Page withFitContent withPaddedContent withLargeContent>
                     <MetricsCatalogPanel />
                 </Page>
             </MantineProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12298](https://github.com/lightdash/lightdash/issues/12298)

### Description:

- Fixes table scroll bar to show only on the body
![image](https://github.com/user-attachments/assets/c7a0bec5-5d5b-4002-bff2-efc22b34c892)

- Makes chart usage scroll bar use a scroll area: 
![image](https://github.com/user-attachments/assets/e77ad363-4795-460f-bb9c-56ba30281a2f)

Note: scroll bar still hides behind the header, this seems to be a limitation on mantine


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
