### PR TITLE
fix: focus editor on load & cmd + enter to submit for table calculation

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -24,6 +24,7 @@ const SOFT_WRAP_LOCAL_STORAGE_KEY = 'lightdash-sql-form-soft-wrap';
 type Props = {
     form: TableCalculationForm;
     isFullScreen: boolean;
+    focusOnRender?: boolean;
 };
 
 export const SqlEditor = styled(AceEditor)<
@@ -44,7 +45,11 @@ export const SqlEditor = styled(AceEditor)<
               `}
 `;
 
-export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
+export const SqlForm: FC<Props> = ({
+    form,
+    isFullScreen,
+    focusOnRender = false,
+}) => {
     const theme = useMantineTheme();
     const [isSoftWrapEnabled, setSoftWrapEnabled] = useLocalStorage({
         key: SOFT_WRAP_LOCAL_STORAGE_KEY,
@@ -52,6 +57,18 @@ export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
     });
 
     const { setAceEditor } = useTableCalculationAceEditorCompleter();
+
+    const handleEditorLoad = (editor: any) => {
+        setAceEditor(editor);
+        if (focusOnRender) {
+            // set timeout throws the focus to the end of the event loop (after the render)
+            // without it the focus would be set before the editor is fully rendered (and not work)
+            setTimeout(() => {
+                editor.focus(); // focus the editor
+                editor.navigateFileEnd(); // navigate to the end of the content
+            }, 0);
+        }
+    };
 
     return (
         <>
@@ -67,7 +84,7 @@ export const SqlForm: FC<Props> = ({ form, isFullScreen }) => {
                         autoScrollEditorIntoView: true,
                     }}
                     style={{ zIndex: 0 }}
-                    onLoad={setAceEditor}
+                    onLoad={handleEditorLoad}
                     enableLiveAutocompletion
                     enableBasicAutocompletion
                     showPrintMargin={false}

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -25,6 +25,7 @@ type Props = {
     form: TableCalculationForm;
     isFullScreen: boolean;
     focusOnRender?: boolean;
+    onCmdEnter?: () => void;
 };
 
 export const SqlEditor = styled(AceEditor)<
@@ -49,6 +50,7 @@ export const SqlForm: FC<Props> = ({
     form,
     isFullScreen,
     focusOnRender = false,
+    onCmdEnter,
 }) => {
     const theme = useMantineTheme();
     const [isSoftWrapEnabled, setSoftWrapEnabled] = useLocalStorage({
@@ -60,6 +62,15 @@ export const SqlForm: FC<Props> = ({
 
     const handleEditorLoad = (editor: any) => {
         setAceEditor(editor);
+        editor.commands.addCommand({
+            name: 'executeCmdEnter',
+            bindKey: { win: 'Ctrl-Enter', mac: 'Cmd-Enter' },
+            exec: () => {
+                if (onCmdEnter) {
+                    onCmdEnter();
+                }
+            },
+        });
         if (focusOnRender) {
             // set timeout throws the focus to the end of the event loop (after the render)
             // without it the focus would be set before the editor is fully rendered (and not work)

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -21,7 +21,7 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconMaximize, IconMinimize } from '@tabler/icons-react';
-import { useEffect, type FC } from 'react';
+import { useRef, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -51,6 +51,7 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const theme = useMantineTheme();
     const [isFullscreen, toggleFullscreen] = useToggle(false);
+    const submitButtonRef = useRef<HTMLButtonElement>(null);
 
     const { addToastError } = useToaster();
 
@@ -120,10 +121,11 @@ const TableCalculationModal: FC<Props> = ({
         }
         // throw error if name is empty
         if (name.length === 0) {
-            return addToastError({
+            addToastError({
                 title: 'Name cannot be empty',
                 key: 'table-calculation-modal',
             });
+            return;
         }
         try {
             onSave({
@@ -141,22 +143,6 @@ const TableCalculationModal: FC<Props> = ({
             });
         }
     });
-
-    // listen for Cmd+Enter or Ctrl+Enter to submit
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                handleSubmit(); // trigger form submission
-                event.preventDefault();
-            }
-        };
-        if (opened) {
-            window.addEventListener('keydown', handleKeyDown);
-        }
-        return () => {
-            window.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [opened, handleSubmit]);
 
     const getFormatInputProps = (path: keyof CustomFormat) => {
         return form.getInputProps(`format.${path}`);
@@ -230,6 +216,11 @@ const TableCalculationModal: FC<Props> = ({
                                 form={form}
                                 isFullScreen={isFullscreen}
                                 focusOnRender={true}
+                                onCmdEnter={() => {
+                                    if (submitButtonRef.current) {
+                                        submitButtonRef.current.click();
+                                    }
+                                }}
                             />
                         </Tabs.Panel>
                         <Tabs.Panel value="format">
@@ -290,6 +281,7 @@ const TableCalculationModal: FC<Props> = ({
                             </Button>
                             <Button
                                 type="submit"
+                                ref={submitButtonRef}
                                 data-testid="table-calculation-save-button"
                             >
                                 Save


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12552 

### Description:
- When adding a table calculation the editor is focused on load
- CMD/Crtl + Enter will attempt to submit the form

![CleanShot 2024-11-21 at 15 42 41](https://github.com/user-attachments/assets/e487cfc8-9fd9-4bbd-8a78-b1eac8a609f2)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
