### PR TITLE
feat: sort x-axis by default in SQL runner

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -16,6 +16,7 @@ import {
 import { type SemanticLayerQuery } from '../types/semanticLayer';
 import { applyCustomFormat } from '../utils/formatting';
 import {
+    SortByDirection,
     VizAggregationOptions,
     VizIndexType,
     type PivotChartData,
@@ -210,10 +211,15 @@ export class CartesianChartDataModel {
             },
         ];
 
+        const sortBy = [
+            { reference: x.reference, direction: SortByDirection.ASC },
+        ];
+
         return {
             x,
             y,
             groupBy: [],
+            sortBy,
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12527 

### Description:

In the SQL runner, the x-axis will now be sorted by default. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
