### PR TITLE
fix: overlapping value labels in sql runner

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -534,6 +534,9 @@ export class CartesianChartDataModel {
                               position: seriesValueLabelPosition,
                           }
                         : undefined,
+                    labelLayout: {
+                        hideOverlap: true,
+                    },
                     color:
                         seriesColor ||
                         CartesianChartDataModel.getDefaultColor(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12485 

### Description:

When there are too many value labels in a chart, they overlap heavily. This makes echarts elide some of them. This could be better, but it's gives us parity with our existing chart config. 

Without this change:
<img width="786" alt="Screenshot 2024-11-18 at 19 30 21" src="https://github.com/user-attachments/assets/ac2408b4-981b-4fd6-b7d2-596c456064d2">

With this change:
<img width="799" alt="Screenshot 2024-11-18 at 19 29 42" src="https://github.com/user-attachments/assets/ffc20303-480a-4e62-b4a0-8fd0bc4582a5">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
