### PR TITLE
fix: listen to project uuid changes and reset on refresh

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -15,7 +15,6 @@ import {
 import { IconInfoCircle, IconRefresh } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { useMount } from 'react-use';
 import MantineIcon from '../../../components/common/MantineIcon';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
 import { useProject } from '../../../hooks/useProject';
@@ -134,11 +133,11 @@ export const MetricsCatalogPanel = () => {
         metricName: string;
     }>();
 
-    useMount(() => {
+    useEffect(() => {
         if (!projectUuid && params.projectUuid) {
             dispatch(setProjectUuid(params.projectUuid));
         }
-    });
+    }, [params.projectUuid, dispatch, projectUuid]);
 
     useEffect(() => {
         if (!organizationUuid && project?.organizationUuid) {

--- a/packages/frontend/src/hooks/useRefreshServer.tsx
+++ b/packages/frontend/src/hooks/useRefreshServer.tsx
@@ -102,6 +102,9 @@ export const useJob = (
         onSuccess: async (job) => {
             if (job.jobStatus === JobStatusType.DONE) {
                 await queryClient.invalidateQueries(['tables']);
+                await queryClient.resetQueries(['metrics-catalog'], {
+                    exact: false,
+                });
 
                 if (job.jobType === JobType.COMPILE_PROJECT) {
                     await queryClient.invalidateQueries([


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12822

### Description:

- listen to changes of project uuid param - it now will trigger a new query if we change the project from the project switcher on the nav bar
- reset metrics-catalog query on refresh of catalog

demo

https://github.com/user-attachments/assets/8b2c4e1c-d356-4494-a603-e1fba1c4abc7



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
