### PR TITLE
fix: get year forward on PoP comparison

### DIFF
--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -222,7 +222,7 @@ export const getMetricExplorerDataPointsWithCompare = (
         (_, date) =>
             comparison.type === MetricExplorerComparison.PREVIOUS_PERIOD
                 ? getDateCalcUtils(TimeFrames.YEAR)
-                      .back(new Date(date))
+                      .forward(new Date(date))
                       .toISOString()
                 : date,
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

get year forward instead of back - after merging this: https://github.com/lightdash/lightdash/pull/12793/files#diff-3618c7b719361cc6c12376a7ebfefc923784745ff035551f32ecd3150011f687

before

<img width="1662" alt="image" src="https://github.com/user-attachments/assets/59024bce-8c66-40f8-80a2-64a18e40c827">


after

<img width="1339" alt="Screenshot 2024-12-10 at 11 32 45" src="https://github.com/user-attachments/assets/3ead5784-b5ff-4a44-9dae-3186e9ce3045">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
