### PR TITLE
fix: only enable metric query on click of explore

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -16,21 +16,20 @@ type Props = {
 };
 
 export const ExploreMetricButton = ({ row }: Props) => {
-    const [exploreUrl, setExploreUrl] = useState<string>();
-    const [shouldOpenInNewTab, setShouldOpenInNewTab] = useState(false);
+    const [shouldFetch, setShouldFetch] = useState(false);
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
     const organizationUuid = useAppSelector(
         (state) => state.metricsCatalog.organizationUuid,
     );
-    const [currentTableName, setCurrentTableName] = useState<string>();
     const { track } = useTracking();
 
     const metricQuery = useMetric({
         projectUuid,
         tableName: row.original.tableName,
         metricName: row.original.name,
+        enabled: shouldFetch,
     });
 
     useEffect(() => {
@@ -48,21 +47,10 @@ export const ExploreMetricButton = ({ row }: Props) => {
         const url = new URL(pathname, window.location.origin);
         url.search = new URLSearchParams(search).toString();
 
-        setExploreUrl(url.href);
-    }, [
-        currentTableName,
-        metricQuery.data,
-        metricQuery.isSuccess,
-        projectUuid,
-        row.original,
-    ]);
+        window.open(url.href, '_blank');
 
-    useEffect(() => {
-        if (shouldOpenInNewTab && exploreUrl) {
-            window.open(exploreUrl, '_blank');
-            setShouldOpenInNewTab(false);
-        }
-    }, [exploreUrl, shouldOpenInNewTab]);
+        setShouldFetch(false); // Reset the fetch trigger
+    }, [metricQuery.data, metricQuery.isSuccess, projectUuid]);
 
     const handleExploreClick = useCallback(() => {
         track({
@@ -75,14 +63,9 @@ export const ExploreMetricButton = ({ row }: Props) => {
             },
         });
 
-        if (exploreUrl) {
-            window.open(exploreUrl, '_blank');
-        } else {
-            setShouldOpenInNewTab(true);
-            setCurrentTableName(row.original.tableName);
-        }
+        // Trigger the fetch
+        setShouldFetch(true);
     }, [
-        exploreUrl,
         organizationUuid,
         projectUuid,
         row.original.name,

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -127,7 +127,7 @@ export const useMetric = ({
     tableName,
     metricName,
     enabled = true,
-}: UseMetricOptions & { enabled: boolean }) => {
+}: UseMetricOptions & { enabled?: boolean }) => {
     return useQuery<ApiGetMetricPeek['results'], ApiError>({
         queryKey: ['metric', projectUuid, tableName, metricName],
         queryFn: () =>

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -126,7 +126,8 @@ export const useMetric = ({
     projectUuid,
     tableName,
     metricName,
-}: UseMetricOptions) => {
+    enabled = true,
+}: UseMetricOptions & { enabled: boolean }) => {
     return useQuery<ApiGetMetricPeek['results'], ApiError>({
         queryKey: ['metric', projectUuid, tableName, metricName],
         queryFn: () =>
@@ -135,6 +136,6 @@ export const useMetric = ({
                 tableName: tableName!,
                 metricName: metricName!,
             }),
-        enabled: !!projectUuid && !!tableName && !!metricName,
+        enabled: enabled && !!projectUuid && !!tableName && !!metricName,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Only enable query on click of explore:
<img width="517" alt="Screenshot 2024-12-05 at 09 49 56" src="https://github.com/user-attachments/assets/a02d1280-93e4-46ce-8821-09f383547ce4">

currently, all metrics present on the catalog will trigger api requests. this is unnecessary.
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/2743b4f4-7fc1-4ea5-94ef-592b223372f2">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
