### PR TITLE
feat: render metric visualization even if no default & config

### DIFF
--- a/packages/backend/src/controllers/metricsExplorerController.ts
+++ b/packages/backend/src/controllers/metricsExplorerController.ts
@@ -1,11 +1,13 @@
 import {
     ApiErrorPayload,
     MetricExplorerComparison,
+    TimeDimensionConfig,
     type ApiMetricsExplorerQueryResults,
     type MetricExplorerComparisonType,
     type MetricExplorerDateRange,
 } from '@lightdash/common';
 import {
+    Body,
     Middlewares,
     OperationId,
     Path,
@@ -45,6 +47,10 @@ export class MetricsExplorerController extends BaseController {
         @Query() endDate: string,
         @Query() compareToPreviousPeriod?: boolean,
         @Query() compareToMetric?: string,
+        @Body()
+        body?: {
+            timeDimensionOverride?: TimeDimensionConfig;
+        },
     ): Promise<ApiMetricsExplorerQueryResults> {
         this.setStatus(200);
 
@@ -79,6 +85,7 @@ export class MetricsExplorerController extends BaseController {
                 metric,
                 dateRange,
                 compare,
+                body?.timeDimensionOverride,
             );
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -937,17 +937,6 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CompiledTable.defaultTimeDimension_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                defaultTimeDimension: { ref: 'DefaultTimeDimension' },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'FieldType.DIMENSION': {
         dataType: 'refEnum',
         enums: ['dimension'],
@@ -1035,7 +1024,6 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 { ref: 'CompiledMetric' },
-                { ref: 'Pick_CompiledTable.defaultTimeDimension_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -1064,6 +1052,28 @@ const models: TsoaRoute.Models = {
                                     },
                                 ],
                             },
+                        },
+                        timeDimension: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'intersection',
+                                    subSchemas: [
+                                        { ref: 'DefaultTimeDimension' },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                table: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
                         },
                     },
                 },
@@ -3798,6 +3808,10 @@ const models: TsoaRoute.Models = {
                 rows: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'ResultRow' },
+                    required: true,
+                },
+                metric: {
+                    ref: 'MetricWithAssociatedTimeDimension',
                     required: true,
                 },
             },
