### PR TITLE
feat: open big number if no default dim on metric explore

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -252,9 +252,20 @@ export const createMetricPreviewUnsavedChartVersion = (
     const defaultTimeFilters =
         getRelevantFilterForDimension(defaultTimeDimension);
 
+    let chartConfig = DEFAULT_EMPTY_EXPLORE_CONFIG.chartConfig;
+
+    // If there is no default time dimension, we want to default to a big number chart because there is no time dimension to plot a chart
+    if (!defaultTimeDimension) {
+        chartConfig = {
+            type: ChartType.BIG_NUMBER,
+            config: {},
+        };
+    }
+
     return {
         ...DEFAULT_EMPTY_EXPLORE_CONFIG,
         tableName: metric.tableName,
+        chartConfig,
         metricQuery: {
             ...DEFAULT_EMPTY_EXPLORE_CONFIG.metricQuery,
             exploreName: metric.tableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12392

### Description:

- does only metric selection if no default dimension in table.
- goes to explorer and displays a big number chart.


demo:


https://github.com/user-attachments/assets/1acf836b-b50a-4cc9-8eca-4157a8b686ab



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
