### PR TITLE
fix: respect time interval defined by default

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     ForbiddenError,
+    getFieldIdForDateDimension,
     getItemId,
     getMetricExplorerDateRangeFilters,
     getMetricExplorerDefaultGrainFilters,
@@ -92,14 +93,17 @@ export class MetricsExplorerService<
             );
         }
 
+        const timeDimension = getItemId({
+            table: metric.table,
+            name: getFieldIdForDateDimension(
+                metric.defaultTimeDimension.field,
+                metric.defaultTimeDimension.interval,
+            ),
+        });
+
         const metricQuery: MetricQuery = {
             exploreName,
-            dimensions: [
-                getItemId({
-                    table: metric.table,
-                    name: metric.defaultTimeDimension.field,
-                }),
-            ],
+            dimensions: [timeDimension],
             metrics: [getItemId(metric)],
             filters: {
                 dimensions: dateRange
@@ -122,10 +126,7 @@ export class MetricsExplorerService<
             },
             sorts: [
                 {
-                    fieldId: getItemId({
-                        table: metric.table,
-                        name: metric.defaultTimeDimension.field,
-                    }),
+                    fieldId: timeDimension,
                     descending: false,
                 },
             ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Currently, we don't take into account the `interval` defined in the yml for default time dimension. 

This PR addresses that. 

So for example, if the `interval` is MONTH, it should plot the data by month. 

Demo:

<img width="1343" alt="Screenshot 2024-12-02 at 10 07 53" src="https://github.com/user-attachments/assets/c05cddea-c532-4053-b207-5afe6f1effef">
<img width="1319" alt="Screenshot 2024-12-02 at 10 07 59" src="https://github.com/user-attachments/assets/fa914d2a-b1cc-49b5-9f6f-744e5cd6a881">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
