### PR TITLE
chore: metric tree layout

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,6 +27,7 @@
     "dependencies": {
         "@casl/ability": "^5.4.4",
         "@casl/react": "^3.0.0",
+        "@dagrejs/dagre": "^1.1.4",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@emotion/react": "^11.10.6",

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -1,3 +1,4 @@
+import Dagre from '@dagrejs/dagre';
 import {
     getMetricsTreeNodeId,
     type CatalogField,
@@ -7,16 +8,18 @@ import { Box } from '@mantine/core';
 import {
     addEdge,
     Background,
+    Panel,
     ReactFlow,
     useEdgesState,
     useNodesState,
+    useReactFlow,
     type Connection,
     type Edge,
     type Node,
     type NodeChange,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { useCallback, useEffect, useMemo, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import {
     useCreateMetricsTreeEdge,
@@ -34,6 +37,116 @@ function getEdgeId(edge: Pick<CatalogMetricsTreeEdge, 'source' | 'target'>) {
     return `${sourceId}_${targetId}`;
 }
 
+const getNodeLayout = (
+    connectedNodes: Node[],
+    freeNodes: Node[],
+    edges: Edge[],
+    _options?: {},
+) => {
+    const treeGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(
+        () => ({}),
+    );
+    treeGraph.setGraph({ rankdir: 'TB' });
+
+    edges.forEach((edge) => treeGraph.setEdge(edge.source, edge.target));
+    connectedNodes.forEach((node) =>
+        treeGraph.setNode(node.id, {
+            ...node,
+            width: node.measured?.width ?? 0,
+            height: node.measured?.height ?? 0,
+        }),
+    );
+
+    Dagre.layout(treeGraph);
+
+    // Draw the connected tree
+    const tree = connectedNodes.map((node) => {
+        const position = treeGraph.node(node.id);
+        const x = position.x - (node.measured?.width ?? 0) / 2;
+        const y = position.y - (node.measured?.height ?? 0) / 2;
+        return { ...node, position: { x, y } };
+    });
+
+    // Main padding
+    const mainPadding = 15;
+
+    // Bounds of grid
+    let top = Infinity;
+    let left = Infinity;
+    let bottom = -Infinity;
+    let right = -Infinity;
+
+    // Draw the unconnected grid
+    const free = freeNodes.map((node, index) => {
+        const nodeWidth = node?.measured?.width ?? 0;
+        const nodeHeight = node?.measured?.height ?? 0;
+
+        // TODO: this is an arbitrary offset that looks ok with the
+        // basic setup. Placement of the grid will probably need to be
+        // more robust and include the tree size
+        const leftOffset = -1 * nodeWidth - 70;
+
+        // 3 column grid
+        const column = index % 3;
+        const row = Math.floor(index / 3);
+        const x = leftOffset - column * (nodeWidth + mainPadding);
+        const y = row * (nodeHeight + mainPadding);
+
+        // Update bounds
+        top = Math.min(top, y);
+        left = Math.min(left, x);
+        bottom = Math.max(bottom, y + nodeHeight);
+        right = Math.max(right, x + nodeWidth);
+
+        return { ...node, position: { x, y }, id: `${node.id}` };
+    });
+
+    console.log({ top, left, bottom, right });
+
+    const groups = [
+        {
+            id: 'unconnected',
+            data: { label: 'Unconnected nodes' },
+            position: { x: left - mainPadding, y: top - mainPadding },
+            style: {
+                backgroundColor: 'rgba(255, 0, 255, 0.2)',
+                height: bottom - top + mainPadding * 2,
+                width: right - left + mainPadding * 2,
+                pointerEvents: 'none' as const,
+            },
+            type: 'group',
+        },
+    ];
+
+    return {
+        nodes: [...groups, ...tree, ...free],
+        edges,
+    };
+};
+
+const getNodeGroups = (nodes: Node[], edges: Edge[]) => {
+    const connectedNodeIds = new Set();
+
+    edges.forEach((edge) => {
+        connectedNodeIds.add(edge.source);
+        connectedNodeIds.add(edge.target);
+    });
+
+    const connectedNodes = nodes.filter((node) =>
+        connectedNodeIds.has(node.id),
+    );
+    const freeNodes = nodes.filter(
+        (node) => !connectedNodeIds.has(node.id) && node.type !== 'group',
+    );
+
+    console.log({ connectedNodes, freeNodes, nodes });
+
+    return {
+        connectedNodes,
+        freeNodes,
+    };
+};
+
 const MetricTree: FC<Props> = ({ metrics }) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
@@ -42,6 +155,7 @@ const MetricTree: FC<Props> = ({ metrics }) => {
     const { data: metricsTree } = useMetricsTree(projectUuid);
     const { mutateAsync: createMetricsTreeEdge } = useCreateMetricsTreeEdge();
     const { mutateAsync: deleteMetricsTreeEdge } = useDeleteMetricsTreeEdge();
+    const { fitView } = useReactFlow();
 
     const initialNodes = useMemo<Node[]>(() => {
         return metrics.map((metric) => ({
@@ -79,11 +193,15 @@ const MetricTree: FC<Props> = ({ metrics }) => {
         return [];
     }, [metrics, metricsTree]);
 
-    const [currentNodes, _setCurrentNodes, onNodesChange] =
+    const [currentNodes, setCurrentNodes, onNodesChange] =
         useNodesState(initialNodes);
 
     const [currentEdges, setCurrentEdges, onEdgesChange] =
         useEdgesState(initialEdges);
+
+    const { connectedNodes, freeNodes } = useMemo(() => {
+        return getNodeGroups(currentNodes, currentEdges);
+    }, [currentNodes, currentEdges]);
 
     // Set the current edges to the initial edges in the case that the request for metrics tree is slow
     useEffect(() => {
@@ -136,6 +254,39 @@ const MetricTree: FC<Props> = ({ metrics }) => {
         [deleteMetricsTreeEdge, projectUuid],
     );
 
+    const [hasLayout, setHasLayout] = useState(false);
+    const onLayout = useCallback(() => {
+        const layout = getNodeLayout(connectedNodes, freeNodes, currentEdges);
+
+        setCurrentNodes([...layout.nodes]);
+        setCurrentEdges([...layout.edges]);
+
+        window.requestAnimationFrame(async () => {
+            await fitView();
+        });
+    }, [
+        connectedNodes,
+        freeNodes,
+        currentEdges,
+        setCurrentNodes,
+        setCurrentEdges,
+        fitView,
+    ]);
+
+    useEffect(() => {
+        if (!metricsTree || hasLayout) return;
+
+        // TODO: The graph doesn't fully layout without this delay.
+        // There maybe be a better way to await layout completion. The layout
+        // engine doesn't return a promise, but maybe we can come up with something.
+        const timeoutId = setTimeout(() => {
+            onLayout();
+            setHasLayout(true);
+        }, 80);
+
+        return () => clearTimeout(timeoutId);
+    }, [onLayout, metricsTree, hasLayout]);
+
     return (
         <Box h="100%">
             <ReactFlow
@@ -149,6 +300,9 @@ const MetricTree: FC<Props> = ({ metrics }) => {
                 edgesReconnectable={false}
                 onEdgesDelete={handleEdgesDelete}
             >
+                <Panel position="top-right">
+                    <button onClick={() => onLayout()}>Clean up</button>
+                </Panel>
                 <Background />
             </ReactFlow>
         </Box>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -109,7 +109,7 @@ const getNodeLayout = (
             data: { label: 'Unconnected nodes' },
             position: { x: left - mainPadding, y: top - mainPadding },
             style: {
-                backgroundColor: 'rgba(255, 0, 255, 0.2)',
+                backgroundColor: '#d8c2fa',
                 height: bottom - top + mainPadding * 2,
                 width: right - left + mainPadding * 2,
                 pointerEvents: 'none' as const,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -291,7 +291,7 @@ const MetricTree: FC<Props> = ({ metrics, metricsTree }) => {
                 edgesReconnectable={false}
                 onEdgesDelete={handleEdgesDelete}
             >
-                <Panel position="top-right">
+                <Panel position="bottom-left">
                     <button onClick={() => onLayout()}>Clean up</button>
                 </Panel>
                 <Background />

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -1,7 +1,6 @@
 import Dagre from '@dagrejs/dagre';
 import {
     getMetricsTreeNodeId,
-    MAX_METRICS_TREE_NODE_COUNT,
     type CatalogField,
     type CatalogMetricsTreeEdge,
 } from '@lightdash/common';
@@ -12,6 +11,7 @@ import {
     Panel,
     ReactFlow,
     useEdgesState,
+    useNodesInitialized,
     useNodesState,
     useReactFlow,
     type Connection,
@@ -21,16 +21,17 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
-import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import {
     useCreateMetricsTreeEdge,
     useDeleteMetricsTreeEdge,
-    useMetricsTree,
 } from '../../hooks/useMetricsTree';
 
 type Props = {
     metrics: CatalogField[];
+    metricsTree: {
+        edges: CatalogMetricsTreeEdge[];
+    };
 };
 
 function getEdgeId(edge: Pick<CatalogMetricsTreeEdge, 'source' | 'target'>) {
@@ -39,12 +40,30 @@ function getEdgeId(edge: Pick<CatalogMetricsTreeEdge, 'source' | 'target'>) {
     return `${sourceId}_${targetId}`;
 }
 
-const getNodeLayout = (
-    connectedNodes: Node[],
-    freeNodes: Node[],
-    edges: Edge[],
-    _options?: {},
-) => {
+const getNodeGroups = (nodes: Node[], edges: Edge[]) => {
+    const connectedNodeIds = new Set();
+
+    edges.forEach((edge) => {
+        connectedNodeIds.add(edge.source);
+        connectedNodeIds.add(edge.target);
+    });
+
+    const connectedNodes = nodes.filter((node) =>
+        connectedNodeIds.has(node.id),
+    );
+    const freeNodes = nodes.filter(
+        (node) => !connectedNodeIds.has(node.id) && node.type !== 'group',
+    );
+
+    return {
+        connectedNodes,
+        freeNodes,
+    };
+};
+
+const getNodeLayout = (nodes: Node[], edges: Edge[], _options?: {}) => {
+    const { connectedNodes, freeNodes } = getNodeGroups(nodes, edges);
+
     const treeGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(
         () => ({}),
     );
@@ -103,8 +122,6 @@ const getNodeLayout = (
         return { ...node, position: { x, y }, id: `${node.id}` };
     });
 
-    console.log({ top, left, bottom, right });
-
     const groups = [
         {
             id: 'unconnected',
@@ -126,52 +143,16 @@ const getNodeLayout = (
     };
 };
 
-const getNodeGroups = (nodes: Node[], edges: Edge[]) => {
-    const connectedNodeIds = new Set();
-
-    edges.forEach((edge) => {
-        connectedNodeIds.add(edge.source);
-        connectedNodeIds.add(edge.target);
-    });
-
-    const connectedNodes = nodes.filter((node) =>
-        connectedNodeIds.has(node.id),
-    );
-    const freeNodes = nodes.filter(
-        (node) => !connectedNodeIds.has(node.id) && node.type !== 'group',
-    );
-
-    console.log({ connectedNodes, freeNodes, nodes });
-
-    return {
-        connectedNodes,
-        freeNodes,
-    };
-};
-
-const MetricTree: FC<Props> = ({ metrics }) => {
+const MetricTree: FC<Props> = ({ metrics, metricsTree }) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
-    );
-
-    const selectedMetricIds = useMemo(() => {
-        return metrics.map((metric) => getMetricsTreeNodeId(metric));
-    }, [metrics]);
-
-    const isValidMetricsTree =
-        metrics.length > 0 && metrics.length <= MAX_METRICS_TREE_NODE_COUNT;
-
-    const { data: metricsTree } = useMetricsTree(
-        projectUuid,
-        selectedMetricIds,
-        {
-            enabled: !!projectUuid && isValidMetricsTree,
-        },
     );
 
     const { mutateAsync: createMetricsTreeEdge } = useCreateMetricsTreeEdge();
     const { mutateAsync: deleteMetricsTreeEdge } = useDeleteMetricsTreeEdge();
     const { fitView } = useReactFlow();
+    const nodesInitialized = useNodesInitialized();
+    const [layoutReady, setLayoutReady] = useState(false);
 
     const initialNodes = useMemo<Node[]>(() => {
         return metrics.map((metric) => ({
@@ -214,20 +195,6 @@ const MetricTree: FC<Props> = ({ metrics }) => {
 
     const [currentEdges, setCurrentEdges, onEdgesChange] =
         useEdgesState(initialEdges);
-
-    const { connectedNodes, freeNodes } = useMemo(() => {
-        return getNodeGroups(currentNodes, currentEdges);
-    }, [currentNodes, currentEdges]);
-
-    // Set the current edges to the initial edges in the case that the request for metrics tree is slow
-    useEffect(() => {
-        setCurrentEdges(initialEdges);
-    }, [initialEdges, setCurrentEdges]);
-
-    // Set the current nodes to the initial nodes in case the filters change
-    useEffect(() => {
-        setCurrentNodes(initialNodes);
-    }, [initialNodes, setCurrentNodes]);
 
     const handleNodeChange = useCallback(
         (changes: NodeChange<Node>[]) => {
@@ -275,64 +242,60 @@ const MetricTree: FC<Props> = ({ metrics }) => {
         [deleteMetricsTreeEdge, projectUuid],
     );
 
-    const [hasLayout, setHasLayout] = useState(false);
     const onLayout = useCallback(() => {
-        const layout = getNodeLayout(connectedNodes, freeNodes, currentEdges);
+        if (!nodesInitialized || !metricsTree) {
+            return;
+        }
+        const layout = getNodeLayout(currentNodes, currentEdges);
 
         setCurrentNodes([...layout.nodes]);
         setCurrentEdges([...layout.edges]);
 
-        window.requestAnimationFrame(async () => {
-            await fitView();
-        });
+        setLayoutReady(true);
     }, [
-        connectedNodes,
-        freeNodes,
+        nodesInitialized,
+        metricsTree,
+        currentNodes,
         currentEdges,
         setCurrentNodes,
         setCurrentEdges,
-        fitView,
     ]);
 
+    // Runs layout when the nodes are initialized
     useEffect(() => {
-        if (!metricsTree || hasLayout) return;
+        if (!metricsTree || !nodesInitialized || layoutReady) {
+            return;
+        }
+        onLayout();
+    }, [onLayout, layoutReady, nodesInitialized, metricsTree, fitView]);
 
-        // TODO: The graph doesn't fully layout without this delay.
-        // There maybe be a better way to await layout completion. The layout
-        // engine doesn't return a promise, but maybe we can come up with something.
-        const timeoutId = setTimeout(() => {
-            onLayout();
-            setHasLayout(true);
-        }, 80);
-
-        return () => clearTimeout(timeoutId);
-    }, [onLayout, metricsTree, hasLayout]);
+    // Fits the view when the layout is ready
+    useEffect(() => {
+        if (nodesInitialized && layoutReady) {
+            window.requestAnimationFrame(async () => {
+                await fitView();
+            });
+        }
+    }, [layoutReady, fitView, nodesInitialized]);
 
     return (
         <Box h="100%">
-            {isValidMetricsTree ? (
-                <ReactFlow
-                    nodes={currentNodes}
-                    edges={currentEdges}
-                    fitView
-                    attributionPosition="top-right"
-                    onNodesChange={handleNodeChange}
-                    onEdgesChange={onEdgesChange}
-                    onConnect={handleConnect}
-                    edgesReconnectable={false}
-                    onEdgesDelete={handleEdgesDelete}
-                >
-                    <Panel position="top-right">
-                        <button onClick={() => onLayout()}>Clean up</button>
-                    </Panel>
-                    <Background />
-                </ReactFlow>
-            ) : (
-                <SuboptimalState
-                    title="Metrics tree not available"
-                    description="Please narrow your search to display up to 30 metrics"
-                />
-            )}
+            <ReactFlow
+                nodes={currentNodes}
+                edges={currentEdges}
+                fitView
+                attributionPosition="top-right"
+                onNodesChange={handleNodeChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={handleConnect}
+                edgesReconnectable={false}
+                onEdgesDelete={handleEdgesDelete}
+            >
+                <Panel position="top-right">
+                    <button onClick={() => onLayout()}>Clean up</button>
+                </Panel>
+                <Background />
+            </ReactFlow>
         </Box>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -14,6 +14,7 @@ import {
     IconArrowUp,
 } from '@tabler/icons-react';
 import { useIsMutating } from '@tanstack/react-query';
+import { ReactFlowProvider } from '@xyflow/react';
 import {
     MantineReactTable,
     useMantineReactTable,
@@ -449,7 +450,9 @@ export const MetricsTable = () => {
                         <Divider color="gray.2" />
                     </Box>
                     <Box w="100%" h="calc(100dvh - 350px)">
-                        <MetricTree metrics={flatData} />
+                        <ReactFlowProvider>
+                            <MetricTree metrics={flatData} />
+                        </ReactFlowProvider>
                     </Box>
                 </Paper>
             );

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -1,4 +1,9 @@
-import { assertUnreachable, type CatalogItem } from '@lightdash/common';
+import {
+    assertUnreachable,
+    getMetricsTreeNodeId,
+    MAX_METRICS_TREE_NODE_COUNT,
+    type CatalogItem,
+} from '@lightdash/common';
 import {
     Box,
     Divider,
@@ -31,10 +36,12 @@ import {
     type UIEvent,
 } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricsCatalog } from '../hooks/useMetricsCatalog';
+import { useMetricsTree } from '../hooks/useMetricsTree';
 import { setCategoryFilters } from '../store/metricsCatalogSlice';
 import { MetricsCatalogColumns } from './MetricsCatalogColumns';
 import {
@@ -103,6 +110,23 @@ export const MetricsTable = () => {
     const flatData = useMemo(
         () => data?.pages.flatMap((page) => page.data) ?? [],
         [data],
+    );
+
+    // Fetch metric tree data
+    const selectedMetricTreeIds = useMemo(() => {
+        return flatData.map((metric) => getMetricsTreeNodeId(metric));
+    }, [flatData]);
+
+    const isValidMetricsTree =
+        selectedMetricTreeIds.length > 0 &&
+        selectedMetricTreeIds.length <= MAX_METRICS_TREE_NODE_COUNT;
+
+    const { data: metricsTree } = useMetricsTree(
+        projectUuid,
+        selectedMetricTreeIds,
+        {
+            enabled: !!projectUuid && isValidMetricsTree,
+        },
     );
 
     const dataHasCategories = useMemo(() => {
@@ -478,7 +502,18 @@ export const MetricsTable = () => {
                     </Box>
                     <Box w="100%" h="calc(100dvh - 350px)">
                         <ReactFlowProvider>
-                            <MetricTree metrics={flatData} />
+                            {isValidMetricsTree && metricsTree && (
+                                <MetricTree
+                                    metrics={flatData}
+                                    metricsTree={metricsTree}
+                                />
+                            )}
+                            {!isValidMetricsTree && (
+                                <SuboptimalState
+                                    title="Metrics tree not available"
+                                    description="Please narrow your search to display up to 30 metrics"
+                                />
+                            )}
                         </ReactFlowProvider>
                     </Box>
                 </Paper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,18 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@dagrejs/dagre@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/dagre/-/dagre-1.1.4.tgz#66f9c0e2b558308f2c268f60e2c28f22ee17e339"
+  integrity sha512-QUTc54Cg/wvmlEUxB+uvoPVKFazM1H18kVHBQNmK2NbrDR5ihOCR6CXLnDSZzMcSQKJtabPUWridBOlJM3WkDg==
+  dependencies:
+    "@dagrejs/graphlib" "2.2.4"
+
+"@dagrejs/graphlib@2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-2.2.4.tgz#d77bfa9ff49e2307c0c6e6b8b26b5dd3c05816c4"
+  integrity sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==
+
 "@databricks/sql@1.8.4":
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/@databricks/sql/-/sql-1.8.4.tgz#80069db55823037334d3f771bfd574aef107868f"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12665 

### Description:



Basic layout for the metric tree including:
- A tree layout of connected nodes
- A grid of unconnected nodes

This is pretty basic and will have to be iterated on, but it will give us something to try. Some obvious missing things:
- Style for the group so it can have a name like "Unconnected nodes". The default group doesn't have a lable
- A spinner or a better await while the tree is building
- Experiments with other data. I only tested locally

<img width="1566" alt="Screenshot 2024-12-02 at 20 19 29" src="https://github.com/user-attachments/assets/f67a7451-6b12-4630-9bd0-7b7e18440f46">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
