### PR TITLE
fix: apply formatting to value labels

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -62,12 +62,30 @@ export class CartesianChartDataModel {
         this.type = args.type ?? ChartKind.VERTICAL_BAR;
     }
 
+    // Get the formatter for the tooltip, which has a simple callback signature
     static getTooltipFormatter(format: Format | undefined) {
         if (format === Format.PERCENT) {
             return (value: number) =>
                 applyCustomFormat(value, {
                     type: CustomFormatType.PERCENT,
                 });
+        }
+        return undefined;
+    }
+
+    // Get the formatter for the value label,
+    // which has more complex inputs
+    static getValueFormatter(format: Format | undefined) {
+        if (format === Format.PERCENT) {
+            // Echarts doesn't export the types for this function
+            return (params: any) => {
+                const value =
+                    params.value[params.dimensionNames[params.encode.y[0]]];
+
+                return applyCustomFormat(value, {
+                    type: CustomFormatType.PERCENT,
+                });
+            };
         }
         return undefined;
     }
@@ -532,6 +550,11 @@ export class CartesianChartDataModel {
                         ? {
                               show: seriesValueLabelPosition !== 'hidden',
                               position: seriesValueLabelPosition,
+                              formatter: seriesFormat
+                                  ? CartesianChartDataModel.getValueFormatter(
+                                        seriesFormat,
+                                    )
+                                  : undefined,
                           }
                         : undefined,
                     color:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12484 

### Description:

Apply formatting to value labels in SQL runner. It was missing. 

To test:
- Make a chart in SQL runner
- Add percentage formatting
- Add value labels formatting
- You should see the value label formatted with percent

<img width="788" alt="Screenshot 2024-11-18 at 19 11 58" src="https://github.com/user-attachments/assets/ccb2d448-7588-4ffc-978b-724e136a0fa5">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
