### PR TITLE
fix: share unsaved chart config

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -62,7 +62,6 @@ import { SyncModal as GoogleSheetsSyncModal } from '../../../features/sync/compo
 import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
 import {
@@ -418,20 +417,6 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
         project?.upstreamProjectUuid !== undefined && userCanPromoteChart
     );
 
-    const urlToShare = useMemo(() => {
-        if (unsavedChartVersion) {
-            const urlArgs = getExplorerUrlFromCreateSavedChartVersion(
-                projectUuid,
-                unsavedChartVersion,
-                true,
-            );
-            return {
-                pathname: urlArgs.pathname,
-                search: `?${urlArgs.search}`,
-            };
-        }
-    }, [unsavedChartVersion, projectUuid]);
-
     return (
         <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
             <Modal
@@ -563,7 +548,6 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                                         </Button>
                                         <ShareShortLinkButton
                                             disabled={!isValidQuery}
-                                            url={urlToShare}
                                         />
                                     </>
                                 ) : (

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -62,6 +62,7 @@ import { SyncModal as GoogleSheetsSyncModal } from '../../../features/sync/compo
 import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
 import {
@@ -417,6 +418,20 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
         project?.upstreamProjectUuid !== undefined && userCanPromoteChart
     );
 
+    const urlToShare = useMemo(() => {
+        if (unsavedChartVersion) {
+            const urlArgs = getExplorerUrlFromCreateSavedChartVersion(
+                projectUuid,
+                unsavedChartVersion,
+                true,
+            );
+            return {
+                pathname: urlArgs.pathname,
+                search: `?${urlArgs.search}`,
+            };
+        }
+    }, [unsavedChartVersion, projectUuid]);
+
     return (
         <TrackSection name={SectionName.EXPLORER_TOP_BUTTONS}>
             <Modal
@@ -548,6 +563,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                                         </Button>
                                         <ShareShortLinkButton
                                             disabled={!isValidQuery}
+                                            url={urlToShare}
                                         />
                                     </>
                                 ) : (

--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -6,7 +6,10 @@ import { useAsyncClipboard } from '../../../hooks/useAsyncClipboard';
 import { useCreateShareMutation } from '../../../hooks/useShare';
 import MantineIcon from '../MantineIcon';
 
-const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
+const ShareShortLinkButton: FC<{
+    disabled?: boolean;
+    url?: { pathname: string; search: string };
+}> = ({ disabled, url }) => {
     const location = useLocation();
 
     const { isLoading, mutateAsync: createShareUrl } = useCreateShareMutation();
@@ -14,8 +17,8 @@ const ShareShortLinkButton: FC<{ disabled?: boolean }> = ({ disabled }) => {
 
     const getSharedUrl = async () => {
         const response = await createShareUrl({
-            path: location.pathname,
-            params: location.search,
+            path: url?.pathname ?? location.pathname,
+            params: url?.search ?? location.search,
         });
         return response.shareUrl;
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12810](https://github.com/lightdash/lightdash/issues/12810)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Generate URL with entire chart config rather than using current URL which removes chart config to keep URL valid.

Same fix as https://github.com/lightdash/lightdash/pull/12400

Sharing from explore

https://github.com/user-attachments/assets/86e6e9bd-cc0c-45f6-9e59-748c0979f78c


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
