### PR TITLE
fix: disable tree for viewer when invalid edge count

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -106,32 +106,6 @@ export const MetricsTable = () => {
         }),
     });
 
-    const flatData = useMemo(
-        () => data?.pages.flatMap((page) => page.data) ?? [],
-        [data],
-    );
-
-    // Fetch metric tree data
-    const selectedMetricUuids = useMemo(() => {
-        return flatData.map((metric) => metric.catalogSearchUuid);
-    }, [flatData]);
-
-    const isValidMetricsTree =
-        selectedMetricUuids.length > 0 &&
-        selectedMetricUuids.length <= MAX_METRICS_TREE_NODE_COUNT;
-
-    const { data: metricsTree } = useMetricsTree(
-        projectUuid,
-        selectedMetricUuids,
-        {
-            enabled: !!projectUuid && isValidMetricsTree,
-        },
-    );
-
-    const dataHasCategories = useMemo(() => {
-        return flatData.some((item) => item.categories?.length);
-    }, [flatData]);
-
     // Check if we are mutating any of the icons or categories related mutations
     // TODO: Move this to separate hook and utilise constants so this scales better
     const isMutating = useIsMutating({
@@ -176,18 +150,6 @@ export const MetricsTable = () => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
-    const totalResults = useMemo(() => {
-        if (!data) return 0;
-        // Return total results from the last page, this should be the same but still we want to have the latest value
-        const lastPage = data.pages[data.pages.length - 1];
-        return lastPage.pagination?.totalResults ?? 0;
-    }, [data]);
-
-    const showLoadingOverlay = useMemo(
-        () => isFetching && isPreviousData && !isMutating,
-        [isFetching, isPreviousData, isMutating],
-    );
-
     const handleViewChange = (view: MetricCatalogView) => {
         setMetricCatalogView(view);
     };
@@ -221,6 +183,69 @@ export const MetricsTable = () => {
         }),
         [theme],
     );
