### PR TITLE
fix: stringify BigInt in scheduler worker

### DIFF
--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -110,6 +110,11 @@ export default class SchedulerApp {
 
     public async start() {
         this.prometheusMetrics.start();
+        // @ts-ignore
+        // eslint-disable-next-line no-extend-native, func-names
+        BigInt.prototype.toJSON = function () {
+            return this.toString();
+        };
         await this.initSentry();
         const worker = await this.initWorker();
         this.prometheusMetrics.monitorQueues(this.clients.getSchedulerClient());


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12735](https://github.com/lightdash/lightdash/issues/12735) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Apply the same BigInt.toJson() method we have in App.ts to SchedulerApp.ts. 

Before:
<img width="1002" alt="Screenshot 2024-12-05 at 12 39 03" src="https://github.com/user-attachments/assets/343cae91-6027-4580-bcaf-29d011ac39ac">

After:
<img width="1090" alt="Screenshot 2024-12-05 at 12 42 38" src="https://github.com/user-attachments/assets/fca31deb-dc78-4fa4-b1ce-05090e39d27c">

<img width="1285" alt="Screenshot 2024-12-05 at 12 42 49" src="https://github.com/user-attachments/assets/757abc7a-a0b2-4faa-8259-faa7ae447c65">

--- 

To reproduce this, you have to run the scheduled app in a different container. 

Edit your `docker/docker-compose.dev.yml` to have:
```
    scheduler:
        build:
            context: ..
            dockerfile: dockerfile
            target: dev
        depends_on:
            - db-dev
        environment:
            - PGHOST=${PGHOST}
            - PGPORT=${PGPORT}
            - PGUSER=${PGUSER}
            - PGPASSWORD=${PGPASSWORD}
            - PGDATABASE=${PGDATABASE}
            - SECURE_COOKIES=${SECURE_COOKIES}
            - LIGHTDASH_SECRET=${LIGHTDASH_SECRET}
            - LIGHTDASH_LOG_LEVEL=${LIGHTDASH_LOG_LEVEL}
            - NODE_ENV=${NODE_ENV}
            - DBT_DEMO_DIR=${DBT_DEMO_DIR}
            - SITE_URL=${SITE_URL}
            - LIGHTDASH_QUERY_MAX_LIMIT=${LIGHTDASH_QUERY_MAX_LIMIT}
            - HEADLESS_BROWSER_HOST=${HEADLESS_BROWSER_HOST}
            - HEADLESS_BROWSER_PORT=${HEADLESS_BROWSER_PORT}
        volumes:
            - '../:/usr/app'
            - '../examples/full-jaffle-shop-demo/dbt:/usr/app/dbt'
            - 'node_modules:/usr/app/node_modules/' # clears the node_modules directory so it doesn't sync (v.slow on MacOS)
        command: ''
        entrypoint: ['/bin/sh', '-c', 'sleep infinity']
```

Setup main container:
```
# set S3 
export S3_ACCESS_KEY=
export S3_SECRET_KEY=
export S3_BUCKET=
export S3_ENDPOINT=
export S3_REGION=

# disable scheduler in this container
export SCHEDULER_ENABLED=false

yarn dev
```

Run the scheduler in the scheduler container in dev mode
```
yarn workspace backend scheduler-dev
```

Steps to have a big int column:

Update raw_plan.csv
```
id,plan_name,metadata,big_number
1,free,{"created_by":"John Miller"},9223358433259708591
2,silver,{"created_by":"Elliot Stone"},9223358433259708592
3,gold,{"created_by":"John Miller"},9223358433259708593
4,platinum,{"created_by":"Elliot Stone"},9223358433259708594
5,diamond,{"created_by":"John Miller"},9223358433259708595
```

Update dbt_project.yml
```
    raw_plan:
      +column_types:
        metadata: jsonb
        big_number: bigint
```

Update plan.yml
```
      - name: big_number
        meta:
          dimension:
            type: number
            format: id
```
Add user attribute is_admin with default true so you can query the plans table.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
