### PR TITLE
style: update metric modal peek styles

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -14,13 +14,13 @@ import {
     Radio,
     Stack,
     Text,
+    Tooltip,
     type ModalProps,
 } from '@mantine/core';
-import { IconCalendar, IconStack } from '@tabler/icons-react';
+import { IconCalendar, IconInfoCircle, IconStack } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { Hash } from '../../../svgs/metricsCatalog';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetric } from '../hooks/useMetricsCatalog';
 import { useRunMetricExplorerQuery } from '../hooks/useRunMetricExplorerQuery';
@@ -94,12 +94,12 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         <Modal.Root
             opened={opened}
             onClose={handleClose}
-            yOffset={150}
+            yOffset={100}
             scrollAreaComponent={undefined}
-            size="80%"
+            size="auto"
         >
             <Modal.Overlay />
-            <Modal.Content sx={{ overflow: 'hidden' }} radius="md">
+            <Modal.Content sx={{ overflow: 'hidden' }} radius="lg" w="100%">
                 <LoadingOverlay
                     visible={
                         metricQuery.isLoading || metricResultsQuery.isLoading
@@ -107,19 +107,40 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                 />
                 <Modal.Header
                     sx={(theme) => ({
-                        borderBottom: `1px solid ${theme.colors.gray[4]}`,
+                        borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                        padding: `${theme.spacing.md} ${theme.spacing.lg}`,
                     })}
                 >
                     <Group spacing="xs">
-                        <Hash />
-                        <Text fw={500}>Metric Details</Text>
+                        <Text fw={600} fz="lg" color="dark.7">
+                            {metricQuery.data?.label}
+                        </Text>
+                        <Tooltip
+                            label={metricQuery.data?.description}
+                            disabled={!metricQuery.data?.description}
+                        >
+                            <MantineIcon
+                                color="dark.3"
+                                icon={IconInfoCircle}
+                                size={18}
+                            />
+                        </Tooltip>
                     </Group>
                     <Modal.CloseButton />
                 </Modal.Header>
 
-                <Modal.Body p={0}>
-                    <Flex align="stretch" gap={0}>
-                        <Stack p="md" bg="gray.0" w={360} spacing="sm">
+                <Modal.Body
+                    p={0}
+                    h="100%"
+                    sx={{ display: 'flex' }}
+                    miw={800}
+                    mih={600}
+                >
+                    <Stack p="xl" bg="#FDFDFD" h="100%" w={360} spacing="xl">
+                        <Stack w="100%" spacing="xs" align="flex-start">
+                            <Text fw={500} c="gray.7">
+                                Time filter
+                            </Text>
                             {metricQuery.isSuccess && (
                                 <MetricPeekDatePicker
                                     defaultTimeDimension={
@@ -127,20 +148,28 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                     }
                                 />
                             )}
+                        </Stack>
 
+                        <Divider color="gray.2" />
+
+                        <Stack w="100%" spacing="xs">
                             <Group position="apart">
                                 <Text fw={500} c="gray.7">
                                     Comparison
                                 </Text>
 
                                 <Button
-                                    variant="default"
+                                    variant="subtle"
                                     compact
+                                    color="dark"
                                     size="xs"
-                                    style={{
-                                        visibility: comparisonType
-                                            ? 'visible'
-                                            : 'hidden',
+                                    radius="md"
+                                    sx={{
+                                        visibility:
+                                            comparisonType ===
+                                            MetricExplorerComparison.NONE
+                                                ? 'hidden'
+                                                : 'visible',
                                     }}
                                     onClick={() =>
                                         setComparisonType(
@@ -180,10 +209,8 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                     ].map((comparison) => (
                                         <Paper
                                             key={comparison.type}
-                                            withBorder
-                                            radius="lg"
-                                            p="lg"
-                                            style={{ cursor: 'pointer' }}
+                                            p="md"
+                                            sx={{ cursor: 'pointer' }}
                                             onClick={() =>
                                                 setComparisonType(
                                                     comparison.type,
@@ -191,12 +218,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                             }
                                         >
                                             <Group align="start" noWrap>
-                                                <Paper
-                                                    p="xs"
-                                                    withBorder
-                                                    radius="md"
-                                                    shadow="md"
-                                                >
+                                                <Paper p="xs">
                                                     <MantineIcon
                                                         icon={comparison.icon}
                                                     />
@@ -210,13 +232,14 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                                         {comparison.label}
                                                     </Text>
 
-                                                    <Text color="gray.7">
+                                                    <Text color="gray.6">
                                                         {comparison.description}
                                                     </Text>
                                                 </Stack>
 
                                                 <Radio
                                                     value={comparison.type}
+                                                    size="xs"
                                                 />
                                             </Group>
                                         </Paper>
@@ -224,18 +247,18 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                 </Stack>
                             </Radio.Group>
                         </Stack>
+                    </Stack>
 
-                        <Divider orientation="vertical" />
+                    <Divider orientation="vertical" color="gray.2" />
 
-                        <Stack style={{ flexGrow: 1 }}>
-                            {metricQuery.isSuccess &&
-                                metricResultsQuery.isSuccess && (
-                                    <MetricsVisualization
-                                        metric={metricQuery.data}
-                                        data={metricResultsQuery.data}
-                                    />
-                                )}
-                        </Stack>
+                    <Flex mih={500} p="xxl" align="center" sx={{ flexGrow: 1 }}>
+                        {metricQuery.isSuccess &&
+                            metricResultsQuery.isSuccess && (
+                                <MetricsVisualization
+                                    metric={metricQuery.data}
+                                    data={metricResultsQuery.data}
+                                />
+                            )}
                     </Flex>
                 </Modal.Body>
             </Modal.Content>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsVisualization.tsx
@@ -3,7 +3,7 @@ import {
     type MetricsExplorerQueryResults,
     type MetricWithAssociatedTimeDimension,
 } from '@lightdash/common';
-import { AspectRatio, useMantineTheme } from '@mantine/core';
+import { useMantineTheme } from '@mantine/core';
 import { scaleTime } from 'd3-scale';
 import {
     timeDay,
@@ -132,61 +132,59 @@ const MetricsVisualization: FC<Props> = ({ metric, data }) => {
     if (!timeSeriesData) return null;
 
     return (
-        <AspectRatio ratio={16 / 9} w="100%">
-            <ResponsiveContainer width="100%" height="100%">
-                <LineChart
-                    data={timeSeriesData}
-                    margin={{ top: 40, right: 40, bottom: 40, left: 40 }}
-                >
-                    <CartesianGrid
-                        horizontal
-                        vertical={false}
-                        stroke={colors.gray[2]}
+        <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+                data={timeSeriesData}
+                margin={{ top: 40, right: 40, bottom: 40, left: 40 }}
+            >
+                <CartesianGrid
+                    horizontal
+                    vertical={false}
+                    stroke={colors.gray[2]}
+                />
+
+                <YAxis axisLine={false} tickLine={false} fontSize={11}>
+                    <Label
+                        angle={-90}
+                        position="insideLeft"
+                        value={metric.label}
+                        fill={colors.gray[7]}
+                        style={{ textAnchor: 'middle' }}
                     />
+                </YAxis>
 
-                    <YAxis axisLine={false} tickLine={false} fontSize={11}>
-                        <Label
-                            angle={-90}
-                            position="insideLeft"
-                            value={metric.label}
-                            fill={colors.gray[7]}
-                            style={{ textAnchor: 'middle' }}
-                        />
-                    </YAxis>
+                <XAxis
+                    dataKey="date"
+                    {...xAxisArgs}
+                    axisLine={false}
+                    tickLine={false}
+                    fontSize={11}
+                />
 
-                    <XAxis
-                        dataKey="date"
-                        {...xAxisArgs}
-                        axisLine={false}
-                        tickLine={false}
-                        fontSize={11}
-                    />
+                <Line
+                    name={metric.label}
+                    type="monotone"
+                    dataKey="metric"
+                    stroke={colors.indigo[7]}
+                    strokeWidth={2}
+                    dot={false}
+                />
 
+                {data.comparisonRows && (
                     <Line
-                        name={metric.label}
+                        name={`${metric.label} (comparison)`}
                         type="monotone"
-                        dataKey="metric"
-                        stroke={colors.indigo[7]}
+                        dataKey="compareMetric"
+                        stroke={colors.teal[7]}
+                        strokeDasharray={'3 3'}
                         strokeWidth={2}
                         dot={false}
                     />
+                )}
 
-                    {data.comparisonRows && (
-                        <Line
-                            name={`${metric.label} (comparison)`}
-                            type="monotone"
-                            dataKey="compareMetric"
-                            stroke={colors.teal[7]}
-                            strokeDasharray={'3 3'}
-                            strokeWidth={2}
-                            dot={false}
-                        />
-                    )}
-
-                    <Legend />
-                </LineChart>
-            </ResponsiveContainer>
-        </AspectRatio>
+                <Legend />
+            </LineChart>
+        </ResponsiveContainer>
     );
 };
 

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -1,4 +1,4 @@
-import { MantineProvider } from '@mantine/core';
+import { MantineProvider, type MantineTheme } from '@mantine/core';
 import { type FC } from 'react';
 import { Provider } from 'react-redux';
 import Page from '../components/common/Page/Page';
@@ -33,6 +33,18 @@ const MetricsCatalog: FC = () => {
                                 withinPortal: true,
                                 radius: 'md',
                                 shadow: 'sm',
+                            },
+                        },
+                        Paper: {
+                            defaultProps: {
+                                radius: 'md',
+                                shadow: 'subtle',
+                                withBorder: true,
+                                sx: (theme: MantineTheme) => ({
+                                    '&[data-with-border]': {
+                                        border: `1px solid ${theme.colors.gray[2]}`,
+                                    },
+                                }),
                             },
                         },
                     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- Some spacing updates, borders, sizes etc
- Added default props to `Paper`, which update the border, shadow used, etc
- Removed usage of `AspectRatio`

Screenshot

<img width="1585" alt="Screenshot 2024-11-28 at 15 05 47" src="https://github.com/user-attachments/assets/d1b8f3e1-bded-465e-b71e-5355cc2687b0">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
