### PR TITLE
chore: cta of explore button opens metrics explorer

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,22 +1,21 @@
 import { type CatalogField } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine/core';
 import { type MRT_Row } from 'mantine-react-table';
-import { useCallback, useEffect, useState } from 'react';
-import {
-    createMetricPreviewUnsavedChartVersion,
-    getExplorerUrlFromCreateSavedChartVersion,
-} from '../../../hooks/useExplorerRoute';
+import { useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
-import { useAppSelector } from '../../sqlRunner/store/hooks';
-import { useMetric } from '../hooks/useMetricsCatalog';
+import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
+import { toggleMetricPeekModal } from '../store/metricsCatalogSlice';
 
 type Props = {
     row: MRT_Row<CatalogField>;
 };
 
 export const ExploreMetricButton = ({ row }: Props) => {
-    const [shouldFetch, setShouldFetch] = useState(false);
+    const dispatch = useAppDispatch();
+    const history = useHistory();
+
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
@@ -24,34 +23,6 @@ export const ExploreMetricButton = ({ row }: Props) => {
         (state) => state.metricsCatalog.organizationUuid,
     );
     const { track } = useTracking();
-
-    const metricQuery = useMetric({
-        projectUuid,
-        tableName: row.original.tableName,
-        metricName: row.original.name,
-        enabled: shouldFetch,
-    });
-
-    useEffect(() => {
-        if (!shouldFetch) return;
-        if (!projectUuid || !metricQuery.isSuccess) return;
-
-        const unsavedChartVersion = createMetricPreviewUnsavedChartVersion(
-            metricQuery.data,
-        );
-
-        const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
-            projectUuid,
-            unsavedChartVersion,
-        );
-
-        const url = new URL(pathname, window.location.origin);
-        url.search = new URLSearchParams(search).toString();
-
-        window.open(url.href, '_blank');
-
-        setShouldFetch(false); // Reset the fetch trigger
-    }, [metricQuery.data, metricQuery.isSuccess, projectUuid, shouldFetch]);
 
     const handleExploreClick = useCallback(() => {
         track({
@@ -64,9 +35,19 @@ export const ExploreMetricButton = ({ row }: Props) => {
             },
         });
 
-        // Trigger the fetch
-        setShouldFetch(true);
+        history.push(
+            `/projects/${projectUuid}/metrics/peek/${row.original.tableName}/${row.original.name}`,
+        );
+
+        dispatch(
+            toggleMetricPeekModal({
+                name: row.original.name,
+                tableName: row.original.tableName,
+            }),
+        );
     }, [
+        dispatch,
+        history,
         organizationUuid,
         projectUuid,
         row.original.name,
@@ -85,7 +66,6 @@ export const ExploreMetricButton = ({ row }: Props) => {
                 bg="linear-gradient(180deg, #202B37 0%, #151C24 100%)"
                 radius="md"
                 onClick={handleExploreClick}
-                loading={metricQuery.isFetching}
                 py="xxs"
                 px={10}
                 h={28}

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -64,6 +64,7 @@ type GenericEvent = {
         | EventName.DASHBOARD_AUTO_REFRESH_UPDATED
         | EventName.METRICS_CATALOG_CHART_USAGE_CLICKED
         | EventName.METRICS_CATALOG_EXPLORE_CLICKED
+        | EventName.METRICS_CATALOG_METRIC_NAME_CLICKED
         | EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED
         | EventName.METRICS_CATALOG_CATEGORY_CLICKED
         | EventName.METRICS_CATALOG_CATEGORY_FILTER_APPLIED
@@ -200,6 +201,16 @@ type MetricsCatalogExploreClickedEvent = {
     };
 };
 
+type MetricsCatalogMetricNameClickedEvent = {
+    name: EventName.METRICS_CATALOG_METRIC_NAME_CLICKED;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        metricName: string;
+        tableName: string;
+    };
+};
+
 type MetricsCatalogChartUsageChartClickedEvent = {
     name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED;
     properties: {
@@ -255,7 +266,8 @@ export type EventData =
     | MetricsCatalogChartUsageChartClickedEvent
     | MetricsCatalogCategoryClickedEvent
     | MetricsCatalogCategoryFilterAppliedEvent
-    | MetricsCatalogIconAppliedEvent;
+    | MetricsCatalogIconAppliedEvent
+    | MetricsCatalogMetricNameClickedEvent;
 
 type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -123,6 +123,7 @@ export enum EventName {
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',
     METRICS_CATALOG_CHART_USAGE_CHART_CLICKED = 'metrics_catalog_chart_usage_chart.clicked',
     METRICS_CATALOG_EXPLORE_CLICKED = 'metrics_catalog_explore.clicked',
+    METRICS_CATALOG_METRIC_NAME_CLICKED = 'metrics_catalog_metric_name.clicked',
     METRICS_CATALOG_CATEGORY_CLICKED = 'metrics_catalog_category.clicked',
     METRICS_CATALOG_CATEGORY_FILTER_APPLIED = 'metrics_catalog_category_filter.applied',
     METRICS_CATALOG_ICON_APPLIED = 'metrics_catalog_icon.applied',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12713](https://github.com/lightdash/lightdash/issues/12713)

### Description:

- Opens metric explorer on explore button click
- Adds new event `METRICS_CATALOG_METRIC_NAME_CLICKED`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
