### PR TITLE
fix: new defaults for SQL runner chart fields

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -167,9 +167,9 @@ export class CartesianChartDataModel {
         );
 
         const xColumn =
+            dateColumns[0] ||
             categoricalColumns[0] ||
             booleanColumns[0] ||
-            dateColumns[0] ||
             numericColumns[0] ||
             dimensions[0];
 

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -3,11 +3,11 @@
 import {
     ChartKind,
     isFormat,
+    VizAggregationOptions,
     VIZ_DEFAULT_AGGREGATION,
     type CartesianChartDisplay,
     type SortByDirection,
     type ValueLabelPositionOptions,
-    type VizAggregationOptions,
     type VizCartesianChartConfig,
     type VizCartesianChartOptions,
     type VizConfigErrors,
@@ -245,16 +245,27 @@ export const cartesianChartConfigSlice = createSlice({
 
             let defaultYAxisField;
 
+            console.log(yAxisFieldsAvailable);
+
             if (yAxisFieldsAvailable.length > 0) {
                 defaultYAxisField = yAxisFieldsAvailable[0];
             } else {
-                defaultYAxisField = state.fieldConfig.y[0];
+                // There are no fields to add
+                return;
             }
+
+            const aggregation =
+                defaultYAxisField.aggregationOptions &&
+                defaultYAxisField.aggregationOptions.includes(
+                    VizAggregationOptions.SUM,
+                )
+                    ? VizAggregationOptions.SUM
+                    : VIZ_DEFAULT_AGGREGATION;
 
             if (yAxisFields) {
                 state.fieldConfig.y.push({
                     reference: defaultYAxisField.reference,
-                    aggregation: VIZ_DEFAULT_AGGREGATION,
+                    aggregation: aggregation,
                 });
             }
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Change the defaults on SQL runner. Now:
- Date fields are selected first for the x-axis
- Numeric fields use 'sum' as the default aggregation

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
