### PR TITLE
style: move time dimension picker to below viz

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekDatePicker.tsx
@@ -98,7 +98,7 @@ export const MetricPeekDatePicker: FC<Props> = ({
     return (
         <Popover opened={isOpen} onChange={handleOpen} position="bottom-start">
             <Popover.Target>
-                <Group position="apart" w="fill-available">
+                <Group position="apart" w="fill-available" noWrap>
                     <SegmentedControl
                         size="xs"
                         h={32}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -20,7 +20,6 @@ import {
     Paper,
     Radio,
     Select,
-    Skeleton,
     Stack,
     Text,
     Tooltip,
@@ -35,7 +34,6 @@ import { useCatalogMetricsWithTimeDimensions } from '../hooks/useCatalogMetricsW
 import { useMetric } from '../hooks/useMetricsCatalog';
 import { useRunMetricExplorerQuery } from '../hooks/useRunMetricExplorerQuery';
 import MetricsVisualization from './visualization/MetricsVisualization';
-import { TimeDimensionPicker } from './visualization/TimeDimensionPicker';
 
 type Props = Pick<ModalProps, 'opened' | 'onClose'>;
 
@@ -305,41 +303,6 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                 >
                     <Stack p="xl" bg="offWhite.0" miw={360}>
                         <Stack spacing="xl">
-                            {metricQuery.data?.availableTimeDimensions && (
-                                <Stack
-                                    w="100%"
-                                    spacing="xs"
-                                    align="flex-start"
-                                    sx={{ flexGrow: 1 }}
-                                >
-                                    <Text fw={500} c="gray.7">
-                                        X-axis
-                                    </Text>
-                                    {metricQuery.isSuccess &&
-                                    timeDimensionBaseField ? (
-                                        <TimeDimensionPicker
-                                            fields={
-                                                metricQuery.data
-                                                    .availableTimeDimensions
-                                            }
-                                            dimension={timeDimensionBaseField}
-                                            onChange={setTimeDimensionOverride}
-                                        />
-                                    ) : (
-                                        <Skeleton w="100%" h={40} />
-                                    )}
-                                </Stack>
-                            )}
-
-                            <Divider
-                                display={
-                                    metricQuery.data?.availableTimeDimensions
-                                        ? 'block'
-                                        : 'none'
-                                }
-                                color="gray.2"
-                            />
-
                             <Stack w="100%" spacing="xs" sx={{ flexGrow: 1 }}>
                                 <Group position="apart">
                                     <Text fw={500} c="gray.7">
@@ -492,7 +455,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
 
                     <Divider orientation="vertical" color="gray.2" />
 
-                    <Box mih={500} w="100%" pt="sm" px="md">
+                    <Box w="100%" pt="sm" px="md">
                         <MetricsVisualization
                             comparison={comparisonParams}
                             dateRange={dateRange ?? undefined}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -255,10 +255,12 @@ export const MetricsCatalogPanel = () => {
                 opened={isMetricUsageModalOpen}
                 onClose={onCloseMetricUsageModal}
             />
-            <MetricPeekModal
-                opened={isMetricPeekModalOpen}
-                onClose={onCloseMetricPeekModal}
-            />
+            {isMetricPeekModalOpen && (
+                <MetricPeekModal
+                    opened={isMetricPeekModalOpen}
+                    onClose={onCloseMetricPeekModal}
+                />
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    capitalize,
     getFieldIdForDateDimension,
     getItemId,
     getMetricExplorerDataPoints,
@@ -12,7 +13,14 @@ import {
     type TimeDimensionConfig,
     type TimeFrames,
 } from '@lightdash/common';
-import { Button, Group, Stack, Text, useMantineTheme } from '@mantine/core';
+import {
+    Button,
+    Flex,
+    Group,
+    Stack,
+    Text,
+    useMantineTheme,
+} from '@mantine/core';
 import { IconZoomReset } from '@tabler/icons-react';
 import { scaleTime } from 'd3-scale';
 import {
@@ -40,6 +48,7 @@ import {
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { MetricPeekDatePicker } from '../MetricPeekDatePicker';
 import { MetricsVisualizationEmptyState } from '../MetricsVisualizationEmptyState';
+import { TimeDimensionPicker } from './TimeDimensionPicker';
 import { FORMATS } from './types';
 import { useChartZoom } from './useChartZoom';
 
@@ -229,13 +238,7 @@ const MetricsVisualization: FC<Props> = ({
     const showEmptyState = dataPoints?.length === 0;
 
     return (
-        <Stack
-            spacing={showEmptyState ? 'sm' : 'lg'}
-            pb={showEmptyState ? 'sm' : undefined}
-            w="100%"
-            h="100%"
-            sx={{ flexGrow: 1 }}
-        >
+        <Stack spacing="sm" pb="sm" w="100%" h="100%">
             <Group spacing="sm" noWrap>
                 {dateRange && results?.metric.timeDimension && (
                     <MetricPeekDatePicker
@@ -266,98 +269,122 @@ const MetricsVisualization: FC<Props> = ({
             {showEmptyState && <MetricsVisualizationEmptyState />}
 
             {!showEmptyState && results && (
-                <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                        data={activeData}
-                        margin={{
-                            top: 40,
-                            right: 40,
-                            bottom: 40,
-                            left: 40,
-                        }}
-                        onMouseDown={handleMouseDown}
-                        onMouseMove={handleMouseMove}
-                        onMouseUp={handleMouseUp}
-                    >
-                        <CartesianGrid
-                            horizontal
-                            vertical={false}
-                            stroke={colors.gray[2]}
-                            strokeDasharray="4 3"
-                        />
-
-                        <YAxis
-                            axisLine={false}
-                            tickLine={false}
-                            fontSize={11}
-                            width={4}
-                            domain={['dataMin - 1', 'dataMax + 1']}
-                            allowDataOverflow={false}
-                        />
-
-                        <XAxis
-                            dataKey="dateValue"
-                            {...xAxisConfig}
-                            axisLine={{ stroke: colors.gray[2] }}
-                            tickLine={false}
-                            fontSize={11}
-                        />
-
-                        <RechartsTooltip
-                            formatter={(value) => [value, results.metric.label]}
-                            labelFormatter={(label) =>
-                                dayjs(label).format('MMM D, YYYY')
-                            }
-                            contentStyle={{
-                                fontSize: fontSizes.xs,
-                                backgroundColor: colors.offWhite[0],
-                                borderRadius: radius.md,
-                                border: `1px solid ${colors.gray[2]}`,
-                                boxShadow: shadows.sm,
+                <Flex sx={{ flex: 1 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                        <LineChart
+                            data={activeData}
+                            margin={{
+                                right: 40,
+                                left: 40,
+                                top: 10,
                             }}
-                        />
+                            onMouseDown={handleMouseDown}
+                            onMouseMove={handleMouseMove}
+                            onMouseUp={handleMouseUp}
+                        >
+                            <Legend
+                                verticalAlign="top"
+                                height={50}
+                                margin={{ bottom: 20 }}
+                                formatter={(value) => (
+                                    <Text span c="dark.5" size={14} fw={400}>
+                                        {value}
+                                    </Text>
+                                )}
+                            />
+                            <CartesianGrid
+                                horizontal
+                                vertical={false}
+                                stroke={colors.gray[2]}
+                                strokeDasharray="4 3"
+                            />
 
-                        <Line
-                            name={results.metric.label}
-                            type="linear"
-                            dataKey="metric"
-                            stroke={colors.indigo[6]}
-                            strokeWidth={1.6}
-                            dot={false}
-                            legendType="plainline"
-                        />
+                            <YAxis
+                                axisLine={false}
+                                tickLine={false}
+                                fontSize={11}
+                                width={4}
+                                domain={['dataMin - 1', 'dataMax + 1']}
+                                allowDataOverflow={false}
+                            />
 
-                        {results.comparisonRows && (
+                            <XAxis
+                                dataKey="dateValue"
+                                {...xAxisConfig}
+                                axisLine={{ stroke: colors.gray[2] }}
+                                tickLine={false}
+                                fontSize={11}
+                            />
+
+                            <RechartsTooltip
+                                formatter={(value) => [
+                                    value,
+                                    results.metric.label,
+                                ]}
+                                labelFormatter={(label) =>
+                                    dayjs(label).format('MMM D, YYYY')
+                                }
+                                contentStyle={{
+                                    fontSize: fontSizes.xs,
+                                    backgroundColor: colors.offWhite[0],
+                                    borderRadius: radius.md,
+                                    border: `1px solid ${colors.gray[2]}`,
+                                    boxShadow: shadows.sm,
+                                }}
+                            />
+
                             <Line
-                                name={`${results.metric.label} (comparison)`}
+                                name={results.metric.label}
                                 type="linear"
-                                dataKey="compareMetric"
-                                stroke={colors.indigo[4]}
-                                strokeDasharray={'3 3'}
-                                strokeWidth={1.3}
+                                dataKey="metric"
+                                stroke={colors.indigo[6]}
+                                strokeWidth={1.6}
                                 dot={false}
                                 legendType="plainline"
                             />
-                        )}
 
-                        <Legend
-                            formatter={(value) => (
-                                <Text span c="dark.5" size={14} fw={400}>
-                                    {value}
-                                </Text>
+                            {results.comparisonRows && (
+                                <Line
+                                    name={`${results.metric.label} (comparison)`}
+                                    type="linear"
+                                    dataKey="compareMetric"
+                                    stroke={colors.indigo[4]}
+                                    strokeDasharray={'3 3'}
+                                    strokeWidth={1.3}
+                                    dot={false}
+                                    legendType="plainline"
+                                />
                             )}
-                        />
 
-                        {zoomState.refAreaLeft && zoomState.refAreaRight && (
-                            <ReferenceArea
-                                x1={zoomState.refAreaLeft}
-                                x2={zoomState.refAreaRight}
-                                strokeOpacity={0.3}
-                                fill={colors.gray[3]}
-                            />
-                        )}
-                    </LineChart>
-                </ResponsiveContainer>
+                            {zoomState.refAreaLeft &&
+                                zoomState.refAreaRight && (
+                                    <ReferenceArea
+                                        x1={zoomState.refAreaLeft}
+                                        x2={zoomState.refAreaRight}
+                                        strokeOpacity={0.3}
+                                        fill={colors.gray[3]}
+                                    />
+                                )}
+                        </LineChart>
+                    </ResponsiveContainer>
+                </Flex>
+            )}
+            {results?.metric.availableTimeDimensions && (
+                <Group position="center" mt="auto">
+                    <Group align="center" noWrap>
+                        <Text fw={500} c="gray.7" fz="sm">
+                            Date ({capitalize(timeDimensionBaseField.interval)})
+                        </Text>
+
+                        <TimeDimensionPicker
+                            fields={results.metric.availableTimeDimensions}
+                            dimension={timeDimensionBaseField}
+                            onChange={(config) =>
+                                setTimeDimensionOverride(config)
+                            }
+                        />
+                    </Group>
+                </Group>
             )}
         </Stack>
     );

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
@@ -3,20 +3,14 @@ import {
     type TimeDimensionConfig,
 } from '@lightdash/common';
 import { Box, Group, Select, Text, useMantineTheme } from '@mantine/core';
-import { IconCalendar } from '@tabler/icons-react';
-import {
-    forwardRef,
-    type ComponentPropsWithoutRef,
-    type Dispatch,
-    type FC,
-    type SetStateAction,
-} from 'react';
+import { IconChevronDown, IconTable } from '@tabler/icons-react';
+import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 
 type Props = {
     fields: NonNullable<ApiGetMetricPeek['results']['availableTimeDimensions']>;
     dimension: TimeDimensionConfig;
-    onChange: Dispatch<SetStateAction<TimeDimensionConfig | undefined>>;
+    onChange: (config: TimeDimensionConfig) => void;
 };
 
 const FieldItem = forwardRef<
@@ -29,13 +23,16 @@ const FieldItem = forwardRef<
     }
 >(({ value, label, tableLabel, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap spacing="xs">
-            <Text size="xs" fw={500}>
+        <Group noWrap position="apart">
+            <Text fz="sm" c="dark.8" fw={500}>
                 {label}
             </Text>
-            <Text size="xs" color="dimmed" span>
-                {tableLabel}
-            </Text>
+            <Group spacing={4} noWrap>
+                <MantineIcon color="gray.6" size={12} icon={IconTable} />
+                <Text fz="xs" c="gray.6" span>
+                    {tableLabel}
+                </Text>
+            </Group>
         </Group>
     </Box>
 ));
@@ -49,25 +46,27 @@ export const TimeDimensionPicker: FC<Props> = ({
 
     return (
         <Select
+            withinPortal
+            size="xs"
             radius="md"
-            icon={<MantineIcon color="dark.3" icon={IconCalendar} />}
+            dropdownPosition="top"
             data={fields.map((f) => ({
                 value: f.name,
                 label: f.label,
                 tableLabel: f.tableLabel,
             }))}
+            h={32}
             value={dimension?.field}
             onChange={(value) => {
                 if (!value) return;
-                onChange((prev) => ({
+                onChange({
                     field: value,
-                    interval: prev?.interval ?? dimension.interval,
+                    interval: dimension.interval,
                     table:
                         fields.find((f) => f.name === value)?.table ??
                         dimension.table,
-                }));
+                });
             }}
-            w="100%"
             itemComponent={FieldItem}
             styles={{
                 input: {
@@ -75,6 +74,7 @@ export const TimeDimensionPicker: FC<Props> = ({
                     borderColor: theme.colors.gray[2],
                     borderRadius: theme.radius.md,
                     boxShadow: theme.shadows.subtle,
+                    padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
                     '&:hover': {
                         backgroundColor: theme.colors.gray[0],
                     },
@@ -83,17 +83,23 @@ export const TimeDimensionPicker: FC<Props> = ({
                     '&[data-selected="true"]': {
                         color: theme.colors.gray[7],
                         fontWeight: 500,
-                        backgroundColor: theme.colors.gray[2],
+                        backgroundColor: theme.colors.gray[0],
                     },
                     '&[data-selected="true"]:hover': {
-                        backgroundColor: theme.colors.gray[3],
+                        backgroundColor: theme.colors.gray[0],
                     },
                     '&:hover': {
-                        backgroundColor: theme.colors.gray[1],
+                        backgroundColor: theme.colors.gray[0],
                     },
                 },
+                dropdown: {
+                    minWidth: 'fit-content',
+                },
+                rightSection: { pointerEvents: 'none' },
             }}
-            rightSectionWidth="min-content"
+            rightSection={
+                <MantineIcon color="dark.2" icon={IconChevronDown} size={12} />
+            }
         />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/12739

### Description:

- Show time dimension picker below chart if there are available dimensions (no default)
- If not, hide it
- Always keep picker visible if its supposed to be visible - resize window
- Do **not** keep Modal mounted - it causes issues between metric peeks - sometimes the chart takes the whole height and it hides the picker, so this was the fix. 
- Moves legend to above the chart

Demo



https://github.com/user-attachments/assets/c1bdfb84-767b-4faa-af8c-4950dc08937b






### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
