### PR TITLE
feat: add warning about default filter override

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -35,7 +35,7 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useToggle } from 'react-use';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -87,6 +87,7 @@ type DashboardHeaderProps = {
     onToggleFullscreen: () => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     onTogglePin: () => void;
+    onEditClicked: () => void;
 };
 
 const DashboardHeader = ({
@@ -112,6 +113,7 @@ const DashboardHeader = ({
     onToggleFullscreen,
     setAddingTab,
     onTogglePin,
+    onEditClicked,
 }: DashboardHeaderProps) => {
     const { search } = useLocation();
     const { projectUuid, dashboardUuid } = useParams<{
@@ -120,7 +122,6 @@ const DashboardHeader = ({
         organizationUuid: string;
     }>();
 
-    const history = useHistory();
     const { data: project } = useProject(projectUuid);
 
     const { track } = useTracking();
@@ -374,11 +375,7 @@ const DashboardHeader = ({
                         >
                             <ActionIcon
                                 variant="default"
-                                onClick={() => {
-                                    history.replace(
-                                        `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
-                                    );
-                                }}
+                                onClick={onEditClicked}
                             >
                                 <MantineIcon icon={IconPencil} />
                             </ActionIcon>

--- a/packages/frontend/src/components/common/modal/DashboardFiltersWarningModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardFiltersWarningModal.tsx
@@ -21,8 +21,8 @@ const DashboardFiltersWarningModal: FC<DashboardFiltersWarningModalProps> = ({
             <Stack pt="sm">
                 <Text>
                     Your current filter values do not match the defaults for
-                    this dashboard. Do you want to continue to edit and lose the
-                    current values?
+                    this dashboard. Do you want to discard your filter changes
+                    and edit the dashboard?
                 </Text>
 
                 <Group position="right" mt="sm">

--- a/packages/frontend/src/components/common/modal/DashboardFiltersWarningModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardFiltersWarningModal.tsx
@@ -1,0 +1,46 @@
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Text,
+    type ModalProps,
+} from '@mantine/core';
+import { type FC } from 'react';
+
+interface DashboardFiltersWarningModalProps extends ModalProps {
+    onConfirm?: () => void;
+}
+
+const DashboardFiltersWarningModal: FC<DashboardFiltersWarningModalProps> = ({
+    onConfirm,
+    ...modalProps
+}) => {
+    return (
+        <Modal withCloseButton={false} {...modalProps}>
+            <Stack pt="sm">
+                <Text>
+                    Your current filter values do not match the defaults for
+                    this dashboard. Do you want to continue to edit and lose the
+                    current values?
+                </Text>
+
+                <Group position="right" mt="sm">
+                    <Button
+                        color="dark"
+                        variant="outline"
+                        onClick={modalProps.onClose}
+                    >
+                        Cancel
+                    </Button>
+
+                    <Button color="red" onClick={onConfirm}>
+                        Yes
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default DashboardFiltersWarningModal;

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.tsx
@@ -16,6 +16,7 @@ export const hasSavedFiltersOverrides = (
 
 const ADD_SAVED_FILTER_OVERRIDE = 'ADD_SAVED_FILTER_OVERRIDE';
 const REMOVE_SAVED_FILTER_OVERRIDE = 'REMOVE_SAVED_FILTER_OVERRIDE';
+const RESET_SAVED_FILTER_OVERRIDES = 'RESET_SAVED_FILTER_OVERRIDES';
 
 interface AddSavedFilterOverrideAction {
     type: typeof ADD_SAVED_FILTER_OVERRIDE;
@@ -27,7 +28,15 @@ interface RemoveSavedFilterOverrideAction {
     payload: DashboardFilterRuleOverride;
 }
 
-type Action = AddSavedFilterOverrideAction | RemoveSavedFilterOverrideAction;
+interface ResetSavedFilterOverridesAction {
+    type: typeof RESET_SAVED_FILTER_OVERRIDES;
+    payload: null;
+}
+
+type Action =
+    | AddSavedFilterOverrideAction
+    | RemoveSavedFilterOverrideAction
+    | ResetSavedFilterOverridesAction;
 
 const reducer = (
     state: Record<keyof DashboardFilters, DashboardFilterRuleOverride[]>,
@@ -52,6 +61,9 @@ const reducer = (
                 (dim) => dim.id !== payload.id,
             );
             return { ...state, dimensions: newDimensions };
+
+        case RESET_SAVED_FILTER_OVERRIDES:
+            return { ...state, dimensions: [], metrics: [] };
 
         default:
             return state;
@@ -84,9 +96,14 @@ export const useSavedDashboardFiltersOverrides = () => {
         dispatch({ type: REMOVE_SAVED_FILTER_OVERRIDE, payload: item });
     };
 
+    const resetSavedFilterOverrides = () => {
+        dispatch({ type: RESET_SAVED_FILTER_OVERRIDES, payload: null });
+    };
+
     return {
         overridesForSavedDashboardFilters: state,
         addSavedFilterOverride,
         removeSavedFilterOverride,
+        resetSavedFilterOverrides,
     };
 };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -18,6 +18,7 @@ import MantineIcon from '../components/common/MantineIcon';
 import DashboardDeleteModal from '../components/common/modal/DashboardDeleteModal';
 import DashboardDuplicateModal from '../components/common/modal/DashboardDuplicateModal';
 import { DashboardExportModal } from '../components/common/modal/DashboardExportModal';
+import DashboardFiltersWarningModal from '../components/common/modal/DashboardFiltersWarningModal';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import DashboardFilter from '../components/DashboardFilter';
@@ -119,6 +120,9 @@ const Dashboard: FC = () => {
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
+    const resetDashboardFilters = useDashboardContext(
+        (c) => c.resetDashboardFilters,
+    );
     const setDashboardTemporaryFilters = useDashboardContext(
         (c) => c.setDashboardTemporaryFilters,
     );
@@ -175,6 +179,9 @@ const Dashboard: FC = () => {
             (tile) => tile.type === DashboardTileTypes.SEMANTIC_VIEWER_CHART,
         );
     }, [dashboardTiles]);
+
+    const [isFilterWarningModalOpen, setIsFilterWarningModalOpen] =
+        useState(false);
 
     // tabs state
     const [activeTab, setActiveTab] = useState<DashboardTab | undefined>();
@@ -551,6 +558,23 @@ const Dashboard: FC = () => {
         haveTabsChanged,
     ]);
 
+    const handleEnterEditMode = useCallback(() => {
+        resetDashboardFilters();
+        setIsFilterWarningModalOpen(false);
+        history.replace({
+            pathname: `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+            search: '',
+        });
+    }, [history, projectUuid, dashboardUuid, resetDashboardFilters]);
+
+    const handleEditModeClicked = useCallback(() => {
+        if (haveFiltersChanged) {
+            setIsFilterWarningModalOpen(true);
+        } else {
+            handleEnterEditMode();
+        }
+    }, [haveFiltersChanged, handleEnterEditMode]);
+
     if (dashboardError) {
         return <ErrorState error={dashboardError.error} />;
     }
@@ -670,6 +694,7 @@ const Dashboard: FC = () => {
                         onExport={exportDashboardModalHandlers.open}
                         setAddingTab={setAddingTab}
                         onTogglePin={handleDashboardPinning}
+                        onEditClicked={handleEditModeClicked}
                     />
                 }
                 withFullHeight={true}
@@ -730,6 +755,13 @@ const Dashboard: FC = () => {
                         uuid={dashboard.uuid}
                         onClose={duplicateModalHandlers.close}
                         onConfirm={duplicateModalHandlers.close}
+                    />
+                )}
+                {isFilterWarningModalOpen && (
+                    <DashboardFiltersWarningModal
+                        onConfirm={handleEnterEditMode}
+                        onClose={() => setIsFilterWarningModalOpen(false)}
+                        opened={isFilterWarningModalOpen}
                     />
                 )}
             </Page>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11642 

### Description:

Adds a warning modal when editing a dashboard with filters changed:
<img width="584" alt="Screenshot 2024-11-12 at 17 34 40" src="https://github.com/user-attachments/assets/a597c872-0ff6-4f9c-aae4-691bb753e64c">

If the user clicks yes, we clear the filters and go into edit mode. If they click cancel, cancel editing. 

To repro: either update a saved filter on a dashboard, or add a temp fitler. Then try to edit. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
