### PR TITLE
fix: delete deadlock

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -455,9 +455,11 @@ export class ProjectModel {
     }
 
     async delete(projectUuid: string): Promise<void> {
-        await this.database('projects')
-            .where('project_uuid', projectUuid)
-            .delete();
+        await this.database.transaction(async (trx) => {
+            await this.database('projects')
+                .where('project_uuid', projectUuid)
+                .delete();
+        });
     }
 
     async getWithSensitiveFields(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -456,7 +456,7 @@ export class ProjectModel {
 
     async delete(projectUuid: string): Promise<void> {
         await this.database.transaction(async (trx) => {
-            await this.database('projects')
+            await trx('projects')
                 .where('project_uuid', projectUuid)
                 .delete();
         });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -456,9 +456,7 @@ export class ProjectModel {
 
     async delete(projectUuid: string): Promise<void> {
         await this.database.transaction(async (trx) => {
-            await trx('projects')
-                .where('project_uuid', projectUuid)
-                .delete();
+            await trx('projects').where('project_uuid', projectUuid).delete();
         });
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12297

### Steps

I'm not 100% sure this will fix the issue, but here is my proposal to minimize time spent. 

- Make this quick fix
- release
- flag sentry issue as resolved https://lightdash.sentry.io/issues/5486173409/events/ab060ab4715b4334a8c29a5c806993cd/?project=5959292
- if it happens again , then we keep investigating


### Description:
<!-- Add a description of the changes proposed in the pull request. -->
The proposal by claude makes sense though 

Based on the error message and the code provided, the deadlock is occurring during project deletion. The main deletion happens in the ProjectModel.delete method:

```
    async delete(projectUuid: string): Promise<void> {
        await this.database('projects')
            .where('project_uuid', projectUuid)
            .delete();
    }
```

The deadlock is likely occurring because there are multiple foreign key relationships with CASCADE DELETE constraints that are trying to delete related records simultaneously. Looking at the migrations and schema, we can see several tables with CASCADE DELETE constraints on project_uuid:
1. Cached explores:
2. DBT Cloud integrations:
3. Preview content:

The deadlock likely occurs when multiple cascading deletes try to acquire locks on related tables in different orders. To fix this, you could:
Wrap the deletion in a transaction to ensure consistent locking order
Explicitly delete related records in a specific order before deleting the project
Consider changing some CASCADE DELETE constraints to SET NULL if appropriate
Here's a suggested fix using a transaction:

```
async delete(projectUuid: string): Promise<void> {
    await this.database.transaction(async (trx) => {
        await trx('projects')
            .where('project_uuid', projectUuid)
            .delete();
    });
}
```

This ensures all cascading deletes happen within a single transaction, which should help prevent deadlocks by maintaining a consistent lock order.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
