### PR TITLE
fix: hide explore button when user doesn't have access to explore

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -59,10 +59,19 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             <HeaderCell Icon={Hash}>{column.columnDef.header}</HeaderCell>
         ),
         Cell: ({ row, table }) => {
+            const canViewExplore = useAppSelector(
+                (state) => state.metricsCatalog.abilities.canViewExplore,
+            );
+
             return (
                 <Flex justify="space-between" align="center" w="100%">
                     <MetricsCatalogColumnName row={row} table={table} />
-                    <ExploreMetricButton row={row} className="explore-button" />
+                    {canViewExplore && (
+                        <ExploreMetricButton
+                            row={row}
+                            className="explore-button"
+                        />
+                    )}
                 </Flex>
             );
         },

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -59,14 +59,14 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             <HeaderCell Icon={Hash}>{column.columnDef.header}</HeaderCell>
         ),
         Cell: ({ row, table }) => {
-            const canViewExplore = useAppSelector(
-                (state) => state.metricsCatalog.abilities.canViewExplore,
+            const canManageExplore = useAppSelector(
+                (state) => state.metricsCatalog.abilities.canManageExplore,
             );
 
             return (
                 <Flex justify="space-between" align="center" w="100%">
                     <MetricsCatalogColumnName row={row} table={table} />
-                    {canViewExplore && (
+                    {canManageExplore && (
                         <ExploreMetricButton
                             row={row}
                             className="explore-button"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -150,7 +150,7 @@ export const MetricsCatalogPanel = () => {
                     user.data.ability.can('manage', 'Job') ||
                     user.data.ability.can('manage', 'CompileProject');
 
-                const canViewExplore = user.data.ability.can(
+                const canManageExplore = user.data.ability.can(
                     'manage',
                     'Explore',
                 );
@@ -159,7 +159,7 @@ export const MetricsCatalogPanel = () => {
                     setAbility({
                         canManageTags,
                         canRefreshCatalog,
-                        canViewExplore,
+                        canManageExplore,
                     }),
                 );
             }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -145,14 +145,18 @@ export const MetricsCatalogPanel = () => {
                         projectUuid,
                     }),
                 );
+
                 const canRefreshCatalog =
                     user.data.ability.can('manage', 'Job') ||
                     user.data.ability.can('manage', 'CompileProject');
+
+                const canViewExplore = user.data.ability.can('view', 'Explore');
 
                 dispatch(
                     setAbility({
                         canManageTags,
                         canRefreshCatalog,
+                        canViewExplore,
                     }),
                 );
             }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -150,7 +150,10 @@ export const MetricsCatalogPanel = () => {
                     user.data.ability.can('manage', 'Job') ||
                     user.data.ability.can('manage', 'CompileProject');
 
-                const canViewExplore = user.data.ability.can('view', 'Explore');
+                const canViewExplore = user.data.ability.can(
+                    'manage',
+                    'Explore',
+                );
 
                 dispatch(
                     setAbility({

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -10,6 +10,7 @@ type MetricsCatalogState = {
     abilities: {
         canManageTags: boolean;
         canRefreshCatalog: boolean;
+        canViewExplore: boolean;
     };
     activeMetric: CatalogField | undefined;
     projectUuid: string | undefined;
@@ -33,6 +34,7 @@ const initialState: MetricsCatalogState = {
     abilities: {
         canManageTags: false,
         canRefreshCatalog: false,
+        canViewExplore: false,
     },
     modals: {
         chartUsageModal: {

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -10,7 +10,7 @@ type MetricsCatalogState = {
     abilities: {
         canManageTags: boolean;
         canRefreshCatalog: boolean;
-        canViewExplore: boolean;
+        canManageExplore: boolean;
     };
     activeMetric: CatalogField | undefined;
     projectUuid: string | undefined;
@@ -34,7 +34,7 @@ const initialState: MetricsCatalogState = {
     abilities: {
         canManageTags: false,
         canRefreshCatalog: false,
-        canViewExplore: false,
+        canManageExplore: false,
     },
     modals: {
         chartUsageModal: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12542

### Description:

- Hides explore button in metrics catalog when user doesn't have access to the explore

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
