### PR TITLE
fix: color picker not matching colors in sql runner

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -466,7 +466,7 @@ export class CartesianChartDataModel {
         }
 
         const { type } = this;
-        const orgColors = colors;
+        const orgColors = colors ?? ECHARTS_DEFAULT_COLORS;
 
         const DEFAULT_X_AXIS_TYPE = VizIndexType.CATEGORY;
 

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -557,8 +557,7 @@ export const ContentPanel: FC = () => {
                                                                             c
                                                                         }
                                                                         spec={pivotedChartInfo?.data?.getChartSpec(
-                                                                            organization?.chartColors ??
-                                                                                [],
+                                                                            organization?.chartColors,
                                                                         )}
                                                                         isLoading={
                                                                             !!pivotedChartInfo?.loading

--- a/packages/frontend/src/features/sqlRunner/store/thunks.ts
+++ b/packages/frontend/src/features/sqlRunner/store/thunks.ts
@@ -115,7 +115,7 @@ export const prepareAndFetchChartData = createAsyncThunk(
             filters: [],
         });
 
-        const getChartSpec = (orgColors: string[]) => {
+        const getChartSpec = (orgColors?: string[]) => {
             const currentState = getState() as RootState;
             const currentDisplay = selectChartDisplayByKind(
                 currentState,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12501 

### Description:

The SQL color picker wasn't matching the colors displayed on the chart by default. We were passing an empty array instead of undefined, which was causing the colors to default incorrectly

To repro:
- Run a query
- Make a bar chart with multiple series
- Notice that the color picker is a different color than the second series by default 

Before:
<img width="1164" alt="before" src="https://github.com/user-attachments/assets/af94a681-8942-48f9-a9c4-6cb9c7516338">

With this fix:
<img width="1163" alt="Screenshot 2024-11-19 at 15 50 02" src="https://github.com/user-attachments/assets/8ff45102-fb64-4c06-a247-80316922d7f8">

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
