### PR TITLE
chore: fixed group update so it doesn't throw on empty list

### DIFF
--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -462,15 +462,13 @@ export class GroupsModel {
                         )
                         .andWhere('groups.group_uuid', groupUuid);
 
-                    // Check if the initial and resulting counts match
-                    if (newMembers.length !== membersToAdd.length) {
-                        throw new Error(`Some provided user UUIDs are invalid`);
+                    // only insert if we found valid members
+                    if (newMembers.length > 0) {
+                        await trx('group_memberships')
+                            .insert(newMembers)
+                            .onConflict()
+                            .ignore();
                     }
-
-                    await trx('group_memberships')
-                        .insert(newMembers)
-                        .onConflict()
-                        .ignore();
                 }
                 if (membersToRemove.length > 0) {
                     await trx('group_memberships')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash-commercial/pull/411 

### Description:
- fixes an issue where newMembers of a group throws an error if it doesn't match the length of what is in the DB. this causes issues for SCIM where the list may contain users that don't exist yet.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
