### PR TITLE
fix: paginate charts in dashboard modals

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -38,9 +38,9 @@ export class ContentController extends BaseController {
         @Query() contentTypes?: ContentType[],
         @Query() pageSize?: number,
         @Query() page?: number,
+        @Query() search?: string,
     ): Promise<ApiContentResponse> {
         this.setStatus(200);
-
         return {
             status: 'ok',
             results: await this.services.getContentService().find(
@@ -49,6 +49,7 @@ export class ContentController extends BaseController {
                     projectUuids,
                     spaceUuids,
                     contentTypes,
+                    search,
                 },
                 {
                     page: page || 1,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3833,6 +3833,14 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'ResultRow' },
                     required: true,
                 },
+                comparisonMetric: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'MetricWithAssociatedTimeDimension' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
                 metric: {
                     ref: 'MetricWithAssociatedTimeDimension',
                     required: true,
@@ -20821,6 +20829,7 @@ export function RegisterRoutes(app: express.Router) {
                 },
                 pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
                 page: { in: 'query', name: 'page', dataType: 'double' },
+                search: { in: 'query', name: 'search', dataType: 'string' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4259,6 +4259,9 @@
                         },
                         "type": "array"
                     },
+                    "comparisonMetric": {
+                        "$ref": "#/components/schemas/MetricWithAssociatedTimeDimension"
+                    },
                     "metric": {
                         "$ref": "#/components/schemas/MetricWithAssociatedTimeDimension"
                     }
@@ -12069,7 +12072,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1398.0",
+        "version": "0.1403.1",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -128,6 +128,12 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                                             order by dashboard_versions.created_at asc
                                             limit 1)`),
                     );
+                    if (filters.search) {
+                        void builder.whereRaw(
+                            `LOWER(${DashboardsTableName}.name) LIKE ?`,
+                            [`%${filters.search.toLowerCase()}%`],
+                        );
+                    }
                 }),
         shouldRowBeConverted: (value): value is SummaryContentRow =>
             value.content_type === ContentType.DASHBOARD,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -132,6 +132,12 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                             filters.spaceUuids,
                         );
                     }
+                    if (filters.search) {
+                        void builder.whereRaw(
+                            `LOWER(${SavedChartsTableName}.name) LIKE ?`,
+                            [`%${filters.search.toLowerCase()}%`],
+                        );
+                    }
                 }),
         shouldRowBeConverted: (value): value is SelectSavedChart => {
             const contentTypeMatch = value.content_type === ContentType.CHART;

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SemanticViewerChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SemanticViewerChartContentConfiguration.ts
@@ -123,6 +123,12 @@ export const semanticViewerChartContentConfiguration: ContentConfiguration<Selec
                             filters.spaceUuids,
                         );
                     }
+                    if (filters.search) {
+                        void builder.whereRaw(
+                            `LOWER(${SavedSemanticViewerChartsTableName}.name) LIKE ?`,
+                            [`%${filters.search.toLowerCase()}%`],
+                        );
+                    }
                 }),
         shouldRowBeConverted: (
             value,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -123,6 +123,12 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                             filters.spaceUuids,
                         );
                     }
+                    if (filters.search) {
+                        void builder.whereRaw(
+                            `LOWER(${SavedSqlTableName}.name) LIKE ?`,
+                            [`%${filters.search.toLowerCase()}%`],
+                        );
+                    }
                 }),
         shouldRowBeConverted: (value): value is SelectSavedSql => {
             const contentTypeMatch = value.content_type === ContentType.CHART;

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -8,6 +8,7 @@ export type ContentFilters = {
     chart?: {
         sources?: ChartContent['source'][];
     };
+    search?: string;
 };
 
 export type SummaryContentRow<

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -12,16 +12,29 @@ import {
     Flex,
     getDefaultZIndex,
     Group,
+    Loader,
     Modal,
     MultiSelect,
+    ScrollArea,
     Stack,
     Text,
     Title,
     Tooltip,
+    type ScrollAreaProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconChartAreaLine } from '@tabler/icons-react';
-import React, { forwardRef, useCallback, useMemo, type FC } from 'react';
+import { uniqBy } from 'lodash';
+import React, {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuid4 } from 'uuid';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';
@@ -75,8 +88,40 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
 
 const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: savedQueries, isInitialLoading } =
-        useChartSummariesV2(projectUuid);
+    const [searchQuery, setSearchQuery] = useState<string>('');
+    const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
+    const selectScrollRef = useRef<HTMLDivElement>(null);
+    const {
+        data: chartPages,
+        isInitialLoading,
+        isFetching,
+        hasNextPage,
+        fetchNextPage,
+    } = useChartSummariesV2(
+        {
+            projectUuid,
+            page: 1,
+            pageSize: 25,
+            search: debouncedSearchQuery,
+        },
+        { keepPreviousData: true },
+    );
+    useEffect(() => {
+        selectScrollRef.current?.scrollTo({
+            top: selectScrollRef.current?.scrollHeight,
+        });
+    }, [chartPages]);
+    // Aggregates all fetched charts across pages and search queries into a unified list.
+    // This ensures that previously fetched chart are preserved even when the search query changes.
+    // Uses 'uuid' to remove duplicates and maintain a consistent set of unique charts.
+    const [savedQueries, setSavedQueries] = useState<ChartContent[]>([]);
+    useEffect(() => {
+        const allPages = chartPages?.pages.map((p) => p.data).flat() ?? [];
+
+        setSavedQueries((previousState) =>
+            uniqBy([...previousState, ...allPages], 'uuid'),
+        );
+    }, [chartPages?.pages]);
 
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboard = useDashboardContext((c) => c.dashboard);
@@ -148,13 +193,21 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     );
 
     const allSavedCharts = useMemo(() => {
-        const reorderedCharts = savedQueries?.sort((chartA, chartB) =>
-            chartA.space.uuid === dashboard?.spaceUuid
-                ? -1
-                : chartB.space.uuid === dashboard?.spaceUuid
-                ? 1
-                : 0,
-        );
+        const reorderedCharts = savedQueries?.sort((chartA, chartB) => {
+            if (
+                chartA.space.uuid === chartB.space.uuid &&
+                !!chartA.lastUpdatedAt &&
+                !!chartB.lastUpdatedAt
+            ) {
+                return chartA.lastUpdatedAt > chartB.lastUpdatedAt ? -1 : 1;
+            } else if (chartA.space.uuid === dashboard?.spaceUuid) {
+                return -1;
+            } else if (chartB.space.uuid === dashboard?.spaceUuid) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
 
         return (reorderedCharts || []).map((chart) => {
             const { uuid, name, space, chartKind } = chart;
@@ -300,6 +353,46 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                         searchable
                         withinPortal
                         itemComponent={SelectItem}
+                        nothingFound="No charts found"
+                        clearable
+                        clearSearchOnChange
+                        clearSearchOnBlur
+                        searchValue={searchQuery}
+                        onSearchChange={setSearchQuery}
+                        maxDropdownHeight={300}
+                        rightSection={
+                            isFetching && <Loader size="xs" color="gray" />
+                        }
+                        dropdownComponent={({
+                            children,
+                            ...rest
+                        }: ScrollAreaProps) => (
+                            <ScrollArea {...rest} viewportRef={selectScrollRef}>
+                                <>
+                                    {children}
+                                    {hasNextPage && (
+                                        <Button
+                                            size="xs"
+                                            variant="white"
+                                            onClick={async () => {
+                                                await fetchNextPage();
+                                            }}
+                                            disabled={isFetching}
+                                        >
+                                            <Text>Load more</Text>
+                                        </Button>
+                                    )}
+                                </>
+                            </ScrollArea>
+                        )}
+                        filter={(searchString, selected, item) => {
+                            return Boolean(
+                                selected ||
+                                    item.label
+                                        ?.toLowerCase()
+                                        .includes(searchString.toLowerCase()),
+                            );
+                        }}
                         {...form.getInputProps('savedChartsUuids')}
                     />
                     <Group spacing="xs" position="right" mt="md">

--- a/packages/frontend/src/hooks/useChartSummariesV2.ts
+++ b/packages/frontend/src/hooks/useChartSummariesV2.ts
@@ -3,28 +3,56 @@ import {
     type ApiChartContentResponse,
     type ApiError,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import {
+    useInfiniteQuery,
+    type UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
-const getChartSummariesInProjectV2 = async (projectUuid: string) => {
+type UseChartSummariesV2Args = {
+    projectUuid: string;
+    pageSize: number;
+    page: number;
+    search?: string;
+};
+
+const getChartSummariesInProjectV2 = async ({
+    projectUuid,
+    page,
+    pageSize,
+    search,
+}: UseChartSummariesV2Args) => {
     return lightdashApi<ApiChartContentResponse['results']>({
         version: 'v2',
-        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.CHART}&pageSize=${Number.MAX_SAFE_INTEGER}`, // TODO: remove pageSize max once we have pagination
+        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.CHART}&pageSize=${pageSize}&page=${page}&search=${search}`,
         method: 'GET',
         body: undefined,
     });
 };
 
-export const useChartSummariesV2 = (projectUuid: string) => {
-    return useQuery<
+export const useChartSummariesV2 = (
+    args: UseChartSummariesV2Args,
+    infinityQueryOpts: UseInfiniteQueryOptions<
         ApiChartContentResponse['results'],
-        ApiError,
-        ApiChartContentResponse['results']['data']
-    >({
-        queryKey: ['project', projectUuid, 'chart-summaries-v2'],
-        queryFn: () => getChartSummariesInProjectV2(projectUuid),
-        select(data) {
-            return data.data;
+        ApiError
+    > = {},
+) => {
+    return useInfiniteQuery<ApiChartContentResponse['results'], ApiError>({
+        queryKey: ['project', 'chart-summaries-v2', args],
+        queryFn: async ({ pageParam }) => {
+            return getChartSummariesInProjectV2({
+                ...args,
+                page: pageParam ?? 1,
+            });
         },
+        getNextPageParam: (lastPage) => {
+            if (lastPage.pagination) {
+                return lastPage.pagination.page <
+                    lastPage.pagination.totalPageCount
+                    ? lastPage.pagination.page + 1
+                    : undefined;
+            }
+        },
+        ...infinityQueryOpts,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#12759](https://github.com/lightdash/lightdash/issues/12759) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Changes:
- update content endpoint to search by name
- replace useChartSummaries for `useChartSummariesV2` in dashboard modals

<img width="477" alt="Screenshot 2024-12-06 at 14 29 25" src="https://github.com/user-attachments/assets/2e4ed109-3027-4167-8c6d-59d40213e9ff">
<img width="646" alt="Screenshot 2024-12-06 at 14 28 34" src="https://github.com/user-attachments/assets/3d6d5871-b818-4984-94a1-7aee9f8e1a08">
<img width="664" alt="Screenshot 2024-12-06 at 14 28 26" src="https://github.com/user-attachments/assets/cf50c816-d032-476e-b7c5-0d98eac046d9">



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
