### PR TITLE
fix: additional dimensions date extra group

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
@@ -133,7 +133,7 @@ const getNodeMapFromItemsMap = (
                     // Limit group nesting levels
                     const groupsWithMaxDepth = groups.slice(0, MAX_GROUP_DEPTH);
                     if (
-                        groups.length > 2 &&
+                        groups.length > MAX_GROUP_DEPTH &&
                         isDimension(item) &&
                         item.timeInterval
                     ) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
max leve was hardcoded in a part of the code, when there were exactly 2 nested groups, it was creating an additional group for dates. We recently increased MAX_GROUP_DEPTH from 2 to 3
When there were 3 (MAX_GROUP_DEPTH) then it was working as expected. 
 

Before
![Screenshot from 2024-11-25 09-20-21](https://github.com/user-attachments/assets/bce02812-01fd-4bab-a28e-a1f3cd8f1991)


After
![Screenshot from 2024-11-25 09-22-35](https://github.com/user-attachments/assets/d596b33e-3ce5-4aed-95da-589ff20122db)




<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
