### PR TITLE
chore: identify Lightdash version behind http request and response

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -5,6 +5,7 @@ import './sentry'; // Sentry has to be initialized before anything else
 import {
     LightdashError,
     LightdashMode,
+    LightdashVersionHeader,
     SessionUser,
     UnexpectedServerError,
 } from '@lightdash/common';
@@ -388,9 +389,10 @@ export default class App {
             }),
         );
 
-        // Permissions-Policy header that is not yet supported by helmet. More details here: https://github.com/helmetjs/helmet/issues/234
         expressApp.use((req, res, next) => {
+            // Permissions-Policy header that is not yet supported by helmet. More details here: https://github.com/helmetjs/helmet/issues/234
             res.setHeader('Permissions-Policy', 'camera=(), microphone=()');
+            res.setHeader(LightdashVersionHeader, VERSION);
             next();
         });
 

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -1,6 +1,7 @@
 import { isRequestMethod, RequestMethod } from '../types/api';
 
 export const LightdashRequestMethodHeader = 'Lightdash-Request-Method';
+export const LightdashVersionHeader = 'Lightdash-Version';
 
 export const getRequestMethod = (
     headerValue: string | undefined,

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import {
     LightdashRequestMethodHeader,
+    LightdashVersionHeader,
     RequestMethod,
     type ApiError,
     type ApiResponse,
@@ -15,6 +16,7 @@ export const BASE_API_URL =
 const defaultHeaders = {
     'Content-Type': 'application/json',
     [LightdashRequestMethodHeader]: RequestMethod.WEB_APP,
+    [LightdashVersionHeader]: __APP_VERSION__,
 };
 
 const handleError = (err: any): ApiError => {

--- a/packages/frontend/vite-env.d.ts
+++ b/packages/frontend/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+declare const __APP_VERSION__: string

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -6,6 +6,9 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    define: {
+        '__APP_VERSION__': JSON.stringify(process.env.npm_package_version),
+    },
     plugins: [
         tsconfigPaths(),
         svgrPlugin(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#12678](https://github.com/lightdash/lightdash/issues/12678)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- BE sets version in response headers
- FE sets version in request headers

Logs
<img width="1132" alt="Screenshot 2024-12-09 at 14 32 18" src="https://github.com/user-attachments/assets/9d4fd753-6d18-4c08-b935-1642720070cf">

Request
<img width="1273" alt="Screenshot 2024-12-09 at 14 33 22" src="https://github.com/user-attachments/assets/7c3ee4f8-d416-4fe4-b3b3-0d6faa124955">

Response
<img width="1274" alt="Screenshot 2024-12-09 at 14 34 02 1" src="https://github.com/user-attachments/assets/739eda77-3dca-440b-8c7d-47893d750eed">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
