### PR TITLE
fix: chart page showing charts from all projects the user has access to

### DIFF
--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
@@ -116,7 +116,7 @@ const AddResourceToSpaceModal: FC<Props> = ({ resourceType, onClose }) => {
         fetchNextPage,
     } = useInfiniteContent(
         {
-            projectUuid,
+            projectUuids: [projectUuid],
             contentTypes:
                 resourceType === AddToSpaceResources.CHART
                     ? [ContentType.CHART]

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -65,7 +65,9 @@ import {
 } from './resourceUtils';
 
 type ResourceView2Props = {
-    filters: Pick<ContentArgs, 'projectUuid' | 'spaceUuids' | 'contentTypes'>;
+    filters: Pick<ContentArgs, 'spaceUuids' | 'contentTypes'> & {
+        projectUuid: string;
+    };
 };
 
 const InfiniteResourceTable = ({ filters }: ResourceView2Props) => {
@@ -280,6 +282,7 @@ const InfiniteResourceTable = ({ filters }: ResourceView2Props) => {
         useInfiniteContent(
             {
                 ...filters,
+                projectUuids: [filters.projectUuid],
                 page: 1,
                 pageSize: 25,
                 search: deferredSearch,

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -14,7 +14,7 @@ import {
 import { lightdashApi } from '../api';
 
 export type ContentArgs = {
-    projectUuid: string;
+    projectUuids: string[];
     spaceUuids?: string[];
     contentTypes?: ContentType[];
     pageSize?: number;

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -54,7 +54,7 @@ const Space: FC = () => {
 
     const { data: allItems, isLoading: isContentLoading } = useContent(
         {
-            projectUuid,
+            projectUuids: [projectUuid],
             spaceUuids: [spaceUuid],
             pageSize: Number.MAX_SAFE_INTEGER,
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Charts page is showing charts from all projects the user has access to.
Space page was working well because it was filtering by space uuid.

Change:
- fix URL param, it was `projectUuid` instead of `projectUuids`

Steps to replicate:
- create preview
- go to charts page

before:

<img width="903" alt="Screenshot 2024-12-10 at 18 26 12" src="https://github.com/user-attachments/assets/b2fa7679-5ee2-4b5d-91bd-e375c52ce250">

after:

<img width="896" alt="Screenshot 2024-12-10 at 18 25 47" src="https://github.com/user-attachments/assets/983d2e0f-3573-4401-8f80-67b24c4244d6">


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
