### PR TITLE
fix: duplicate user on create throws correct error

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1,5 +1,6 @@
 import {
     ActivateUser,
+    AlreadyExistsError,
     CreateUserArgs,
     CreateUserWithRole,
     ForbiddenError,
@@ -643,7 +644,7 @@ export class UserModel {
                 email,
             );
             if (duplicatedEmails.length > 0) {
-                throw new ParameterError(`Email ${email} already in use`);
+                throw new AlreadyExistsError(`Email ${email} already in use`);
             }
 
             const newUser = await this.createUserTransaction(trx, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Dependant Commercial PR: https://github.com/lightdash/lightdash-commercial/pull/407

### Description:
- on user create conflict in userModel it now throws a more appropriate `AlreadyExistsError` instead of `ParameterError`

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
