### PR TITLE
chore: upgrade intercom react 4.1.0

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -90,7 +90,7 @@
         "react-resizable-panels": "^2.1.2",
         "react-router-dom": "5.3.4",
         "react-use": "^17.3.2",
-        "react-use-intercom": "^1.5.1",
+        "react-use-intercom": "^4.1.0",
         "react-vega": "^7.6.0",
         "rudder-sdk-js": "^2.8.0",
         "scheduler": "^0.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18209,10 +18209,10 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use-intercom@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/react-use-intercom/-/react-use-intercom-1.5.1.tgz"
-  integrity sha512-rsSiW3j6yv0bBWCaX+VOCK/ndh/VzntlYjxHLHhV++iQtFurFhcRD249rF07ZaLH8ZP5SR6FzP3Alqdi3usBQg==
+react-use-intercom@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-use-intercom/-/react-use-intercom-4.1.0.tgz#26df942225cb9f5cc71a02ad49ac35345c6cf181"
+  integrity sha512-yjHV0zpKkezs2feETP8ecVP0zP6rIw52KfFy0Yj0pGBk6FiCeDf/6PyUliLBEESlzJIjEDbx+vgOoFP1W8aDvg==
 
 react-use@^17.3.2:
   version "17.3.2"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12165

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Latest version is 5.4.1. however, that version had an issue with `hideDefaultLauncher: false` inside useEffects, I tried to timebox a fix but I couldn't find a way to solve this, . I was able to toggle the property using setInterval, it sounds like a race condition or the property is overwritten later. 

This was causing that the messenger was appearing on pages like explore


![Screenshot from 2024-11-25 13-01-20](https://github.com/user-attachments/assets/f467772e-224f-43e2-81d3-b48cad588e74)

So I upgraded to the previous major version , which seems ok. 


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
