### PR TITLE
fix: show only relevant date filters for year, month, etc..

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -32,6 +32,27 @@ export const unitOfTimeFormat: Record<UnitOfTime, string> = {
     years: 'YYYY',
 };
 
+export const getUnitsOfTimeGreaterOrEqual = (
+    unit: UnitOfTime,
+): UnitOfTime[] => {
+    const unitsInOrder: UnitOfTime[] = [
+        UnitOfTime.milliseconds,
+        UnitOfTime.seconds,
+        UnitOfTime.minutes,
+        UnitOfTime.hours,
+        UnitOfTime.days,
+        UnitOfTime.weeks,
+        UnitOfTime.months,
+        UnitOfTime.quarters,
+        UnitOfTime.years,
+    ];
+    const index = unitsInOrder.indexOf(unit);
+    if (index === -1) {
+        throw new Error(`Invalid unit of time: ${unit}`);
+    }
+    return unitsInOrder.slice(index);
+};
+
 export type FieldTarget = {
     fieldId: string;
 };

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -48,7 +48,8 @@ export const getUnitsOfTimeGreaterOrEqual = (
     ];
     const index = unitsInOrder.indexOf(unit);
     if (index === -1) {
-        throw new Error(`Invalid unit of time: ${unit}`);
+        // return the original array if the unit is not found
+        return unitsInOrder;
     }
     return unitsInOrder.slice(index);
 };

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -7,6 +7,7 @@ import {
     isFilterRule,
     parseDate,
     TimeFrames,
+    UnitOfTime,
     type ConditionalRule,
     type DateFilterRule,
 } from '@lightdash/common';
@@ -44,6 +45,21 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
         operator: rule.operator,
         disabled: rule.disabled && !rule.values,
     });
+
+    const timeframeToUnitOfTime = (timeframe: TimeFrames) => {
+        switch (timeframe) {
+            case TimeFrames.DAY:
+                return UnitOfTime.days;
+            case TimeFrames.WEEK:
+                return UnitOfTime.weeks;
+            case TimeFrames.MONTH:
+                return UnitOfTime.months;
+            case TimeFrames.YEAR:
+                return UnitOfTime.years;
+            default:
+                return undefined;
+        }
+    };
 
     switch (rule.operator) {
         case FilterOperator.EQUALS:
@@ -252,6 +268,11 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                         disabled={disabled}
                         sx={{ flexShrink: 0, flexGrow: 3 }}
                         isTimestamp={isTimestamp}
+                        minUnitOfTime={
+                            isDimension(field) && field.timeInterval
+                                ? timeframeToUnitOfTime(field.timeInterval)
+                                : undefined
+                        }
                         unitOfTime={rule.settings?.unitOfTime}
                         completed={rule.settings?.completed || false}
                         withinPortal={popoverProps?.withinPortal}
@@ -277,6 +298,11 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     disabled={disabled}
                     isTimestamp={isTimestamp}
                     unitOfTime={rule.settings?.unitOfTime}
+                    minUnitOfTime={
+                        isDimension(field) && field.timeInterval
+                            ? timeframeToUnitOfTime(field.timeInterval)
+                            : undefined
+                    }
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
                     completed={false}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -48,12 +48,22 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
 
     const timeframeToUnitOfTime = (timeframe: TimeFrames) => {
         switch (timeframe) {
+            case TimeFrames.MILLISECOND:
+                return UnitOfTime.milliseconds;
+            case TimeFrames.SECOND:
+                return UnitOfTime.seconds;
+            case TimeFrames.MINUTE:
+                return UnitOfTime.minutes;
+            case TimeFrames.HOUR:
+                return UnitOfTime.hours;
             case TimeFrames.DAY:
                 return UnitOfTime.days;
             case TimeFrames.WEEK:
                 return UnitOfTime.weeks;
             case TimeFrames.MONTH:
                 return UnitOfTime.months;
+            case TimeFrames.QUARTER:
+                return UnitOfTime.quarters;
             case TimeFrames.YEAR:
                 return UnitOfTime.years;
             default:

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
@@ -98,7 +98,7 @@ const FilterUnitOfTimeAutoComplete: FC<Props> = ({
         if (unitOfTime) {
             return `${unitOfTime}${completed ? '-completed' : ''}`;
         }
-        // return the last option value if it's not valid
+        // return the last option value
         if (options.length > 0) {
             return options[options.length - 1]?.value;
         }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { UnitOfTime } from '@lightdash/common';
+import { getUnitsOfTimeGreaterOrEqual, UnitOfTime } from '@lightdash/common'; // Modified import to include getUnitsOfTimeGreaterOrEqual
 import { Select, type SelectProps } from '@mantine/core';
 import { type FC } from 'react';
 
@@ -14,17 +14,20 @@ const getUnitOfTimeLabel = (
 
 const getUnitOfTimeOptions = ({
     isTimestamp,
+    minUnitOfTime,
     showCompletedOptions,
     showOptionsInPlural,
 }: {
     isTimestamp: boolean;
+    minUnitOfTime?: UnitOfTime;
     showCompletedOptions: boolean;
     showOptionsInPlural: boolean;
 }) => {
     const dateIndex = Object.keys(UnitOfTime).indexOf(UnitOfTime.days);
 
-    // Filter unitTimes before Days if we are filtering Dates only
-    const unitsOfTime = isTimestamp
+    const unitsOfTime = minUnitOfTime
+        ? getUnitsOfTimeGreaterOrEqual(minUnitOfTime)
+        : isTimestamp
         ? Object.values(UnitOfTime)
         : Object.values(UnitOfTime).slice(dateIndex);
 
@@ -60,6 +63,7 @@ const getUnitOfTimeOptions = ({
 interface Props extends Omit<SelectProps, 'data' | 'onChange'> {
     isTimestamp: boolean;
     unitOfTime: UnitOfTime | null;
+    minUnitOfTime?: UnitOfTime;
     showOptionsInPlural?: boolean;
     showCompletedOptions?: boolean;
     completed: boolean;
@@ -69,6 +73,7 @@ interface Props extends Omit<SelectProps, 'data' | 'onChange'> {
 const FilterUnitOfTimeAutoComplete: FC<Props> = ({
     isTimestamp,
     unitOfTime,
+    minUnitOfTime,
     showOptionsInPlural = true,
     showCompletedOptions = true,
     completed,
@@ -83,6 +88,7 @@ const FilterUnitOfTimeAutoComplete: FC<Props> = ({
         value={completed ? `${unitOfTime}-completed` : unitOfTime}
         data={getUnitOfTimeOptions({
             isTimestamp,
+            minUnitOfTime,
             showCompletedOptions,
             showOptionsInPlural,
         })}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterUnitOfTimeAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { getUnitsOfTimeGreaterOrEqual, UnitOfTime } from '@lightdash/common'; // Modified import to include getUnitsOfTimeGreaterOrEqual
+import { getUnitsOfTimeGreaterOrEqual, UnitOfTime } from '@lightdash/common';
 import { Select, type SelectProps } from '@mantine/core';
 import { type FC } from 'react';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12604

### Description:
- when adding querying from tables and adding filters, it will now only show relevant values. Previously when `Date years` was selected along with `in the last` it will list `days` which is not intuitive

![CleanShot 2024-11-27 at 17 30 55](https://github.com/user-attachments/assets/db527346-03ca-4863-8136-59048054a5ee)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
