### PR TITLE
fix: filter project on charts as code

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -151,6 +151,7 @@ export class CoderService extends BaseService {
         }
         const [chart] = await this.savedChartModel.find({
             slug,
+            projectUuid,
         });
         if (chart === undefined) {
             // TODO create space if does not exist


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
I was not filtering by project, so it was getting the chart from another project with the same slug (likely production rather than preview) 
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
