### PR TITLE
feat: added created_at and updated_at to user and organization member objects

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -354,4 +354,6 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -265,6 +265,8 @@ export class OrganizationMemberProfileModel {
                 `${OrganizationTableName}.organization_uuid`,
                 `${OrganizationMembershipsTableName}.role`,
                 `${InviteLinkTableName}.expires_at`,
+                `${UserTableName}.created_at as user_created_at`,
+                `${UserTableName}.updated_at as user_updated_at`,
             )
             .select<DbOrganizationMemberProfile[]>(
                 this.database.raw(

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -28,6 +28,8 @@ import { UserModel } from './UserModel';
 
 type DbOrganizationMemberProfile = {
     user_uuid: string;
+    user_created_at: Date;
+    user_updated_at: Date;
     first_name: string;
     last_name: string;
     is_active: boolean;
@@ -47,6 +49,8 @@ const SelectColumns = [
     `${OrganizationTableName}.organization_uuid`,
     `${OrganizationMembershipsTableName}.role`,
     `${InviteLinkTableName}.expires_at`,
+    `${UserTableName}.created_at as user_created_at`,
+    `${UserTableName}.updated_at as user_updated_at`,
 ];
 
 export class OrganizationMemberProfileModel {
@@ -98,6 +102,8 @@ export class OrganizationMemberProfileModel {
             isActive: member.is_active,
             isInviteExpired,
             isPending,
+            userCreatedAt: member.user_created_at,
+            userUpdatedAt: member.user_updated_at,
         };
     }
 

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -86,6 +86,8 @@ export const mapDbUserDetailsToLightdashUser = (
     role: user.role,
     isActive: user.is_active,
     isPending: !hasAuthentication,
+    createdAt: user.created_at,
+    updatedAt: user.updated_at,
 });
 
 const userDetailsQueryBuilder = (

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -40,6 +40,8 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const space: SpaceTable['base'] = {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -25,6 +25,8 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const organization: Organization = {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -56,6 +56,8 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const validExplore: Explore = {

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -38,6 +38,8 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 const updatedByUser = {

--- a/packages/backend/src/services/ShareService/ShareService.mock.ts
+++ b/packages/backend/src/services/ShareService/ShareService.mock.ts
@@ -34,6 +34,8 @@ export const User: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const UserFromAnotherOrg: SessionUser = {

--- a/packages/backend/src/services/UserService.mock.ts
+++ b/packages/backend/src/services/UserService.mock.ts
@@ -44,6 +44,8 @@ export const sessionUser: SessionUser = {
     ability: new Ability([{ subject: 'InviteLink', action: ['create'] }]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const authenticatedUser: SessionUser = {
@@ -91,6 +93,8 @@ export const newUser: SessionUser = {
     ability: new Ability([]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const organisation: Organization = {
@@ -107,4 +111,6 @@ export const userWithoutOrg: LightdashUser = {
     isMarketingOptedIn: false,
     isSetupComplete: false,
     isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -47,6 +47,8 @@ export const user: SessionUser = {
     ]),
     isActive: true,
     abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
 };
 
 export const chartForValidation: Awaited<

--- a/packages/common/src/authorization/index.mock.ts
+++ b/packages/common/src/authorization/index.mock.ts
@@ -16,6 +16,8 @@ export const orgProfile: OrganizationMemberProfile = {
     lastName: '',
     organizationUuid: 'organization-uuid-view',
     isActive: true,
+    userCreatedAt: new Date(),
+    userUpdatedAt: new Date(),
 };
 export const projectProfile: ProjectMemberProfile = {
     userUuid: 'user-uuid-1234',

--- a/packages/common/src/authorization/organizationMemberAbility.mock.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.mock.ts
@@ -11,6 +11,8 @@ export const ORGANIZATION_MEMBER: OrganizationMemberProfile = {
     lastName: 'jackson',
     email: 'jane@gmail.com',
     isActive: true,
+    userCreatedAt: new Date(),
+    userUpdatedAt: new Date(),
 };
 
 export const ORGANIZATION_VIEWER: OrganizationMemberProfile = {

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -19,6 +19,8 @@ export type OrganizationMemberProfile = {
      * @format uuid
      */
     userUuid: string;
+    userCreatedAt: Date;
+    userUpdatedAt: Date;
     firstName: string;
     lastName: string;
     email: string;

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -15,6 +15,8 @@ export interface LightdashUser {
     isMarketingOptedIn: boolean;
     isSetupComplete: boolean;
     role?: OrganizationMemberRole;
+    createdAt: Date;
+    updatedAt: Date;
     /**
      * Whether the user can login
      */

--- a/packages/frontend/src/testing/__mocks__/api/userResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/userResponse.mock.ts
@@ -225,6 +225,8 @@ export function mockUserResponse(
                 },
             },
         ],
+        updatedAt: new Date('2024-01-11T03:46:50.732Z'),
+        createdAt: new Date('2024-01-11T03:46:50.732Z'),
         ...overrides,
     };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Dependant Commercial PR: https://github.com/lightdash/lightdash-commercial/pull/396 

### Description:
- This adds `updated_at` and `created_at` from the users table to both `LightdashUser` and `OrganizationMeMberProfile` 
- These values are grabbed by the SCIM service when returning user metadata back to the identity requester in the form of `created` and `lastModified` 

![CleanShot 2024-11-14 at 15 36 16](https://github.com/user-attachments/assets/6300a233-3706-4a1e-b81d-f2d17d0ce6c0)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
