### PR TITLE
chore: improve chart usage update query

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12072,7 +12072,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1404.2",
+        "version": "0.1405.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -16,6 +16,7 @@ import {
     type CatalogItemSummary,
     type CatalogItemWithTagUuids,
     type CatalogMetricsTreeEdge,
+    type ChartFieldUsageChanges,
     type ChartUsageIn,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -434,15 +435,9 @@ export class CatalogModel {
         });
     }
 
-    async updateChartUsages(
+    async updateFieldsChartUsage(
         projectUuid: string,
-        {
-            fieldsToIncrement,
-            fieldsToDecrement,
-        }: {
-            fieldsToIncrement: CatalogFieldWhere[];
-            fieldsToDecrement: CatalogFieldWhere[];
-        },
+        { fieldsToIncrement, fieldsToDecrement }: ChartFieldUsageChanges,
     ) {
         const incrementByCachedExploreUuid =
             getUpdatesByCachedExploreUuid(fieldsToIncrement);

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -8,6 +8,7 @@ import {
     type CatalogFieldWhere,
     type ChartFieldChanges,
     type ChartFieldUpdates,
+    type ChartFieldUsageChanges,
     type ExploreError,
 } from '@lightdash/common';
 import { uniq } from 'lodash';
@@ -179,7 +180,7 @@ export function getCatalogFieldWhereStatements(
         .filter((fieldWhere): fieldWhere is CatalogFieldWhere => !!fieldWhere);
 }
 
-export async function getChartUsageFieldsToUpdate(
+export async function getChartFieldUsageChanges(
     projectUuid: string,
     chartExplore: Explore | ExploreError,
     chartFields: ChartFieldUpdates,
@@ -187,7 +188,7 @@ export async function getChartUsageFieldsToUpdate(
         projectUuid: string,
         tableNames: string[],
     ) => Promise<Record<string, string>>,
-) {
+): Promise<ChartFieldUsageChanges> {
     const chartFieldChanges = getChartFieldChanges(chartFields);
     const { added, removed } = chartFieldChanges;
 

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -82,7 +82,7 @@ export const convertExploresToCatalog = (
 
 export function getTableNamesByFieldIds(
     fieldIds: string[],
-    fieldsType: FieldType,
+    fieldType: FieldType,
     explore: Explore | ExploreError,
 ) {
     if (isExploreError(explore)) {
@@ -93,7 +93,7 @@ export function getTableNamesByFieldIds(
         [string, string | undefined]
     >((fieldId) => {
         const table = Object.values(explore.tables).find((exploreTable) => {
-            if (fieldsType === FieldType.DIMENSION) {
+            if (fieldType === FieldType.DIMENSION) {
                 return Object.values(exploreTable.dimensions).some(
                     (dimension) =>
                         getItemId({
@@ -159,7 +159,7 @@ export function getCatalogFieldWhereStatements(
     fieldIds: string[],
     fieldTableNameMap: Record<string, string | undefined>,
     cachedExploreUuidTableNameMap: Record<string, string>,
-    fieldsType: FieldType,
+    fieldType: FieldType,
 ): Array<CatalogFieldWhere> {
     return fieldIds
         .map((fieldId) => {
@@ -174,7 +174,7 @@ export function getCatalogFieldWhereStatements(
             return {
                 cachedExploreUuid,
                 fieldName: fieldId.replace(`${tableName}_`, ''),
-                fieldType: fieldsType,
+                fieldType,
             };
         })
         .filter((fieldWhere): fieldWhere is CatalogFieldWhere => !!fieldWhere);

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -1,12 +1,16 @@
 import {
     CatalogType,
     Explore,
+    FieldType,
     getItemId,
     isExploreError,
     type CatalogFieldMap,
     type CatalogFieldWhere,
+    type ChartFieldChanges,
+    type ChartFieldUpdates,
     type ExploreError,
 } from '@lightdash/common';
+import { uniq } from 'lodash';
 import { DbCatalogIn } from '../../../database/entities/catalog';
 
 export const convertExploresToCatalog = (
@@ -74,14 +78,10 @@ export const convertExploresToCatalog = (
     };
 };
 
-export async function getCatalogFieldWhereByFieldIds(
-    projectUuid: string,
+export function getTableNamesByFieldIds(
     fieldIds: string[],
+    fieldsType: FieldType,
     explore: Explore | ExploreError,
-    findTablesCachedExploreUuid: (
-        projectUuid: string,
-        tableNames: string[],
-    ) => Promise<Record<string, string>>,
 ) {
     if (isExploreError(explore)) {
         return {};
@@ -90,25 +90,26 @@ export async function getCatalogFieldWhereByFieldIds(
     const tableNameByFieldIdEntries = fieldIds.map<
         [string, string | undefined]
     >((fieldId) => {
-        const table = Object.values(explore.tables).find(
-            (exploreTable) =>
-                Object.values(exploreTable.dimensions).some(
+        const table = Object.values(explore.tables).find((exploreTable) => {
+            if (fieldsType === FieldType.DIMENSION) {
+                return Object.values(exploreTable.dimensions).some(
                     (dimension) =>
                         getItemId({
                             table:
                                 exploreTable.originalName ?? exploreTable.name,
                             name: dimension.name,
                         }) === fieldId,
-                ) ||
-                Object.values(exploreTable.metrics).some(
-                    (metric) =>
-                        getItemId({
-                            table:
-                                exploreTable.originalName ?? exploreTable.name,
-                            name: metric.name,
-                        }) === fieldId,
-                ),
-        );
+                );
+            }
+
+            return Object.values(exploreTable.metrics).some(
+                (metric) =>
+                    getItemId({
+                        table: exploreTable.originalName ?? exploreTable.name,
+                        name: metric.name,
+                    }) === fieldId,
+            );
+        });
 
         if (!table) {
             return [fieldId, undefined];
@@ -117,85 +118,159 @@ export async function getCatalogFieldWhereByFieldIds(
         return [fieldId, table.originalName ?? table.name];
     });
 
-    const tableNameByFieldIds = Object.fromEntries(tableNameByFieldIdEntries);
+    return Object.fromEntries(tableNameByFieldIdEntries);
+}
 
-    const tableNames = Object.values(tableNameByFieldIds).filter(
-        (tableName): tableName is string => tableName !== undefined,
+export function getChartFieldChanges({
+    oldChartFields,
+    newChartFields,
+}: ChartFieldUpdates): ChartFieldChanges {
+    const addedDimensions = newChartFields.dimensions.filter(
+        (field) => !oldChartFields.dimensions.includes(field),
     );
 
-    const cachedExploreUuidsByTableName = await findTablesCachedExploreUuid(
-        projectUuid,
-        tableNames,
+    const addedMetrics = newChartFields.metrics.filter(
+        (field) => !oldChartFields.metrics.includes(field),
     );
 
-    return Object.fromEntries(
-        Object.entries(tableNameByFieldIds).map<
-            [string, CatalogFieldWhere | undefined]
-        >(([fieldId, tableName]) => {
-            const cachedExploreUuid =
-                tableName && cachedExploreUuidsByTableName[tableName];
-
-            if (!cachedExploreUuid) {
-                return [fieldId, undefined];
-            }
-
-            return [
-                fieldId,
-                {
-                    cachedExploreUuid,
-                    fieldName: fieldId.replace(`${tableName}_`, ''),
-                },
-            ];
-        }),
+    const removedDimensions = oldChartFields.dimensions.filter(
+        (field) => !newChartFields.dimensions.includes(field),
     );
+
+    const removedMetrics = oldChartFields.metrics.filter(
+        (field) => !newChartFields.metrics.includes(field),
+    );
+
+    return {
+        added: {
+            dimensions: addedDimensions,
+            metrics: addedMetrics,
+        },
+        removed: {
+            dimensions: removedDimensions,
+            metrics: removedMetrics,
+        },
+    };
+}
+
+export function getCatalogFieldWhereByFieldIds(
+    fieldIds: string[],
+    fieldTableNameMap: Record<string, string | undefined>,
+    cachedExploreUuidTableNameMap: Record<string, string>,
+    fieldsType: FieldType,
+) {
+    return fieldIds.map((fieldId) => {
+        const tableName = fieldTableNameMap[fieldId];
+        const cachedExploreUuid =
+            tableName && cachedExploreUuidTableNameMap[tableName];
+
+        if (!cachedExploreUuid) {
+            return undefined;
+        }
+
+        return {
+            cachedExploreUuid,
+            fieldName: fieldId.replace(`${tableName}_`, ''),
+            fieldType: fieldsType,
+        };
+    });
 }
 
 export async function getChartUsageFieldsToUpdate(
     projectUuid: string,
     chartExplore: Explore | ExploreError,
-    {
-        oldChartFields,
-        newChartFields,
-    }: {
-        oldChartFields: string[];
-        newChartFields: string[];
-    },
-    findTablesCachedExploreUuid: (
+    chartFields: ChartFieldUpdates,
+    getCachedExploresTableNameMap: (
         projectUuid: string,
         tableNames: string[],
     ) => Promise<Record<string, string>>,
 ) {
-    const addedFields = newChartFields.filter(
-        (field) => !oldChartFields.includes(field),
-    );
+    const chartFieldChanges = getChartFieldChanges(chartFields);
+    const { added, removed } = chartFieldChanges;
 
-    const removedFields = oldChartFields.filter(
-        (field) => !newChartFields.includes(field),
-    );
-
-    const catalogFieldWhereByFieldId = await getCatalogFieldWhereByFieldIds(
-        projectUuid,
-        [...addedFields, ...removedFields],
+    const metricTableNameMap = getTableNamesByFieldIds(
+        [...added.metrics, ...removed.metrics],
+        FieldType.METRIC,
         chartExplore,
-        findTablesCachedExploreUuid,
     );
 
-    const fieldsToIncrement: CatalogFieldWhere[] = addedFields
-        .map((fieldId) => catalogFieldWhereByFieldId[fieldId])
-        .filter(
-            (fieldWhere): fieldWhere is CatalogFieldWhere =>
-                fieldWhere !== undefined,
-        );
+    const dimensionTableNameMap = getTableNamesByFieldIds(
+        [...added.dimensions, ...removed.dimensions],
+        FieldType.DIMENSION,
+        chartExplore,
+    );
 
-    const fieldsToDecrement: CatalogFieldWhere[] = removedFields
-        .map((fieldId) => catalogFieldWhereByFieldId[fieldId])
-        .filter(
-            (fieldWhere): fieldWhere is CatalogFieldWhere =>
-                fieldWhere !== undefined,
-        );
+    const cachedExploreUuidTableNameMap = await getCachedExploresTableNameMap(
+        projectUuid,
+        uniq(
+            [
+                ...Object.values(dimensionTableNameMap),
+                ...Object.values(metricTableNameMap),
+            ].filter(
+                (tableName): tableName is string => tableName !== undefined,
+            ),
+        ),
+    );
+
+    const metricsToIncrement = getCatalogFieldWhereByFieldIds(
+        chartFieldChanges.added.metrics,
+        metricTableNameMap,
+        cachedExploreUuidTableNameMap,
+        FieldType.METRIC,
+    );
+
+    const metricsToDecrement = getCatalogFieldWhereByFieldIds(
+        chartFieldChanges.removed.metrics,
+        metricTableNameMap,
+        cachedExploreUuidTableNameMap,
+        FieldType.METRIC,
+    );
+
+    const dimensionsToIncrement = getCatalogFieldWhereByFieldIds(
+        chartFieldChanges.added.dimensions,
+        dimensionTableNameMap,
+        cachedExploreUuidTableNameMap,
+        FieldType.DIMENSION,
+    );
+
+    const dimensionsToDecrement = getCatalogFieldWhereByFieldIds(
+        chartFieldChanges.removed.dimensions,
+        dimensionTableNameMap,
+        cachedExploreUuidTableNameMap,
+        FieldType.DIMENSION,
+    );
 
     return {
-        fieldsToIncrement,
-        fieldsToDecrement,
+        fieldsToIncrement: [
+            ...metricsToIncrement,
+            ...dimensionsToIncrement,
+        ].filter((field) => !!field),
+
+        fieldsToDecrement: [
+            ...metricsToDecrement,
+            ...dimensionsToDecrement,
+        ].filter((field) => !!field),
     };
+}
+
+export function getUpdatesByCachedExploreUuid(
+    updates: CatalogFieldWhere[],
+): Record<string, Record<FieldType, string[]>> {
+    return updates.reduce<Record<string, Record<FieldType, string[]>>>(
+        (acc, field) => {
+            const current = acc[field.cachedExploreUuid] ?? {
+                [FieldType.METRIC]: [],
+                [FieldType.DIMENSION]: [],
+            };
+
+            current[field.fieldType] = [
+                ...current[field.fieldType],
+                field.fieldName,
+            ];
+
+            acc[field.cachedExploreUuid] = current;
+            return acc;
+        },
+        {},
+    );
 }

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -249,25 +249,3 @@ export async function getChartFieldUsageChanges(
         fieldsToDecrement: [...metricsToDecrement, ...dimensionsToDecrement],
     };
 }
-
-export function getUpdatesByCachedExploreUuid(
-    updates: CatalogFieldWhere[],
-): Record<string, Record<FieldType, string[]>> {
-    return updates.reduce<Record<string, Record<FieldType, string[]>>>(
-        (acc, field) => {
-            const current = acc[field.cachedExploreUuid] ?? {
-                [FieldType.METRIC]: [],
-                [FieldType.DIMENSION]: [],
-            };
-
-            current[field.fieldType] = [
-                ...current[field.fieldType],
-                field.fieldName,
-            ];
-
-            acc[field.cachedExploreUuid] = current;
-            return acc;
-        },
-        {},
-    );
-}

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -770,10 +770,12 @@ export class CatalogService<
         const chartUsageUpdates = Object.entries(chartUsagesByFieldId).reduce<
             ChartUsageIn[]
         >((acc, [fieldId, chartSummaries]) => {
-            const { fieldName, cachedExploreUuid } = catalogFieldMap[fieldId];
+            const { fieldName, cachedExploreUuid, fieldType } =
+                catalogFieldMap[fieldId];
 
             acc.push({
                 fieldName,
+                fieldType,
                 chartUsage: chartSummaries.length,
                 cachedExploreUuid,
             });

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -8,6 +8,7 @@ import {
     DashboardTab,
     DashboardTileTypes,
     ExploreType,
+    FieldType,
     ForbiddenError,
     generateSlug,
     hasChartsInDashboard,
@@ -25,12 +26,14 @@ import {
     TogglePinnedItemInfo,
     UpdateDashboard,
     UpdateMultipleDashboards,
+    type ChartFieldUpdates,
     type DashboardBasicDetailsWithTileTypes,
     type DuplicateDashboardParams,
     type Explore,
     type ExploreError,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
+import { uniq } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import {
     CreateDashboardOrVersionEvent,
@@ -41,7 +44,11 @@ import { SlackClient } from '../../clients/Slack/SlackClient';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
-import { getChartUsageFieldsToUpdate } from '../../models/CatalogModel/utils';
+import {
+    getChartFieldChanges,
+    getChartUsageFieldsToUpdate,
+    getTableNamesByFieldIds,
+} from '../../models/CatalogModel/utils';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -277,12 +284,9 @@ export class DashboardService extends BaseService {
     private async updateChartFieldUsage(
         projectUuid: string,
         chartExplore: Explore | ExploreError,
-        chartFields: {
-            oldChartFields: string[];
-            newChartFields: string[];
-        },
+        chartFields: ChartFieldUpdates,
     ) {
-        const fieldsToUpdate = await getChartUsageFieldsToUpdate(
+        const fieldUpdates = await getChartUsageFieldsToUpdate(
             projectUuid,
             chartExplore,
             chartFields,
@@ -291,7 +295,7 @@ export class DashboardService extends BaseService {
             ),
         );
 
-        await this.catalogModel.updateChartUsages(projectUuid, fieldsToUpdate);
+        await this.catalogModel.updateChartUsages(projectUuid, fieldUpdates);
     }
 
     async create(
@@ -461,12 +465,17 @@ export class DashboardService extends BaseService {
                                 projectUuid,
                                 cachedExplore,
                                 {
-                                    oldChartFields: [],
-                                    newChartFields: [
-                                        ...duplicatedChart.metricQuery.metrics,
-                                        ...duplicatedChart.metricQuery
-                                            .dimensions,
-                                    ],
+                                    oldChartFields: {
+                                        metrics: [],
+                                        dimensions: [],
+                                    },
+                                    newChartFields: {
+                                        metrics:
+                                            duplicatedChart.metricQuery.metrics,
+                                        dimensions:
+                                            duplicatedChart.metricQuery
+                                                .dimensions,
+                                    },
                                 },
                             );
                         } catch (error) {
@@ -901,12 +910,18 @@ export class DashboardService extends BaseService {
                                 projectUuid,
                                 cachedExplore,
                                 {
-                                    oldChartFields: [
-                                        ...chartInDashboard.metricQuery.metrics,
-                                        ...chartInDashboard.metricQuery
-                                            .dimensions,
-                                    ],
-                                    newChartFields: [],
+                                    oldChartFields: {
+                                        metrics:
+                                            chartInDashboard.metricQuery
+                                                .metrics,
+                                        dimensions:
+                                            chartInDashboard.metricQuery
+                                                .dimensions,
+                                    },
+                                    newChartFields: {
+                                        metrics: [],
+                                        dimensions: [],
+                                    },
                                 },
                             );
                         }

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -3,12 +3,10 @@ import {
     CreateDashboard,
     CreateSchedulerAndTargetsWithoutIds,
     Dashboard,
-    DashboardBasicDetails,
     DashboardDAO,
     DashboardTab,
     DashboardTileTypes,
     ExploreType,
-    FieldType,
     ForbiddenError,
     generateSlug,
     hasChartsInDashboard,
@@ -44,11 +42,7 @@ import { SlackClient } from '../../clients/Slack/SlackClient';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
-import {
-    getChartFieldChanges,
-    getChartUsageFieldsToUpdate,
-    getTableNamesByFieldIds,
-} from '../../models/CatalogModel/utils';
+import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -286,7 +280,7 @@ export class DashboardService extends BaseService {
         chartExplore: Explore | ExploreError,
         chartFields: ChartFieldUpdates,
     ) {
-        const fieldUpdates = await getChartUsageFieldsToUpdate(
+        const fieldUsageChanges = await getChartFieldUsageChanges(
             projectUuid,
             chartExplore,
             chartFields,
@@ -295,7 +289,10 @@ export class DashboardService extends BaseService {
             ),
         );
 
-        await this.catalogModel.updateChartUsages(projectUuid, fieldUpdates);
+        await this.catalogModel.updateFieldsChartUsage(
+            projectUuid,
+            fieldUsageChanges,
+        );
     }
 
     async create(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -13,13 +13,11 @@ import {
     ExploreType,
     ForbiddenError,
     generateSlug,
-    getItemId,
     getTimezoneLabel,
     isChartScheduler,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
     isCustomSqlDimension,
-    isExploreError,
     isUserWithOrg,
     isValidFrequency,
     ParameterError,
@@ -34,7 +32,7 @@ import {
     UpdateMultipleSavedChart,
     UpdateSavedChart,
     ViewStatistics,
-    type CatalogFieldWhere,
+    type ChartFieldUpdates,
     type Explore,
     type ExploreError,
 } from '@lightdash/common';
@@ -320,10 +318,7 @@ export class SavedChartService extends BaseService {
     private async updateChartFieldUsage(
         projectUuid: string,
         chartExplore: Explore | ExploreError,
-        chartFields: {
-            oldChartFields: string[];
-            newChartFields: string[];
-        },
+        chartFields: ChartFieldUpdates,
     ) {
         const fieldsToUpdate = await getChartUsageFieldsToUpdate(
             projectUuid,
@@ -413,11 +408,14 @@ export class SavedChartService extends BaseService {
             );
 
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {
-                oldChartFields: [...oldChartMetrics, ...oldChartDimensions],
-                newChartFields: [
-                    ...data.metricQuery.metrics,
-                    ...data.metricQuery.dimensions,
-                ],
+                oldChartFields: {
+                    metrics: oldChartMetrics,
+                    dimensions: oldChartDimensions,
+                },
+                newChartFields: {
+                    metrics: data.metricQuery.metrics,
+                    dimensions: data.metricQuery.dimensions,
+                },
             });
         } catch (error) {
             this.logger.error(
@@ -662,8 +660,14 @@ export class SavedChartService extends BaseService {
             );
 
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {
-                oldChartFields: [...metrics, ...dimensions],
-                newChartFields: [],
+                oldChartFields: {
+                    metrics,
+                    dimensions,
+                },
+                newChartFields: {
+                    metrics: [],
+                    dimensions: [],
+                },
             });
         } catch (error) {
             this.logger.error(
@@ -847,11 +851,14 @@ export class SavedChartService extends BaseService {
 
         try {
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {
-                oldChartFields: [],
-                newChartFields: [
-                    ...newSavedChart.metricQuery.metrics,
-                    ...newSavedChart.metricQuery.dimensions,
-                ],
+                oldChartFields: {
+                    metrics: [],
+                    dimensions: [],
+                },
+                newChartFields: {
+                    metrics: newSavedChart.metricQuery.metrics,
+                    dimensions: newSavedChart.metricQuery.dimensions,
+                },
             });
         } catch (error) {
             this.logger.error(
@@ -953,11 +960,14 @@ export class SavedChartService extends BaseService {
 
         try {
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {
-                oldChartFields: [],
-                newChartFields: [
-                    ...newSavedChart.metricQuery.metrics,
-                    ...newSavedChart.metricQuery.dimensions,
-                ],
+                oldChartFields: {
+                    metrics: [],
+                    dimensions: [],
+                },
+                newChartFields: {
+                    metrics: newSavedChart.metricQuery.metrics,
+                    dimensions: newSavedChart.metricQuery.dimensions,
+                },
             });
         } catch (error) {
             this.logger.error(
@@ -1175,14 +1185,14 @@ export class SavedChartService extends BaseService {
                 newChartVersion.projectUuid,
                 cachedExplore,
                 {
-                    oldChartFields: [
-                        ...currentChartVersion.metricQuery.metrics,
-                        ...currentChartVersion.metricQuery.dimensions,
-                    ],
-                    newChartFields: [
-                        ...newChartVersion.metricQuery.metrics,
-                        ...newChartVersion.metricQuery.dimensions,
-                    ],
+                    oldChartFields: {
+                        metrics: currentChartVersion.metricQuery.metrics,
+                        dimensions: currentChartVersion.metricQuery.dimensions,
+                    },
+                    newChartFields: {
+                        metrics: newChartVersion.metricQuery.metrics,
+                        dimensions: newChartVersion.metricQuery.dimensions,
+                    },
                 },
             );
         } catch (error) {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -47,7 +47,7 @@ import { SlackClient } from '../../clients/Slack/SlackClient';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
-import { getChartUsageFieldsToUpdate } from '../../models/CatalogModel/utils';
+import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -320,7 +320,7 @@ export class SavedChartService extends BaseService {
         chartExplore: Explore | ExploreError,
         chartFields: ChartFieldUpdates,
     ) {
-        const fieldsToUpdate = await getChartUsageFieldsToUpdate(
+        const fieldUsageChanges = await getChartFieldUsageChanges(
             projectUuid,
             chartExplore,
             chartFields,
@@ -329,7 +329,10 @@ export class SavedChartService extends BaseService {
             ),
         );
 
-        await this.catalogModel.updateChartUsages(projectUuid, fieldsToUpdate);
+        await this.catalogModel.updateFieldsChartUsage(
+            projectUuid,
+            fieldUsageChanges,
+        );
     }
 
     async createVersion(

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -208,6 +208,7 @@ export type CatalogFieldMap = {
         fieldName: string;
         tableName: string;
         cachedExploreUuid: string;
+        fieldType: FieldType;
     };
 };
 

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -270,6 +270,11 @@ export type CatalogFieldWhere = {
     cachedExploreUuid: string;
 };
 
+export type ChartFieldUsageChanges = {
+    fieldsToIncrement: CatalogFieldWhere[];
+    fieldsToDecrement: CatalogFieldWhere[];
+};
+
 export type ChartUsageIn = CatalogFieldWhere & {
     chartUsage: number;
 };

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -241,8 +241,31 @@ export type SchedulerIndexCatalogJobPayload = {
     prevMetricTreeEdges: CatalogMetricsTreeEdge[];
 };
 
+export type ChartFieldUpdates = {
+    oldChartFields: {
+        metrics: string[];
+        dimensions: string[];
+    };
+    newChartFields: {
+        metrics: string[];
+        dimensions: string[];
+    };
+};
+
+export type ChartFieldChanges = {
+    added: {
+        dimensions: string[];
+        metrics: string[];
+    };
+    removed: {
+        dimensions: string[];
+        metrics: string[];
+    };
+};
+
 export type CatalogFieldWhere = {
     fieldName: string;
+    fieldType: FieldType;
     cachedExploreUuid: string;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- Updates the chart usage taking into account field type
- Improves the chart usage update query so that it only performs at most 2 queries, one for increments and one for decrements

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
