### PR TITLE
fix: address time interval overrride on comparison of metrics

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -28,6 +28,7 @@ import {
     SummaryExplore,
     TablesConfiguration,
     TableSelectionType,
+    TimeFrames,
     UserAttributeValueMap,
     type ApiMetricsTreeEdgePayload,
     type ApiSort,
@@ -899,6 +900,7 @@ export class CatalogService<
         projectUuid: string,
         tableName: string,
         metricName: string,
+        timeIntervalOverride?: TimeFrames,
     ): Promise<MetricWithAssociatedTimeDimension> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -975,7 +977,9 @@ export class CatalogService<
 
             timeDimension = {
                 field: firstAvailableTimeDimension.name,
-                interval: DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+                interval:
+                    timeIntervalOverride ??
+                    DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
                 table: firstAvailableTimeDimension.table,
             };
         }

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -263,8 +263,6 @@ export class MetricsExplorerService<
             }
         }
 
-        console.log({ compareMetric });
-
         return {
             rows: currentResults,
             comparisonRows: comparisonResults,

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -192,6 +192,7 @@ export class MetricsExplorerService<
                         projectUuid,
                         compare.metricTable,
                         compare.metricName,
+                        timeDimensionOverride?.interval,
                     );
 
                     const compareTimeDimension = compareMetric.timeDimension;
@@ -202,8 +203,8 @@ export class MetricsExplorerService<
                         );
                     }
 
-                    const compareMetricDimensionGrain = dateRange
-                        ? getGrainForDateRange(dateRange)
+                    const compareMetricDimensionGrain = timeDimensionOverride
+                        ? timeDimensionOverride.interval
                         : compareTimeDimension.interval;
 
                     const differentDimensionId = getItemId({
@@ -261,6 +262,8 @@ export class MetricsExplorerService<
                     break;
             }
         }
+
+        console.log({ compareMetric });
 
         return {
             rows: currentResults,

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -147,6 +147,14 @@ export const getMetricExplorerDateRangeFilters = (
     ];
 };
 
