### PR TITLE
fix: strip subquery query limits and append to end

### DIFF
--- a/packages/backend/src/queryBuilder.test.ts
+++ b/packages/backend/src/queryBuilder.test.ts
@@ -993,7 +993,7 @@ describe('Time frame sorting', () => {
 });
 
 describe('applyLimitToSqlQuery', () => {
-    // strip out formatting so we just test content
+    // strip out white space formatting so we just test content
     const normalizeSQL = (sql: string) => sql.replace(/\s+/g, ' ').trim();
 
     it('should return the original query if limit is undefined', () => {
@@ -1056,10 +1056,9 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 20;
 
-        const expectedQuery = `WITH user_sql AS (\n            WITH subquery AS (\n                SELECT * FROM orders\n            )\n            SELECT * FROM subquery\n        ) select * from user_sql limit ${limit}`;
+        const expectedQuery = `WITH user_sql AS (\n        WITH subquery AS (\n            SELECT * FROM orders\n        )\n        SELECT * FROM subquery\n    ) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
-        console.log(result);
 
         expect(normalizeSQL(result)).toBe(normalizeSQL(expectedQuery));
     });
@@ -1070,7 +1069,10 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 10;
 
-        const expectedQuery = `WITH user_sql AS (\n${sqlQuery.trim()}\n) select * from user_sql limit ${limit}`;
+        // adjust the expected query to exclude the semicolon
+        const expectedQuery = `WITH user_sql AS (\n${sqlQuery
+            .trim()
+            .replace(/;$/, '')}\n) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
 
@@ -1085,7 +1087,7 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 5;
 
-        const expectedQuery = `WITH user_sql AS (\n            SELECT * FROM users\n        ) select * from user_sql limit ${limit}`;
+        const expectedQuery = `WITH user_sql AS (\n        SELECT * FROM users\n    ) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
 
@@ -1098,7 +1100,7 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 20;
 
-        const expectedQuery = `WITH user_sql AS (\n            SELECT * FROM users\n        ) select * from user_sql limit ${limit}`;
+        const expectedQuery = `WITH user_sql AS (\n        SELECT * FROM users\n    ) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
 
@@ -1111,7 +1113,10 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 10;
 
-        const expectedQuery = `WITH user_sql AS (\n${sqlQuery.trim()}\n) select * from user_sql limit ${limit}`;
+        // Adjust the expected query to exclude the semicolon
+        const expectedQuery = `WITH user_sql AS (\n${sqlQuery
+            .trim()
+            .replace(/;$/, '')}\n) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
 
@@ -1125,8 +1130,20 @@ describe('applyLimitToSqlQuery', () => {
         `;
         const limit = 15;
 
-        // Since comments are removed, adjust the expected query
+        // since comments and semicolons are removed, adjust the expected query
         const expectedQuery = `WITH user_sql AS (\nSELECT * FROM users\n) select * from user_sql limit ${limit}`;
+
+        const result = applyLimitToSqlQuery({ sqlQuery, limit });
+
+        expect(normalizeSQL(result)).toBe(normalizeSQL(expectedQuery));
+    });
+
+    it('should not remove semicolons inside strings', () => {
+        const sqlQuery = `SELECT * FROM users WHERE name = 'John;Doe';`;
+        const limit = 10;
+
+        // sdjust the expected query to exclude the semicolon at the end
+        const expectedQuery = `WITH user_sql AS (\nSELECT * FROM users WHERE name = 'John;Doe'\n) select * from user_sql limit ${limit}`;
 
         const result = applyLimitToSqlQuery({ sqlQuery, limit });
 

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -383,8 +383,8 @@ const removeCommentsAndOuterLimitOffset = (sql: string): string => {
     const limitOffsetRegex =
         /(\b(?:(?:limit\s+\d+(?:\s+offset\s+\d+)?)|(?:offset\s+\d+\s+limit\s+\d+))\s*(?:;|\s*)?)$/i;
     let sqlWithoutLimit = sqlWithoutStrings.replace(limitOffsetRegex, '');
-    // remove all semicolons
-    sqlWithoutLimit = sqlWithoutLimit.replace(/;/g, '');
+    // remove semicolon from the end of the query
+    sqlWithoutLimit = sqlWithoutLimit.trim().replace(/;+$/g, '');
     // restore strings
     let sqlRestored = restoreStringsFromPlaceholders(
         sqlWithoutLimit,
@@ -408,7 +408,7 @@ export const applyLimitToSqlQuery = ({
     // do nothing if limit is undefined
     if (limit === undefined) {
         // strip any trailing semicolons and comments
-        let sql = sqlQuery.replace(/;+\s*$/g, '').trim();
+        let sql = sqlQuery.trim().replace(/;+$/g, '');
         sql = removeComments(sql);
         return sql.trim();
     }

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -319,8 +319,10 @@ const removeCommentsAndLimits = (sql: string): string => {
     // remove LIMIT clauses without removing preceding whitespace
     const limitClauseRegex = /(\bLIMIT\b\s+\d+(\s+OFFSET\s+\d+)?\s*;?)/gi;
     const sqlWithoutLimits = sqlWithoutStrings.replace(limitClauseRegex, ' ');
+    // remove semicolons outside of strings
+    const sqlWithoutSemicolons = sqlWithoutLimits.replace(/;/g, '');
     // restore strings
-    const sqlRestored = sqlWithoutLimits.replace(
+    const sqlRestored = sqlWithoutSemicolons.replace(
         /__STRING_PLACEHOLDER_(\d+)__/g,
         (_, p1) => placeholders[Number(p1)],
     );

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -196,6 +196,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             values?: any[];
             tags?: Record<string, string>;
             timezone?: string;
+            limit?: number;
         },
     ): Promise<void> {
         let connection: Connection;
@@ -279,6 +280,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         streamCallback: (data: WarehouseResults) => void,
         options?: {
             values?: any[];
+            limit?: number;
         },
     ): Promise<void> {
         return new Promise<void>((resolve, reject) => {
@@ -306,18 +308,31 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                           )
                         : {};
 
+                    let rowCount = 0;
                     pipeline(
                         stmt.streamRows(),
                         new Transform({
                             objectMode: true,
                             transform(chunk, encoding, callback) {
+                                // if we have reached the limit, stop the stream
+                                if (
+                                    options?.limit &&
+                                    rowCount >= options.limit
+                                ) {
+                                    callback(null, null);
+                                    return;
+                                }
+                                rowCount += 1;
                                 callback(null, parseRow(chunk));
                             },
                         }),
                         new Writable({
                             objectMode: true,
                             write(chunk, encoding, callback) {
-                                streamCallback({ fields, rows: [chunk] });
+                                // send chunk if not null (i.e. not the end of the stream)
+                                if (chunk !== null) {
+                                    streamCallback({ fields, rows: [chunk] });
+                                }
                                 callback();
                             },
                         }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12574 

### Description:
- modifies the `applyLimitToSqlQuery` function to strip out limits and semicolons from subqueries and applies limit to end of query
- It also looks for the smallest outer limit applied and will use the smaller one

<!-- Even better add a screenshot / gif / loom -->

// keyword to include frontend tests
test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
