### PR TITLE
chore: updated types of errors thrown on updateGroup

### DIFF
--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -427,9 +427,7 @@ export class GroupsModel {
                             `Group name already exists`,
                         );
                     }
-                    throw new UnexpectedDatabaseError(
-                        'Failed to update group name',
-                    );
+                    throw new UnexpectedDatabaseError(error.message);
                 }
             }
 
@@ -495,7 +493,6 @@ export class GroupsModel {
                 }
             }
         });
-        // TODO: fix include member count
         return this.getGroupWithMembers(groupUuid, 10000);
     }
 

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -402,9 +402,6 @@ export class GroupsModel {
         groupUuid: string;
         update: UpdateGroupWithMembers;
     }): Promise<GroupWithMembers> {
-        if (!groupUuid || !update) {
-            throw new ParameterError('Invalid parameters for updating group');
-        }
         const existingGroup = await this.getGroupWithMembers(groupUuid, 10000);
         if (existingGroup === undefined) {
             throw new NotFoundError(`No group found`);

--- a/packages/e2e/cypress/e2e/api/groups.cy.ts
+++ b/packages/e2e/cypress/e2e/api/groups.cy.ts
@@ -193,7 +193,7 @@ describe('Groups API', () => {
                 },
                 failOnStatusCode: false,
             }).then((response2) => {
-                expect(response2.status).to.eq(500);
+                expect(response2.status).to.eq(400);
             });
         });
     });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+    - 'packages/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-packages:
-    - 'packages/*'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
- Adds more specific error types thrown if there are errors in `GroupModel.updateGroup()` for use downstream

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
