### PR TITLE
fix: reverted check in GroupModel if the initial and resulting counts match

### DIFF
--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -462,13 +462,15 @@ export class GroupsModel {
                         )
                         .andWhere('groups.group_uuid', groupUuid);
 
-                    // only insert if we found valid members
-                    if (newMembers.length > 0) {
-                        await trx('group_memberships')
-                            .insert(newMembers)
-                            .onConflict()
-                            .ignore();
+                    // Check if the initial and resulting counts match
+                    if (newMembers.length !== membersToAdd.length) {
+                        throw new Error(`Some provided user UUIDs are invalid`);
                     }
+
+                    await trx('group_memberships')
+                        .insert(newMembers)
+                        .onConflict()
+                        .ignore();
                 }
                 if (membersToRemove.length > 0) {
                     await trx('group_memberships')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
- Previous merge was breaking expected results in tests. Reverting for now

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
