### PR TITLE
fix: space group permissions gets duplicated over on preview create

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1410,6 +1410,27 @@ export class ProjectModel {
                           .returning('*')
                     : [];
 
+            const spaceGroupAccesses = await trx('space_group_access').whereIn(
+                'space_uuid',
+                spaceUuids,
+            );
+
+            Logger.info(
+                `Duplicating ${spaceGroupAccesses.length} space group accesses on ${previewProjectUuid}`,
+            );
+
+            const newSpaceGroupAccesses =
+                spaceGroupAccesses.length > 0
+                    ? await trx('space_group_access')
+                          .insert(
+                              spaceGroupAccesses.map((d) => ({
+                                  ...d,
+                                  space_uuid: getNewSpaceUuid(d.space_uuid),
+                              })),
+                          )
+                          .returning('*')
+                    : [];
+
             // .dP"Y8    db    Yb    dP 888888 8888b.      .dP"Y8  dP"Yb  88
             // `Ybo."   dPYb    Yb  dP  88__    8I  Yb     `Ybo." dP   Yb 88
             // o.`Y8b  dP__Yb    YbdP   88""    8I  dY     o.`Y8b Yb b dP 88  .o


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #2273

### Description:
- fixes issue with space group permissions not being copied on preview.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
