### PR TITLE
fix: Pin the version of `trino-client` at v0.2.3

### DIFF
--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -16,7 +16,7 @@
         "pg-cursor": "^2.10.0",
         "snowflake-sdk": "~1.14.0",
         "ssh2": "^1.14.0",
-        "trino-client": "^0.2.3"
+        "trino-client": "0.2.3"
     },
     "devDependencies": {
         "@types/pg": "^8.10.7",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12387

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

This is a tentative solution to build Lightdash CLI to quickly avoid the `ERR_REQUIRE_ESM` error. 

The Lithdash CLI can't be built with `trino-js-client` [v0.2.4](https://github.com/trinodb/trino-js-client/releases/tag/v0.2.4). I am doubting changes from trino-js-client v0.2.3 to v0.2.4. It seems that "type": "module" was added to the package.json` of trino-js-client. We have to change something to handle it.

<!-- Even better add a screenshot / gif / loom -->

According to my research, I was able to build the Lightdash CLI with trino-client v0.2.3. Meanwhile, I could reproduce the error with trino-client v0.2.4.

- (Succeeded) Build with trino-client v0.2.3: https://github.com/yu-iskw/lightdash/pull/1#issuecomment-2472414181
- (Failed) Build with trino-client v0.2.4:https://github.com/yu-iskw/lightdash/pull/2#issuecomment-2472416342

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