@@ -13524,6 +13538,14 @@ export function RegisterRoutes(app: express.Router) {
                     in: 'query',
                     name: 'compareToMetric',
                     dataType: 'string',
+                },
+                body: {
+                    in: 'body',
+                    name: 'body',
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        timeDimensionOverride: { ref: 'TimeDimensionConfig' },
+                    },
                 },
             };
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -948,6 +948,87 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'FieldType.DIMENSION': {
+        dataType: 'refEnum',
+        enums: ['dimension'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DimensionType: {
+        dataType: 'refEnum',
+        enums: ['string', 'number', 'timestamp', 'date', 'boolean'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.string_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CompiledDimension: {
+        dataType: 'refObject',
+        properties: {
+            fieldType: { ref: 'FieldType.DIMENSION', required: true },
+            type: { ref: 'DimensionType', required: true },
+            name: { dataType: 'string', required: true },
+            label: { dataType: 'string', required: true },
+            table: { dataType: 'string', required: true },
+            tableLabel: { dataType: 'string', required: true },
+            sql: { dataType: 'string', required: true },
+            description: { dataType: 'string' },
+            source: {
+                dataType: 'union',
+                subSchemas: [{ ref: 'Source' }, { dataType: 'undefined' }],
+            },
+            hidden: { dataType: 'boolean', required: true },
+            compact: { ref: 'CompactOrAlias' },
+            round: { dataType: 'double' },
+            format: { ref: 'Format' },
+            groupLabel: { dataType: 'string' },
+            groups: { dataType: 'array', array: { dataType: 'string' } },
+            urls: {
+                dataType: 'array',
+                array: { dataType: 'refAlias', ref: 'FieldUrl' },
+            },
+            index: { dataType: 'double' },
+            tags: { dataType: 'array', array: { dataType: 'string' } },
+            group: { dataType: 'string' },
+            requiredAttributes: {
+                ref: 'Record_string.string-or-string-Array_',
+            },
+            timeInterval: { ref: 'TimeFrames' },
+            timeIntervalBaseDimensionName: { dataType: 'string' },
+            isAdditionalDimension: { dataType: 'boolean' },
+            colors: { ref: 'Record_string.string_' },
+            isIntervalBase: { dataType: 'boolean' },
+            compiledSql: { dataType: 'string', required: true },
+            tablesReferences: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'array', array: { dataType: 'string' } },
+                    { dataType: 'undefined' },
+                ],
+                required: true,
+            },
+            tablesRequiredAttributes: {
+                ref: 'Record_string.Record_string.string-or-string-Array__',
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'DimensionType.DATE': {
+        dataType: 'refEnum',
+        enums: ['date'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'DimensionType.TIMESTAMP': {
+        dataType: 'refEnum',
+        enums: ['timestamp'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricWithAssociatedTimeDimension: {
         dataType: 'refAlias',
         type: {
@@ -955,6 +1036,37 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'CompiledMetric' },
                 { ref: 'Pick_CompiledTable.defaultTimeDimension_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        availableTimeDimensions: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'intersection',
+                                subSchemas: [
+                                    { ref: 'CompiledDimension' },
+                                    {
+                                        dataType: 'nestedObjectLiteral',
+                                        nestedProperties: {
+                                            type: {
+                                                dataType: 'union',
+                                                subSchemas: [
+                                                    {
+                                                        ref: 'DimensionType.DATE',
+                                                    },
+                                                    {
+                                                        ref: 'DimensionType.TIMESTAMP',
+                                                    },
+                                                ],
+                                                required: true,
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
             ],
             validators: {},
         },
@@ -1964,11 +2076,6 @@ const models: TsoaRoute.Models = {
         enums: ['sql'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DimensionType: {
-        dataType: 'refEnum',
-        enums: ['string', 'number', 'timestamp', 'date', 'boolean'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CustomSqlDimension: {
         dataType: 'refObject',
         properties: {
@@ -2499,15 +2606,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'enum',
             enums: ['hidden', 'inside', 'outside'],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.string_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
             validators: {},
         },
     },
@@ -3715,6 +3813,23 @@ const models: TsoaRoute.Models = {
                 results: { ref: 'MetricsExplorerQueryResults', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TimeDimensionConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DefaultTimeDimension' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        table: { dataType: 'string', required: true },
+                    },
+                },
+            ],
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -937,15 +937,6 @@
                 "type": "object",
                 "additionalProperties": true
             },
-            "Pick_CompiledTable.defaultTimeDimension_": {
-                "properties": {
-                    "defaultTimeDimension": {
-                        "$ref": "#/components/schemas/DefaultTimeDimension"
-                    }
-                },
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
             "FieldType.DIMENSION": {
                 "enum": ["dimension"],
                 "type": "string"
@@ -1090,9 +1081,6 @@
                         "$ref": "#/components/schemas/CompiledMetric"
                     },
                     {
-                        "$ref": "#/components/schemas/Pick_CompiledTable.defaultTimeDimension_"
-                    },
-                    {
                         "properties": {
                             "availableTimeDimensions": {
                                 "items": {
@@ -1119,6 +1107,22 @@
                                     ]
                                 },
                                 "type": "array"
+                            },
+                            "timeDimension": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DefaultTimeDimension"
+                                    },
+                                    {
+                                        "properties": {
+                                            "table": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["table"],
+                                        "type": "object"
+                                    }
+                                ]
                             }
                         },
                         "type": "object"
@@ -4231,9 +4235,12 @@
                             "$ref": "#/components/schemas/ResultRow"
                         },
                         "type": "array"
+                    },
+                    "metric": {
+                        "$ref": "#/components/schemas/MetricWithAssociatedTimeDimension"
                     }
                 },
-                "required": ["fields", "rows"],
+                "required": ["fields", "rows", "metric"],
                 "type": "object"
             },
             "ApiMetricsExplorerQueryResults": {
@@ -11990,7 +11997,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1395.0",
+        "version": "0.1396.3",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -946,6 +946,144 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
+            "FieldType.DIMENSION": {
+                "enum": ["dimension"],
+                "type": "string"
+            },
+            "DimensionType": {
+                "enum": ["string", "number", "timestamp", "date", "boolean"],
+                "type": "string"
+            },
+            "Record_string.string_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "CompiledDimension": {
+                "properties": {
+                    "fieldType": {
+                        "$ref": "#/components/schemas/FieldType.DIMENSION"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/DimensionType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "table": {
+                        "type": "string"
+                    },
+                    "tableLabel": {
+                        "type": "string"
+                    },
+                    "sql": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/Source"
+                    },
+                    "hidden": {
+                        "type": "boolean"
+                    },
+                    "compact": {
+                        "$ref": "#/components/schemas/CompactOrAlias"
+                    },
+                    "round": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "format": {
+                        "$ref": "#/components/schemas/Format"
+                    },
+                    "groupLabel": {
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "urls": {
+                        "items": {
+                            "$ref": "#/components/schemas/FieldUrl"
+                        },
+                        "type": "array"
+                    },
+                    "index": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "group": {
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "requiredAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
+                    "timeInterval": {
+                        "$ref": "#/components/schemas/TimeFrames"
+                    },
+                    "timeIntervalBaseDimensionName": {
+                        "type": "string"
+                    },
+                    "isAdditionalDimension": {
+                        "type": "boolean"
+                    },
+                    "colors": {
+                        "$ref": "#/components/schemas/Record_string.string_"
+                    },
+                    "isIntervalBase": {
+                        "type": "boolean"
+                    },
+                    "compiledSql": {
+                        "type": "string"
+                    },
+                    "tablesReferences": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "tablesRequiredAttributes": {
+                        "$ref": "#/components/schemas/Record_string.Record_string.string-or-string-Array__"
+                    }
+                },
+                "required": [
+                    "fieldType",
+                    "type",
+                    "name",
+                    "label",
+                    "table",
+                    "tableLabel",
+                    "sql",
+                    "hidden",
+                    "compiledSql"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "DimensionType.DATE": {
+                "enum": ["date"],
+                "type": "string"
+            },
+            "DimensionType.TIMESTAMP": {
+                "enum": ["timestamp"],
+                "type": "string"
+            },
             "MetricWithAssociatedTimeDimension": {
                 "allOf": [
                     {
@@ -953,6 +1091,37 @@
                     },
                     {
                         "$ref": "#/components/schemas/Pick_CompiledTable.defaultTimeDimension_"
+                    },
+                    {
+                        "properties": {
+                            "availableTimeDimensions": {
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/CompiledDimension"
+                                        },
+                                        {
+                                            "properties": {
+                                                "type": {
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/components/schemas/DimensionType.DATE"
+                                                        },
+                                                        {
+                                                            "$ref": "#/components/schemas/DimensionType.TIMESTAMP"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": ["type"],
+                                            "type": "object"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
                     }
                 ]
             },
@@ -2107,10 +2276,6 @@
                 "enum": ["sql"],
                 "type": "string"
             },
-            "DimensionType": {
-                "enum": ["string", "number", "timestamp", "date", "boolean"],
-                "type": "string"
-            },
             "CustomSqlDimension": {
                 "properties": {
                     "id": {
@@ -2720,11 +2885,6 @@
                 "type": "string",
                 "enum": ["hidden", "inside", "outside"],
                 "nullable": false
-            },
-            "Record_string.string_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
             },
             "Record_string.Partial_PieChartValueOptions__": {
                 "properties": {},
@@ -4089,6 +4249,22 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
+            },
+            "TimeDimensionConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DefaultTimeDimension"
+                    },
+                    {
+                        "properties": {
+                            "table": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["table"],
+                        "type": "object"
+                    }
+                ]
             },
             "NotificationBase": {
                 "properties": {
@@ -14148,7 +14324,22 @@
                             "type": "string"
                         }
                     }
-                ]
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "timeDimensionOverride": {
+                                        "$ref": "#/components/schemas/TimeDimensionConfig"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/notifications": {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -13,6 +13,7 @@ import {
     CompiledDimension,
     CompiledMetric,
     CompiledTable,
+    DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
     DimensionType,
     Explore,
     ExploreError,
@@ -891,12 +892,16 @@ export class CatalogService<
         // Priority 3: Use the only time dimension if there's exactly one
         if (table?.dimensions) {
             const timeDimensions = Object.values(table.dimensions).filter(
-                (dim) => dim.type === 'date' || dim.type === 'timestamp',
+                (dim) =>
+                    (dim.type === DimensionType.DATE ||
+                        dim.type === DimensionType.TIMESTAMP) &&
+                    !!dim.isIntervalBase &&
+                    !dim.hidden,
             );
             if (timeDimensions.length === 1) {
                 return {
                     field: timeDimensions[0].name,
-                    interval: TimeFrames.MONTH, // TODO: Should this be dynamic?
+                    interval: DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
                 };
             }
         }
@@ -918,7 +923,8 @@ export class CatalogService<
                 } =>
                     (dim.type === DimensionType.DATE ||
                         dim.type === DimensionType.TIMESTAMP) &&
-                    !!dim.isIntervalBase,
+                    !!dim.isIntervalBase &&
+                    !dim.hidden,
             ),
         );
     }

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -942,12 +942,7 @@ export class CatalogService<
             availableTimeDimensions &&
             availableTimeDimensions.length > 0
         ) {
-            console.log({ availableTimeDimensions });
             const firstAvailableTimeDimension = availableTimeDimensions[0];
-
-            console.log({
-                firstAvailableTimeDimension,
-            });
 
             if (!firstAvailableTimeDimension.isIntervalBase) {
                 throw new Error(

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -3,10 +3,8 @@ import {
     assertUnreachable,
     ForbiddenError,
     getFieldIdForDateDimension,
-    getGrainForDateRange,
     getItemId,
     getMetricExplorerDateRangeFilters,
-    getTimeDimensionConfig,
     MetricExplorerComparison,
     MetricExplorerComparisonType,
     oneYearBack,
@@ -90,10 +88,8 @@ export class MetricsExplorerService<
             metricName,
         );
 
-        const { defaultTimeDimension } = metric;
-
         const timeDimensionConfig =
-            timeDimensionOverride ?? getTimeDimensionConfig(metric);
+            timeDimensionOverride ?? metric.timeDimension;
 
         if (!timeDimensionConfig) {
             throw new Error(
@@ -101,9 +97,7 @@ export class MetricsExplorerService<
             );
         }
 
-        const dimensionGrain = dateRange
-            ? getGrainForDateRange(dateRange)
-            : timeDimensionConfig.interval;
+        const dimensionGrain = timeDimensionConfig.interval;
 
         const timeDimension = getItemId({
             table: timeDimensionConfig.table,
@@ -203,6 +197,7 @@ export class MetricsExplorerService<
             rows: currentResults,
             comparisonRows: comparisonResults,
             fields: allFields,
+            metric: { ...metric, timeDimension: timeDimensionConfig },
         };
     }
 }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -1,7 +1,6 @@
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     type CompiledExploreJoin,
-    type CompiledTable,
     type Explore,
     type ExploreError,
     type InlineError,
@@ -113,12 +112,14 @@ export type ApiMetricsCatalog = {
     results: KnexPaginatedData<ApiMetricsCatalogResults>;
 };
 
-export type MetricWithAssociatedTimeDimension = CompiledMetric &
-    Pick<CompiledTable, 'defaultTimeDimension'> & {
-        availableTimeDimensions?: (CompiledDimension & {
-            type: DimensionType.DATE | DimensionType.TIMESTAMP;
-        })[];
-    };
+export type MetricWithAssociatedTimeDimension = CompiledMetric & {
+    timeDimension:
+        | (CompiledMetric['defaultTimeDimension'] & { table: string })
+        | undefined;
+    availableTimeDimensions?: (CompiledDimension & {
+        type: DimensionType.DATE | DimensionType.TIMESTAMP;
+    })[];
+};
 
 export type ApiGetMetricPeek = {
     status: 'ok';

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -114,7 +114,11 @@ export type ApiMetricsCatalog = {
 };
 
 export type MetricWithAssociatedTimeDimension = CompiledMetric &
-    Pick<CompiledTable, 'defaultTimeDimension'>;
+    Pick<CompiledTable, 'defaultTimeDimension'> & {
+        availableTimeDimensions?: (CompiledDimension & {
+            type: DimensionType.DATE | DimensionType.TIMESTAMP;
+        })[];
+    };
 
 export type ApiGetMetricPeek = {
     status: 'ok';

--- a/packages/common/src/types/metricsExplorer.ts
+++ b/packages/common/src/types/metricsExplorer.ts
@@ -1,3 +1,4 @@
+import { type MetricWithAssociatedTimeDimension } from './catalog';
 import type { ItemsMap } from './field';
 import type { ResultRow } from './results';
 
@@ -22,6 +23,7 @@ export type MetricExploreDataPoint = {
 };
 
 export type MetricsExplorerQueryResults = {
+    metric: MetricWithAssociatedTimeDimension;
     rows: ResultRow[];
     comparisonRows: ResultRow[] | undefined;
     fields: ItemsMap;

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -14,7 +14,7 @@ import type {
     MetricExplorerDateRange,
 } from '../types/metricsExplorer';
 import type { ResultRow } from '../types/results';
-import { TimeFrames } from '../types/timeFrames';
+import { TimeFrames, type DefaultTimeDimension } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 import { getItemId } from './item';
 
@@ -234,4 +234,28 @@ export const getDefaultDateRangeFromInterval = (
         default:
             return assertUnimplementedTimeframe(timeInterval);
     }
+};
+
+/**
+ * Default time interval to use when no time interval is provided.
+ * For example, when there is no default time dimension defined for a metric or table.
+ */
+export const DEFAULT_METRICS_EXPLORER_TIME_INTERVAL = TimeFrames.MONTH;
+
+export type TimeDimensionConfig = DefaultTimeDimension & { table: string };
+
+export const getFirstAvailableTimeDimension = (
+    metric: MetricWithAssociatedTimeDimension,
+): TimeDimensionConfig | undefined => {
+    if (
+        metric.availableTimeDimensions &&
+        metric.availableTimeDimensions.length > 0
+    ) {
+        return {
+            table: metric.availableTimeDimensions[0].table,
+            field: metric.availableTimeDimensions[0].name,
+            interval: DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+        };
+    }
+    return undefined;
 };

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -266,37 +266,6 @@ export const getFirstAvailableTimeDimension = (
     return undefined;
 };
 
-/**
- * Helper method to determine the correct time dimension configuration
- * It covers the case where the metric has a default time dimension
- * and the case where the metric has available time dimensions (could be multiple and from different tables that are joined)
- */
-export const getTimeDimensionConfig = (
-    metric: CompiledMetric,
-): TimeDimensionConfig | undefined => {
-    if (metric.defaultTimeDimension) {
-        // Use the metric's table when default time dimension is specified
-        return {
-            table: metric.table,
-            field: metric.defaultTimeDimension.field,
-            interval: metric.defaultTimeDimension.interval,
-        };
-    }
-
-    // Fall back to the first available time dimension
-    const firstAvailableTimeDimension = getFirstAvailableTimeDimension(metric);
-    if (!firstAvailableTimeDimension) {
-        return undefined;
-    }
-
-    // Use the dimension's own table in case it's joined
-    return {
-        table: firstAvailableTimeDimension.table,
-        field: firstAvailableTimeDimension.field,
-        interval: firstAvailableTimeDimension.interval,
-    };
-};
-
 export const getDefaultTimeDimension = (
     metric: CompiledMetric,
     table?: CompiledTable,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { IconCalendar, IconChevronDown } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useDateRangePicker } from '../hooks/useDateRangePicker';
 
@@ -25,11 +25,13 @@ type Props = {
         | ApiGetMetricPeek['results']['defaultTimeDimension']
         | undefined;
     onChange: (dateRange: MetricExplorerDateRange) => void;
+    rightSection?: ReactNode;
 };
 
 export const MetricPeekDatePicker: FC<Props> = ({
     defaultTimeDimension,
     onChange,
+    rightSection,
 }) => {
     const {
         isOpen,
@@ -63,6 +65,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
                         styles={(theme) => ({
                             root: {
                                 border: `1px solid ${theme.colors.gray[2]}`,
+                                boxShadow: theme.shadows.subtle,
                             },
                             label: {
                                 width: '100%',
@@ -78,10 +81,14 @@ export const MetricPeekDatePicker: FC<Props> = ({
                                 />
                                 {buttonLabel}
                             </Group>
-                            <MantineIcon
-                                color="dark.3"
-                                icon={IconChevronDown}
-                            />
+                            {rightSection ? (
+                                rightSection
+                            ) : (
+                                <MantineIcon
+                                    color="dark.3"
+                                    icon={IconChevronDown}
+                                />
+                            )}
                         </Group>
                     </Button>
                 </Tooltip>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -1,6 +1,6 @@
 import {
-    type ApiGetMetricPeek,
     type MetricExplorerDateRange,
+    type TimeDimensionConfig,
 } from '@lightdash/common';
 import {
     Box,
@@ -16,22 +16,27 @@ import {
 } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { IconCalendar, IconChevronDown } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
+import { type Dispatch, type FC, type SetStateAction } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useDateRangePicker } from '../hooks/useDateRangePicker';
+import { TimeDimensionIntervalPicker } from './visualization/TimeDimensionIntervalPicker';
 
 type Props = {
-    defaultTimeDimension:
-        | ApiGetMetricPeek['results']['defaultTimeDimension']
-        | undefined;
+    dateRange: MetricExplorerDateRange;
     onChange: (dateRange: MetricExplorerDateRange) => void;
-    rightSection?: ReactNode;
+    showTimeDimensionIntervalPicker: boolean;
+    timeDimensionBaseField: TimeDimensionConfig | undefined;
+    setTimeDimensionOverride: Dispatch<
+        SetStateAction<TimeDimensionConfig | undefined>
+    >;
 };
 
 export const MetricPeekDatePicker: FC<Props> = ({
-    defaultTimeDimension,
+    dateRange,
     onChange,
-    rightSection,
+    showTimeDimensionIntervalPicker,
+    timeDimensionBaseField,
+    setTimeDimensionOverride,
 }) => {
     const {
         isOpen,
@@ -45,7 +50,8 @@ export const MetricPeekDatePicker: FC<Props> = ({
         handleApply,
         handlePresetSelect,
         handleDateRangeChange,
-    } = useDateRangePicker({ defaultTimeDimension, onChange });
+        reset,
+    } = useDateRangePicker({ value: dateRange, onChange });
 
     return (
         <Popover opened={isOpen} onChange={handleOpen} position="bottom-start">
@@ -81,8 +87,15 @@ export const MetricPeekDatePicker: FC<Props> = ({
                                 />
                                 {buttonLabel}
                             </Group>
-                            {rightSection ? (
-                                rightSection
+                            {showTimeDimensionIntervalPicker &&
+                            timeDimensionBaseField ? (
+                                <TimeDimensionIntervalPicker
+                                    dimension={timeDimensionBaseField}
+                                    onChange={(value) => {
+                                        setTimeDimensionOverride(value);
+                                        reset();
+                                    }}
+                                />
                             ) : (
                                 <MantineIcon
                                     color="dark.3"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -90,8 +90,6 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         null,
     );
 
-    console.log({ dateRange });
-
     const metricResultsQuery = useRunMetricExplorerQuery({
         projectUuid,
         exploreName: tableName,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
@@ -1,0 +1,70 @@
+import { TimeFrames, type TimeDimensionConfig } from '@lightdash/common';
+import { Select, useMantineTheme } from '@mantine/core';
+import { type Dispatch, type FC, type SetStateAction } from 'react';
+import { usePillSelectStyles } from '../../../../components/DataViz/hooks/usePillSelectStyles';
+
+type Props = {
+    dimension: TimeDimensionConfig;
+    onChange: Dispatch<SetStateAction<TimeDimensionConfig | undefined>>;
+};
+
+export const TimeDimensionIntervalPicker: FC<Props> = ({
+    dimension,
+    onChange,
+}) => {
+    const theme = useMantineTheme();
+    const { classes } = usePillSelectStyles({
+        backgroundColor: theme.colors.indigo[0],
+        textColor: theme.colors.indigo[4],
+    });
+    return (
+        <Select
+            data={[
+                {
+                    value: TimeFrames.DAY,
+                    label: 'Day',
+                },
+                {
+                    value: TimeFrames.WEEK,
+                    label: 'Week',
+                },
+                {
+                    value: TimeFrames.MONTH,
+                    label: 'Month',
+                },
+                {
+                    value: TimeFrames.YEAR,
+                    label: 'Year',
+                },
+            ]}
+            value={dimension?.interval}
+            onClick={(event) => {
+                event.stopPropagation();
+            }}
+            onChange={(value: TimeFrames) => {
+                if (!value) return;
+                onChange((prev) => ({
+                    interval: value,
+                    field: prev?.field ?? dimension.field,
+                    table: dimension.table,
+                }));
+            }}
+            withinPortal
+            classNames={{
+                item: classes.item,
+                dropdown: classes.dropdown,
+                input: classes.input,
+                rightSection: classes.rightSection,
+            }}
+            styles={{
+                root: {
+                    fontWeight: 500,
+                    fontSize: theme.fontSizes.xs,
+                },
+                input: {
+                    width: '50px',
+                },
+            }}
+        />
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
@@ -1,0 +1,99 @@
+import {
+    type ApiGetMetricPeek,
+    type TimeDimensionConfig,
+} from '@lightdash/common';
+import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
+import { IconCalendar } from '@tabler/icons-react';
+import {
+    forwardRef,
+    type ComponentPropsWithoutRef,
+    type Dispatch,
+    type FC,
+    type SetStateAction,
+} from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type Props = {
+    fields: NonNullable<ApiGetMetricPeek['results']['availableTimeDimensions']>;
+    dimension: TimeDimensionConfig;
+    onChange: Dispatch<SetStateAction<TimeDimensionConfig | undefined>>;
+};
+
+const FieldItem = forwardRef<
+    HTMLDivElement,
+    ComponentPropsWithoutRef<'div'> & {
+        value: string;
+        label: string;
+        tableLabel: string;
+        selected: boolean;
+    }
+>(({ value, label, tableLabel, ...others }, ref) => (
+    <Box ref={ref} {...others}>
+        <Group noWrap spacing="xs">
+            <Text size="xs" fw={500}>
+                {label}
+            </Text>
+            <Text size="xs" color="dimmed" span>
+                {tableLabel}
+            </Text>
+        </Group>
+    </Box>
+));
+
+export const TimeDimensionPicker: FC<Props> = ({
+    fields,
+    dimension,
+    onChange,
+}) => {
+    const theme = useMantineTheme();
+
+    return (
+        <Select
+            radius="md"
+            icon={<MantineIcon color="dark.3" icon={IconCalendar} />}
+            data={fields.map((f) => ({
+                value: f.name,
+                label: f.label,
+                tableLabel: f.tableLabel,
+            }))}
+            value={dimension?.field}
+            onChange={(value) => {
+                if (!value) return;
+                onChange((prev) => ({
+                    field: value,
+                    interval: prev?.interval ?? dimension.interval,
+                    table:
+                        fields.find((f) => f.name === value)?.table ??
+                        dimension.table,
+                }));
+            }}
+            w="100%"
+            itemComponent={FieldItem}
+            styles={{
+                input: {
+                    fontWeight: 500,
+                    borderColor: theme.colors.gray[2],
+                    borderRadius: theme.radius.md,
+                    boxShadow: theme.shadows.subtle,
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[0],
+                    },
+                },
+                item: {
+                    '&[data-selected="true"]': {
+                        color: theme.colors.gray[7],
+                        fontWeight: 500,
+                        backgroundColor: theme.colors.gray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.gray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[1],
+                    },
+                },
+            }}
+            rightSectionWidth="min-content"
+        />
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -1,4 +1,5 @@
 import {
+    DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
     getDefaultDateRangeFromInterval,
     type ApiGetMetricPeek,
     type MetricExplorerDateRange,
@@ -34,9 +35,10 @@ export const useDateRangePicker = ({
     const [isOpen, setIsOpen] = useState(false);
 
     const [dateRange, setDateRange] = useState<DateRange>(
-        defaultTimeDimension?.interval
-            ? getDefaultDateRangeFromInterval(defaultTimeDimension.interval)
-            : [null, null],
+        getDefaultDateRangeFromInterval(
+            defaultTimeDimension?.interval ??
+                DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+        ),
     );
     const [tempDateRange, setTempDateRange] = useState<DateRange>(dateRange);
 

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -1,11 +1,8 @@
 import {
-    DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
-    getDefaultDateRangeFromInterval,
-    type ApiGetMetricPeek,
     type MetricExplorerDateRange,
     type MetricExplorerPartialDateRange,
 } from '@lightdash/common';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { formatDate, getDateRangePresets } from '../utils/metricPeekDate';
 
 type DateRange = MetricExplorerPartialDateRange;
@@ -17,7 +14,7 @@ export interface DateRangePreset {
 }
 
 interface UseDateRangePickerProps {
-    defaultTimeDimension?: ApiGetMetricPeek['results']['defaultTimeDimension'];
+    value: MetricExplorerDateRange;
     onChange?: (range: MetricExplorerDateRange) => void;
 }
 
@@ -28,24 +25,24 @@ interface UseDateRangePickerProps {
  * (used when the user is selecting a preset, but has not applied it yet)
  */
 export const useDateRangePicker = ({
-    defaultTimeDimension,
+    value,
     onChange,
 }: UseDateRangePickerProps) => {
     const presets = getDateRangePresets();
     const [isOpen, setIsOpen] = useState(false);
 
-    const [dateRange, setDateRange] = useState<DateRange>(
-        getDefaultDateRangeFromInterval(
-            defaultTimeDimension?.interval ??
-                DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
-        ),
-    );
+    const [dateRange, setDateRange] = useState<DateRange>(value);
+
     const [tempDateRange, setTempDateRange] = useState<DateRange>(dateRange);
 
     const [selectedPreset, setSelectedPreset] =
         useState<DateRangePreset | null>(null);
     const [tempSelectedPreset, setTempSelectedPreset] =
         useState<DateRangePreset | null>(null);
+
+    useEffect(() => {
+        setDateRange(value);
+    }, [value]);
 
     const buttonLabel =
         selectedPreset?.label ||
@@ -87,6 +84,11 @@ export const useDateRangePicker = ({
         setTempSelectedPreset(null);
     };
 
+    const reset = () => {
+        setDateRange(value);
+        setSelectedPreset(null);
+    };
+
     return {
         isOpen,
         tempDateRange,
@@ -99,5 +101,6 @@ export const useDateRangePicker = ({
         handleApply,
         handlePresetSelect,
         handleDateRangeChange,
+        reset,
     };
 };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -5,6 +5,7 @@ import {
     type ApiMetricsExplorerQueryResults,
     type MetricExplorerComparisonType,
     type MetricExplorerDateRange,
+    type TimeDimensionConfig,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
@@ -15,6 +16,7 @@ type RunMetricExplorerQueryArgs = {
     metricName: string;
     dateRange: MetricExplorerDateRange;
     comparison: MetricExplorerComparisonType;
+    timeDimensionOverride?: TimeDimensionConfig;
 };
 
 const getUrlParams = (
@@ -52,6 +54,7 @@ const postRunMetricExplorerQuery = async ({
     metricName,
     comparison,
     dateRange,
+    timeDimensionOverride,
 }: RunMetricExplorerQueryArgs) => {
     const queryString = getUrlParams(dateRange, comparison);
 
@@ -60,7 +63,11 @@ const postRunMetricExplorerQuery = async ({
             queryString ? `?${queryString}` : ''
         }`,
         method: 'POST',
-        body: undefined,
+        body: timeDimensionOverride
+            ? JSON.stringify({
+                  timeDimensionOverride,
+              })
+            : undefined,
     });
 };
 
@@ -70,6 +77,7 @@ export const useRunMetricExplorerQuery = ({
     metricName,
     comparison,
     dateRange,
+    timeDimensionOverride,
 }: Partial<RunMetricExplorerQueryArgs>) => {
     return useQuery<ApiMetricsExplorerQueryResults['results'], ApiError>({
         queryKey: [
@@ -80,6 +88,7 @@ export const useRunMetricExplorerQuery = ({
             dateRange?.[0],
             dateRange?.[1],
             comparison?.type,
+            timeDimensionOverride,
         ],
         queryFn: () =>
             postRunMetricExplorerQuery({
@@ -88,6 +97,7 @@ export const useRunMetricExplorerQuery = ({
                 metricName: metricName!,
                 comparison: comparison!,
                 dateRange: dateRange!,
+                timeDimensionOverride,
             }),
         enabled:
             !!projectUuid &&

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -49,23 +49,21 @@ export const DEFAULT_EMPTY_EXPLORE_CONFIG: CreateSavedChartVersion = {
 export const createMetricPreviewUnsavedChartVersion = (
     metric: MetricWithAssociatedTimeDimension,
 ): CreateSavedChartVersion => {
-    const defaultTimeDimension = metric.defaultTimeDimension;
+    const timeDimension = metric.timeDimension;
 
     const defaultTimeFilters =
-        defaultTimeDimension && defaultTimeDimension.interval
+        timeDimension && timeDimension.interval
             ? getMetricExplorerDateRangeFilters(
                   metric.table,
-                  defaultTimeDimension.field,
-                  getDefaultDateRangeFromInterval(
-                      defaultTimeDimension.interval,
-                  ),
+                  timeDimension.field,
+                  getDefaultDateRangeFromInterval(timeDimension.interval),
               )
             : [];
 
     let chartConfig = DEFAULT_EMPTY_EXPLORE_CONFIG.chartConfig;
 
     // If there is no default time dimension, we want to default to a big number chart because there is no time dimension to plot a chart
-    if (!defaultTimeDimension) {
+    if (!timeDimension) {
         chartConfig = {
             type: ChartType.BIG_NUMBER,
             config: {},
@@ -79,13 +77,13 @@ export const createMetricPreviewUnsavedChartVersion = (
         metricQuery: {
             ...DEFAULT_EMPTY_EXPLORE_CONFIG.metricQuery,
             exploreName: metric.table,
-            dimensions: defaultTimeDimension
+            dimensions: timeDimension
                 ? [
                       getItemId({
                           table: metric.table,
                           name: getFieldIdForDateDimension(
-                              defaultTimeDimension.field,
-                              defaultTimeDimension.interval,
+                              timeDimension.field,
+                              timeDimension.interval,
                           ),
                       }),
                   ]

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -54,7 +54,7 @@ export const createMetricPreviewUnsavedChartVersion = (
     const defaultTimeFilters =
         timeDimension && timeDimension.interval
             ? getMetricExplorerDateRangeFilters(
-                  metric.table,
+                  timeDimension.table,
                   timeDimension.field,
                   getDefaultDateRangeFromInterval(timeDimension.interval),
               )
@@ -80,7 +80,7 @@ export const createMetricPreviewUnsavedChartVersion = (
             dimensions: timeDimension
                 ? [
                       getItemId({
-                          table: metric.table,
+                          table: timeDimension.table,
                           name: getFieldIdForDateDimension(
                               timeDimension.field,
                               timeDimension.interval,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12667](https://github.com/lightdash/lightdash/issues/12667)

### Description:

- Generates a default time dimension for a metric if defined on table yml - test with `Average order size`
- metric yml - test with `Total order amount`
- if the table only has ONE date dim - test with `Unique customer count`

If no defaults available ⬆️ , we then get the available time dimensions for that metric and allow the changing of the field and/or interval - you can test this with anything in `payments` table, `events` table etc


demo:


https://github.com/user-attachments/assets/d5c669d7-30ef-417d-af62-41eb61e22769



> [!IMPORTANT]
> The granularity/interval changes the chart as it should, as well as the filtered range - however, the filter component is not in sync with the change. I want to tackle this on this ticket: https://github.com/lightdash/lightdash/issues/12659


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