+// TODO: Should we just use the formatted value instead?
+// Parse the metric value to a number, returning null if it's not a number
+const parseMetricValue = (value: unknown): number | null => {
+    if (value === null || value === undefined) return null;
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+};
+
 export const getMetricExplorerDataPoints = (
     dimension: Dimension,
     metric: MetricWithAssociatedTimeDimension,
@@ -161,7 +169,9 @@ export const getMetricExplorerDataPoints = (
 
     return Object.keys(groupByMetricRows).map((date) => ({
         date: new Date(date),
-        metric: groupByMetricRows[date]?.[0]?.[metricId]?.value.raw ?? null,
+        metric: parseMetricValue(
+            groupByMetricRows[date]?.[0]?.[metricId]?.value.raw,
+        ),
         compareMetric: null,
     }));
 };
@@ -213,10 +223,13 @@ export const getMetricExplorerDataPointsWithCompare = (
 
     return Array.from(dates).map((date) => ({
         date: new Date(date),
-        metric: groupByMetricRows[date]?.[0]?.[metricId]?.value.raw ?? null,
-        compareMetric:
+        metric: parseMetricValue(
+            groupByMetricRows[date]?.[0]?.[metricId]?.value.raw,
+        ),
+        compareMetric: parseMetricValue(
             offsetGroupByCompareMetricRows[date]?.[0]?.[compareMetricId]?.value
-                .raw ?? null,
+                .raw,
+        ),
     }));
 };
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -80,19 +80,49 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         useState<MetricWithAssociatedTimeDimension | null>(null);
 
     const handleMetricChange = useCallback(
-        (metricId: string) => {
+        (metricId: string | null) => {
             if (!metricsWithTimeDimensionsQuery.isSuccess) return;
+
+            if (!metricId) {
+                setSelectedMetric(null);
+                return;
+            }
+
             const metric = metricsWithTimeDimensionsQuery.data.find(
                 (m) => getItemId(m) === metricId,
             );
-            if (!metric) return;
 
-            setSelectedMetric(metric);
+            setSelectedMetric(metric ?? null);
         },
         [
             metricsWithTimeDimensionsQuery.data,
             metricsWithTimeDimensionsQuery.isSuccess,
         ],
+    );
+
+    const handleComparisonTypeChange = useCallback(
+        (value: MetricExplorerComparison) => {
+            setComparisonType(value);
+
+            if (
+                value === MetricExplorerComparison.NONE ||
+                value === MetricExplorerComparison.PREVIOUS_PERIOD
+            ) {
+                setSelectedMetric(null);
+            }
+
+            if (value === MetricExplorerComparison.NONE) {
+                setDateRange(null);
+                setTimeDimensionOverride(undefined);
+            } else if (timeDimensionOverride) {
+                setDateRange(
+                    getDefaultDateRangeFromInterval(
+                        timeDimensionOverride.interval,
+                    ),
+                );
+            }
+        },
+        [timeDimensionOverride],
     );
 
     const comparisonParams = useMemo((): MetricExplorerComparisonType => {
@@ -188,8 +218,6 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         [timeDimensionOverride, timeDimensionBaseField, dateRange],
     );
 
-    const hasData = metricQuery.isSuccess && metricResultsQuery.isSuccess;
-
     const handleClose = useCallback(() => {
         history.push(`/projects/${projectUuid}/metrics`);
         setComparisonType(MetricExplorerComparison.NONE);
@@ -199,11 +227,22 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         onClose();
     }, [history, onClose, projectUuid]);
 
-    const handleTimeIntervalChange = useCallback((timeInterval: TimeFrames) => {
-        // Always reset the date range to the default range for the new interval
-        setDateRange(getDefaultDateRangeFromInterval(timeInterval));
-    }, []);
+    const handleTimeIntervalChange = useCallback(
+        (timeInterval: TimeFrames) => {
+            // Always reset the date range to the default range for the new interval
+            setDateRange(getDefaultDateRangeFromInterval(timeInterval));
 
+            if (timeDimensionBaseField) {
+                setTimeDimensionOverride({
+                    ...timeDimensionBaseField,
+                    interval: timeInterval,
+                });
+            }
+        },
+        [timeDimensionBaseField],
+    );
+
+    console.log({ timeDimensionOverride });
     return (
         <Modal.Root
             opened={opened}
@@ -317,9 +356,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
 
                                 <Radio.Group
                                     value={comparisonType}
-                                    onChange={(
-                                        value: MetricExplorerComparison,
-                                    ) => setComparisonType(value)}
+                                    onChange={handleComparisonTypeChange}
                                 >
                                     <Stack spacing="sm">
                                         {[
@@ -395,21 +432,25 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
 
                                                     {metricsWithTimeDimensionsQuery.isSuccess &&
                                                         comparison.type ===
+                                                            MetricExplorerComparison.DIFFERENT_METRIC &&
+                                                        comparisonType ===
                                                             MetricExplorerComparison.DIFFERENT_METRIC && (
                                                             <Select
                                                                 placeholder="Select metric"
                                                                 radius="md"
                                                                 size="xs"
-                                                                data={metricsWithTimeDimensionsQuery.data.map(
-                                                                    (
-                                                                        metric,
-                                                                    ) => ({
-                                                                        value: getItemId(
+                                                                data={
+                                                                    metricsWithTimeDimensionsQuery.data?.map(
+                                                                        (
                                                                             metric,
-                                                                        ),
-                                                                        label: metric.label,
-                                                                    }),
-                                                                )}
+                                                                        ) => ({
+                                                                            value: getItemId(
+                                                                                metric,
+                                                                            ),
+                                                                            label: metric.label,
+                                                                        }),
+                                                                    ) ?? []
+                                                                }
                                                                 value={
                                                                     selectedMetric
                                                                         ? getItemId(
@@ -419,6 +460,9 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                                                 }
                                                                 onChange={
                                                                     handleMetricChange
+                                                                }
+                                                                disabled={
+                                                                    !metricsWithTimeDimensionsQuery.isSuccess
                                                                 }
                                                             />
                                                         )}
@@ -434,26 +478,22 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                     <Divider orientation="vertical" color="gray.2" />
 
                     <Box mih={500} w="100%" pt="sm" px="md">
-                        {hasData && (
-                            <MetricsVisualization
-                                comparison={comparisonParams}
-                                dateRange={dateRange ?? undefined}
-                                results={metricResultsQuery.data}
-                                onDateRangeChange={setDateRange}
-                                showTimeDimensionIntervalPicker={
-                                    !!timeDimensionBaseField
-                                }
-                                timeDimensionBaseField={
-                                    timeDimensionBaseField ??
-                                    ({} as TimeDimensionConfig)
-                                }
-                                setTimeDimensionOverride={
-                                    setTimeDimensionOverride
-                                }
-                                onTimeIntervalChange={handleTimeIntervalChange}
-                                isFetching={metricResultsQuery.isFetching}
-                            />
-                        )}
+                        <MetricsVisualization
+                            comparison={comparisonParams}
+                            dateRange={dateRange ?? undefined}
+                            results={metricResultsQuery.data}
+                            onDateRangeChange={setDateRange}
+                            showTimeDimensionIntervalPicker={
+                                !!timeDimensionBaseField
+                            }
+                            timeDimensionBaseField={
+                                timeDimensionBaseField ??
+                                ({} as TimeDimensionConfig)
+                            }
+                            setTimeDimensionOverride={setTimeDimensionOverride}
+                            onTimeIntervalChange={handleTimeIntervalChange}
+                            isFetching={metricResultsQuery.isFetching}
+                        />
                     </Box>
                 </Modal.Body>
             </Modal.Content>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -155,6 +155,21 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         }
     }, [comparisonType, selectedMetric]);
 
+    const metricExplorerQueryOptions = {
+        enabled:
+            !!projectUuid &&
+            !!tableName &&
+            !!metricName &&
+            !!comparisonParams &&
+            !!dateRange &&
+            (comparisonParams.type !==
+                MetricExplorerComparison.DIFFERENT_METRIC ||
+                (comparisonParams.type ===
+                    MetricExplorerComparison.DIFFERENT_METRIC &&
+                    !!comparisonParams.metricName &&
+                    !!comparisonParams.metricTable)),
+        keepPreviousData: true,
+    };
     const metricResultsQuery = useRunMetricExplorerQuery({
         projectUuid,
         exploreName: tableName,
@@ -162,6 +177,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         dateRange: dateRange ?? undefined,
         comparison: comparisonParams,
         timeDimensionOverride,
+        options: metricExplorerQueryOptions,
     });
 
     const timeDimensionBaseField: TimeDimensionConfig | undefined =
@@ -242,7 +258,6 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         [timeDimensionBaseField],
     );
 
-    console.log({ timeDimensionOverride });
     return (
         <Modal.Root
             opened={opened}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -64,7 +64,7 @@ const tickFormatter = (date: Date) => {
 };
 
 type Props = {
-    results: MetricsExplorerQueryResults;
+    results: MetricsExplorerQueryResults | undefined;
     dateRange: MetricExplorerDateRange | undefined;
     comparison: MetricExplorerComparisonType;
     onDateRangeChange: (range: MetricExplorerDateRange) => void;
@@ -90,7 +90,7 @@ const MetricsVisualization: FC<Props> = ({
 
     const dataPoints = useMemo(() => {
         if (isFetching) return null;
-        if (!results.rows) return null;
+        if (!results?.rows) return null;
 
         const timeDimension = results.metric.timeDimension;
         if (!timeDimension) return null;
@@ -114,6 +114,10 @@ const MetricsVisualization: FC<Props> = ({
                     results.rows,
                 );
             case MetricExplorerComparison.PREVIOUS_PERIOD:
+                if (isFetching) {
+                    return null;
+                }
+
                 if (!results.comparisonRows) {
                     throw new Error(
                         `Comparison rows are required for comparison type ${comparison.type}`,
@@ -129,6 +133,10 @@ const MetricsVisualization: FC<Props> = ({
                     comparison,
                 );
             case MetricExplorerComparison.DIFFERENT_METRIC:
+                if (isFetching) {
+                    return null;
+                }
+
                 if (!results.comparisonRows) {
                     return null;
                 }
@@ -157,6 +165,7 @@ const MetricsVisualization: FC<Props> = ({
                 );
 
                 const compareDimension = results.fields[compareDimensionId];
+
                 if (!compareDimension || !isDimension(compareDimension)) {
                     throw new Error(
                         `Comparison dimension not found for comparison type ${comparison.type}`,
@@ -228,7 +237,7 @@ const MetricsVisualization: FC<Props> = ({
             sx={{ flexGrow: 1 }}
         >
             <Group spacing="sm" noWrap>
-                {dateRange && results.metric.timeDimension && (
+                {dateRange && results?.metric.timeDimension && (
                     <MetricPeekDatePicker
                         dateRange={dateRange}
                         onChange={onDateRangeChange}
@@ -256,7 +265,7 @@ const MetricsVisualization: FC<Props> = ({
 
             {showEmptyState && <MetricsVisualizationEmptyState />}
 
-            {!showEmptyState && (
+            {!showEmptyState && results && (
                 <ResponsiveContainer width="100%" height="100%">
                     <LineChart
                         data={activeData}

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -1,12 +1,10 @@
 import {
-    MetricExplorerComparison,
-    type ApiError,
     type ApiMetricsExplorerQueryResults,
     type MetricExplorerComparisonType,
     type MetricExplorerDateRange,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type RunMetricExplorerQueryArgs = {
@@ -16,6 +14,7 @@ type RunMetricExplorerQueryArgs = {
     dateRange: MetricExplorerDateRange;
     comparison: MetricExplorerComparisonType;
     timeDimensionOverride?: TimeDimensionConfig;
+    options?: UseQueryOptions<ApiMetricsExplorerQueryResults['results']>;
 };
 
 const getUrlParams = (dateRange: MetricExplorerDateRange) => {
@@ -59,8 +58,9 @@ export const useRunMetricExplorerQuery = ({
     comparison,
     dateRange,
     timeDimensionOverride,
+    options,
 }: Partial<RunMetricExplorerQueryArgs>) => {
-    return useQuery<ApiMetricsExplorerQueryResults['results'], ApiError>({
+    return useQuery({
         queryKey: [
             'runMetricExplorerQuery',
             projectUuid,
@@ -80,17 +80,6 @@ export const useRunMetricExplorerQuery = ({
                 dateRange: dateRange!,
                 timeDimensionOverride,
             }),
-        enabled:
-            !!projectUuid &&
-            !!exploreName &&
-            !!metricName &&
-            !!comparison &&
-            !!dateRange &&
-            (comparison.type !== MetricExplorerComparison.DIFFERENT_METRIC ||
-                (comparison.type ===
-                    MetricExplorerComparison.DIFFERENT_METRIC &&
-                    !!comparison.metricName &&
-                    !!comparison.metricTable)),
-        keepPreviousData: true,
+        ...options,
     });
 };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -1,4 +1,5 @@
 import {
+    MetricExplorerComparison,
     type ApiError,
     type ApiMetricsExplorerQueryResults,
     type MetricExplorerComparisonType,
@@ -67,7 +68,7 @@ export const useRunMetricExplorerQuery = ({
             metricName,
             dateRange?.[0],
             dateRange?.[1],
-            comparison?.type,
+            comparison,
             timeDimensionOverride,
         ],
         queryFn: () =>
@@ -84,7 +85,12 @@ export const useRunMetricExplorerQuery = ({
             !!exploreName &&
             !!metricName &&
             !!comparison &&
-            !!dateRange,
+            !!dateRange &&
+            (comparison.type !== MetricExplorerComparison.DIFFERENT_METRIC ||
+                (comparison.type ===
+                    MetricExplorerComparison.DIFFERENT_METRIC &&
+                    !!comparison.metricName &&
+                    !!comparison.metricTable)),
         keepPreviousData: true,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After this merge: https://github.com/lightdash/lightdash/pull/12748, I found some issues when interacting with the Date zoom + metric comparison. This PR addresses that.

This PR ensures that Date zoom works ok when comparing metric A with another metric. 
Granularity is respected. 

Values are parsed so that the y axis range is correct - can revert this change if we want to tackle this differently.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
