### PR TITLE
fix: saved chart with null timezone

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -9,9 +9,7 @@ import {
     DimensionType,
     MetricFilterRule,
     MetricType,
-    NumberSeparator,
     TableCalculationType,
-    TimeZone,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -89,10 +87,10 @@ export type DbSavedChartVersion = {
     row_limit: number;
     chart_type: ChartType;
     saved_query_id: number;
-    chart_config: ChartConfig['config'] | undefined;
-    pivot_dimensions: string[] | undefined;
-    updated_by_user_uuid: string | undefined;
-    timezone: string | undefined;
+    chart_config: ChartConfig['config'] | null;
+    pivot_dimensions: string[] | null;
+    updated_by_user_uuid: string | null;
+    timezone: string | null;
 };
 
 export type SavedChartVersionsTable = Knex.CompositeTableType<

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -87,7 +87,7 @@ type DbSavedChartDetails = {
     last_name: string;
     pinned_list_uuid: string;
     dashboard_uuid: string | null;
-    timezone: TimeZone | undefined;
+    timezone: TimeZone | null;
 };
 
 const createSavedChartVersionFields = async (
@@ -191,11 +191,11 @@ const createSavedChartVersion = async (
                 filters: JSON.stringify(filters),
                 explore_name: tableName,
                 saved_query_id: savedChartId,
-                pivot_dimensions: pivotConfig ? pivotConfig.columns : undefined,
+                pivot_dimensions: pivotConfig ? pivotConfig.columns : null,
                 chart_type: chartConfig.type,
                 chart_config: chartConfig.config,
-                updated_by_user_uuid: updatedByUser?.userUuid,
-                timezone,
+                updated_by_user_uuid: updatedByUser?.userUuid || null,
+                timezone: timezone || null,
             })
             .returning('*');
         await createSavedChartVersionFields(
@@ -966,7 +966,7 @@ export class SavedChartModel {
                                 dimensionType: cd.dimension_type,
                             })),
                         ],
-                        timezone: savedQuery.timezone,
+                        timezone: savedQuery.timezone || undefined,
                     },
                     chartConfig,
                     tableConfig: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Fix issue where results table would not show column totals.

Before:

Save chart returns `timezone: null` when it expects `string | undefined` 
<img width="1893" alt="Screenshot 2024-12-03 at 13 52 45" src="https://github.com/user-attachments/assets/1d2f5c6c-8e7f-4e35-b694-625c16918a62">
Total request fails because `timezone: null` is not a valid value.
<img width="1869" alt="Screenshot 2024-12-03 at 13 52 05" src="https://github.com/user-attachments/assets/d176ecf7-3574-49e9-aaee-8985e0dc53aa">
Validation error in BE
<img width="1329" alt="Screenshot 2024-12-03 at 13 57 43" src="https://github.com/user-attachments/assets/9ff2bd56-6ce2-45b4-9ee3-d75e63fd7ab2">


After:
Save chart doesn't return a timezone if there isn't one.
<img width="1895" alt="Screenshot 2024-12-03 at 13 58 18" src="https://github.com/user-attachments/assets/f4cafc8b-c7a7-46fa-ba34-c05584a0ccfd">

Total request works.
<img width="1121" alt="Screenshot 2024-12-03 at 13 58 45" src="https://github.com/user-attachments/assets/81e6027a-7fac-4336-82dc-76b19f455ea9">
<img width="1875" alt="Screenshot 2024-12-03 at 13 58 37" src="https://github.com/user-attachments/assets/26a9403c-e425-46b4-a55b-e5921a3eb9bf">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
