### PR TITLE
feat: make default limit configurable

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -16,6 +16,7 @@ export const lightdashConfigWithNoSMTP: Pick<
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 100,
+        defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
     },
@@ -47,6 +48,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 100,
+        defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
     },
@@ -67,6 +69,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 100,
+        defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
     },
@@ -83,6 +86,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 100,
+        defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
     },

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -141,6 +141,7 @@ export const lightdashConfigMock: LightdashConfig = {
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 5000,
+        defaultLimit: 500,
         csvCellsLimit: 100000,
         timezone: undefined,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -248,6 +248,7 @@ export type LightdashConfig = {
     maxPayloadSize: string;
     query: {
         maxLimit: number;
+        defaultLimit: number;
         csvCellsLimit: number;
         timezone: string | undefined;
     };
@@ -704,6 +705,10 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_LIMIT',
                 ) || 5000,
+            defaultLimit:
+                getIntegerFromEnvironmentVariable(
+                    'LIGHTDASH_QUERY_DEFAULT_LIMIT',
+                ) || 500,
             csvCellsLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_CSV_CELLS_LIMIT',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -61,6 +61,7 @@ export const BaseResponse: HealthState = {
     query: {
         csvCellsLimit: 100000,
         maxLimit: 5000,
+        defaultLimit: 500,
     },
     rudder: {
         dataPlaneUrl: '',

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -407,6 +407,7 @@ export const lightdashConfigWithNoSMTP: Pick<
     siteUrl: 'https://test.lightdash.cloud',
     query: {
         maxLimit: 100,
+        defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
     },

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -845,6 +845,7 @@ export type HealthState = {
     staticIp: string;
     query: {
         maxLimit: number;
+        defaultLimit: number;
         csvCellsLimit: number;
     };
     pivotTable: {

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -48,7 +48,7 @@ const ExplorerPage = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
     const explorerUrlState = useExplorerUrlState();
-    const { user } = useApp();
+    const { user, health } = useApp();
 
     const dateZoomGranularity = useDateZoomGranularitySearch();
 
@@ -78,6 +78,7 @@ const ExplorerPage = memo(() => {
             isEditMode={true}
             initialState={explorerUrlState}
             queryResults={queryResults}
+            defaultLimit={health.data?.query.defaultLimit}
         >
             <ExplorerWithUrlParams />
         </ExplorerProvider>

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -72,6 +72,8 @@ const MinimalSavedExplorer: FC = () => {
     }>();
     const context = useSearchParams('context') || undefined;
 
+    const { health } = useApp();
+
     const { data, isInitialLoading, isError, error } = useSavedQuery({
         id: savedQueryUuid,
     });
@@ -120,6 +122,7 @@ const MinimalSavedExplorer: FC = () => {
                       }
                     : undefined
             }
+            defaultLimit={health.data?.query.defaultLimit}
         >
             <MantineProvider inherit theme={themeOverride}>
                 <MinimalExplorer />

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -72,8 +72,6 @@ const MinimalSavedExplorer: FC = () => {
     }>();
     const context = useSearchParams('context') || undefined;
 
-    const { health } = useApp();
-
     const { data, isInitialLoading, isError, error } = useSavedQuery({
         id: savedQueryUuid,
     });
@@ -122,7 +120,6 @@ const MinimalSavedExplorer: FC = () => {
                       }
                     : undefined
             }
-            defaultLimit={health.data?.query.defaultLimit}
         >
             <MantineProvider inherit theme={themeOverride}>
                 <MinimalExplorer />

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -13,12 +13,15 @@ import { useChartPinningMutation } from '../hooks/pinning/useChartPinningMutatio
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
 import { useQueryResults } from '../hooks/useQueryResults';
 import { useSavedQuery } from '../hooks/useSavedQuery';
+import { useApp } from '../providers/AppProvider';
 import {
     ExplorerProvider,
     ExplorerSection,
 } from '../providers/ExplorerProvider';
 
 const SavedExplorer = () => {
+    const { health } = useApp();
+
     const { savedQueryUuid, mode, projectUuid } = useParams<{
         savedQueryUuid: string;
         projectUuid: string;
@@ -108,6 +111,7 @@ const SavedExplorer = () => {
                     : undefined
             }
             savedChart={data}
+            defaultLimit={health.data?.query.defaultLimit}
         >
             <Page
                 title={data?.name}

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -38,6 +38,7 @@ export default function mockHealthResponse(
         posthog: undefined,
         query: {
             maxLimit: 1000000,
+            defaultLimit: 500,
             csvCellsLimit: 100,
         },
         pivotTable: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5082 

### Description:

Adds an environment variable to make the default limit configurable. I believe this is the first explore default param that is set in the env config, so there is a little plumbing to make that work. 

Note that this is *not* currently plumbed into the SQL runner or Semantic viewer, but that could be added here or in a follow up. 

To test: 
- set `LIGHTDASH_QUERY_DEFAULT_LIMIT` 
- check that the new default is used in explores

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
