### PR TITLE
fix: show error when downloading CSV

### DIFF
--- a/packages/backend/src/controllers/csvController.ts
+++ b/packages/backend/src/controllers/csvController.ts
@@ -1,4 +1,8 @@
-import { ApiCsvUrlResponse, ApiErrorPayload } from '@lightdash/common';
+import {
+    ApiCsvUrlResponse,
+    ApiErrorPayload,
+    UnexpectedServerError,
+} from '@lightdash/common';
 import {
     Get,
     Middlewares,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -725,7 +725,7 @@ export default class SchedulerTask {
                 status: SchedulerJobStatus.ERROR,
                 details: {
                     createdByUserUuid: payload.createdByUserUuid,
-                    error: e,
+                    error: e.message,
                 },
             });
             throw e;
@@ -779,7 +779,7 @@ export default class SchedulerTask {
                 status: SchedulerJobStatus.ERROR,
                 details: {
                     createdByUserUuid: payload.createdByUserUuid,
-                    error: e,
+                    error: e.message,
                 },
             });
             throw e;
@@ -906,7 +906,10 @@ export default class SchedulerTask {
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
                 status: SchedulerJobStatus.ERROR,
-                details: { createdByUserUuid: payload.userUuid, error: e },
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    error: e.message,
+                },
             });
             throw e; // Cascade error to it can be retried by graphile
         }
@@ -1111,7 +1114,10 @@ export default class SchedulerTask {
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
                 status: SchedulerJobStatus.ERROR,
-                details: { createdByUserUuid: payload.userUuid, error: e },
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    error: e.message,
+                },
             });
 
             this.analytics.track({

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -12,6 +12,7 @@ import {
     isDashboardScheduler,
     isUserWithOrg,
     isValidFrequency,
+    NotExistsError,
     ParameterError,
     ScheduledJobs,
     Scheduler,
@@ -19,6 +20,7 @@ import {
     SchedulerCronUpdate,
     SchedulerFormat,
     SessionUser,
+    UnexpectedServerError,
     UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
 import { arrayToString, stringToArray } from 'cron-converter';
@@ -384,6 +386,11 @@ export class SchedulerService extends BaseService {
             )
         ) {
             throw new ForbiddenError();
+        }
+        if (job.status === 'error') {
+            throw new NotExistsError(
+                job.details?.error ?? 'Unable to download CSV',
+            );
         }
         return job;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12561](https://github.com/lightdash/lightdash/issues/12561)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- amend all scheduled jobs to store the error message in the log
- amend the csv service to throw an error when there is an error log

Before the FE would not detect an error and kept pulling the request resulting in a infinite spinner.

Now it shows the error message

<img width="1278" alt="Screenshot 2024-11-22 at 14 47 21" src="https://github.com/user-attachments/assets/ab545a5c-5127-46c1-9f04-e27ce3f1d7ca">

To reproduce:
- create a chart from "customers" add last name in x axis, a metric in y axis and pivot by first name
- add chart to dashboard
- go to dashboard
- click export CSV from chart tile

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
