### PR TITLE
feat: allow default time dimension on a metric-level

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -202,6 +202,9 @@ models:
               type: sum
               format: usd
               round: 2
+              default_time_dimension:
+                field: order_date
+                interval: DAY
             total_completed_order_amount:
               type: sum
               format: usd

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -810,6 +810,18 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DefaultTimeDimension: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                interval: { ref: 'TimeFrames', required: true },
+                field: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SourcePosition: {
         dataType: 'refAlias',
         type: {
@@ -908,6 +920,7 @@ const models: TsoaRoute.Models = {
             requiredAttributes: {
                 ref: 'Record_string.string-or-string-Array_',
             },
+            defaultTimeDimension: { ref: 'DefaultTimeDimension' },
             compiledSql: { dataType: 'string', required: true },
             tablesReferences: {
                 dataType: 'union',
@@ -929,13 +942,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                defaultTimeDimension: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        interval: { ref: 'TimeFrames', required: true },
-                        field: { dataType: 'string', required: true },
-                    },
-                },
+                defaultTimeDimension: { ref: 'DefaultTimeDimension' },
             },
             validators: {},
         },
@@ -3017,13 +3024,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                defaultTimeDimension: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        interval: { ref: 'TimeFrames', required: true },
-                        field: { dataType: 'string', required: true },
-                    },
-                },
+                defaultTimeDimension: { ref: 'DefaultTimeDimension' },
                 groupDetails: { ref: 'Record_string.GroupType_' },
                 requiredAttributes: {
                     ref: 'Record_string.string-or-string-Array_',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -732,6 +732,18 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "DefaultTimeDimension": {
+                "properties": {
+                    "interval": {
+                        "$ref": "#/components/schemas/TimeFrames"
+                    },
+                    "field": {
+                        "type": "string"
+                    }
+                },
+                "required": ["interval", "field"],
+                "type": "object"
+            },
             "SourcePosition": {
                 "properties": {
                     "character": {
@@ -894,6 +906,9 @@
                     "requiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     },
+                    "defaultTimeDimension": {
+                        "$ref": "#/components/schemas/DefaultTimeDimension"
+                    },
                     "compiledSql": {
                         "type": "string"
                     },
@@ -925,16 +940,7 @@
             "Pick_CompiledTable.defaultTimeDimension_": {
                 "properties": {
                     "defaultTimeDimension": {
-                        "properties": {
-                            "interval": {
-                                "$ref": "#/components/schemas/TimeFrames"
-                            },
-                            "field": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["interval", "field"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/DefaultTimeDimension"
                     }
                 },
                 "type": "object",
@@ -3304,16 +3310,7 @@
             "TableBase": {
                 "properties": {
                     "defaultTimeDimension": {
-                        "properties": {
-                            "interval": {
-                                "$ref": "#/components/schemas/TimeFrames"
-                            },
-                            "field": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["interval", "field"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/DefaultTimeDimension"
                     },
                     "groupDetails": {
                         "$ref": "#/components/schemas/Record_string.GroupType_"
@@ -11528,7 +11525,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1387.0",
+        "version": "0.1390.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -855,11 +855,13 @@ export class CatalogService<
 
         const filteredExplore = getFilteredExplore(explore, userAttributes);
 
-        const defaultTimeDimension =
-            filteredExplore?.tables?.[tableName]?.defaultTimeDimension;
-
         const metric =
             filteredExplore?.tables?.[tableName]?.metrics?.[metricName];
+
+        // Get the default time dimension from the metric, or the explore if not set on the metric
+        const defaultTimeDimension =
+            metric.defaultTimeDimension ??
+            filteredExplore?.tables?.[tableName]?.defaultTimeDimension;
 
         if (!metric) {
             throw new NotFoundError('Metric not found');

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -134,6 +134,7 @@
                                                 "type": "boolean"
                                             },
                                             "round": {
+                                                "description": "Rounds the metric to the specified number of decimal places",
                                                 "type": "number",
                                                 "minimum": 0
                                             },
@@ -160,6 +161,30 @@
                                                     "minLength": 1
                                                 },
                                                 "maxItems": 3
+                                            },
+                                            "default_time_dimension": {
+                                                "type": "object",
+                                                "description": "Specifies the default time dimension field and interval to use for time-based analysis on this metric. If specified, both field and interval are required. If there is already a default time dimension set in the model, this will override it.",
+                                                "properties": {
+                                                    "field": {
+                                                        "type": "string",
+                                                        "description": "The name of the field to use as the default time dimension"
+                                                    },
+                                                    "interval": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "DAY",
+                                                            "WEEK",
+                                                            "MONTH",
+                                                            "YEAR"
+                                                        ],
+                                                        "description": "The default time interval to use when analyzing this time dimension"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "field",
+                                                    "interval"
+                                                ]
                                             }
                                         },
                                         "required": ["type", "sql"]
@@ -303,6 +328,30 @@
                                                                 "minLength": 1
                                                             },
                                                             "maxItems": 3
+                                                        },
+                                                        "default_time_dimension": {
+                                                            "type": "object",
+                                                            "description": "Specifies the default time dimension field and interval to use for time-based analysis on this metric. If specified, both field and interval are required. If there is already a default time dimension set in the model, this will override it.",
+                                                            "properties": {
+                                                                "field": {
+                                                                    "type": "string",
+                                                                    "description": "The name of the field to use as the default time dimension"
+                                                                },
+                                                                "interval": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "DAY",
+                                                                        "WEEK",
+                                                                        "MONTH",
+                                                                        "YEAR"
+                                                                    ],
+                                                                    "description": "The default time interval to use when analyzing this time dimension"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "field",
+                                                                "interval"
+                                                            ]
                                                         }
                                                     },
                                                     "required": ["type"]
@@ -552,6 +601,27 @@
                                     "percent",
                                     "id"
                                 ]
+                            },
+                            "default_time_dimension": {
+                                "type": "object",
+                                "description": "Specifies the default time dimension field and interval to use for time-based analysis on this metric. If specified, both field and interval are required. If there is already a default time dimension set in the model, this will override it.",
+                                "properties": {
+                                    "field": {
+                                        "type": "string",
+                                        "description": "The name of the field to use as the default time dimension"
+                                    },
+                                    "interval": {
+                                        "type": "string",
+                                        "enum": [
+                                            "DAY",
+                                            "WEEK",
+                                            "MONTH",
+                                            "YEAR"
+                                        ],
+                                        "description": "The default time interval to use when analyzing this time dimension"
+                                    }
+                                },
+                                "required": ["field", "interval"]
                             }
                         }
                     }

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -20,7 +20,7 @@ import {
 } from './field';
 import { parseFilters } from './filterGrammar';
 import { type OrderFieldsByStrategy } from './table';
