### PR TITLE
fix: fix cell context menu embedding

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellMenu.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellMenu.tsx
@@ -42,8 +42,8 @@ const CellMenu: FC<React.PropsWithChildren<CellMenuProps>> = ({
                             pointerEvents: 'none',
                             position: 'absolute',
                             zIndex: -1,
-                            left: elementBounds.x,
-                            top: elementBounds.y,
+                            left: elementBounds.x + window.scrollX,
+                            top: elementBounds.y + window.scrollY,
                             width: elementBounds.width,
                             height: elementBounds.height,
                         }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12496


### Alternative solution: 

I think the issue is only happening on embedding because other dashboards/pages are wrapped by perhaps a scrollable component , with relative position, where `window.scrollY` is always 0. We could use the same wrapper on embedding to fix the issue, however, I'm not sure exactly how this is done, or if that will cause other issues (eg: when printing the page) 

I belive this solution (given we are already hacking the position using absolute) it is more reusable, since it doesn't depend on the wrapper. 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Added scroll to absolute position of the menu

Before


![Screenshot from 2024-11-19 08-53-25](https://github.com/user-attachments/assets/abd00d89-0344-4768-b38a-126864c479ca)

After

![Screenshot from 2024-11-19 09-13-00](https://github.com/user-attachments/assets/95911ccc-b4c3-409a-9fcf-4cf2ac876e5f)

I also tessted this on `dashboard tables` , `explore table` and `results` 

![Screenshot from 2024-11-19 09-13-10](https://github.com/user-attachments/assets/7282aa92-edf8-46c8-987d-d33ee98103b9)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
