### PR TITLE
feat: value label options for sql runner charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3237,6 +3237,23 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 organizationUuid: { dataType: 'string', required: true },
+                updatedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 createdAt: { dataType: 'datetime', required: true },
                 name: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
@@ -7599,6 +7616,7 @@ const models: TsoaRoute.Models = {
                     additionalProperties: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
+                            valueLabelPosition: { dataType: 'string' },
                             type: {
                                 dataType: 'union',
                                 subSchemas: [

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7616,7 +7616,6 @@ const models: TsoaRoute.Models = {
                     additionalProperties: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
-                            valueLabelPosition: { dataType: 'string' },
                             type: {
                                 dataType: 'union',
                                 subSchemas: [

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7580,6 +7580,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValueLabelPositionOptions: {
+        dataType: 'refEnum',
+        enums: ['hidden', 'top', 'bottom', 'left', 'right', 'inside'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CartesianChartDisplay: {
         dataType: 'refAlias',
         type: {
@@ -7616,6 +7621,9 @@ const models: TsoaRoute.Models = {
                     additionalProperties: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
+                            valueLabelPosition: {
+                                ref: 'ValueLabelPositionOptions',
+                            },
                             type: {
                                 dataType: 'union',
                                 subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8354,6 +8354,10 @@
                 "required": ["y"],
                 "type": "object"
             },
+            "ValueLabelPositionOptions": {
+                "enum": ["hidden", "top", "bottom", "left", "right", "inside"],
+                "type": "string"
+            },
             "CartesianChartDisplay": {
                 "properties": {
                     "stack": {
@@ -8377,6 +8381,9 @@
                         "properties": {},
                         "additionalProperties": {
                             "properties": {
+                                "valueLabelPosition": {
+                                    "$ref": "#/components/schemas/ValueLabelPositionOptions"
+                                },
                                 "type": {
                                     "anyOf": [
                                         {
@@ -11008,7 +11015,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1363.1",
+        "version": "0.1364.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8377,9 +8377,6 @@
                         "properties": {},
                         "additionalProperties": {
                             "properties": {
-                                "valueLabelPosition": {
-                                    "type": "string"
-                                },
                                 "type": {
                                     "anyOf": [
                                         {
@@ -11011,7 +11008,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1362.0",
+        "version": "0.1363.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3523,6 +3523,21 @@
                         "type": "string",
                         "description": "The UUID of the organization that the group belongs to"
                     },
+                    "updatedByUserUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The UUID of the user that last updated the group"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The time that the group was last updated"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The UUID of the user that created the group"
+                    },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
@@ -3537,7 +3552,15 @@
                         "description": "The group's UUID"
                     }
                 },
-                "required": ["organizationUuid", "createdAt", "name", "uuid"],
+                "required": [
+                    "organizationUuid",
+                    "updatedByUserUuid",
+                    "updatedAt",
+                    "createdByUserUuid",
+                    "createdAt",
+                    "name",
+                    "uuid"
+                ],
                 "type": "object"
             },
             "GroupMember": {
@@ -8354,6 +8377,9 @@
                         "properties": {},
                         "additionalProperties": {
                             "properties": {
+                                "valueLabelPosition": {
+                                    "type": "string"
+                                },
                                 "type": {
                                     "anyOf": [
                                         {
@@ -10985,7 +11011,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1357.0",
+        "version": "0.1362.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -499,6 +499,10 @@ export class CartesianChartDataModel {
                     (s) => s.yAxisIndex === index,
                 )?.color;
 
+                const seriesValueLabelPosition = Object.values(
+                    display?.series || {},
+                ).find((s) => s.yAxisIndex === index)?.valueLabelPosition;
+
                 return {
                     dimensions: [xAxisReference, seriesColumn],
                     type: defaultSeriesType,
@@ -524,6 +528,12 @@ export class CartesianChartDataModel {
                               )
                             : undefined,
                     },
+                    label: seriesValueLabelPosition
+                        ? {
+                              show: seriesValueLabelPosition !== 'hidden',
+                              position: seriesValueLabelPosition,
+                          }
+                        : undefined,
                     color:
                         seriesColor ||
                         CartesianChartDataModel.getDefaultColor(
@@ -619,6 +629,15 @@ export class CartesianChartDataModel {
     }
 }
 
+export enum ValueLabelPositionOptions {
+    HIDDEN = 'hidden',
+    TOP = 'top',
+    BOTTOM = 'bottom',
+    LEFT = 'left',
+    RIGHT = 'right',
+    INSIDE = 'inside',
+}
+
 export type CartesianChartDisplay = {
     xAxis?: {
         label?: string;
@@ -631,11 +650,14 @@ export type CartesianChartDisplay = {
     }[];
     series?: {
         [key: string]: {
+            // Label maps to 'name' in ECharts
             label?: string;
             format?: Format;
             yAxisIndex?: number;
             color?: string;
             type?: ChartKind.LINE | ChartKind.VERTICAL_BAR;
+            // Value labels maps to 'label' in ECharts
+            valueLabelPosition?: ValueLabelPositionOptions;
         };
     };
     legend?: {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartStyling.tsx
@@ -1,6 +1,7 @@
 import {
     ECHARTS_DEFAULT_COLORS,
     friendlyName,
+    ValueLabelPositionOptions,
     type ChartKind,
 } from '@lightdash/common';
 import { Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
@@ -22,6 +23,7 @@ import {
     CartesianChartSeries,
     type ConfigurableSeries,
 } from './CartesianChartSeries';
+import { CartesianChartValueLabelConfig } from './CartesianChartValueLabelConfig';
 
 export const CartesianChartStyling = ({
     selectedChartType,
@@ -176,21 +178,54 @@ export const CartesianChartStyling = ({
                         </Group>
                     </Config.Group>
                     {series.length < 1 && (
-                        <Config.Group>
-                            <Config.Label>{`Format`}</Config.Label>
-                            <CartesianChartFormatConfig
-                                format={
-                                    currentConfig?.display?.yAxis?.[0]?.format
-                                }
-                                onChangeFormat={(value) => {
-                                    dispatch(
-                                        actions.setYAxisFormat({
-                                            format: value,
-                                        }),
-                                    );
-                                }}
-                            />
-                        </Config.Group>
+                        <>
+                            <Config.Group>
+                                <Config.Label>{`Format`}</Config.Label>
+                                <CartesianChartFormatConfig
+                                    format={
+                                        currentConfig?.display?.yAxis?.[0]
+                                            ?.format
+                                    }
+                                    onChangeFormat={(value) => {
+                                        dispatch(
+                                            actions.setYAxisFormat({
+                                                format: value,
+                                            }),
+                                        );
+                                    }}
+                                />
+                            </Config.Group>
+                            <Config.Group>
+                                <Config.Label>Value labels</Config.Label>
+                                <CartesianChartValueLabelConfig
+                                    valueLabelPosition={
+                                        Object.values(
+                                            currentConfig?.display?.series ||
+                                                {},
+                                        )[0]?.valueLabelPosition ??
+                                        ValueLabelPositionOptions.HIDDEN
+                                    }
+                                    onChangeValueLabelPosition={(value) => {
+                                        if (
+                                            !currentConfig?.fieldConfig?.y[0]
+                                                .reference
+                                        )
+                                            return;
+                                        dispatch(
+                                            actions.setSeriesValueLabelPosition(
+                                                {
+                                                    reference:
+                                                        currentConfig
+                                                            ?.fieldConfig?.y[0]
+                                                            .reference,
+                                                    valueLabelPosition: value,
+                                                },
+                                            ),
+                                        );
+                                    }}
+                                />
+                            </Config.Group>
+                        </>
                     )}
 
                     <Config.Group>

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -1,0 +1,105 @@
+import { ValueLabelPositionOptions } from '@lightdash/common';
+import { Box, Group, Select, Text } from '@mantine/core';
+import {
+    IconArrowDown,
+    IconArrowLeft,
+    IconArrowRight,
+    IconArrowUp,
+    IconClearAll,
+    IconEyeOff,
+    IconLayoutAlignCenter,
+} from '@tabler/icons-react';
+import { capitalize } from 'lodash';
+import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+
+const ValueLabelIcon: FC<{
+    position: ValueLabelPositionOptions | undefined;
+}> = ({ position }) => {
+    let icon;
+    switch (position) {
+        case ValueLabelPositionOptions.HIDDEN:
+            icon = IconEyeOff;
+            break;
+        case ValueLabelPositionOptions.TOP:
+            icon = IconArrowUp;
+            break;
+        case ValueLabelPositionOptions.BOTTOM:
+            icon = IconArrowDown;
+            break;
+        case ValueLabelPositionOptions.LEFT:
+            icon = IconArrowLeft;
+            break;
+        case ValueLabelPositionOptions.RIGHT:
+            icon = IconArrowRight;
+            break;
+        case ValueLabelPositionOptions.INSIDE:
+            icon = IconLayoutAlignCenter;
+            break;
+        default:
+            icon = IconClearAll;
+    }
+
+    return <MantineIcon color={position ? 'indigo.4' : 'gray.4'} icon={icon} />;
+};
+
+type Props = {
+    valueLabelPosition: ValueLabelPositionOptions | undefined;
+    onChangeValueLabelPosition: (value: ValueLabelPositionOptions) => void;
+};
+
+const ValueLabelItem = forwardRef<
+    HTMLDivElement,
+    ComponentPropsWithoutRef<'div'> & {
+        value: ValueLabelPositionOptions;
+        selected: boolean;
+    }
+>(({ value, ...others }, ref) => (
+    <Box ref={ref} {...others}>
+        <Group noWrap spacing="xs">
+            <ValueLabelIcon position={value} />
+            <Text>{capitalize(value)}</Text>
+        </Group>
+    </Box>
+));
+
+export const CartesianChartValueLabelConfig: FC<Props> = ({
+    onChangeValueLabelPosition,
+    valueLabelPosition,
+}) => {
+    return (
+        <Select
+            radius="md"
+            data={Object.values(ValueLabelPositionOptions).map((option) => ({
+                value: option,
+                label: capitalize(option),
+            }))}
+            itemComponent={ValueLabelItem}
+            icon={<ValueLabelIcon position={valueLabelPosition} />}
+            value={valueLabelPosition}
+            onChange={(value) =>
+                value &&
+                onChangeValueLabelPosition(value as ValueLabelPositionOptions)
+            }
+            styles={(theme) => ({
+                input: {
+                    width: '110px',
+                    fontWeight: 500,
+                },
+                item: {
+                    '&[data-selected="true"]': {
+                        color: theme.colors.gray[7],
+                        fontWeight: 500,
+                        backgroundColor: theme.colors.gray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.gray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[1],
+                    },
+                },
+            })}
+        />
+    );
+};

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -6,6 +6,7 @@ import {
     VIZ_DEFAULT_AGGREGATION,
     type CartesianChartDisplay,
     type SortByDirection,
+    type ValueLabelPositionOptions,
     type VizAggregationOptions,
     type VizCartesianChartConfig,
     type VizCartesianChartOptions,
@@ -429,6 +430,30 @@ export const cartesianChartConfigSlice = createSlice({
                     yAxisIndex: action.payload.index,
                     color: action.payload.color,
                 };
+            }
+        },
+        setSeriesValueLabelPosition: (
+            { fieldConfig, display },
+            action: PayloadAction<{
+                reference: string;
+                valueLabelPosition: ValueLabelPositionOptions;
+                index?: number;
+            }>,
+        ) => {
+            if (!fieldConfig) return;
+            display = display || {};
+            display.yAxis = display.yAxis || [];
+            display.series = display.series || {};
+
+            if (fieldConfig?.y.length === 1) {
+                const yReference = fieldConfig?.y[0].reference;
+                if (yReference) {
+                    display.series[yReference] = {
+                        ...display.series[yReference],
+                        yAxisIndex: 0,
+                        valueLabelPosition: action.payload.valueLabelPosition,
+                    };
+                }
             }
         },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11924 

### Description:

Adds options for value labels in SQL runner charts. For now this is only enabled in chart with one series. Multiple series is blocked on fixing multi-series settings, the main ticket for which is: #11925 

<img width="1218" alt="Screenshot 2024-11-13 at 17 59 29" src="https://github.com/user-attachments/assets/ec37b5c4-a024-4929-b38e-71957d0cf46c">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
