### PR TITLE
fix(dashboards): autocomplete for joined tables using alias

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2459,7 +2459,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         table: string,
-        fieldId: string,
+        initialFieldId: string,
         search: string,
         limit: number,
         filters: AndFilterGroup | undefined,
@@ -2483,13 +2483,26 @@ export class ProjectService extends BaseService {
             );
         }
 
-        const explore = await this.projectModel.findExploreByTableName(
+        let explore = await this.projectModel.findExploreByTableName(
             projectUuid,
             table,
         );
+        let fieldId = initialFieldId;
+        if (!explore) {
+            // fallback: find explore by join alias and replace fieldId
+            explore = await this.projectModel.findJoinAliasExplore(
+                projectUuid,
+                table,
+            );
+            if (explore && !isExploreError(explore)) {
+                fieldId = initialFieldId.replace(table, explore.baseTable);
+            }
+        }
 
-        if (!explore || isExploreError(explore)) {
-            throw new NotExistsError(`Explore does not exist or has errors`);
+        if (!explore) {
+            throw new NotExistsError(`Explore ${table} does not exist`);
+        } else if (isExploreError(explore)) {
+            throw new NotExistsError(`Explore ${table} has errors`);
         }
 
         const field = findFieldByIdInExplore(explore, fieldId);
@@ -2517,7 +2530,10 @@ export class ProjectService extends BaseService {
             const filtersCompatibleWithExplore = filters.and.filter(
                 (filter) =>
                     isFilterRule(filter) &&
-                    findFieldByIdInExplore(explore, filter.target.fieldId),
+                    findFieldByIdInExplore(
+                        explore as Explore,
+                        filter.target.fieldId,
+                    ),
             );
             autocompleteDimensionFilters.push(...filtersCompatibleWithExplore);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Relates to: https://github.com/lightdash/lightdash-internal-work/issues/2312

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

**Note:** this doesn't fix all the issues related to using join alias. There is a separate ticket for that:https://github.com/lightdash/lightdash/issues/12680

Update autocomplete logic to find the original explore for join alias instead of using the explore where the join belongs to.


Needs to be tested locally and update payments joins to have an alias:

```
  - name: payments
    description: This table has information about individual payments
    meta:
      joins:
        - join: orders
          sql_on: ${orders.order_id} = ${payments.order_id}
        - join: customers
          alias: customer_alias
          sql_on: ${customer_alias.customer_id} = ${orders.customer_id}
```


### Adding a filter for "customer alias":

Before it would use the "payments" explore and join "customer alias".
Now it uses the "customers" explore.

<img width="1266" alt="Screenshot 2024-12-02 at 17 43 33" src="https://github.com/user-attachments/assets/4f2315cf-5247-4921-ab4f-30978d3fb837">

<img width="383" alt="Screenshot 2024-12-02 at 17 55 15" src="https://github.com/user-attachments/assets/698d2851-84c4-4593-8e2e-d6efd10e6b19">

### Adding a filter for "payments"

Working the same as before.

<img width="1180" alt="Screenshot 2024-12-02 at 17 44 24" src="https://github.com/user-attachments/assets/22788998-eacf-4ca2-9e74-9f1761cbf399">

<img width="399" alt="Screenshot 2024-12-02 at 17 44 32" src="https://github.com/user-attachments/assets/1cc3894a-e2b3-4a26-8526-1708f3cecd4d">






### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
