### PR TITLE
fix: open dashboard filter popover within portal

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -8,7 +8,7 @@ describe('Dashboard', () => {
     it('Should see dashboard', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
-        // wiat for the dashboard to load
+        // wait for the dashboard to load
         cy.findByText('Loading dashboards').should('not.exist');
 
         cy.contains('a', 'Jaffle dashboard').click();

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -184,6 +184,7 @@ const Filter: FC<Props> = ({
             shadow="md"
             offset={1}
             arrowOffset={14}
+            withinPortal
         >
             <Popover.Target>
                 {isCreatingNew ? (

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -690,23 +690,26 @@ const Dashboard: FC = () => {
                 withFullHeight={true}
             >
                 <Group position="apart" align="flex-start" noWrap px={'lg'}>
-                    <Box style={{ flexGrow: 1, overflow: 'auto' }}>
-                        {/* This Group will take up remaining space (and not push DateZoom) */}
-                        <Group
-                            position="apart"
-                            align="flex-start"
-                            noWrap
-                            px={'lg'}
-                        >
-                            {dashboardChartTiles &&
-                                dashboardChartTiles.length > 0 && (
-                                    <DashboardFilter
-                                        isEditMode={isEditMode}
-                                        activeTabUuid={activeTab?.uuid}
-                                    />
-                                )}
-                        </Group>
-                    </Box>
+                    {/* This Group will take up remaining space (and not push DateZoom) */}
+                    <Group
+                        position="apart"
+                        align="flex-start"
+                        noWrap
+                        px="lg"
+                        grow
+                        sx={{
+                            overflow: 'auto',
+                        }}
+                    >
+                        {dashboardChartTiles &&
+                            dashboardChartTiles.length > 0 && (
+                                <DashboardFilter
+                                    isEditMode={isEditMode}
+                                    activeTabUuid={activeTab?.uuid}
+                                />
+                            )}
+                    </Group>
+
                     {/* DateZoom section will adjust width dynamically */}
                     {hasDashboardTiles && !hasNewSemanticLayerChart && (
                         <Box style={{ marginLeft: 'auto' }}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After this merge: https://github.com/lightdash/lightdash/pull/12439, filter pills are scrollable if no space left/too long, but that included a change to the parent box of these where there's an overflow applied, leading to cypress issues like: 
```
This element <input#mantine-0nhrxw6dt.mantine-Input-input.mantine-Select-input.mantine-gcbe4a> is not visible because its content is being clipped by one of its parent elements, which has a CSS property of overflow: hidden, scroll or auto

```

even though a real user could interact with the popovers, cypress couldn't because it was classified as not visible. 

1. Simplified styles
2. added withinPortal prop to filter popover.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
