### PR TITLE
chore: log http requests with and without response metadata

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -44,7 +44,10 @@ import { errorHandler } from './errors';
 import { RegisterRoutes } from './generated/routes';
 import apiSpec from './generated/swagger.json';
 import Logger from './logging/logger';
-import { expressWinstonMiddleware } from './logging/winston';
+import {
+    expressWinstonMiddleware,
+    expressWinstonPreResponseMiddleware,
+} from './logging/winston';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import { postHogClient } from './postHog';
 import { apiV1Router } from './routers/apiV1Router';
@@ -418,7 +421,8 @@ export default class App {
         expressApp.use(passport.initialize());
         expressApp.use(passport.session());
 
-        expressApp.use(expressWinstonMiddleware);
+        expressApp.use(expressWinstonPreResponseMiddleware); // log request before response is sent
+        expressApp.use(expressWinstonMiddleware); // log request + response
 
         expressApp.get('/', (req, res) => {
             res.sendFile(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#2276](https://github.com/lightdash/lightdash-internal-work/issues/2276)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Log HTTP requests with and without response so allow us to detect which requests crash the server.
Logs without response are disabled in dev environment.

Example
<img width="1268" alt="Screenshot 2024-11-27 at 17 15 19" src="https://github.com/user-attachments/assets/c8ac5e08-ed92-4dcd-abc8-bb5d03df8339">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
