### PR TITLE
fix: change ui feedback when no perms to manage catalog

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -104,6 +104,9 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
         const projectUuid = useAppSelector(
             (state) => state.metricsCatalog.projectUuid,
         );
+        const canManageTags = useAppSelector(
+            (state) => state.metricsCatalog.abilities.canManageTags,
+        );
 
         const [isPickerOpen, setIsPickerOpen] = useState(false);
         const [pickerPosition, setPickerPosition] = useState<{
@@ -197,6 +200,7 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
                     <ActionIcon
                         ref={setIconRef}
                         variant="default"
+                        disabled={!canManageTags}
                         onClick={handleIconClick}
                         sx={(theme) => ({
                             width: 28,
@@ -208,6 +212,9 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
                                 boxShadow:
                                     '0px -2px 0px 0px rgba(10, 13, 18, 0.07) inset, 0px 1px 2px 0px rgba(16, 24, 40, 0.05)',
                             }),
+                            '&:disabled': {
+                                backgroundColor: 'initial',
+                            },
                         })}
                     >
                         {isEmojiIcon(row.original.icon) ? (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -123,7 +123,16 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             );
 
             return (
-                <Group pos="absolute" w="100%" h="100%" left={0} top={0}>
+                <Group
+                    pos="absolute"
+                    w="100%"
+                    h="100%"
+                    left={0}
+                    top={0}
+                    sx={{
+                        cursor: canManageTags ? 'pointer' : 'default',
+                    }}
+                >
                     <Group mx="md" spacing="xxs">
                         {categories.map((category) => (
                             <CatalogCategory
@@ -163,6 +172,9 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             const isDescriptionPopoverClosing = useAppSelector(
                 (state) => state.metricsCatalog.popovers.description.isClosing,
             );
+            const canManageTags = useAppSelector(
+                (state) => state.metricsCatalog.abilities.canManageTags,
+            );
 
             const categories = useMemo(
                 () => row.original.categories ?? [],
@@ -190,8 +202,11 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
 
                         table.setEditingCell(cell);
                     }}
+                    sx={{
+                        cursor: canManageTags ? 'pointer' : 'default',
+                    }}
                 >
-                    {categories.length === 0 && hovered ? (
+                    {categories.length === 0 && hovered && canManageTags ? (
                         <Group spacing={2}>
                             <MantineIcon
                                 color="dark.1"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Demo for < editor

https://github.com/user-attachments/assets/1ab1d2a9-cb33-4806-be94-62936d893844


Demo for >= editor


https://github.com/user-attachments/assets/201c19c6-9244-430a-8500-6d1f66307711


> [!NOTE]
> The backend already checks for permissions, so even though the user with insufficient perms could change some stuff on the ui, it would error on the BE, reverting back to the original state.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
