### PR TITLE
feat: limit metric node count

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -326,12 +326,13 @@ export class CatalogController extends BaseController {
     async getMetricsTree(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() metricIds: string[],
     ): Promise<ApiGetMetricsTree> {
         this.setStatus(200);
 
         const results = await this.services
             .getCatalogService()
-            .getMetricsTree(req.user!, projectUuid);
+            .getMetricsTree(req.user!, projectUuid, metricIds);
 
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11309,6 +11309,13 @@ export function RegisterRoutes(app: express.Router) {
                     required: true,
                     dataType: 'object',
                 },
+                metricIds: {
+                    in: 'query',
+                    name: 'metricIds',
+                    required: true,
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12435,6 +12435,17 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "metricIds",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     }
                 ]
             }

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -884,10 +884,10 @@ export class CatalogService<
     async getMetricsTree(
         user: SessionUser,
         projectUuid: string,
+        // Using metricIds instead of filters and searching metrics because we might want to have the ability to select specific metrics rather than filter by catalog tags
         metricIds: string[],
     ) {
         // TODO: check permissions
-
         if (metricIds.length > MAX_METRICS_TREE_NODE_COUNT) {
             throw new ParameterError(
                 `Cannot get more than ${MAX_METRICS_TREE_NODE_COUNT} metrics in the metrics tree`,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -16,7 +16,9 @@ import {
     hasIntersection,
     InlineErrorType,
     isExploreError,
+    MAX_METRICS_TREE_NODE_COUNT,
     NotFoundError,
+    ParameterError,
     parseMetricsTreeNodeId,
     SessionUser,
     SummaryExplore,
@@ -879,9 +881,23 @@ export class CatalogService<
         };
     }
 
-    getMetricsTree(user: SessionUser, projectUuid: string) {
+    async getMetricsTree(
+        user: SessionUser,
+        projectUuid: string,
+        metricIds: string[],
+    ) {
         // TODO: check permissions
-        return this.catalogModel.getMetricsTree(projectUuid);
+
+        if (metricIds.length > MAX_METRICS_TREE_NODE_COUNT) {
+            throw new ParameterError(
+                `Cannot get more than ${MAX_METRICS_TREE_NODE_COUNT} metrics in the metrics tree`,
+            );
+        }
+
+        return this.catalogModel.getMetricsTree(
+            projectUuid,
+            metricIds.map((id) => parseMetricsTreeNodeId(id)),
+        );
     }
 
     async createMetricsTreeEdge(

--- a/packages/common/src/utils/catalogMetricsTree.ts
+++ b/packages/common/src/utils/catalogMetricsTree.ts
@@ -1,5 +1,7 @@
 import type { CatalogMetricsTreeNode } from '../types/catalog';
 
+export const MAX_METRICS_TREE_NODE_COUNT = 30;
+
 export function getMetricsTreeNodeId(field: CatalogMetricsTreeNode) {
     return `${field.tableName}::${field.name}`;
 }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useCallback, useEffect, useMemo, type FC } from 'react';
+import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import {
     useCreateMetricsTreeEdge,
@@ -44,14 +45,14 @@ const MetricTree: FC<Props> = ({ metrics }) => {
         return metrics.map((metric) => getMetricsTreeNodeId(metric));
     }, [metrics]);
 
+    const isValidMetricsTree =
+        metrics.length > 0 && metrics.length <= MAX_METRICS_TREE_NODE_COUNT;
+
     const { data: metricsTree } = useMetricsTree(
         projectUuid,
         selectedMetricIds,
         {
-            enabled:
-                !!projectUuid &&
-                metrics.length > 0 &&
-                metrics.length <= MAX_METRICS_TREE_NODE_COUNT,
+            enabled: !!projectUuid && isValidMetricsTree,
         },
     );
 
@@ -158,19 +159,26 @@ const MetricTree: FC<Props> = ({ metrics }) => {
 
     return (
         <Box h="100%">
-            <ReactFlow
-                nodes={currentNodes}
-                edges={currentEdges}
-                fitView
-                attributionPosition="top-right"
-                onNodesChange={handleNodeChange}
-                onEdgesChange={onEdgesChange}
-                onConnect={handleConnect}
-                edgesReconnectable={false}
-                onEdgesDelete={handleEdgesDelete}
-            >
-                <Background />
-            </ReactFlow>
+            {isValidMetricsTree ? (
+                <ReactFlow
+                    nodes={currentNodes}
+                    edges={currentEdges}
+                    fitView
+                    attributionPosition="top-right"
+                    onNodesChange={handleNodeChange}
+                    onEdgesChange={onEdgesChange}
+                    onConnect={handleConnect}
+                    edgesReconnectable={false}
+                    onEdgesDelete={handleEdgesDelete}
+                >
+                    <Background />
+                </ReactFlow>
+            ) : (
+                <SuboptimalState
+                    title="Metrics tree not available"
+                    description="Please narrow your search to display up to 30 metrics"
+                />
+            )}
         </Box>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
@@ -282,7 +282,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             type="search"
                             variant="default"
                             placeholder="Search by name or description"
-                            value={search}
+                            value={search ?? ''}
                             icon={
                                 <MantineIcon
                                     size="md"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
@@ -26,7 +26,7 @@ import {
     IconTag,
     IconX,
 } from '@tabler/icons-react';
-import { memo, useCallback, useEffect, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { TotalMetricsDot } from '../../../svgs/metricsCatalog';
@@ -237,14 +237,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
 
         const isValidMetricsTree =
             totalResults > 0 && totalResults <= MAX_METRICS_TREE_NODE_COUNT;
-
-        // If the metrics tree is not valid, set the view to list
-        // can happen when changing filters while in tree view
-        useEffect(() => {
-            if (!isValidMetricsTree) {
-                onMetricCatalogViewChange?.(MetricCatalogView.LIST);
-            }
-        }, [isValidMetricsTree, onMetricCatalogViewChange]);
 
         return (
             <Group {...props}>

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsTree.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsTree.tsx
@@ -4,22 +4,40 @@ import type {
     ApiMetricsTreeEdgePayload,
     ApiSuccessEmpty,
 } from '@lightdash/common';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQuery,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-const getMetricsTree = async (projectUuid: string | undefined) => {
+const getMetricsTree = async (
+    projectUuid: string | undefined,
+    metricIds: string[],
+) => {
+    const queryParams = metricIds.length
+        ? `?${new URLSearchParams(
+              metricIds.map((metricId) => ['metricIds', metricId]),
+          ).toString()}`
+        : '';
+
     return lightdashApi<ApiGetMetricsTree['results']>({
-        url: `/projects/${projectUuid}/dataCatalog/metrics/tree`,
+        url: `/projects/${projectUuid}/dataCatalog/metrics/tree${queryParams}`,
         method: 'GET',
         body: undefined,
     });
 };
 
-export const useMetricsTree = (projectUuid: string | undefined) => {
+export const useMetricsTree = (
+    projectUuid: string | undefined,
+    metricIds: string[],
+    options?: UseQueryOptions<ApiGetMetricsTree['results'], ApiError>,
+) => {
     return useQuery<ApiGetMetricsTree['results'], ApiError>({
-        queryKey: ['metrics-tree', projectUuid],
-        queryFn: () => getMetricsTree(projectUuid),
+        queryKey: ['metrics-tree', projectUuid, metricIds],
+        queryFn: () => getMetricsTree(projectUuid, metricIds),
         enabled: !!projectUuid,
+        ...options,
     });
 };
 

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -84,9 +84,6 @@ export const metricsCatalogSlice = createSlice({
         ) => {
             state.categoryFilters = action.payload;
         },
-        clearCategoryFilters: (state) => {
-            state.categoryFilters = [];
-        },
         setAbility: (
             state,
             action: PayloadAction<{
@@ -123,7 +120,6 @@ export const {
     setActiveMetric,
     setProjectUuid,
     setCategoryFilters,
-    clearCategoryFilters,
     setOrganizationUuid,
     setAbility,
     setCategoryPopoverIsClosing,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12679 

⚠️ Depends on https://github.com/lightdash/lightdash/pull/12643

### Description:

- Adds limit of 30 metrics to display on the tree
- When there are more than 30 metrics (by changing filters) and user is on the tree, show suboptimal state


https://github.com/user-attachments/assets/64f8258e-5739-4439-9f79-27607403d138



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
