### PR TITLE
chore: copy warehouse certificates on dev command

### DIFF
--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -34,7 +34,7 @@
         "fix-format": "yarn run formatter ./src --write",
         "test": "jest",
         "copy-files": "copyfiles -u 1 src/warehouseClients/ca-bundle-aws-redshift.crt src/warehouseClients/ca-bundle-aws-rds-global.pem dist/",
-        "build": "tsc --build tsconfig.json && yarn copy-files",
-        "dev": "tsc --build --watch --preserveWatchOutput tsconfig.json"
+        "build": "yarn copy-files && tsc --build tsconfig.json",
+        "dev": "yarn copy-files && tsc --build --watch --preserveWatchOutput tsconfig.json"
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Multiple developers get the error about missing certificate because it was only copied on `build` and not on `dev` command.

Two recent threads: 
- https://lightdash-community.slack.com/archives/C03MG2VTR08/p1730713172417309
- https://lightdash-community.slack.com/archives/C03MG2VTR08/p1731741092008529


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
