### PR TITLE
fix: check if project has saved charts

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -7,6 +7,7 @@ import EmailClient from '../../clients/EmailClient/EmailClient';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentModel } from '../../models/ContentModel/ContentModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { EmailModel } from '../../models/EmailModel';
@@ -60,6 +61,7 @@ describe('Csv service', () => {
             groupsModel: {} as GroupsModel,
             tagsModel: {} as TagsModel,
             catalogModel: {} as CatalogModel,
+            contentModel: {} as ContentModel,
         }),
         s3Client: {} as S3Client,
         savedChartModel: {} as SavedChartModel,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -13,6 +13,7 @@ import EmailClient from '../../clients/EmailClient/EmailClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentModel } from '../../models/ContentModel/ContentModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { EmailModel } from '../../models/EmailModel';
@@ -135,6 +136,7 @@ describe('ProjectService', () => {
         groupsModel: {} as GroupsModel,
         tagsModel: {} as TagsModel,
         catalogModel: {} as CatalogModel,
+        contentModel: {} as ContentModel,
     });
     afterEach(() => {
         jest.clearAllMocks();

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -446,6 +446,7 @@ export class ServiceRepository
                     groupsModel: this.models.getGroupsModel(),
                     tagsModel: this.models.getTagsModel(),
                     catalogModel: this.models.getCatalogModel(),
+                    contentModel: this.models.getContentModel(),
                 }),
         );
     }

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -5,9 +5,9 @@ import {
     IconLayoutDashboard,
     IconPlayerPlay,
 } from '@tabler/icons-react';
-import { SetStateAction, type FC } from 'react';
+import { type FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { useChartSummaries } from '../../../hooks/useChartSummaries';
+import { useProjectSavedChartStatus } from '../../../hooks/useOnboardingStatus';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { useApp } from '../../../providers/AppProvider';
 import { TrackSection } from '../../../providers/TrackingProvider';
@@ -37,10 +37,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
-    const savedChartsRequest = useChartSummaries(projectUuid);
-
-    const savedCharts = savedChartsRequest.data || [];
-    const hasSavedCharts = savedCharts.length > 0;
+    const { data: hasSavedCharts } = useProjectSavedChartStatus(projectUuid);
 
     const userCanCreateDashboard = useCreateInAnySpaceAccess(
         projectUuid,

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -13,10 +13,7 @@ import PinnedItemsPanel from '../components/PinnedItemsPanel';
 
 import { subject } from '@casl/ability';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
-import {
-    useOnboardingStatus,
-    useProjectSavedChartStatus,
-} from '../hooks/useOnboardingStatus';
+import { useOnboardingStatus } from '../hooks/useOnboardingStatus';
 import {
     useMostPopularAndRecentlyUpdated,
     useProject,
@@ -27,7 +24,6 @@ import { PinnedItemsProvider } from '../providers/PinnedItemsProvider';
 const Home: FC = () => {
     const params = useParams<{ projectUuid: string }>();
     const selectedProjectUuid = params.projectUuid;
-    const savedChartStatus = useProjectSavedChartStatus(selectedProjectUuid);
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
     const pinnedItems = usePinnedItems(
@@ -45,11 +41,10 @@ const Home: FC = () => {
     const isLoading =
         onboarding.isInitialLoading ||
         project.isInitialLoading ||
-        savedChartStatus.isInitialLoading ||
         isMostPopularAndRecentlyUpdatedLoading ||
         pinnedItems.isInitialLoading;
 
-    const error = onboarding.error || project.error || savedChartStatus.error;
+    const error = onboarding.error || project.error;
 
     useUnmount(() => onboarding.remove());
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- remove unnecessary call in home page
- change request in empty dashboard to check if project has charts
- update endpoint that checks if project has charts to only request 1 chart from the database

Demo: new request working when project has charts or not.

<img width="1337" alt="Screenshot 2024-12-06 at 10 19 34" src="https://github.com/user-attachments/assets/221f677c-f243-45cd-b482-cd49905f1558">

<img width="1336" alt="Screenshot 2024-12-06 at 10 20 17" src="https://github.com/user-attachments/assets/d6a2b0c3-8eb2-4e25-ae16-acd1cb03d387">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
