### PR TITLE
fix: metrics catalog double border

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -400,6 +400,7 @@ export const MetricsTable = () => {
                         : `1px solid ${theme.colors.gray[2]}`,
                     borderBottom: `1px solid ${theme.colors.gray[2]}`,
                     borderTop: 'none',
+                    borderLeft: 'none',
                 },
                 sx: {
                     display: 'inline-flex',

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -359,9 +359,10 @@ export const MetricsTable = () => {
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
+                // This is needed to remove the bottom border of the last row when there are no rows (cell props are not used)
+                // It doesn't work when there are rows because they more specific selectors for default styles, so TableBodyCellProps are used instead
                 'tr:last-of-type > td': {
                     borderBottom: 'none',
-                    borderLeft: 'none !important',
                 },
             },
         },
@@ -390,6 +391,8 @@ export const MetricsTable = () => {
                 props.table.getAllColumns().indexOf(props.column) ===
                 props.table.getAllColumns().length - 1;
 
+            const isLastRow = flatData.length === props.row.index + 1;
+
             return {
                 h: 72,
                 // Adding to inline styles to override the default ones which can't be overridden with sx
@@ -398,7 +401,10 @@ export const MetricsTable = () => {
                     borderRight: isLastColumn
                         ? 'none'
                         : `1px solid ${theme.colors.gray[2]}`,
-                    borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                    // This is needed to remove the bottom border of the last row when there are rows
+                    borderBottom: isLastRow
+                        ? 'none'
+                        : `1px solid ${theme.colors.gray[2]}`,
                     borderTop: 'none',
                     borderLeft: 'none',
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12715 

### Description:

- Removes double borders on bottom last row and left last column
![image](https://github.com/user-attachments/assets/54efd648-1024-4a22-a2dc-18a67b0fbd28)
![image](https://github.com/user-attachments/assets/0c5d4fdb-12eb-4ebb-b0be-ba8e611e80ba)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
