### PR TITLE
chore: metric tree nodes styles

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeConnectedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeConnectedNode.tsx
@@ -1,0 +1,64 @@
+import { friendlyName } from '@lightdash/common';
+import { Group, Stack, Text } from '@mantine/core';
+import { IconArrowUp, IconNumber } from '@tabler/icons-react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
+import React, { useMemo } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type MetricTreeConnectedNodeData = Node<{
+    label: string;
+}>;
+
+const MetricTreeConnectedNode: React.FC<
+    NodeProps<MetricTreeConnectedNodeData>
+> = ({ data }) => {
+    //TODO: fetch real data for these
+    const title = useMemo(() => friendlyName(data.label), [data.label]);
+    const value = useMemo(() => Math.floor(Math.random() * 1001), []);
+    const change = useMemo(() => Math.floor(Math.random() * 101) - 50, []);
+    const compareString = useMemo(() => 'Compared to previous month', []);
+
+    return (
+        <div
+            style={{
+                padding: '10px',
+                border: '1px solid #ddd',
+                borderRadius: '5px',
+                backgroundColor: '#fff',
+            }}
+        >
+            <Handle type="target" position={Position.Top} />
+            <Stack spacing="xxs" key={data.label}>
+                <Group>
+                    <Text size="sm" c="dimmed">
+                        {title}
+                    </Text>
+                    <MantineIcon icon={IconNumber} size={22} stroke={1.5} />
+                </Group>
+
+                <Group align="flex-end" mt="sm">
+                    <Text fz="md" fw={700}>
+                        {value}
+                    </Text>
+                    <Group spacing={1} c={change > 0 ? 'teal' : 'red'}>
+                        <Text fz="sm" fw={500}>
+                            <span>{change}%</span>
+                        </Text>
+                        <MantineIcon
+                            icon={IconArrowUp}
+                            size={16}
+                            stroke={1.5}
+                        />
+                    </Group>
+                </Group>
+
+                <Text fz="xs" c="dimmed">
+                    {compareString}
+                </Text>
+            </Stack>
+            <Handle type="source" position={Position.Bottom} />
+        </div>
+    );
+};
+
+export default MetricTreeConnectedNode;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeUnconnectedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeUnconnectedNode.tsx
@@ -1,0 +1,40 @@
+import { friendlyName } from '@lightdash/common';
+import { Group, Stack, Text } from '@mantine/core';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
+import React, { useMemo } from 'react';
+
+type MetricTreeUnconnectedNodeData = Node<{
+    label: string;
+}>;
+
+const MetricTreeUnconnectedNode: React.FC<
+    NodeProps<MetricTreeUnconnectedNodeData>
+> = ({ data }) => {
+    //TODO: fetch real data for these
+    const title = useMemo(() => friendlyName(data.label), [data.label]);
+
+    return (
+        <div
+            style={{
+                padding: '10px',
+                border: '1px solid #ddd',
+                borderRadius: '5px',
+                backgroundColor: '#fff',
+                width: '170px',
+                height: '38px',
+            }}
+        >
+            <Handle type="target" position={Position.Top} />
+            <Stack key={data.label}>
+                <Group>
+                    <Text size="xs" c="dimmed" truncate>
+                        {title}
+                    </Text>
+                </Group>
+            </Stack>
+            <Handle type="source" position={Position.Bottom} />
+        </div>
+    );
+};
+
+export default MetricTreeUnconnectedNode;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -78,8 +78,9 @@ const getNodeLayout = (nodes: Node[], edges: Edge[], _options?: {}) => {
     connectedNodes.forEach((node) =>
         treeGraph.setNode(node.id, {
             ...node,
-            width: node.measured?.width ?? 0,
-            height: node.measured?.height ?? 0,
+            // TODO: node sizes are hardcoded. We need to do more to have them be dynamic
+            width: 200,
+            height: 110,
         }),
     );
 
@@ -104,8 +105,9 @@ const getNodeLayout = (nodes: Node[], edges: Edge[], _options?: {}) => {
 
     // Draw the unconnected grid
     const free = freeNodes.map((node, index) => {
-        const nodeWidth = node?.measured?.width ?? 0;
-        const nodeHeight = node?.measured?.height ?? 0;
+        // TODO: node sizes are hardcoded. We need to do more to have them be dynamic
+        const nodeWidth = 170;
+        const nodeHeight = 38;
 
         // TODO: this is an arbitrary offset that looks ok with the
         // basic setup. Placement of the grid will probably need to be
@@ -273,17 +275,12 @@ const MetricTree: FC<Props> = ({ metrics, metricsTree }) => {
 
     // Fits the view when the layout is ready
     useEffect(() => {
-        if (nodesInitialized && layoutReady) {
+        if (layoutReady) {
             window.requestAnimationFrame(async () => {
-                // TODO: this second call to onLayout shouldnt be here,
-                // but it was one way I found to make sure layout happens
-                // after nodes are initialized. We could improve this.
-                onLayout();
-                setLayoutReady(false);
                 await fitView();
             });
         }
-    }, [layoutReady, fitView, nodesInitialized, onLayout]);
+    }, [layoutReady, fitView]);
 
     return (
         <Box h="100%">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

relates to: #12693 

### Description:

First round of styles for metric tree nodes. The numeric data is faked at the moment, but this sets up custom tree nodes.

<img width="1563" alt="Screenshot 2024-12-03 at 21 14 21" src="https://github.com/user-attachments/assets/e0df0725-55d5-41dc-b63a-4a91f2e061c3">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
