### PR TITLE
fix: I shouldnt be able to sort by a pivoted column

### DIFF
--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,7 +4,7 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Badge, Flex, Group, type FlexProps } from '@mantine/core';
+import { Badge, Flex, Group, Tooltip, type FlexProps } from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { useMemo } from 'react';
@@ -62,73 +62,83 @@ export const ChartDataTable = ({
             className="sentry-block ph-no-capture"
         >
             <TableStyled>
-                <thead>
-                    <tr>
-                        {headerGroups.map((headerGroup) =>
-                            headerGroup.headers.map((header) => {
-                                const sortConfig = thSortConfig?.[header.id];
-                                const onClick =
-                                    sortConfig && onTHClick
-                                        ? () => onTHClick(header.id)
-                                        : undefined;
+                <Tooltip.Group>
+                    <thead>
+                        <tr>
+                            {headerGroups.map((headerGroup) =>
+                                headerGroup.headers.map((header) => {
+                                    const sortConfig =
+                                        thSortConfig?.[header.id];
+                                    const onClick =
+                                        sortConfig && onTHClick
+                                            ? () => onTHClick(header.id)
+                                            : undefined;
 
-                                return (
-                                    <th
-                                        key={header.id}
-                                        onClick={onClick}
-                                        style={
-                                            onClick
-                                                ? {
-                                                      cursor: 'pointer',
-                                                      backgroundColor:
-                                                          TABLE_HEADER_BG,
-                                                  }
-                                                : {
-                                                      backgroundColor:
-                                                          TABLE_HEADER_BG,
-                                                  }
-                                        }
-                                    >
-                                        <Group spacing="two" fz={13}>
-                                            {columnsConfig?.[header.id]
-                                                ?.aggregation && (
-                                                <Badge
-                                                    size="sm"
-                                                    color="indigo"
-                                                    radius="xs"
-                                                >
-                                                    {
-                                                        columnsConfig?.[
-                                                            header.id
-                                                        ]?.aggregation
-                                                    }
-                                                </Badge>
-                                            )}
-                                            {/* TODO: do we need to check if it's a
-                                      placeholder? */}
-                                            {flexRender(
-                                                header.column.columnDef.header,
-                                                header.getContext(),
-                                            )}
+                                    return (
+                                        <th
+                                            key={header.id}
+                                            onClick={onClick}
+                                            style={
+                                                onClick
+                                                    ? {
+                                                          cursor: 'pointer',
+                                                          backgroundColor:
+                                                              TABLE_HEADER_BG,
+                                                      }
+                                                    : {
+                                                          backgroundColor:
+                                                              TABLE_HEADER_BG,
+                                                      }
+                                            }
+                                        >
+                                            <Tooltip
+                                                label="You cannot sort by a group column"
+                                                disabled={!!onClick}
+                                                position="top"
+                                                withinPortal
+                                            >
+                                                <Group spacing="two" fz={13}>
+                                                    {columnsConfig?.[header.id]
+                                                        ?.aggregation && (
+                                                        <Badge
+                                                            size="sm"
+                                                            color="indigo"
+                                                            radius="xs"
+                                                        >
+                                                            {
+                                                                columnsConfig?.[
+                                                                    header.id
+                                                                ]?.aggregation
+                                                            }
+                                                        </Badge>
+                                                    )}
 
-                                            {onClick &&
-                                                sortConfig?.direction && (
-                                                    <MantineIcon
-                                                        icon={
-                                                            sortConfig.direction ===
-                                                            SortByDirection.ASC
-                                                                ? IconArrowUp
-                                                                : IconArrowDown
-                                                        }
-                                                    ></MantineIcon>
-                                                )}
-                                        </Group>
-                                    </th>
-                                );
-                            }),
-                        )}
-                    </tr>
-                </thead>
+                                                    {flexRender(
+                                                        header.column.columnDef
+                                                            .header,
+                                                        header.getContext(),
+                                                    )}
+
+                                                    {onClick &&
+                                                        sortConfig?.direction && (
+                                                            <MantineIcon
+                                                                icon={
+                                                                    sortConfig.direction ===
+                                                                    SortByDirection.ASC
+                                                                        ? IconArrowUp
+                                                                        : IconArrowDown
+                                                                }
+                                                            ></MantineIcon>
+                                                        )}
+                                                </Group>
+                                            </Tooltip>
+                                        </th>
+                                    );
+                                }),
+                            )}
+                        </tr>
+                    </thead>
+                </Tooltip.Group>
                 <tbody>
                     {paddingTop > 0 && (
                         <VirtualizedArea

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -274,8 +274,19 @@ export const ContentPanel: FC = () => {
             return undefined;
         }
 
+        const isPivoted =
+            currentVizConfig.fieldConfig?.groupBy &&
+            currentVizConfig.fieldConfig?.groupBy.length > 0;
+
         return pivotedChartInfo?.data?.tableData?.columns.reduce<VizTableHeaderSortConfig>(
             (acc, col) => {
+                if (
+                    isPivoted &&
+                    pivotedChartInfo.data?.indexColumn?.reference !== col
+                ) {
+                    return acc;
+                }
+
                 const columnSort = currentVizConfig?.fieldConfig?.sortBy?.find(
                     (sort) => sort.reference === col,
                 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Disable sorting on grouped cols in SQL runner. Repro: make a chart in SQL runner, add a group, check that you can't click on the pivoted columns in the chart table. 

<img width="782" alt="Screenshot 2024-11-21 at 18 08 24" src="https://github.com/user-attachments/assets/0494e261-257a-41e6-84c7-e775ed8bd67c">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
