### PR TITLE
fix: migrations catalog search

### DIFF
--- a/packages/backend/src/database/migrations/20241129140659_add-table-name-to-catalog-search.ts
+++ b/packages/backend/src/database/migrations/20241129140659_add-table-name-to-catalog-search.ts
@@ -20,6 +20,8 @@ export async function up(knex: Knex): Promise<void> {
     // make table_name not nullable and add unique constraint
     await knex.schema.alterTable(CATALOG_SEARCH_TABLE, (table) => {
         table.text('table_name').notNullable().alter();
+
+        // this index was created incorrectly, has to be fixed in 20241203175631_fix-catalog-search-index.ts and changed in this migration
         table.unique(['table_name', 'name', 'project_uuid', 'type']);
     });
 }

--- a/packages/backend/src/database/migrations/20241129140659_add-table-name-to-catalog-search.ts
+++ b/packages/backend/src/database/migrations/20241129140659_add-table-name-to-catalog-search.ts
@@ -20,12 +20,13 @@ export async function up(knex: Knex): Promise<void> {
     // make table_name not nullable and add unique constraint
     await knex.schema.alterTable(CATALOG_SEARCH_TABLE, (table) => {
         table.text('table_name').notNullable().alter();
-        table.unique(['table_name', 'name', 'project_uuid']);
+        table.unique(['table_name', 'name', 'project_uuid', 'type']);
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.schema.alterTable(CATALOG_SEARCH_TABLE, (table) => {
+        table.dropUnique(['table_name', 'name', 'project_uuid', 'type']);
         table.dropColumn('table_name');
     });
 }

--- a/packages/backend/src/database/migrations/20241129140724_add-metrics-tree-edges-table.ts
+++ b/packages/backend/src/database/migrations/20241129140724_add-metrics-tree-edges-table.ts
@@ -8,8 +8,10 @@ export async function up(knex: Knex): Promise<void> {
         await knex.schema.createTable(METRICS_TREE_EDGES_TABLE, (table) => {
             table.string('source_metric_name').notNullable();
             table.string('source_metric_table_name').notNullable();
+            table.string('source_metric_type').notNullable();
             table.string('target_metric_name').notNullable();
             table.string('target_metric_table_name').notNullable();
+            table.string('target_metric_type').notNullable();
             table.uuid('project_uuid').notNullable();
 
             // Create composite foreign keys
@@ -17,9 +19,10 @@ export async function up(knex: Knex): Promise<void> {
                 .foreign([
                     'source_metric_name',
                     'source_metric_table_name',
+                    'source_metric_type',
                     'project_uuid',
                 ])
-                .references(['name', 'table_name', 'project_uuid'])
+                .references(['name', 'table_name', 'type', 'project_uuid'])
                 .inTable(CATALOG_SEARCH_TABLE)
                 .onDelete('CASCADE');
 
@@ -27,9 +30,10 @@ export async function up(knex: Knex): Promise<void> {
                 .foreign([
                     'target_metric_name',
                     'target_metric_table_name',
+                    'target_metric_type',
                     'project_uuid',
                 ])
-                .references(['name', 'table_name', 'project_uuid'])
+                .references(['name', 'table_name', 'type', 'project_uuid'])
                 .inTable(CATALOG_SEARCH_TABLE)
                 .onDelete('CASCADE');
 
@@ -37,12 +41,14 @@ export async function up(knex: Knex): Promise<void> {
             table.index([
                 'source_metric_name',
                 'source_metric_table_name',
+                'source_metric_type',
                 'project_uuid',
             ]);
 
             table.index([
                 'target_metric_name',
                 'target_metric_table_name',
+                'target_metric_type',
                 'project_uuid',
             ]);
 
@@ -50,8 +56,10 @@ export async function up(knex: Knex): Promise<void> {
             table.primary([
                 'source_metric_name',
                 'source_metric_table_name',
+                'source_metric_type',
                 'target_metric_name',
                 'target_metric_table_name',
+                'target_metric_type',
                 'project_uuid',
             ]);
 

--- a/packages/backend/src/database/migrations/20241203175631_fix-catalog-search-index.ts
+++ b/packages/backend/src/database/migrations/20241203175631_fix-catalog-search-index.ts
@@ -1,0 +1,112 @@
+import { Knex } from 'knex';
+
+const CATALOG_SEARCH_TABLE = 'catalog_search';
+const METRICS_TREE_EDGES_TABLE = 'metrics_tree_edges';
+
+export async function up(knex: Knex): Promise<void> {
+    const wrongCatalogSearchUniqueIndexExists = await knex.raw(`
+        SELECT 1
+        FROM pg_indexes
+        WHERE tablename = '${CATALOG_SEARCH_TABLE}'
+        AND indexname = 'catalog_search_table_name_name_project_uuid_unique'
+    `);
+
+    // Fixing the wrong index added in 20241129140659_add-table-name-to-catalog-search.ts
+    // The index was created without the type column, which is required as fields could have the same name but be different types
+    if (wrongCatalogSearchUniqueIndexExists.rows.length > 0) {
+        await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+            table.dropForeign([
+                'source_metric_name',
+                'source_metric_table_name',
+                'project_uuid',
+            ]);
+            table.dropForeign([
+                'target_metric_name',
+                'target_metric_table_name',
+                'project_uuid',
+            ]);
+            table.dropIndex([
+                'source_metric_name',
+                'source_metric_table_name',
+                'project_uuid',
+            ]);
+            table.dropIndex([
+                'target_metric_name',
+                'target_metric_table_name',
+                'project_uuid',
+            ]);
+            table.dropPrimary();
+        });
+
+        await knex.schema.alterTable(CATALOG_SEARCH_TABLE, (table) => {
+            table.dropUnique(['table_name', 'name', 'project_uuid']);
+            table.unique(['table_name', 'name', 'project_uuid', 'type']);
+        });
+
+        if (
+            !(await knex.schema.hasColumn(
+                METRICS_TREE_EDGES_TABLE,
+                'source_metric_type',
+            )) &&
+            !(await knex.schema.hasColumn(
+                METRICS_TREE_EDGES_TABLE,
+                'target_metric_type',
+            ))
+        ) {
+            await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+                table.string('source_metric_type').notNullable();
+                table.string('target_metric_type').notNullable();
+
+                table
+                    .foreign([
+                        'source_metric_name',
+                        'source_metric_table_name',
+                        'source_metric_type',
+                        'project_uuid',
+                    ])
+                    .references(['name', 'table_name', 'type', 'project_uuid'])
+                    .inTable(CATALOG_SEARCH_TABLE)
+                    .onDelete('CASCADE');
+
+                table
+                    .foreign([
+                        'target_metric_name',
+                        'target_metric_table_name',
+                        'target_metric_type',
+                        'project_uuid',
+                    ])
+                    .references(['name', 'table_name', 'type', 'project_uuid'])
+                    .inTable(CATALOG_SEARCH_TABLE)
+                    .onDelete('CASCADE');
+
+                table.index([
+                    'source_metric_name',
+                    'source_metric_table_name',
+                    'source_metric_type',
+                    'project_uuid',
+                ]);
+
+                table.index([
+                    'target_metric_name',
+                    'target_metric_table_name',
+                    'target_metric_type',
+                    'project_uuid',
+                ]);
+
+                table.primary([
+                    'source_metric_name',
+                    'source_metric_table_name',
+                    'source_metric_type',
+                    'target_metric_name',
+                    'target_metric_table_name',
+                    'target_metric_type',
+                    'project_uuid',
+                ]);
+            });
+        }
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // no-op
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- Fixes incorrect index created in https://github.com/lightdash/lightdash/pull/12639 because fields could have the same name as the table and therefore it would duplicate entries if type wasn't part of the index
- This has to be done via changing the old migration + adding a migration that only runs when the index is the incorrect one

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
