### PR TITLE
fix: remove divider when no results and double borders

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -162,6 +162,8 @@ export const MetricsTable = () => {
                 border: `1px solid ${theme.colors.gray[2]}`,
                 borderRadius: theme.spacing.sm, // ! radius doesn't have rem(12) -> 0.75rem
                 boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
             },
         },
         mantineTableContainerProps: {
@@ -169,13 +171,25 @@ export const MetricsTable = () => {
             sx: {
                 maxHeight: 'calc(100dvh - 350px)',
                 minHeight: '600px',
+                display: 'flex',
+                flexDirection: 'column',
             },
             onScroll: (event: UIEvent<HTMLDivElement>) =>
                 fetchMoreOnBottomReached(event.target as HTMLDivElement),
         },
         mantineTableProps: {
             highlightOnHover: true,
-            withColumnBorders: true,
+            withColumnBorders: Boolean(flatData.length),
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableHeadProps: {
+            sx: {
+                flexShrink: 1,
+            },
         },
         mantineTableHeadRowProps: {
             sx: {
@@ -224,6 +238,19 @@ export const MetricsTable = () => {
                     },
                 },
             };
+        },
+        mantineTableBodyProps: {
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                ...(!flatData.length && {
+                    'tr:last-of-type > td': {
+                        borderBottom: 'none',
+                    },
+                }),
+            },
         },
         mantineTableBodyRowProps: {
             sx: {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -211,6 +211,11 @@ export const MetricsTable = () => {
             const isAnyColumnResizing = props.table
                 .getAllColumns()
                 .some((c) => c.getIsResizing());
+
+            const isLastColumn =
+                props.table.getAllColumns().indexOf(props.column) ===
+                props.table.getAllColumns().length - 1;
+
             return {
                 bg: 'gray.0',
                 h: '3xl',
@@ -221,7 +226,11 @@ export const MetricsTable = () => {
                     borderBottom: `1px solid ${theme.colors.gray[2]}`,
                     borderRight: props.column.getIsResizing()
                         ? `2px solid ${theme.colors.blue[3]}`
-                        : `1px solid ${theme.colors.gray[2]}`,
+                        : `1px solid ${
+                              isLastColumn
+                                  ? 'transparent'
+                                  : theme.colors.gray[2]
+                          }`,
                     borderTop: 'none',
                     borderLeft: 'none',
                 },
@@ -245,11 +254,9 @@ export const MetricsTable = () => {
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
-                ...(!flatData.length && {
-                    'tr:last-of-type > td': {
-                        borderBottom: 'none',
-                    },
-                }),
+                'tr:last-of-type > td': {
+                    borderBottom: 'none',
+                },
             },
         },
         mantineTableBodyRowProps: {
@@ -272,21 +279,33 @@ export const MetricsTable = () => {
                 },
             },
         },
-        mantineTableBodyCellProps: {
-            h: 72,
-            // Adding to inline styles to override the default ones which can't be overridden with sx
-            style: {
-                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
-                borderRight: `1px solid ${theme.colors.gray[2]}`,
-                borderBottom: `1px solid ${theme.colors.gray[2]}`,
-                borderTop: 'none',
-                borderLeft: 'none',
-            },
-            sx: {
-                display: 'inline-flex',
-                alignItems: 'center',
-                flexShrink: 0,
-            },
+        mantineTableBodyCellProps: (props) => {
+            const isLastColumn =
+                props.table.getAllColumns().indexOf(props.column) ===
+                props.table.getAllColumns().length - 1;
+
+            const isLastRow = props.row.index === totalResults - 1;
+
+            return {
+                h: 72,
+                // Adding to inline styles to override the default ones which can't be overridden with sx
+                style: {
+                    padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                    borderRight: isLastColumn
+                        ? 'none'
+                        : `1px solid ${theme.colors.gray[2]}`,
+                    borderBottom: isLastRow
+                        ? 'none'
+                        : `1px solid ${theme.colors.gray[2]}`,
+                    borderTop: 'none',
+                    borderLeft: 'none',
+                },
+                sx: {
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    flexShrink: 0,
+                },
+            };
         },
         renderTopToolbar: () => (
             <Box>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -284,8 +284,6 @@ export const MetricsTable = () => {
                 props.table.getAllColumns().indexOf(props.column) ===
                 props.table.getAllColumns().length - 1;
 
-            const isLastRow = props.row.index === totalResults - 1;
-
             return {
                 h: 72,
                 // Adding to inline styles to override the default ones which can't be overridden with sx
@@ -294,9 +292,7 @@ export const MetricsTable = () => {
                     borderRight: isLastColumn
                         ? 'none'
                         : `1px solid ${theme.colors.gray[2]}`,
-                    borderBottom: isLastRow
-                        ? 'none'
-                        : `1px solid ${theme.colors.gray[2]}`,
+                    borderBottom: `1px solid ${theme.colors.gray[2]}`,
                     borderTop: 'none',
                     borderLeft: 'none',
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12542 

### Description:

- Removes bottom border when there are no results
- Fixes misc double borders on right and bottom (last row and last column)

Before:
![image](https://github.com/user-attachments/assets/194ba2fa-2cb0-4b17-bb65-11d216a45a22)
![image](https://github.com/user-attachments/assets/f1dc9fbe-5083-40b8-bb6e-5fe9d2e43cb6)


After:

![image](https://github.com/user-attachments/assets/ddc3575b-af97-4c6e-96ef-e35930381df9)
![image](https://github.com/user-attachments/assets/b3949485-ab8b-4f89-95cf-45036acfe250)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
