### PR TITLE
fix: dont open url if shouldFetch is false

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,5 +1,5 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button, Text, Tooltip } from '@mantine/core';
+import { Button, Tooltip } from '@mantine/core';
 import { type MRT_Row } from 'mantine-react-table';
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -33,6 +33,7 @@ export const ExploreMetricButton = ({ row }: Props) => {
     });
 
     useEffect(() => {
+        if (!shouldFetch) return;
         if (!projectUuid || !metricQuery.isSuccess) return;
 
         const unsavedChartVersion = createMetricPreviewUnsavedChartVersion(
@@ -50,7 +51,7 @@ export const ExploreMetricButton = ({ row }: Props) => {
         window.open(url.href, '_blank');
 
         setShouldFetch(false); // Reset the fetch trigger
-    }, [metricQuery.data, metricQuery.isSuccess, projectUuid]);
+    }, [metricQuery.data, metricQuery.isSuccess, projectUuid, shouldFetch]);
 
     const handleExploreClick = useCallback(() => {
         track({
@@ -88,14 +89,14 @@ export const ExploreMetricButton = ({ row }: Props) => {
                 py="xxs"
                 px={10}
                 h={28}
+                fz="sm"
+                fw={500}
                 sx={{
                     border: `1px solid #414E62`,
                     boxShadow: '0px 0px 0px 1px #151C24',
                 }}
             >
-                <Text fz="sm" fw={500}>
-                    Explore
-                </Text>
+                Explore
             </Button>
         </Tooltip>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relats to: https://github.com/lightdash/lightdash/pull/12732

### Description:

After https://github.com/lightdash/lightdash/pull/12732, the metrics explorer and standard explorer were opening at the same time. 
This PR fixes that and skips the opening on a new tab if the button hasn't been clicked.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
