### PR TITLE
fix: allow metric name to use the whole width of the cell and cta to overlay

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,5 +1,5 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button, Text, Tooltip } from '@mantine/core';
+import { Button, Text, Tooltip, type ButtonProps } from '@mantine/core';
 import { type MRT_Row } from 'mantine-react-table';
 import { useCallback, useEffect, useState } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
@@ -13,11 +13,11 @@ import { useAppSelector } from '../../sqlRunner/store/hooks';
 
 type Props = {
     className?: string;
-    visibility?: 'visible' | 'hidden';
     row: MRT_Row<CatalogField>;
+    sx?: ButtonProps['sx'];
 };
 
-export const ExploreMetricButton = ({ row, visibility, className }: Props) => {
+export const ExploreMetricButton = ({ row, className, sx }: Props) => {
     const [exploreUrl, setExploreUrl] = useState<string>();
     const [shouldOpenInNewTab, setShouldOpenInNewTab] = useState(false);
     const projectUuid = useAppSelector(
@@ -103,7 +103,7 @@ export const ExploreMetricButton = ({ row, visibility, className }: Props) => {
                 sx={{
                     border: `1px solid #414E62`,
                     boxShadow: '0px 0px 0px 1px #151C24',
-                    visibility,
+                    ...sx,
                 }}
             >
                 <Text fz="sm" fw={500}>

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,5 +1,5 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button, Text, Tooltip, type ButtonProps } from '@mantine/core';
+import { Button, Text, Tooltip } from '@mantine/core';
 import { type MRT_Row } from 'mantine-react-table';
 import { useCallback, useEffect, useState } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
@@ -12,12 +12,10 @@ import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 
 type Props = {
-    className?: string;
     row: MRT_Row<CatalogField>;
-    sx?: ButtonProps['sx'];
 };
 
-export const ExploreMetricButton = ({ row, className, sx }: Props) => {
+export const ExploreMetricButton = ({ row }: Props) => {
     const [exploreUrl, setExploreUrl] = useState<string>();
     const [shouldOpenInNewTab, setShouldOpenInNewTab] = useState(false);
     const projectUuid = useAppSelector(
@@ -91,7 +89,6 @@ export const ExploreMetricButton = ({ row, className, sx }: Props) => {
             label="Open this metric in the explorer for detailed insights."
         >
             <Button
-                className={className}
                 compact
                 bg="linear-gradient(180deg, #202B37 0%, #151C24 100%)"
                 radius="md"
@@ -103,7 +100,6 @@ export const ExploreMetricButton = ({ row, className, sx }: Props) => {
                 sx={{
                     border: `1px solid #414E62`,
                     boxShadow: '0px 0px 0px 1px #151C24',
-                    ...sx,
                 }}
             >
                 <Text fz="sm" fw={500}>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,5 +1,5 @@
 import { type CatalogField } from '@lightdash/common';
-import { Flex, Group, Text, Tooltip } from '@mantine/core';
+import { Box, Flex, Group, Text, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus } from '@tabler/icons-react';
 import { type MRT_ColumnDef } from 'mantine-react-table';
@@ -72,14 +72,13 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
                 >
                     <MetricsCatalogColumnName row={row} table={table} />
                     {canManageExplore && (
-                        <ExploreMetricButton
-                            row={row}
-                            className="explore-button"
-                            sx={{
-                                position: 'absolute',
-                                right: 0,
-                            }}
-                        />
+                        <Box
+                            pos="absolute"
+                            right={0}
+                            className="explore-button-container"
+                        >
+                            <ExploreMetricButton row={row} />
+                        </Box>
                     )}
                 </Flex>
             );

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -64,12 +64,21 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             );
 
             return (
-                <Flex justify="space-between" align="center" w="100%">
+                <Flex
+                    justify="space-between"
+                    align="center"
+                    w="100%"
+                    pos="relative"
+                >
                     <MetricsCatalogColumnName row={row} table={table} />
                     {canManageExplore && (
                         <ExploreMetricButton
                             row={row}
                             className="explore-button"
+                            sx={{
+                                position: 'absolute',
+                                right: 0,
+                            }}
                         />
                     )}
                 </Flex>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -227,7 +227,7 @@ export const MetricsTable = () => {
         },
         mantineTableBodyRowProps: {
             sx: {
-                'td:first-of-type > div > .explore-button': {
+                'td:first-of-type > div > .explore-button-container': {
                     visibility: 'hidden',
                     opacity: 0,
                 },
@@ -237,7 +237,7 @@ export const MetricsTable = () => {
                         transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
                     },
 
-                    'td:first-of-type > div > .explore-button': {
+                    'td:first-of-type > div > .explore-button-container': {
                         visibility: 'visible',
                         opacity: 1,
                         transition: `visibility 0ms, opacity ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12542

### Description:

Before:

![image](https://github.com/user-attachments/assets/4490715b-8902-45ed-a442-2c3e0d030a1c)
![image](https://github.com/user-attachments/assets/0ca4d69e-f7c1-4bf1-bac4-6f7bd690f5ef)


After:

![image](https://github.com/user-attachments/assets/9780f228-38f5-465c-8a97-d6d76fb8e0a1)
![image](https://github.com/user-attachments/assets/6d9181b3-a4b0-442a-8044-e35466d1d15d)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
