### PR TITLE
fix: get all tags when filtering

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -316,10 +316,18 @@ export class CatalogModel {
         }
 
         if (catalogTags) {
-            catalogItemsQuery = catalogItemsQuery.andWhere(
-                `${CatalogTagsTableName}.tag_uuid`,
-                'in',
-                catalogTags,
+            catalogItemsQuery = catalogItemsQuery.whereExists(
+                function getAllCatalogCategoriesThatMatchTags() {
+                    void this.select('*')
+                        .from(CatalogTagsTableName)
+                        .whereRaw(
+                            `${CatalogTagsTableName}.catalog_search_uuid = ${CatalogTableName}.catalog_search_uuid`,
+                        )
+                        .whereIn(
+                            `${CatalogTagsTableName}.tag_uuid`,
+                            catalogTags,
+                        );
+                },
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12391](https://github.com/lightdash/lightdash/issues/12391)

### Description:

Now it returns the catalog item will all tags if one of them is included in the filtering query

demo: 


https://github.com/user-attachments/assets/3c331329-156d-46a6-a959-19e00dcb5ca5



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