+
+    const flatData = useMemo(
+        () => data?.pages.flatMap((page) => page.data) ?? [],
+        [data],
+    );
+
+    // Fetch metric tree data
+    const selectedMetricUuids = useMemo(() => {
+        return flatData.map((metric) => metric.catalogSearchUuid);
+    }, [flatData]);
+
+    const totalResults = useMemo(() => {
+        if (!data) return 0;
+        // Return total results from the last page, this should be the same but still we want to have the latest value
+        const lastPage = data.pages[data.pages.length - 1];
+        return lastPage.pagination?.totalResults ?? 0;
+    }, [data]);
+
+    const showLoadingOverlay = useMemo(
+        () => isFetching && isPreviousData && !isMutating,
+        [isFetching, isPreviousData, isMutating],
+    );
+
+    const isValidMetricsNodeCount =
+        selectedMetricUuids.length > 0 &&
+        selectedMetricUuids.length <= MAX_METRICS_TREE_NODE_COUNT;
+
+    const { data: metricsTree } = useMetricsTree(
+        projectUuid,
+        selectedMetricUuids,
+        {
+            enabled: !!projectUuid && isValidMetricsNodeCount,
+        },
+    );
+
+    // Viewers cannot access metrics tree if there are no edges
+    const isValidMetricsEdgeCount = useMemo(
+        () => canManageMetricsTree || (metricsTree?.edges.length ?? 0) > 0,
+        [canManageMetricsTree, metricsTree],
+    );
+
+    const isValidMetricsTree = useMemo(
+        () => isValidMetricsNodeCount && isValidMetricsEdgeCount,
+        [isValidMetricsNodeCount, isValidMetricsEdgeCount],
+    );
+
+    const segmentedControlTooltipLabel = useMemo(() => {
+        if (totalResults === 0) {
+            return 'There are no metrics to display in the metrics tree';
+        }
+
+        if (!isValidMetricsNodeCount) {
+            return 'You can only select up to 30 metrics for the metrics tree';
+        }
+
+        if (!isValidMetricsEdgeCount) {
+            return 'There are no connections between the selected metrics';
+        }
+    }, [isValidMetricsEdgeCount, isValidMetricsNodeCount, totalResults]);
+
+    const dataHasCategories = useMemo(() => {
+        return flatData.some((item) => item.categories?.length);
+    }, [flatData]);
 
     const table = useMantineReactTable({
         columns: MetricsCatalogColumns,
@@ -396,6 +421,8 @@ export const MetricsTable = () => {
                     showCategoriesFilter={canManageTags || dataHasCategories}
                     onMetricCatalogViewChange={handleViewChange}
                     metricCatalogView={metricCatalogView}
+                    isValidMetricsTree={isValidMetricsTree}
+                    segmentedControlTooltipLabel={segmentedControlTooltipLabel}
                 />
                 <Divider color="gray.2" />
             </Box>
@@ -496,6 +523,10 @@ export const MetricsTable = () => {
                             }
                             onMetricCatalogViewChange={handleViewChange}
                             metricCatalogView={metricCatalogView}
+                            isValidMetricsTree={isValidMetricsTree}
+                            segmentedControlTooltipLabel={
+                                segmentedControlTooltipLabel
+                            }
                         />
                         <Divider color="gray.2" />
                     </Box>
@@ -510,7 +541,11 @@ export const MetricsTable = () => {
                             ) : (
                                 <SuboptimalState
                                     title="Metrics tree not available"
-                                    description="Please narrow your search to display up to 30 metrics"
+                                    description={
+                                        isValidMetricsEdgeCount
+                                            ? 'Please narrow your search to display up to 30 metrics'
+                                            : 'There are no connections between the selected metrics'
+                                    }
                                 />
                             )}
                         </ReactFlowProvider>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -542,9 +542,10 @@ export const MetricsTable = () => {
                                 <SuboptimalState
                                     title="Metrics tree not available"
                                     description={
-                                        isValidMetricsEdgeCount
-                                            ? 'Please narrow your search to display up to 30 metrics'
-                                            : 'There are no connections between the selected metrics'
+                                        !isValidMetricsEdgeCount &&
+                                        isValidMetricsNodeCount
+                                            ? 'There are no connections between the selected metrics'
+                                            : 'Please narrow your search to display up to 30 metrics'
                                     }
                                 />
                             )}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    MAX_METRICS_TREE_NODE_COUNT,
-    type CatalogField,
-} from '@lightdash/common';
+import { FeatureFlags, type CatalogField } from '@lightdash/common';
 import {
     ActionIcon,
     Badge,
@@ -212,7 +208,9 @@ type MetricsTableTopToolbarProps = GroupProps & {
         categories: CatalogField['categories'][number]['tagUuid'][],
     ) => void;
     totalResults: number;
+    segmentedControlTooltipLabel?: string;
     showCategoriesFilter?: boolean;
+    isValidMetricsTree: boolean;
     onMetricCatalogViewChange?: (view: MetricCatalogView) => void;
     metricCatalogView: MetricCatalogView;
 };
@@ -225,18 +223,17 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
         selectedCategories,
         setSelectedCategories,
         showCategoriesFilter,
+        isValidMetricsTree,
+        segmentedControlTooltipLabel,
         onMetricCatalogViewChange,
         metricCatalogView,
         ...props
     }) => {
         const clearSearch = useCallback(() => setSearch(''), [setSearch]);
 
-        const isMetricTreesEnabled = useFeatureFlagEnabled(
+        const isMetricTreesFeatureFlagEnabled = useFeatureFlagEnabled(
             FeatureFlags.MetricTrees,
         );
-
-        const isValidMetricsTree =
-            totalResults > 0 && totalResults <= MAX_METRICS_TREE_NODE_COUNT;
 
         return (
             <Group {...props}>
@@ -332,7 +329,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             </Text>
                         </Group>
                     </Badge>
-                    {isMetricTreesEnabled && (
+                    {isMetricTreesFeatureFlagEnabled && (
                         <>
                             <Divider
                                 orientation="vertical"
@@ -346,11 +343,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             <Tooltip
                                 withinPortal
                                 variant="xs"
-                                label={
-                                    totalResults > 0
-                                        ? `You can only select up to ${MAX_METRICS_TREE_NODE_COUNT} metrics for the metrics tree`
-                                        : 'There are no metrics to display in the metrics tree'
-                                }
+                                label={segmentedControlTooltipLabel}
                                 disabled={isValidMetricsTree}
                             >
                                 <SegmentedControl


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12752 

### Description:

- Disables metric tree for viewers when there are no edges between the selected metrics
- Editors and up can still access the tree in that case and only have access disabled when the metric count is invalid


https://github.com/user-attachments/assets/ecc8121f-650e-4e4a-923a-5c4cd6b84d1b



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