-import { type TimeFrames } from './timeFrames';
+import { type DefaultTimeDimension, type TimeFrames } from './timeFrames';
 
 export enum SupportedDbtAdapter {
     BIGQUERY = 'bigquery',
@@ -145,6 +145,7 @@ export type DbtColumnLightdashMetric = {
     show_underlying_values?: string[];
     filters?: { [key: string]: any }[];
     percentile?: number;
+    default_time_dimension?: DefaultTimeDimension;
 } & DbtLightdashFieldTags;
 
 export type DbtModelLightdashMetric = DbtColumnLightdashMetric &
@@ -459,6 +460,14 @@ export const convertModelMetric = ({
                       : [metric.tags],
               }
             : {}),
+        ...(metric.default_time_dimension
+            ? {
+                  defaultTimeDimension: {
+                      field: metric.default_time_dimension.field,
+                      interval: metric.default_time_dimension.interval,
+                  },
+              }
+            : {}),
     };
 };
 type ConvertColumnMetricArgs = Omit<ConvertModelMetricArgs, 'metric'> & {
@@ -497,6 +506,14 @@ export const convertColumnMetric = ({
             ? getItemId({ table: modelName, name: dimensionName })
             : undefined,
         requiredAttributes,
+        ...(metric.default_time_dimension
+            ? {
+                  defaultTimeDimension: {
+                      field: metric.default_time_dimension.field,
+                      interval: metric.default_time_dimension.interval,
+                  },
+              }
+            : {}),
     });
 
 export enum DbtManifestVersion {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -1,4 +1,4 @@
-import type { AdditionalMetric, currencies } from '..';
+import type { AdditionalMetric, currencies, DefaultTimeDimension } from '..';
 import { CompileError } from './errors';
 import { type MetricFilterRule } from './filter';
 import { type TimeFrames } from './timeFrames';
@@ -445,6 +445,7 @@ export interface Metric extends Field {
     formatOptions?: CustomFormat;
     dimensionReference?: string; // field id of the dimension this metric is based on
     requiredAttributes?: Record<string, string | string[]>; // Required attributes for the dimension this metric is based on
+    defaultTimeDimension?: DefaultTimeDimension; // Default time dimension for the metric when the user has not specified a time dimension
 }
 
 export const isFilterableDimension = (

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -1,5 +1,5 @@
 import { type MetricFilterRule } from './filter';
-import type { TimeFrames } from './timeFrames';
+import type { DefaultTimeDimension } from './timeFrames';
 
 export enum OrderFieldsByStrategy {
     LABEL = 'LABEL',
@@ -26,8 +26,5 @@ export type TableBase = {
     hidden?: boolean;
     requiredAttributes?: Record<string, string | string[]>;
     groupDetails?: Record<string, GroupType>;
-    defaultTimeDimension?: {
-        field: string;
-        interval: TimeFrames;
-    };
+    defaultTimeDimension?: DefaultTimeDimension;
 };

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -44,3 +44,8 @@ export const dateGranularityToTimeFrameMap: Record<
     [DateGranularity.QUARTER]: TimeFrames.QUARTER,
     [DateGranularity.YEAR]: TimeFrames.YEAR,
 };
+
+export type DefaultTimeDimension = {
+    field: string;
+    interval: TimeFrames;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12585](https://github.com/lightdash/lightdash/issues/12585)

### Description:

Similar to work done on: https://github.com/lightdash/lightdash/pull/12505

- can specify metric-level `default_time_dimension`
- if both are given, the metric level will take precedence, otherwise, fallback to the table-level defined default time dimension

demo: 

**metric-level: DAY**

<img width="282" alt="Screenshot 2024-12-02 at 17 31 18" src="https://github.com/user-attachments/assets/6d26f3f4-480e-4a3d-8cd8-8570621b9fbe">

<img width="1281" alt="Screenshot 2024-12-02 at 17 32 08" src="https://github.com/user-attachments/assets/15d84cc0-2f1c-48ad-b46b-bb5845260bcb">


**table-level: MONTH** for another metric that has no metric-level info set

<img width="633" alt="Screenshot 2024-12-02 at 17 32 16" src="https://github.com/user-attachments/assets/9e69837f-cccb-4bd9-a6f3-3ae38444f39d">
<img width="1288" alt="Screenshot 2024-12-02 at 17 32 28" src="https://github.com/user-attachments/assets/060c77c5-0af1-48d2-83b2-bd9ab6d703e7">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
