### PR TITLE
chore: mark group sync as deprecated

### DIFF
--- a/docs/docs/references/groups.mdx
+++ b/docs/docs/references/groups.mdx
@@ -44,6 +44,13 @@ You can assign user attributes to groups as well as individual users. To learn m
 
 ## Using OKTA to manage groups in Lightdash
 
+:::warning Deprecated feature
+
+This feature is deprecated and will be removed in a future release.
+For more information on how to provision users and groups in Lightdash, see the [SCIM integration](/references/scim-integration.mdx) documentation.
+
+:::
+
 If your Lightdash instance is configured to [use OKTA as an authentication provider](../self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx#okta), then users will automatically be assigned to the same groups in Lightdash as they are in OKTA. See the guide to [setting up OKTA](../self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx#okta) for more information on setting the correct environment variables as well as Okta configuration: with/without custom authorization server.
 
 :::info

--- a/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
+++ b/docs/docs/self-host/customize-deployment/use-sso-login-for-self-hosted-lightdash.mdx
@@ -102,6 +102,13 @@ You'll need to set the following environment variables in your Lightdash deploym
 
 ### Enable Automatic Assignment of Okta Users to Groups in Lightdash
 
+:::warning Deprecated feature
+
+This feature is deprecated and will be removed in a future release.
+For more information on how to provision users and groups in Lightdash, see the [SCIM integration](/references/scim-integration.mdx) documentation.
+
+:::
+
 Okta users will automatically be assigned to the same groups in Lightdash as they are in Okta if you have [configured Okta to share groups with Lightdash](../../references/groups.mdx#using-okta-to-manage-groups-in-lightdash). To enable this functionality, ensure the following environment variable is set:
 
 | Variable                 | Description                               | Required? |

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -393,6 +393,9 @@ type AuthOidcConfig = {
 
 export type AuthConfig = {
     disablePasswordAuthentication: boolean;
+    /**
+     * @deprecated Group Sync is deprecated. https://github.com/lightdash/lightdash/issues/12430
+     */
     enableGroupSync: boolean;
     enableOidcLinking: boolean;
     enableOidcToEmailLinking: boolean;

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -473,6 +473,9 @@ export class UserService extends BaseService {
         });
     }
 
+    /**
+     * @deprecated Group Sync is deprecated. https://github.com/lightdash/lightdash/issues/12430
+     */
     private async tryAddUserToGroups(
         ...data: ArgumentsOf<GroupsModel['addUserToGroupsIfExist']>
     ) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#384](https://github.com/lightdash/lightdash-commercial/issues/384)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

This is just marking the feature as deprecated. There is a separate ticket to remove the code after some time https://github.com/lightdash/lightdash/issues/12430

<img width="1002" alt="Screenshot 2024-11-14 at 14 44 21" src="https://github.com/user-attachments/assets/ffa52cb2-b3cf-44cd-a940-98d8a674609e">
<img width="999" alt="Screenshot 2024-11-14 at 14 43 32" src="https://github.com/user-attachments/assets/5ac3a310-c78e-4754-9c9a-52f7572c423a">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
