### PR TITLE
fix: apply date granularity to filters

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -1212,7 +1212,6 @@ export const buildQuery = ({
     ]
         .filter((l) => l !== undefined)
         .join('\n');
-
     return {
         query: metricQuerySql,
         hasExampleMetric,

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -216,6 +216,41 @@ export const updateFieldIdInFilters = (
     }
 };
 
+export const updateFilterValueInFilters = (
+    filterGroup: FilterGroup | undefined,
+    valueChange: (
+        fieldId: string,
+        oldValue: any[] | undefined,
+    ) => any[] | undefined,
+): void => {
+    const updateFilterValueInFilterGroupItem = (
+        filterGroupItem: FilterGroupItem,
+    ): void => {
+        if (isFilterGroup(filterGroupItem)) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            updateFilterValueInFilters(filterGroupItem, valueChange);
+        } else {
+            // eslint-disable-next-line no-param-reassign
+            filterGroupItem.values = valueChange(
+                filterGroupItem.target.fieldId,
+                filterGroupItem.values,
+            );
+        }
+    };
+
+    if (filterGroup) {
+        if (isOrFilterGroup(filterGroup)) {
+            filterGroup.or.forEach((item) =>
+                updateFilterValueInFilterGroupItem(item),
+            );
+        } else if (isAndFilterGroup(filterGroup)) {
+            filterGroup.and.forEach((item) =>
+                updateFilterValueInFilterGroupItem(item),
+            );
+        }
+    }
+};
+
 export const removeFieldFromFilterGroup = (
     filterGroup: FilterGroup | undefined,
     fieldId: string,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import timezone from 'dayjs/plugin/timezone';
 import moment, { type MomentInput } from 'moment';
 import {
@@ -25,6 +26,7 @@ import assertUnreachable from './assertUnreachable';
 import { getItemType } from './item';
 
 dayjs.extend(timezone);
+dayjs.extend(quarterOfYear);
 
 export const currencies = [
     'USD',
@@ -112,6 +114,14 @@ export const isMomentInput = (value: unknown): value is MomentInput =>
     value instanceof Date ||
     value instanceof moment ||
     value instanceof dayjs;
+
+export function getFirstDayOfQuarter(
+    date: string,
+    convertToUTC: boolean = false,
+): string {
+    const momentDate = convertToUTC ? dayjs(date).utc() : dayjs(date);
+    return momentDate.startOf('quarter').format('YYYY-MM-DD');
+}
 
 export function formatDate(
     date: MomentInput,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12448

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
No date zoom 
![Screenshot from 2024-11-19 17-13-21](https://github.com/user-attachments/assets/4a4ff482-5823-4ccc-a7f5-73c761b7283f)

With month date zoom 


Before

![Screenshot from 2024-11-19 17-13-16](https://github.com/user-attachments/assets/fb83415b-c0b9-43fb-8d11-3ed50c0e44d1)

After
<!-- Even better add a screenshot / gif / loom -->
![Screenshot from 2024-11-19 17-13-00](https://github.com/user-attachments/assets/0d70153e-0ce3-48bb-a0ca-41a0f30cf987)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
