### PR TITLE
fix: dont shorten urls before creating EFH share link

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -583,11 +583,13 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
             return getExplorerUrlFromCreateSavedChartVersion(
                 chartWithDashboardFilters.projectUuid,
                 queryWithoutCustomDimensions,
+                true,
             );
         }
         return getExplorerUrlFromCreateSavedChartVersion(
             chartWithDashboardFilters.projectUuid,
             chartWithDashboardFilters,
+            true,
         );
     }, [chartWithDashboardFilters, cannotUseCustomDimensions]);
 

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -19,6 +19,7 @@ const ExploreFromHereButton = () => {
             return getExplorerUrlFromCreateSavedChartVersion(
                 savedChart.projectUuid,
                 savedChart,
+                true,
             );
         }
     }, [savedChart]);

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -101,6 +101,11 @@ export const createMetricPreviewUnsavedChartVersion = (
 export const getExplorerUrlFromCreateSavedChartVersion = (
     projectUuid: string,
     createSavedChart: CreateSavedChartVersion,
+    // Pass true to preserve long url. This is sometimes desireable when we want
+    // all of the information in the URL, but don't use it for navigation.
+    // For example, the explore from here button uses the entire URL to create
+    // shareable, shortened links.
+    preserveLongUrl?: boolean,
 ): { pathname: string; search: string } => {
     const newParams = new URLSearchParams();
 
@@ -108,6 +113,7 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     const stringifiedChartSize = stringifiedChart.length;
     if (
         stringifiedChartSize > 3000 &&
+        !preserveLongUrl &&
         isCartesianChartConfig(createSavedChart.chartConfig.config)
     ) {
         console.warn(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12367 

### Description:

NOTE: that this is a pretty targeted fix to make sure Explore From Here doesn't lose chart configuration. We could make our URL params and shared/shortened URL interaction better. 

The Explore from here button was using `getExplorerUrlFromCreateSavedChartVersion` to generate an in-memory URL, then using the share URL generator to produce a redirect url from that. But since `getExplorerUrlFromCreateSavedChartVersion` would truncate the url by removing chart config, chart configs were lost in Exploring. This just adds an option to preserve long urls and uses that option for Explore From Here. 

To test:
- go to an explore
- select dimensions and columns
- add a big pivot value (eg: orders day)
- set stacking to 'stack'
- save to a dashboard
- explore from here on that chart
- stacking should be preserved

I have also tested the scenario from the ticket where this url shortening was introduced and it works: 
https://github.com/lightdash/lightdash/pull/11889

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
