### PR TITLE
feat(wip): clearable axis labels in explorer

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -6,6 +6,7 @@ import {
     type ItemsMap,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Checkbox,
     Group,
     NumberInput,
@@ -14,7 +15,11 @@ import {
     Switch,
     TextInput,
 } from '@mantine/core';
-import { IconSortAscending, IconSortDescending } from '@tabler/icons-react';
+import {
+    IconSortAscending,
+    IconSortDescending,
+    IconX,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/VisualizationConfigCartesian';
@@ -213,7 +218,17 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                 itemsMap,
                             })
                         }
-                        onBlur={(e) => setYAxisName(0, e.currentTarget.value)}
+                        rightSection={
+                            <ActionIcon
+                                variant="transparent"
+                                onClick={() => setYAxisName(0, ' ')}
+                            >
+                                <MantineIcon icon={IconX} size="xs" />
+                            </ActionIcon>
+                        }
+                        onBlur={(e) => {
+                            setYAxisName(0, e.currentTarget.value);
+                        }}
                     />
                     {showFirstAxisRange && (
                         <AxisMinMax


### PR DESCRIPTION
discussion: it's not possible to clear the y-axis label beacuse it's registered as an empty string, which is overridden when we render echarts code.

**Workaround** - set the field to a single whitespace `' '` - but quite annoying UX

**Suggestion** - have a clear button that sets the value to `' '`

**Altenative** - we could change the default render behaviour so that having `''` as the default name doesn't render the default name. But this would remove the default label from all existing charts for users that didn't specify this label.

**Future learning** - we should have a clearer `undefined` state

https://github.com/user-attachments/assets/50df60ab-6200-40e1-8b18-89cd7da2dc06



