### PR TITLE
feat: add clear buttons for item type and users dropdown

### DIFF
--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -4,7 +4,7 @@ import {
     type OrganizationMemberProfile,
     type SearchFilters,
 } from '@lightdash/common';
-import { Button, Flex, Group, Menu, Select } from '@mantine/core';
+import { Button, Flex, Group, Menu, Select, Text } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -91,7 +91,6 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
             filters?.createdByUuid
         );
     }, [filters]);
-
     return (
         <Group px="md" py="sm">
             <Menu
@@ -118,6 +117,29 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                 </Menu.Target>
 
                 <Menu.Dropdown>
+                    <Flex
+                        justify="space-between"
+                        align="center"
+                        mb="xs"
+                        px="sm"
+                    >
+                        <Text size="xs">Select Item Type</Text>
+                        {filters?.type && (
+                            <Button
+                                compact
+                                variant="subtle"
+                                size="xs"
+                                onClick={() =>
+                                    onSearchFilterChange({
+                                        ...filters,
+                                        type: undefined,
+                                    })
+                                }
+                            >
+                                Clear
+                            </Button>
+                        )}
+                    </Flex>
                     {allSearchItemTypes.map((type) => (
                         <Menu.Item
                             key={type}
@@ -245,6 +267,24 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                 </Menu.Target>
 
                 <Menu.Dropdown>
+                    <Flex justify="end">
+                        {filters?.createdByUuid && (
+                            <Button
+                                compact
+                                variant="subtle"
+                                size="xs"
+                                onClick={() =>
+                                    onSearchFilterChange({
+                                        ...filters,
+                                        createdByUuid: undefined,
+                                    })
+                                }
+                            >
+                                Clear
+                            </Button>
+                        )}
+                    </Flex>
+
                     <Select
                         placeholder="Select a user"
                         searchable


### PR DESCRIPTION


Closes: #12070
### Description:
<img width="962" alt="image" src="https://github.com/user-attachments/assets/2921bdbc-8497-43d9-938b-23f4f5391920">
<img width="994" alt="image" src="https://github.com/user-attachments/assets/99c3c528-24bd-4f8c-aa14-9849211c1a31">


Added Clear Button For Item Type and Users Dropdown


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
