### PR TITLE
feat: display expanded cell on click of description

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -274,7 +274,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
 
             {header}
 
-            <Box className={classes.root}>
+            <Box id="page-root" className={classes.root}>
                 {sidebar ? (
                     <Sidebar
                         noSidebarPadding={noSidebarPadding}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
@@ -1,0 +1,122 @@
+import { type CatalogField } from '@lightdash/common';
+import {
+    Box,
+    getDefaultZIndex,
+    Portal,
+    px,
+    useMantineTheme,
+} from '@mantine/core';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { type MRT_TableInstance } from 'mantine-react-table';
+import { useEffect, useRef, type FC } from 'react';
+import { useLockScroll } from '../../../hooks/useLockScroll';
+
+type Props = {
+    isOpen: boolean;
+    setIsOpen: (isOpen: boolean) => void;
+    content: string;
+    cellRef: React.RefObject<HTMLDivElement>;
+    table: MRT_TableInstance<CatalogField>;
+};
+
+export const MetricCatalogCellOverlay: FC<Props> = ({
+    isOpen,
+    setIsOpen,
+    content,
+    cellRef,
+    table,
+}) => {
+    const theme = useMantineTheme();
+    const overlayRef = useRef<HTMLDivElement>(null);
+    const pageRootRef = useRef<HTMLDivElement>(
+        document.getElementById('page-root') as HTMLDivElement,
+    );
+
+    // Lock body and table container scroll when overlay is open
+    useLockScroll(pageRootRef, isOpen);
+    useLockScroll(table.refs.tableContainerRef, isOpen);
+
+    useEffect(() => {
+        // Close the overlay if clicked outside
+        // NOTE: Mantine's useClickOutside hook doesn't work here
+        const handleClickOutside = (event: MouseEvent) => {
+            if (!isOpen) return;
+            const clickedElement = event.target as Node;
+            if (!overlayRef.current?.contains(clickedElement)) {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () =>
+            document.removeEventListener('mousedown', handleClickOutside);
+    }, [overlayRef, isOpen, setIsOpen]);
+
+    const getCellRect = () => {
+        if (!cellRef.current) return null;
+        const rect = cellRef.current.getBoundingClientRect();
+
+        return {
+            top: rect.top + window.scrollY,
+            left: rect.left + window.scrollX - px(theme.spacing.xl), // -16px - accounts for padding from parent
+            width: rect.width + px(theme.spacing.xl) * 2 + px(theme.spacing.xs), // +32px + 8px - accounts for padding from parent and goes out 8px to help the user
+        };
+    };
+
+    if (!isOpen || !content) return null;
+
+    return (
+        <Portal>
+            <Box
+                ref={overlayRef}
+                pos="absolute"
+                py="sm"
+                px="xl"
+                mah={500}
+                sx={{
+                    position: 'absolute',
+                    ...getCellRect(),
+                    backgroundColor: theme.fn.lighten(
+                        theme.colors.violet[1],
+                        0.8,
+                    ),
+                    border: `1px solid ${theme.colors.indigo[6]}`,
+                    borderRadius: theme.radius.md,
+                    zIndex: getDefaultZIndex('popover'),
+                    overflowY: 'auto',
+                    boxShadow: theme.shadows.sm,
+                }}
+            >
+                <MarkdownPreview
+                    source={content}
+                    style={{
+                        fontSize: theme.fontSizes.sm,
+                        color: theme.colors.dark[4],
+                        fontFamily: 'Inter',
+                        backgroundColor: theme.fn.lighten(
+                            theme.colors.violet[1],
+                            0.8,
+                        ),
+                    }}
+                    components={{
+                        h1: ({ children }) => (
+                            <h1 style={{ fontWeight: 600 }}>{children}</h1>
+                        ),
+                        h2: ({ children }) => (
+                            <h2 style={{ fontWeight: 600 }}>{children}</h2>
+                        ),
+                        h3: ({ children }) => (
+                            <h3 style={{ fontWeight: 600 }}>{children}</h3>
+                        ),
+                        p: ({ children }) => (
+                            <p style={{ fontWeight: 400 }}>{children}</p>
+                        ),
+                        li: ({ children }) => (
+                            <li style={{ fontWeight: 400 }}>{children}</li>
+                        ),
+                    }}
+                />
+            </Box>
+        </Portal>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -1,0 +1,52 @@
+import { type CatalogField } from '@lightdash/common';
+import { Box, Highlight } from '@mantine/core';
+import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
+import { useRef, useState, type FC } from 'react';
+import { useIsLineClamped } from '../../../hooks/useIsLineClamped';
+import { MetricCatalogCellOverlay } from './MetricCatalogCellOverlay';
+
+type Props = {
+    row: MRT_Row<CatalogField>;
+    table: MRT_TableInstance<CatalogField>;
+};
+
+export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
+    const cellRef = useRef<HTMLDivElement>(null);
+    const { ref: highlightRef, isLineClamped } =
+        useIsLineClamped<HTMLDivElement>(2);
+    const [isOpen, setIsOpen] = useState(false);
+    const canOpen = isLineClamped && row.original.description;
+
+    return (
+        <Box ref={cellRef} p="sm">
+            <Highlight
+                ref={highlightRef}
+                c={row.original.description ? 'dark.4' : 'dark.1'}
+                fz="sm"
+                fw={400}
+                lh="150%"
+                onClick={() => {
+                    if (canOpen) {
+                        setIsOpen(true);
+                    }
+                }}
+                highlight={table.getState().globalFilter || ''}
+                lineClamp={2}
+                sx={{
+                    cursor: canOpen ? 'pointer' : 'default',
+                    color: row.original.description ? 'dark.4' : 'dark.1',
+                }}
+            >
+                {row.original.description ?? '-'}
+            </Highlight>
+
+            <MetricCatalogCellOverlay
+                isOpen={isOpen}
+                setIsOpen={setIsOpen}
+                content={row.original.description || ''}
+                cellRef={cellRef}
+                table={table}
+            />
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,15 +1,7 @@
 import { type CatalogField } from '@lightdash/common';
-import {
-    Flex,
-    Group,
-    Highlight,
-    HoverCard,
-    Text,
-    Tooltip,
-} from '@mantine/core';
+import { Flex, Group, Text, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus } from '@tabler/icons-react';
-import MarkdownPreview from '@uiw/react-markdown-preview';
 import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo, type FC, type SVGProps } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -25,6 +17,7 @@ import { CatalogCategory } from './CatalogCategory';
 import { ExploreMetricButton } from './ExploreMetricButton';
 import { MetricChartUsageButton } from './MetricChartUsageButton';
 import { MetricsCatalogCategoryForm } from './MetricsCatalogCategoryForm';
+import { MetricsCatalogColumnDescription } from './MetricsCatalogColumnDescription';
 import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
 
 const HeaderCell = ({
@@ -88,40 +81,9 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
                 {column.columnDef.header}
             </HeaderCell>
         ),
-        Cell: ({ table, row }) => (
-            <HoverCard
-                withinPortal
-                shadow="lg"
-                position="right"
-                disabled={!row.original.description}
-                radius="md"
-            >
-                <HoverCard.Target>
-                    <Text
-                        lineClamp={2}
-                        c={row.original.description ? 'dark.4' : 'dark.1'}
-                        fz="sm"
-                        fw={400}
-                        lh="150%"
-                    >
-                        <Highlight
-                            highlight={table.getState().globalFilter || ''}
-                            lh="150%"
-                        >
-                            {row.original.description ?? '-'}
-                        </Highlight>
-                    </Text>
-                </HoverCard.Target>
-                <HoverCard.Dropdown maw={300}>
-                    <MarkdownPreview
-                        source={row.original.description}
-                        style={{
-                            fontSize: '12px',
-                        }}
-                    />
-                </HoverCard.Dropdown>
-            </HoverCard>
-        ),
+        Cell: ({ row, table }) => {
+            return <MetricsCatalogColumnDescription row={row} table={table} />;
+        },
     },
     {
         accessorKey: 'categories',

--- a/packages/frontend/src/hooks/useIsLineClamped/index.tsx
+++ b/packages/frontend/src/hooks/useIsLineClamped/index.tsx
@@ -1,0 +1,29 @@
+import { useElementSize } from '@mantine/hooks';
+import { useEffect, useState } from 'react';
+
+/**
+ * Detects if the element is line clamped by comparing its scrollHeight to computed max height
+ * @param lineClamp - number of lines to clamp at
+ * @returns {ref, isLineClamped} - ref to attach to the element and isLineClamped boolean
+ */
+export const useIsLineClamped = <T extends HTMLElement = any>(
+    lineClamp: number,
+) => {
+    const { ref, width, height } = useElementSize<T>();
+    const [isLineClamped, setIsLineClamped] = useState(false);
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        const lineHeight = parseInt(getComputedStyle(element).lineHeight);
+        const maxHeight = lineHeight * lineClamp;
+
+        setIsLineClamped(element.scrollHeight > maxHeight);
+    }, [ref, width, height, lineClamp]);
+
+    return {
+        ref,
+        isLineClamped,
+    } as const;
+};

--- a/packages/frontend/src/hooks/useLockScroll/index.tsx
+++ b/packages/frontend/src/hooks/useLockScroll/index.tsx
@@ -1,0 +1,29 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Locks the scroll of the element referenced by the ref object
+ * @param ref - RefObject<HTMLElement>
+ * @param isLocked - boolean
+ */
+export const useLockScroll = (
+    ref: RefObject<HTMLElement>,
+    isLocked: boolean = false,
+) => {
+    useEffect(() => {
+        if (!isLocked || !ref.current) return;
+
+        // Save initial style
+        const element = ref.current;
+        const originalStyle = window.getComputedStyle(element).overflow;
+
+        // Prevent scrolling
+        element.style.overflow = 'hidden';
+
+        // Cleanup: restore original style
+        return () => {
+            if (element) {
+                element.style.overflow = originalStyle;
+            }
+        };
+    }, [isLocked, ref]);
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12278 

### Description:

- Creates portal that renders markdown on cell click 
- locks scroll on click 
- allows user to expand the description if clamped

demo


https://github.com/user-attachments/assets/4c8c17d4-93e0-4c15-8006-b03832377f70



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
