### PR TITLE
fix: improve cache autocomplete UI

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -187,10 +187,13 @@ const FilterStringAutoComplete: FC<Props> = ({
                                 size="xs"
                                 px="sm"
                                 p="xxs"
-                                sx={{
+                                sx={(theme) => ({
                                     cursor: 'pointer',
-                                    borderTop: '1px solid #E5E5E5',
-                                }}
+                                    borderTop: `1px solid ${theme.colors.gray[2]}`,
+                                    '&:hover': {
+                                        backgroundColor: theme.colors.gray[1],
+                                    },
+                                })}
                                 onClick={() => setForceRefresh(true)}
                             >
                                 Results loaded at {refreshedAt.toLocaleString()}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -5,6 +5,7 @@ import {
     Loader,
     MultiSelect,
     ScrollArea,
+    Stack,
     Text,
     Tooltip,
     type MultiSelectProps,
@@ -156,13 +157,9 @@ const FilterStringAutoComplete: FC<Props> = ({
     // memo override component so list doesn't scroll to the top on each click
     const DropdownComponentOverride = useCallback(
         ({ children, ...props }: { children: ReactNode }) => (
-            <ScrollArea {...props}>
-                {refreshedAt && healthData?.hasCacheAutocompleResults ? (
-                    <Tooltip
-                        withinPortal
-                        position="left"
-                        label={`Click here to cache results now`}
-                    >
+            <Stack w="100%" spacing={0}>
+                <ScrollArea {...props}>
+                    {searchedMaxResults ? (
                         <Text
                             color="dimmed"
                             size="xs"
@@ -170,30 +167,38 @@ const FilterStringAutoComplete: FC<Props> = ({
                             pt="xs"
                             pb="xxs"
                             bg="white"
-                            pr="xs"
-                            sx={{ cursor: 'pointer' }}
-                            onClick={() => setForceRefresh(true)}
                         >
-                            Results loaded at {refreshedAt.toLocaleString()}
+                            Showing first {MAX_AUTOCOMPLETE_RESULTS} results.{' '}
+                            {search ? 'Continue' : 'Start'} typing...
                         </Text>
-                    </Tooltip>
-                ) : null}
-                {searchedMaxResults ? (
-                    <Text
-                        color="dimmed"
-                        size="xs"
-                        px="sm"
-                        pt="xs"
-                        pb="xxs"
-                        bg="white"
-                    >
-                        Showing first {MAX_AUTOCOMPLETE_RESULTS} results.{' '}
-                        {search ? 'Continue' : 'Start'} typing...
-                    </Text>
-                ) : null}
+                    ) : null}
 
-                {children}
-            </ScrollArea>
+                    {children}
+                </ScrollArea>
+                {healthData?.hasCacheAutocompleResults ? (
+                    <>
+                        <Tooltip
+                            withinPortal
+                            position="left"
+                            label={`Click here to refresh cache filter values`}
+                        >
+                            <Text
+                                color="dimmed"
+                                size="xs"
+                                px="sm"
+                                p="xxs"
+                                sx={{
+                                    cursor: 'pointer',
+                                    borderTop: '1px solid #E5E5E5',
+                                }}
+                                onClick={() => setForceRefresh(true)}
+                            >
+                                Results loaded at {refreshedAt.toLocaleString()}
+                            </Text>
+                        </Tooltip>
+                    </>
+                ) : null}
+            </Stack>
         ),
         [
             searchedMaxResults,
@@ -298,6 +303,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                     handleResetSearch();
                     onDropdownClose?.();
                 }}
+                dropdownPosition="bottom"
                 onChange={handleChange}
                 onCreate={handleAdd}
                 onKeyDown={handleKeyDown}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -303,7 +303,6 @@ const FilterStringAutoComplete: FC<Props> = ({
                     handleResetSearch();
                     onDropdownClose?.();
                 }}
-                dropdownPosition="bottom"
                 onChange={handleChange}
                 onCreate={handleAdd}
                 onKeyDown={handleKeyDown}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12790

## Changes: 
- pinned to the bottom
- change tooltip copy 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
[Screencast from 2024-12-11 11-17-13.webm](https://github.com/user-attachments/assets/52e46f46-2002-4432-845f-3a92dcb3f331)

In dashboards:

![image](https://github.com/user-attachments/assets/f479ef8a-3e67-4ab7-ae1d-8a3c62be68df)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
