### PR TITLE
feat: show tooltip on hover of metric peek viz

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsVisualization.tsx
@@ -23,6 +23,7 @@ import {
     Line,
     LineChart,
     ResponsiveContainer,
+    Tooltip as RechartsTooltip,
     XAxis,
     YAxis,
 } from 'recharts';
@@ -64,7 +65,7 @@ type Props = {
 };
 
 const MetricsVisualization: FC<Props> = ({ metric, data }) => {
-    const { colors } = useMantineTheme();
+    const { colors, radius, shadows, fontSizes } = useMantineTheme();
 
     const timeDimension = metric.defaultTimeDimension;
 
@@ -159,6 +160,20 @@ const MetricsVisualization: FC<Props> = ({ metric, data }) => {
                     axisLine={false}
                     tickLine={false}
                     fontSize={11}
+                />
+
+                <RechartsTooltip
+                    formatter={(value) => [value, metric.label]}
+                    labelFormatter={(label) =>
+                        dayjs(label).format('MMM D, YYYY')
+                    }
+                    contentStyle={{
+                        fontSize: fontSizes.xs,
+                        backgroundColor: colors.offWhite[0],
+                        borderRadius: radius.md,
+                        border: `1px solid ${colors.gray[2]}`,
+                        boxShadow: shadows.sm,
+                    }}
                 />
 
                 <Line


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12653 

### Description:

Adds simply-styled tooltip on hover and also shows comparison when that is selected

<img width="875" alt="Screenshot 2024-11-29 at 10 00 10" src="https://github.com/user-attachments/assets/01423e46-f8fe-4aa6-b390-945b3b3a549e">
<img width="747" alt="Screenshot 2024-11-29 at 10 00 04" src="https://github.com/user-attachments/assets/03b61f96-e8e8-44cc-aab5-fe82a45a9324">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
