### PR TITLE
feat: allow deleting a metric icon

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -177,20 +177,24 @@ export const MetricsCatalogColumnName: FC<Props> = ({ row, table }) => {
                 <ActionIcon
                     ref={setIconRef}
                     variant="default"
-                    w={25}
-                    h={25}
-                    radius="md"
-                    p="two"
-                    sx={{ flexShrink: 0 }}
                     onClick={handleIconClick}
+                    sx={(theme) => ({
+                        width: 28,
+                        height: 28,
+                        flexShrink: 0,
+                        borderRadius: '8px',
+                        border: `1px solid ${theme.colors.gray[3]}`,
+                        boxShadow:
+                            '0px -2px 0px 0px rgba(10, 13, 18, 0.07) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05)',
+                    })}
                 >
                     {isEmojiIcon(row.original.icon) ? (
-                        <Emoji size={22} unified={row.original.icon.unicode} />
+                        <Emoji size={18} unified={row.original.icon.unicode} />
                     ) : (
                         <MetricIconPlaceholder
                             strokeWidth={1.5}
-                            width={22}
-                            height={22}
+                            width={18}
+                            height={18}
                         />
                     )}
                 </ActionIcon>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -184,18 +184,16 @@ export const MetricsCatalogColumnName: FC<Props> = ({ row, table }) => {
                         flexShrink: 0,
                         borderRadius: '8px',
                         border: `1px solid ${theme.colors.gray[3]}`,
-                        boxShadow:
-                            '0px -2px 0px 0px rgba(10, 13, 18, 0.07) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05)',
+                        ...(!isEmojiIcon(row.original.icon) && {
+                            boxShadow:
+                                '0px -2px 0px 0px rgba(10, 13, 18, 0.07) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05)',
+                        }),
                     })}
                 >
                     {isEmojiIcon(row.original.icon) ? (
                         <Emoji size={18} unified={row.original.icon.unicode} />
                     ) : (
-                        <MetricIconPlaceholder
-                            strokeWidth={1.5}
-                            width={18}
-                            height={18}
-                        />
+                        <MetricIconPlaceholder width={12} height={12} />
                     )}
                 </ActionIcon>
                 <Highlight highlight={table.getState().globalFilter || ''}>

--- a/packages/frontend/src/svgs/metrics-catalog-metric-icon.svg
+++ b/packages/frontend/src/svgs/metrics-catalog-metric-icon.svg
@@ -1,3 +1,3 @@
-<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.12499 2.25L4.87499 15.75M13.125 2.25L10.875 15.75M15.375 6H2.625M14.625 12H1.875" stroke="#845EF7" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+  <path d="M1 4.33333H13M1 9.66667H13M4 1V13M10 1V13" stroke="#9775FA" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12363](https://github.com/lightdash/lightdash/issues/12363)

### Description:

This PR: 
- adds the ability to remove an icon from a metric
- applies styles to the metric icon as requested by @PriPatel 

<img width="383" alt="image" src="https://github.com/user-attachments/assets/469b3e53-9629-43c0-b39e-e69c55a24d9a">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
