### PR TITLE
feat: tune date zoom when metric-exploring

### DIFF
--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -41,7 +41,7 @@ type ImpelemntedTimeframe =
 
 type UnimplementedTimeframe = Exclude<TimeFrames, ImpelemntedTimeframe>;
 
-const assertUnimplementedTimeframe = (
+export const assertUnimplementedTimeframe = (
     timeframe: UnimplementedTimeframe,
 ): never => {
     switch (timeframe) {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -141,7 +141,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
                     <Divider orientation="vertical" color="gray.2" />
                     <Stack spacing={0}>
                         <Box px="xs">
-                            {calendarConfig.type === TimeFrames.YEAR ? (
+                            {calendarConfig?.type === TimeFrames.YEAR ? (
                                 <YearPicker
                                     {...calendarConfig.props}
                                     mih={180}
@@ -173,7 +173,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
                                         },
                                     })}
                                 />
-                            ) : calendarConfig.type === TimeFrames.MONTH ? (
+                            ) : calendarConfig?.type === TimeFrames.MONTH ? (
                                 <MonthPicker
                                     {...calendarConfig.props}
                                     mih={180}
@@ -206,7 +206,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
                                 />
                             ) : (
                                 <DatePicker
-                                    {...calendarConfig.props}
+                                    {...calendarConfig?.props}
                                     mih={225}
                                     color="dark"
                                     size="xs"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -45,7 +45,6 @@ export const MetricPeekDatePicker: FC<Props> = ({
 }) => {
     const {
         isOpen,
-        selectedPreset,
         tempSelectedPreset,
         presets,
         buttonLabel,
@@ -60,11 +59,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
     return (
         <Popover opened={isOpen} onChange={handleOpen} position="bottom-start">
             <Popover.Target>
-                <Tooltip
-                    label={
-                        selectedPreset?.getTooltipLabel() ?? 'Select date range'
-                    }
-                >
+                <Tooltip label={'Select date range'}>
                     <Button
                         variant="default"
                         radius="md"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -1,4 +1,5 @@
 import {
+    TimeFrames,
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
@@ -14,9 +15,9 @@ import {
     Tooltip,
     UnstyledButton,
 } from '@mantine/core';
-import { DatePicker } from '@mantine/dates';
+import { DatePicker, MonthPicker, YearPicker } from '@mantine/dates';
 import { IconCalendar, IconChevronDown } from '@tabler/icons-react';
-import { type Dispatch, type FC, type SetStateAction } from 'react';
+import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useDateRangePicker } from '../hooks/useDateRangePicker';
 import { TimeDimensionIntervalPicker } from './visualization/TimeDimensionIntervalPicker';
@@ -26,9 +27,11 @@ type Props = {
     onChange: (dateRange: MetricExplorerDateRange) => void;
     showTimeDimensionIntervalPicker: boolean;
     timeDimensionBaseField: TimeDimensionConfig | undefined;
-    setTimeDimensionOverride: Dispatch<
-        SetStateAction<TimeDimensionConfig | undefined>
-    >;
+    setTimeDimensionOverride: (
+        timeDimensionOverride: TimeDimensionConfig | undefined,
+    ) => void;
+    timeInterval: TimeFrames;
+    onTimeIntervalChange: (timeInterval: TimeFrames) => void;
 };
 
 export const MetricPeekDatePicker: FC<Props> = ({
@@ -36,11 +39,12 @@ export const MetricPeekDatePicker: FC<Props> = ({
     onChange,
     showTimeDimensionIntervalPicker,
     timeDimensionBaseField,
+    timeInterval,
+    onTimeIntervalChange,
     setTimeDimensionOverride,
 }) => {
     const {
         isOpen,
-        tempDateRange,
         selectedPreset,
         tempSelectedPreset,
         presets,
@@ -49,9 +53,9 @@ export const MetricPeekDatePicker: FC<Props> = ({
         handleOpen,
         handleApply,
         handlePresetSelect,
-        handleDateRangeChange,
         reset,
-    } = useDateRangePicker({ value: dateRange, onChange });
+        calendarConfig,
+    } = useDateRangePicker({ value: dateRange, onChange, timeInterval });
 
     return (
         <Popover opened={isOpen} onChange={handleOpen} position="bottom-start">
@@ -93,6 +97,9 @@ export const MetricPeekDatePicker: FC<Props> = ({
                                     dimension={timeDimensionBaseField}
                                     onChange={(value) => {
                                         setTimeDimensionOverride(value);
+                                        onTimeIntervalChange(
+                                            value?.interval ?? timeInterval,
+                                        );
                                         reset();
                                     }}
                                 />
@@ -139,66 +146,172 @@ export const MetricPeekDatePicker: FC<Props> = ({
                     <Divider orientation="vertical" color="gray.2" />
                     <Stack spacing={0}>
                         <Box px="xs">
-                            <DatePicker
-                                mih={225}
-                                type="range"
-                                value={tempDateRange}
-                                onChange={handleDateRangeChange}
-                                numberOfColumns={2}
-                                color="dark"
-                                size="xs"
-                                withCellSpacing={false}
-                                styles={(theme) => ({
-                                    yearLevel: {
-                                        color: theme.colors.gray[7],
-                                        padding: theme.spacing.xs,
-                                    },
-                                    decadeLevel: {
-                                        color: theme.colors.gray[7],
-                                        padding: theme.spacing.xs,
-                                    },
-                                    calendarHeaderControlIcon: {
-                                        color: theme.colors.gray[5],
-                                    },
-                                    calendarHeaderLevel: {
-                                        color: theme.colors.gray[7],
-                                    },
-                                    monthLevel: {
-                                        padding: theme.spacing.xs,
-                                        '&[data-month-level]:not(:last-of-type)':
-                                            {
-                                                borderRight: `1px solid ${theme.colors.gray[2]}`,
-                                                marginRight: 0,
+                            {calendarConfig.type === TimeFrames.YEAR ? (
+                                <YearPicker
+                                    {...calendarConfig.props}
+                                    mih={180}
+                                    w="100%"
+                                    color="dark"
+                                    size="xs"
+                                    styles={(theme) => ({
+                                        yearsList: {
+                                            padding: theme.spacing.xs,
+                                        },
+                                        yearsListCell: {
+                                            '&[data-selected]': {
+                                                backgroundColor:
+                                                    theme.colors.dark[7],
+                                                borderRadius: theme.radius.lg,
                                             },
-                                    },
-                                    day: {
-                                        borderRadius: theme.radius.lg,
-                                        // Revert color for weekends that are not selected
-                                        '&[data-weekend="true"]&:not([data-selected])':
-                                            {
-                                                color: theme.colors.gray[7],
+                                            '&[data-selected]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.dark[9],
                                             },
-                                        '&[data-in-range]': {
-                                            backgroundColor:
-                                                theme.colors.gray[1],
+                                            '&[data-in-range]': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-in-range]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
                                         },
-                                        '&[data-in-range]:hover': {
-                                            backgroundColor:
-                                                theme.colors.gray[1],
+                                    })}
+                                />
+                            ) : calendarConfig.type === TimeFrames.MONTH ? (
+                                <MonthPicker
+                                    {...calendarConfig.props}
+                                    mih={180}
+                                    color="dark"
+                                    size="xs"
+                                    styles={(theme) => ({
+                                        monthsList: {
+                                            padding: theme.spacing.xs,
                                         },
-                                        '&[data-selected]': {
-                                            backgroundColor:
-                                                theme.colors.dark[7],
+                                        monthsListCell: {
+                                            '&[data-selected]': {
+                                                backgroundColor:
+                                                    theme.colors.dark[7],
+                                                borderRadius: theme.radius.lg,
+                                            },
+                                            '&[data-selected]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.dark[9],
+                                            },
+                                            '&[data-in-range]': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-in-range]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                        },
+                                    })}
+                                />
+                            ) : (
+                                <DatePicker
+                                    {...calendarConfig.props}
+                                    mih={225}
+                                    color="dark"
+                                    size="xs"
+                                    withCellSpacing={false}
+                                    styles={(theme) => ({
+                                        yearLevel: {
+                                            color: theme.colors.gray[7],
+                                            padding: theme.spacing.xs,
+                                        },
+                                        decadeLevel: {
+                                            color: theme.colors.gray[7],
+                                            padding: theme.spacing.xs,
+                                        },
+                                        calendarHeaderControlIcon: {
+                                            color: theme.colors.gray[5],
+                                        },
+                                        calendarHeaderLevel: {
+                                            color: theme.colors.gray[7],
+                                        },
+                                        monthLevel: {
+                                            padding: theme.spacing.xs,
+                                            '&[data-month-level]:not(:last-of-type)':
+                                                {
+                                                    borderRight: `1px solid ${theme.colors.gray[2]}`,
+                                                    marginRight: 0,
+                                                },
+                                        },
+                                        day: {
                                             borderRadius: theme.radius.lg,
+                                            // Revert color for weekends that are not selected
+                                            '&[data-weekend="true"]&:not([data-selected])':
+                                                {
+                                                    color: theme.colors.gray[7],
+                                                },
+                                            '&[data-in-range]': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-in-range]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-selected]': {
+                                                backgroundColor:
+                                                    theme.colors.dark[7],
+                                                borderRadius: theme.radius.lg,
+                                            },
+                                            '&[data-selected]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.dark[9],
+                                                borderRadius: theme.radius.lg,
+                                            },
                                         },
-                                        '&[data-selected]:hover': {
-                                            backgroundColor:
-                                                theme.colors.dark[9],
-                                            borderRadius: theme.radius.lg,
+                                        monthsList: {
+                                            padding: theme.spacing.xs,
                                         },
-                                    },
-                                })}
-                            />
+                                        monthsListCell: {
+                                            '&[data-selected]': {
+                                                backgroundColor:
+                                                    theme.colors.dark[7],
+                                                borderRadius: theme.radius.lg,
+                                            },
+                                            '&[data-selected]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.dark[9],
+                                            },
+                                            '&[data-in-range]': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-in-range]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                        },
+                                        yearsList: {
+                                            padding: theme.spacing.xs,
+                                        },
+                                        yearsListCell: {
+                                            '&[data-selected]': {
+                                                backgroundColor:
+                                                    theme.colors.dark[7],
+                                                borderRadius: theme.radius.lg,
+                                            },
+                                            '&[data-selected]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.dark[9],
+                                            },
+                                            '&[data-in-range]': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                            '&[data-in-range]:hover': {
+                                                backgroundColor:
+                                                    theme.colors.gray[1],
+                                            },
+                                        },
+                                    })}
+                                />
+                            )}
                         </Box>
                         <Divider color="gray.2" />
                         <Box p="sm">

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -6,6 +6,7 @@ import {
     type MetricExplorerComparisonType,
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
+    type TimeFrames,
 } from '@lightdash/common';
 import {
     Box,
@@ -165,14 +166,10 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         onClose();
     }, [history, onClose, projectUuid]);
 
-    const handleTimeIntervalChange = useCallback(() => {
-        if (!timeDimensionOverride?.interval) return;
-        // if the time dimension override is different from the time dimension base field,
-        // we need to reset the date range to the default range for the new interval
-        setDateRange(
-            getDefaultDateRangeFromInterval(timeDimensionOverride.interval),
-        );
-    }, [timeDimensionOverride?.interval]);
+    const handleTimeIntervalChange = useCallback((timeInterval: TimeFrames) => {
+        // Always reset the date range to the default range for the new interval
+        setDateRange(getDefaultDateRangeFromInterval(timeInterval));
+    }, []);
 
     return (
         <Modal.Root

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
@@ -1,11 +1,11 @@
 import { TimeFrames, type TimeDimensionConfig } from '@lightdash/common';
 import { Select, useMantineTheme } from '@mantine/core';
-import { type Dispatch, type FC, type SetStateAction } from 'react';
+import { type FC } from 'react';
 import { usePillSelectStyles } from '../../../../components/DataViz/hooks/usePillSelectStyles';
 
 type Props = {
     dimension: TimeDimensionConfig;
-    onChange: Dispatch<SetStateAction<TimeDimensionConfig | undefined>>;
+    onChange: (timeDimensionOverride: TimeDimensionConfig) => void;
 };
 
 export const TimeDimensionIntervalPicker: FC<Props> = ({
@@ -43,11 +43,11 @@ export const TimeDimensionIntervalPicker: FC<Props> = ({
             }}
             onChange={(value: TimeFrames) => {
                 if (!value) return;
-                onChange((prev) => ({
+                onChange({
                     interval: value,
-                    field: prev?.field ?? dimension.field,
+                    field: dimension.field,
                     table: dimension.table,
-                }));
+                });
             }}
             withinPortal
             classNames={{

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -1,8 +1,15 @@
 import {
+    TimeFrames,
     type MetricExplorerDateRange,
     type MetricExplorerPartialDateRange,
 } from '@lightdash/common';
-import { useEffect, useMemo, useState } from 'react';
+import {
+    type DatePickerProps,
+    type MonthPickerProps,
+    type YearPickerProps,
+} from '@mantine/dates';
+import dayjs from 'dayjs';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatDate, getDateRangePresets } from '../utils/metricPeekDate';
 
 type DateRange = MetricExplorerPartialDateRange;
@@ -16,7 +23,39 @@ export interface DateRangePreset {
 interface UseDateRangePickerProps {
     value: MetricExplorerDateRange;
     onChange?: (range: MetricExplorerDateRange) => void;
+    timeInterval: TimeFrames;
 }
+
+type BaseCalendarProps = {
+    value: DateRange;
+    onChange: (dates: DateRange) => void;
+};
+
+type DayPickerConfig = {
+    type: TimeFrames.DAY;
+    props: BaseCalendarProps & Omit<DatePickerProps, 'value' | 'onChange'>;
+};
+
+type WeekPickerConfig = {
+    type: TimeFrames.WEEK;
+    props: BaseCalendarProps & Omit<DatePickerProps, 'value' | 'onChange'>;
+};
+
+type MonthPickerConfig = {
+    type: TimeFrames.MONTH;
+    props: BaseCalendarProps & Omit<MonthPickerProps, 'value' | 'onChange'>;
+};
+
+type YearPickerConfig = {
+    type: TimeFrames.YEAR;
+    props: BaseCalendarProps & Omit<YearPickerProps, 'value' | 'onChange'>;
+};
+
+type CalendarVisualizationType =
+    | DayPickerConfig
+    | WeekPickerConfig
+    | MonthPickerConfig
+    | YearPickerConfig;
 
 /**
  * Hook to handle the date range picker for the metric peek
@@ -27,8 +66,10 @@ interface UseDateRangePickerProps {
 export const useDateRangePicker = ({
     value,
     onChange,
+    timeInterval,
 }: UseDateRangePickerProps) => {
-    const presets = getDateRangePresets();
+    const presets = getDateRangePresets(timeInterval);
+
     const [isOpen, setIsOpen] = useState(false);
 
     const [dateRange, setDateRange] = useState<DateRange>(value);
@@ -40,17 +81,24 @@ export const useDateRangePicker = ({
     const [tempSelectedPreset, setTempSelectedPreset] =
         useState<DateRangePreset | null>(null);
 
+    const [initialWeek, setInitialWeek] = useState<Date | null>(null);
+
     useEffect(() => {
         setDateRange(value);
-    }, [value]);
+        onChange?.(value);
+    }, [value, onChange]);
 
-    const buttonLabel =
-        selectedPreset?.label ||
-        (dateRange[0]
-            ? dateRange[1]
+    const buttonLabel = useMemo(() => {
+        if (selectedPreset) {
+            return selectedPreset.label;
+        }
+        if (dateRange[0]) {
+            return dateRange[1]
                 ? `${formatDate(dateRange[0])} - ${formatDate(dateRange[1])}`
-                : formatDate(dateRange[0])
-            : 'Select date range');
+                : formatDate(dateRange[0]);
+        }
+        return 'Select date range';
+    }, [selectedPreset, dateRange]);
 
     const formattedTempDateRange = useMemo(() => {
         return [formatDate(tempDateRange[0]), formatDate(tempDateRange[1])];
@@ -67,6 +115,10 @@ export const useDateRangePicker = ({
     const handleApply = () => {
         setDateRange(tempDateRange);
         setSelectedPreset(tempSelectedPreset);
+
+        // Reset initialWeek when applying a new date range - this is used for week range selection
+        setInitialWeek(null);
+
         if (onChange && tempDateRange[0] && tempDateRange[1]) {
             onChange([tempDateRange[0], tempDateRange[1]]);
         }
@@ -79,15 +131,163 @@ export const useDateRangePicker = ({
         setTempSelectedPreset(preset);
     };
 
-    const handleDateRangeChange = (newRange: DateRange) => {
+    const handleDateRangeChange = useCallback((newRange: DateRange) => {
+        if (!Array.isArray(newRange)) {
+            return;
+        }
         setTempDateRange(newRange);
         setTempSelectedPreset(null);
-    };
+    }, []);
 
     const reset = () => {
         setDateRange(value);
         setSelectedPreset(null);
     };
+
+    const calendarConfig: CalendarVisualizationType = useMemo(() => {
+        switch (timeInterval) {
+            case TimeFrames.YEAR:
+                return {
+                    type: TimeFrames.YEAR,
+                    props: {
+                        type: 'range',
+                        value: tempDateRange,
+                        onChange: (dates) => {
+                            if (!Array.isArray(dates)) return;
+                            const startDate = dates[0]
+                                ? dayjs(dates[0]).startOf('year').toDate()
+                                : null;
+                            const endDate = dates[1]
+                                ? dayjs(dates[1]).endOf('year').toDate()
+                                : null;
+                            handleDateRangeChange([startDate, endDate]);
+                        },
+                        numberOfColumns: 2,
+                    },
+                } satisfies YearPickerConfig;
+            case TimeFrames.MONTH:
+                return {
+                    type: TimeFrames.MONTH,
+                    props: {
+                        type: 'range',
+                        value: tempDateRange,
+                        onChange: (dates) => {
+                            if (!Array.isArray(dates)) return;
+                            const startDate = dates[0]
+                                ? dayjs(dates[0]).startOf('month').toDate()
+                                : null;
+                            const endDate = dates[1]
+                                ? dayjs(dates[1]).endOf('month').toDate()
+                                : null;
+                            console.log('startDate', startDate);
+                            console.log('endDate', endDate);
+                            handleDateRangeChange([startDate, endDate]);
+                        },
+                        numberOfColumns: 2,
+                    },
+                } satisfies MonthPickerConfig;
+            case TimeFrames.WEEK:
+                return {
+                    type: TimeFrames.WEEK,
+                    props: {
+                        type: 'range',
+                        value: tempDateRange,
+                        onChange: (dates) => {
+                            if (!Array.isArray(dates)) return;
+
+                            const getWeekBoundaries = (date: Date) => {
+                                const weekStart = dayjs(date)
+                                    .startOf('week')
+                                    .toDate();
+                                const weekEnd = dayjs(date)
+                                    .endOf('week')
+                                    .toDate();
+                                return { weekStart, weekEnd };
+                            };
+
+                            // If we're starting a new selection and already had a complete range
+                            if (
+                                dates[0] &&
+                                !dates[1] &&
+                                tempDateRange[0] &&
+                                tempDateRange[1]
+                            ) {
+                                setInitialWeek(null); // Clear initialWeek when starting a new selection
+                            }
+
+                            // Start of a new range selection
+                            if (dates[0] && !dates[1]) {
+                                const { weekStart, weekEnd } =
+                                    getWeekBoundaries(dates[0]);
+                                if (!initialWeek) {
+                                    // Store the start of the week to use as the initial week so we can use it for the next selection
+                                    setInitialWeek(weekStart);
+                                    handleDateRangeChange([weekStart, weekEnd]);
+                                } else {
+                                    handleDateRangeChange([
+                                        initialWeek,
+                                        weekEnd,
+                                    ]);
+                                }
+                            }
+                            // Complete range selection
+                            else if (dates[0] && dates[1]) {
+                                const endWeek = getWeekBoundaries(dates[1]);
+                                if (initialWeek) {
+                                    handleDateRangeChange([
+                                        initialWeek,
+                                        endWeek.weekEnd,
+                                    ]);
+                                } else {
+                                    const startWeek = getWeekBoundaries(
+                                        dates[0],
+                                    );
+                                    handleDateRangeChange([
+                                        startWeek.weekStart,
+                                        endWeek.weekEnd,
+                                    ]);
+                                }
+                            }
+                        },
+                        numberOfColumns: 2,
+                        firstDayOfWeek: 0,
+                        hideOutsideDates: true,
+                        // Highlight the week of the selected date
+                        getDayProps: (date) => {
+                            const isSelected = Boolean(
+                                tempDateRange[0] &&
+                                    tempDateRange[1] &&
+                                    date >=
+                                        dayjs(tempDateRange[0])
+                                            .startOf('week')
+                                            .toDate() &&
+                                    date <=
+                                        dayjs(tempDateRange[1])
+                                            .endOf('week')
+                                            .toDate(),
+                            );
+                            return {
+                                selected: isSelected,
+                                inRange: isSelected,
+                                firstInRange: date.getDay() === 0 && isSelected, // Highlight the first day of the week
+                                lastInRange: date.getDay() === 6 && isSelected, // Highlight the last day of the week
+                            };
+                        },
+                    },
+                } satisfies WeekPickerConfig;
+            case TimeFrames.DAY:
+            default:
+                return {
+                    type: TimeFrames.DAY,
+                    props: {
+                        type: 'range',
+                        value: tempDateRange,
+                        onChange: handleDateRangeChange,
+                        numberOfColumns: 2,
+                    },
+                } satisfies DayPickerConfig;
+        }
+    }, [timeInterval, tempDateRange, handleDateRangeChange, initialWeek]);
 
     return {
         isOpen,
@@ -101,6 +301,7 @@ export const useDateRangePicker = ({
         handleApply,
         handlePresetSelect,
         handleDateRangeChange,
+        calendarConfig,
         reset,
     };
 };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -1,4 +1,5 @@
 import {
+    assertUnimplementedTimeframe,
     TimeFrames,
     type MetricExplorerDateRange,
     type MetricExplorerPartialDateRange,
@@ -54,7 +55,8 @@ type CalendarVisualizationType =
     | DayPickerConfig
     | WeekPickerConfig
     | MonthPickerConfig
-    | YearPickerConfig;
+    | YearPickerConfig
+    | undefined;
 
 /**
  * Hook to handle the date range picker for the metric peek
@@ -274,7 +276,6 @@ export const useDateRangePicker = ({
                     },
                 } satisfies WeekPickerConfig;
             case TimeFrames.DAY:
-            default:
                 return {
                     type: TimeFrames.DAY,
                     props: {
@@ -284,6 +285,8 @@ export const useDateRangePicker = ({
                         numberOfColumns: 2,
                     },
                 } satisfies DayPickerConfig;
+            default:
+                assertUnimplementedTimeframe(timeInterval);
         }
     }, [timeInterval, tempDateRange, handleDateRangeChange, initialWeek]);
 

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -179,8 +179,7 @@ export const useDateRangePicker = ({
                             const endDate = dates[1]
                                 ? dayjs(dates[1]).endOf('month').toDate()
                                 : null;
-                            console.log('startDate', startDate);
-                            console.log('endDate', endDate);
+
                             handleDateRangeChange([startDate, endDate]);
                         },
                         numberOfColumns: 2,

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -17,7 +17,6 @@ type DateRange = MetricExplorerPartialDateRange;
 export interface DateRangePreset {
     label: string;
     getValue: () => DateRange;
-    getTooltipLabel: () => string;
 }
 
 interface UseDateRangePickerProps {

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -137,12 +137,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 1 week',
                     getValue: () => [
-                        today.subtract(1, 'week').toDate(),
+                        today.subtract(1, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(1, 'week')
+                            .startOf('week')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -150,12 +151,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 4 weeks',
                     getValue: () => [
-                        today.subtract(4, 'week').toDate(),
+                        today.subtract(4, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(4, 'week')
+                            .startOf('week')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -163,12 +165,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 3 months',
                     getValue: () => [
-                        today.subtract(12, 'week').toDate(),
+                        today.subtract(12, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(12, 'week')
+                            .startOf('week')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -176,12 +179,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 12 months',
                     getValue: () => [
-                        today.subtract(12, 'month').toDate(),
+                        today.subtract(12, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(12, 'month')
+                            .startOf('month')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -189,12 +193,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 5 years',
                     getValue: () => [
-                        today.subtract(5, 'year').toDate(),
+                        today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(5, 'year')
+                            .startOf('year')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -33,10 +33,6 @@ export const getDateRangePresets = (
                 {
                     label: 'Today',
                     getValue: () => [today.toDate(), now.toDate()],
-                    getTooltipLabel: () =>
-                        `${today.format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 7 days',
@@ -44,12 +40,6 @@ export const getDateRangePresets = (
                         today.subtract(7, 'day').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(7, 'day')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 30 days',
@@ -57,12 +47,6 @@ export const getDateRangePresets = (
                         today.subtract(30, 'day').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(30, 'day')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 3 months',
@@ -70,12 +54,6 @@ export const getDateRangePresets = (
                         today.subtract(12, 'week').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(12, 'week')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 12 months',
@@ -83,12 +61,6 @@ export const getDateRangePresets = (
                         today.subtract(12, 'month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(12, 'month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 5 years',
@@ -96,17 +68,10 @@ export const getDateRangePresets = (
                         today.subtract(5, 'year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(5, 'year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'All time',
                     getValue: () => [null, null],
-                    getTooltipLabel: () => 'No filter',
                 },
             ];
 
@@ -127,12 +92,6 @@ export const getDateRangePresets = (
                         today.startOf('week').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .startOf('week')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 1 week',
@@ -140,13 +99,6 @@ export const getDateRangePresets = (
                         today.subtract(1, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(1, 'week')
-                            .startOf('week')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 4 weeks',
@@ -154,13 +106,6 @@ export const getDateRangePresets = (
                         today.subtract(4, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(4, 'week')
-                            .startOf('week')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 3 months',
@@ -168,13 +113,6 @@ export const getDateRangePresets = (
                         today.subtract(12, 'week').startOf('week').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(12, 'week')
-                            .startOf('week')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 12 months',
@@ -182,13 +120,6 @@ export const getDateRangePresets = (
                         today.subtract(12, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(12, 'month')
-                            .startOf('month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 5 years',
@@ -196,18 +127,10 @@ export const getDateRangePresets = (
                         today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(5, 'year')
-                            .startOf('year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'All time',
                     getValue: () => [null, null],
-                    getTooltipLabel: () => 'No filter',
                 },
             ];
 
@@ -227,12 +150,6 @@ export const getDateRangePresets = (
                         today.startOf('month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .startOf('month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 3 months',
@@ -240,13 +157,6 @@ export const getDateRangePresets = (
                         today.subtract(3, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(3, 'month')
-                            .startOf('month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 6 months',
@@ -254,13 +164,6 @@ export const getDateRangePresets = (
                         today.subtract(6, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(6, 'month')
-                            .startOf('month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 12 months',
@@ -268,13 +171,6 @@ export const getDateRangePresets = (
                         today.subtract(12, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(12, 'month')
-                            .startOf('month')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 5 years',
@@ -282,18 +178,10 @@ export const getDateRangePresets = (
                         today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(5, 'year')
-                            .startOf('year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'All time',
                     getValue: () => [null, null],
-                    getTooltipLabel: () => 'No filter',
                 },
             ];
 
@@ -311,12 +199,6 @@ export const getDateRangePresets = (
                         today.startOf('year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .startOf('year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 1 year',
@@ -324,13 +206,6 @@ export const getDateRangePresets = (
                         today.subtract(1, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(1, 'year')
-                            .startOf('year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'Past 5 years',
@@ -338,18 +213,10 @@ export const getDateRangePresets = (
                         today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
-                    getTooltipLabel: () =>
-                        `${today
-                            .subtract(5, 'year')
-                            .startOf('year')
-                            .format('MMM D, YYYY')} - ${now.format(
-                            'MMM D, YYYY',
-                        )}`,
                 },
                 {
                     label: 'All time',
                     getValue: () => [null, null],
-                    getTooltipLabel: () => 'No filter',
                 },
             ];
 

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -1,3 +1,4 @@
+import { assertUnimplementedTimeframe, TimeFrames } from '@lightdash/common';
 import dayjs from 'dayjs';
 import { type DateRangePreset } from '../hooks/useDateRangePicker';
 
@@ -8,76 +9,340 @@ export const formatDate = (date: Date | null): string | undefined => {
 
 /**
  * Get the date range presets for the metric peek date picker
- * Preset	What does it mean?
- * Today - 00:00 until present time |
- * Past 7 days - 7 full days + this unfinished day |
- * Past 30 days - 30 full days + this unfinished day |
- * Past 3 months - 12 full weeks + this unfinished week |
- * Past 12 months - 12 full months + this unfinished month |
- * Past 5 years - 5 full years + this unfinished year |
- * All time / empty state - No filter |
+ * @param timeInterval - The timeframe for which to get the date range presets
  * @returns The date range presets
  */
-export const getDateRangePresets = (): DateRangePreset[] => {
+export const getDateRangePresets = (
+    timeInterval: TimeFrames,
+): DateRangePreset[] => {
     const now = dayjs();
     const today = now.startOf('day');
 
-    const presets: DateRangePreset[] = [
-        {
-            label: 'Today',
-            getValue: () => [today.toDate(), now.toDate()],
-            getTooltipLabel: () =>
-                `${today.format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'Past 7 days',
-            getValue: () => [today.subtract(7, 'day').toDate(), now.toDate()],
-            getTooltipLabel: () =>
-                `${today
-                    .subtract(7, 'day')
-                    .format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'Past 30 days',
-            getValue: () => [today.subtract(30, 'day').toDate(), now.toDate()],
-            getTooltipLabel: () =>
-                `${today
-                    .subtract(30, 'day')
-                    .format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'Past 3 months',
-            getValue: () => [today.subtract(12, 'week').toDate(), now.toDate()],
-            getTooltipLabel: () =>
-                `${today
-                    .subtract(12, 'week')
-                    .format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'Past 12 months',
-            getValue: () => [
-                today.subtract(12, 'month').toDate(),
-                now.toDate(),
-            ],
-            getTooltipLabel: () =>
-                `${today
-                    .subtract(12, 'month')
-                    .format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'Past 5 years',
-            getValue: () => [today.subtract(5, 'year').toDate(), now.toDate()],
-            getTooltipLabel: () =>
-                `${today
-                    .subtract(5, 'year')
-                    .format('MMM D, YYYY')} - ${now.format('MMM D, YYYY')}`,
-        },
-        {
-            label: 'All time',
-            getValue: () => [null, null],
-            getTooltipLabel: () => 'No filter',
-        },
-    ];
+    switch (timeInterval) {
+        // Timeframe: Day
+        // Presets include:
+        // - Today: From 00:00 until the current time
+        // - Past 7 days: 7 full days plus the current day
+        // - Past 30 days: 30 full days plus the current day
+        // - Past 3 months: 12 full weeks plus the current week
+        // - Past 12 months: 12 full months plus the current month
+        // - Past 5 years: 5 full years plus the current year
+        // - All time: No filter applied
+        case TimeFrames.DAY:
+            return [
+                {
+                    label: 'Today',
+                    getValue: () => [today.toDate(), now.toDate()],
+                    getTooltipLabel: () =>
+                        `${today.format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 7 days',
+                    getValue: () => [
+                        today.subtract(7, 'day').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(7, 'day')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 30 days',
+                    getValue: () => [
+                        today.subtract(30, 'day').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(30, 'day')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 3 months',
+                    getValue: () => [
+                        today.subtract(12, 'week').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(12, 'week')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 12 months',
+                    getValue: () => [
+                        today.subtract(12, 'month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(12, 'month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 5 years',
+                    getValue: () => [
+                        today.subtract(5, 'year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(5, 'year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'All time',
+                    getValue: () => [null, null],
+                    getTooltipLabel: () => 'No filter',
+                },
+            ];
 
-    return presets;
+        // Timeframe: Week
+        // Presets include:
+        // - This week: From the start of the current week until now
+        // - Past 1 week: 1 full week plus the current week
+        // - Past 4 weeks: 4 full weeks plus the current week
+        // - Past 3 months: 12 full weeks plus the current week
+        // - Past 12 months: 12 full months plus the current month
+        // - Past 5 years: 5 full years plus the current year
+        // - All time: No filter applied
+        case TimeFrames.WEEK:
+            return [
+                {
+                    label: 'This week',
+                    getValue: () => [
+                        today.startOf('week').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .startOf('week')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 1 week',
+                    getValue: () => [
+                        today.subtract(1, 'week').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(1, 'week')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 4 weeks',
+                    getValue: () => [
+                        today.subtract(4, 'week').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(4, 'week')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 3 months',
+                    getValue: () => [
+                        today.subtract(12, 'week').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(12, 'week')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 12 months',
+                    getValue: () => [
+                        today.subtract(12, 'month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(12, 'month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 5 years',
+                    getValue: () => [
+                        today.subtract(5, 'year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(5, 'year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'All time',
+                    getValue: () => [null, null],
+                    getTooltipLabel: () => 'No filter',
+                },
+            ];
+
+        // Timeframe: Month
+        // Presets include:
+        // - This month: From the start of the current month until now
+        // - Past 3 months: 3 full months plus the current month
+        // - Past 6 months: 6 full months plus the current month
+        // - Past 12 months: 12 full months plus the current month
+        // - Past 5 years: 5 full years plus the current year
+        // - All time: No filter applied
+        case TimeFrames.MONTH:
+            return [
+                {
+                    label: 'This month',
+                    getValue: () => [
+                        today.startOf('month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .startOf('month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 3 months',
+                    getValue: () => [
+                        today.subtract(3, 'month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(3, 'month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 6 months',
+                    getValue: () => [
+                        today.subtract(6, 'month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(6, 'month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 12 months',
+                    getValue: () => [
+                        today.subtract(12, 'month').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(12, 'month')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 5 years',
+                    getValue: () => [
+                        today.subtract(5, 'year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(5, 'year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'All time',
+                    getValue: () => [null, null],
+                    getTooltipLabel: () => 'No filter',
+                },
+            ];
+
+        // Timeframe: Year
+        // Presets include:
+        // - This year: From the start of the current year until now
+        // - Past 1 year: 1 full year plus the current year
+        // - Past 5 years: 5 full years plus the current year
+        // - All time: No filter applied
+        case TimeFrames.YEAR:
+            return [
+                {
+                    label: 'This year',
+                    getValue: () => [
+                        today.startOf('year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .startOf('year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 1 year',
+                    getValue: () => [
+                        today.subtract(1, 'year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(1, 'year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'Past 5 years',
+                    getValue: () => [
+                        today.subtract(5, 'year').toDate(),
+                        now.toDate(),
+                    ],
+                    getTooltipLabel: () =>
+                        `${today
+                            .subtract(5, 'year')
+                            .format('MMM D, YYYY')} - ${now.format(
+                            'MMM D, YYYY',
+                        )}`,
+                },
+                {
+                    label: 'All time',
+                    getValue: () => [null, null],
+                    getTooltipLabel: () => 'No filter',
+                },
+            ];
+
+        default:
+            return assertUnimplementedTimeframe(timeInterval);
+    }
 };

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -232,12 +232,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 3 months',
                     getValue: () => [
-                        today.subtract(3, 'month').toDate(),
+                        today.subtract(3, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(3, 'month')
+                            .startOf('month')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -245,12 +246,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 6 months',
                     getValue: () => [
-                        today.subtract(6, 'month').toDate(),
+                        today.subtract(6, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(6, 'month')
+                            .startOf('month')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -258,12 +260,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 12 months',
                     getValue: () => [
-                        today.subtract(12, 'month').toDate(),
+                        today.subtract(12, 'month').startOf('month').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(12, 'month')
+                            .startOf('month')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -271,12 +274,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 5 years',
                     getValue: () => [
-                        today.subtract(5, 'year').toDate(),
+                        today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(5, 'year')
+                            .startOf('year')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -312,12 +316,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 1 year',
                     getValue: () => [
-                        today.subtract(1, 'year').toDate(),
+                        today.subtract(1, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(1, 'year')
+                            .startOf('year')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,
@@ -325,12 +330,13 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 5 years',
                     getValue: () => [
-                        today.subtract(5, 'year').toDate(),
+                        today.subtract(5, 'year').startOf('year').toDate(),
                         now.toDate(),
                     ],
                     getTooltipLabel: () =>
                         `${today
                             .subtract(5, 'year')
+                            .startOf('year')
                             .format('MMM D, YYYY')} - ${now.format(
                             'MMM D, YYYY',
                         )}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12659](https://github.com/lightdash/lightdash/issues/12659)

### Description:

> [!IMPORTANT]
> See Miro attached to ticket on all the rules

 This PR:
- adds presets per each time frame/interval
- adds week-range picker
- has different pickers depending on the interval chosen



DAY


https://github.com/user-attachments/assets/b668f828-093f-4305-8c59-a3f54dc88b74



MONTH


https://github.com/user-attachments/assets/d85177ce-b6e5-40a0-915c-244deb1cca55



YEAR


https://github.com/user-attachments/assets/aeaabde2-e686-402e-a332-9f7ff02053b6



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
