### PR TITLE
chore: allow default time dimension for tables

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -111,6 +111,9 @@ models:
           type: number
           sql: ${total_completed_order_amount}/${total_order_amount}
           format: percent
+      default_time_dimension:
+        field: order_date
+        interval: MONTH
     columns:
       - name: order_id
         tests:

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -521,6 +521,14 @@ export const convertTable = (
         requiredFilters: parseFilters(meta.required_filters),
         requiredAttributes: meta.required_attributes,
         groupDetails,
+        ...(meta.default_time_dimension
+            ? {
+                  defaultTimeDimension: {
+                      field: meta.default_time_dimension.field,
+                      interval: meta.default_time_dimension.interval,
+                  },
+              }
+            : {}),
     };
 };
 

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -180,7 +180,6 @@
                                             "DAY",
                                             "WEEK",
                                             "MONTH",
-                                            "QUARTER",
                                             "YEAR"
                                         ],
                                         "description": "The default time interval to use when analyzing this time dimension"

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -165,6 +165,28 @@
                                         "required": ["type", "sql"]
                                     }
                                 }
+                            },
+                            "default_time_dimension": {
+                                "type": "object",
+                                "description": "Specifies the default time dimension field and interval to use for time-based analysis (on any metric in the model). If specified, both field and interval are required.",
+                                "properties": {
+                                    "field": {
+                                        "type": "string",
+                                        "description": "The name of the field to use as the default time dimension"
+                                    },
+                                    "interval": {
+                                        "type": "string",
+                                        "enum": [
+                                            "DAY",
+                                            "WEEK",
+                                            "MONTH",
+                                            "QUARTER",
+                                            "YEAR"
+                                        ],
+                                        "description": "The default time interval to use when analyzing this time dimension"
+                                    }
+                                },
+                                "required": ["field", "interval"]
                             }
                         }
                     },

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -75,6 +75,10 @@ type DbtModelLightdashConfig = {
     required_filters?: { [key: string]: any }[];
     required_attributes?: Record<string, string | string[]>;
     group_details?: Record<string, DbtModelGroup>;
+    default_time_dimension?: {
+        field: string;
+        interval: TimeFrames;
+    };
 };
 
 export type DbtModelGroup = {
@@ -290,6 +294,10 @@ export type DbtMetricLightdashMetadata = {
     groups?: string[];
     show_underlying_values?: string[];
     filters: Record<string, any>[];
+    default_time_dimension?: {
+        field: string;
+        interval: TimeFrames;
+    };
 };
 
 export type DbtDoc = {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -294,10 +294,6 @@ export type DbtMetricLightdashMetadata = {
     groups?: string[];
     show_underlying_values?: string[];
     filters: Record<string, any>[];
-    default_time_dimension?: {
-        field: string;
-        interval: TimeFrames;
-    };
 };
 
 export type DbtDoc = {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -445,6 +445,10 @@ export interface Metric extends Field {
     formatOptions?: CustomFormat;
     dimensionReference?: string; // field id of the dimension this metric is based on
     requiredAttributes?: Record<string, string | string[]>; // Required attributes for the dimension this metric is based on
+    defaultTimeDimension?: {
+        field: string;
+        interval: TimeFrames;
+    };
 }
 
 export const isFilterableDimension = (

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -445,10 +445,6 @@ export interface Metric extends Field {
     formatOptions?: CustomFormat;
     dimensionReference?: string; // field id of the dimension this metric is based on
     requiredAttributes?: Record<string, string | string[]>; // Required attributes for the dimension this metric is based on
-    defaultTimeDimension?: {
-        field: string;
-        interval: TimeFrames;
-    };
 }
 
 export const isFilterableDimension = (

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -1,4 +1,5 @@
 import { type MetricFilterRule } from './filter';
+import type { TimeFrames } from './timeFrames';
 
 export enum OrderFieldsByStrategy {
     LABEL = 'LABEL',
@@ -25,4 +26,8 @@ export type TableBase = {
     hidden?: boolean;
     requiredAttributes?: Record<string, string | string[]>;
     groupDetails?: Record<string, GroupType>;
+    defaultTimeDimension?: {
+        field: string;
+        interval: TimeFrames;
+    };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12392

### Description:

allow this definition on the table/model-level:
```yml
 default_time_dimension:
   field: timestamp_tz
   interval: MONTH
```

- demo

<img width="565" alt="Screenshot 2024-11-19 at 10 39 44" src="https://github.com/user-attachments/assets/35cecbe1-67eb-489f-be8e-4413c539374d">

<img width="770" alt="image" src="https://github.com/user-attachments/assets/f4bc266e-5aa5-488c-a70a-afe50c08fa3c">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


test-cli
test-frontend
test-backend