### PR TITLE
fix: cant invite project users to space

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -1,4 +1,8 @@
-import { OrganizationMemberRole, type Space } from '@lightdash/common';
+import {
+    OrganizationMemberRole,
+    type OrganizationMemberProfile,
+    type Space,
+} from '@lightdash/common';
 import {
     Avatar,
     Badge,
@@ -16,6 +20,7 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconUsers } from '@tabler/icons-react';
+import { uniq, uniqBy } from 'lodash';
 import {
     forwardRef,
     useEffect,
@@ -57,6 +62,9 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     const { mutateAsync: shareGroupSpaceMutation } =
         useAddGroupSpaceShareMutation(projectUuid, space.uuid);
 
+    const [allSearchedOrganizationUsers, setAllSearchedOrganizationUsers] =
+        useState<OrganizationMemberProfile[]>([]);
+
     const {
         data: infiniteOrganizationGroups,
         fetchNextPage: fetchGroupsNextPage,
@@ -86,25 +94,33 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         { keepPreviousData: true },
     );
 
-    const organizationUsers = useMemo(
-        () => infiniteOrganizationUsers?.pages.map((p) => p.data).flat(),
-        [infiniteOrganizationUsers?.pages],
-    );
+    useEffect(() => {
+        const allPages =
+            infiniteOrganizationUsers?.pages.map((p) => p.data).flat() ?? [];
+
+        setAllSearchedOrganizationUsers((previousState) =>
+            uniqBy([...previousState, ...allPages], 'userUuid'),
+        );
+    }, [infiniteOrganizationUsers?.pages]);
 
     const groups = useMemo(
         () => infiniteOrganizationGroups?.pages.map((p) => p.data).flat(),
         [infiniteOrganizationGroups?.pages],
     );
 
-    const userUuids: string[] = useMemo(() => {
-        if (organizationUsers === undefined) return [];
+    const organizationUsers = useMemo(
+        () => infiniteOrganizationUsers?.pages.map((p) => p.data).flat(),
+        [infiniteOrganizationUsers?.pages],
+    );
 
+    const userUuids: string[] = useMemo(() => {
         const projectUserUuids =
             projectAccess?.map((project) => project.userUuid) || [];
 
-        const orgUserUuids = organizationUsers
-            .filter((user) => user.role !== OrganizationMemberRole.MEMBER)
-            .map((user) => user.userUuid);
+        const orgUserUuids =
+            organizationUsers
+                ?.filter((user) => user.role !== OrganizationMemberRole.MEMBER)
+                .map((user) => user.userUuid) ?? [];
 
         return [...new Set([...projectUserUuids, ...orgUserUuids])];
     }, [organizationUsers, projectAccess]);
@@ -126,7 +142,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 );
             }
 
-            const user = organizationUsers?.find(
+            const user = allSearchedOrganizationUsers.find(
                 (userAccess) => userAccess.userUuid === props.value,
             );
 
@@ -183,34 +199,38 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 </Group>
             );
         });
-    }, [organizationUsers, space.access]);
+    }, [allSearchedOrganizationUsers, space.access]);
 
     const data = useMemo(() => {
-        const usersSet = userUuids.map((userUuid): SelectItem | null => {
-            const user = organizationUsers?.find(
-                (a) => a.userUuid === userUuid,
-            );
+        const userUuidsAndSelected = uniq([...userUuids, ...usersSelected]);
 
-            if (!user) return null;
+        const usersSet = userUuidsAndSelected.map(
+            (userUuid): SelectItem | null => {
+                const user = allSearchedOrganizationUsers.find(
+                    (a) => a.userUuid === userUuid,
+                );
 
-            const hasDirectAccess = !!(space.access || []).find(
-                (access) => access.userUuid === userUuid,
-            )?.hasDirectAccess;
+                if (!user) return null;
 
-            if (hasDirectAccess) return null;
+                const hasDirectAccess = !!(space.access || []).find(
+                    (access) => access.userUuid === userUuid,
+                )?.hasDirectAccess;
 
-            return {
-                value: userUuid,
-                label: getUserNameOrEmail(
-                    user.userUuid,
-                    user.firstName,
-                    user.lastName,
-                    user.email,
-                ),
-                group: 'Users',
-                email: user.email,
-            };
-        });
+                if (hasDirectAccess) return null;
+
+                return {
+                    value: userUuid,
+                    label: getUserNameOrEmail(
+                        user.userUuid,
+                        user.firstName,
+                        user.lastName,
+                        user.email,
+                    ),
+                    group: 'Users',
+                    email: user.email,
+                };
+            },
+        );
 
         const groupsSet = groups
             ?.filter(
@@ -231,10 +251,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
             (item): item is SelectItem => item !== null,
         );
     }, [
-        organizationUsers,
         userUuids,
-        space.access,
+        usersSelected,
         groups,
+        allSearchedOrganizationUsers,
+        space.access,
         space.groupsAccess,
     ]);
 

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -62,9 +62,6 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     const { mutateAsync: shareGroupSpaceMutation } =
         useAddGroupSpaceShareMutation(projectUuid, space.uuid);
 
-    const [allSearchedOrganizationUsers, setAllSearchedOrganizationUsers] =
-        useState<OrganizationMemberProfile[]>([]);
-
     const {
         data: infiniteOrganizationGroups,
         fetchNextPage: fetchGroupsNextPage,
@@ -94,6 +91,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         { keepPreviousData: true },
     );
 
+    // Aggregates all fetched users across pages and search queries into a unified list.
+    // This ensures that previously fetched users are preserved even when the search query changes.
+    // Uses 'userUuid' to remove duplicates and maintain a consistent set of unique users.
+    const [allSearchedOrganizationUsers, setAllSearchedOrganizationUsers] =
+        useState<OrganizationMemberProfile[]>([]);
     useEffect(() => {
         const allPages =
             infiniteOrganizationUsers?.pages.map((p) => p.data).flat() ?? [];


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/12316

### Description:

this bug happens because of react query caching + infinite pagination combination. I can discuss this further but the short story is, react query produces different cache spaces for search queries because search query is in the cache key.

https://github.com/user-attachments/assets/da43b4f2-25fa-4cf6-98cf-e9cd132e3631




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
