### PR TITLE
fix: calculate y axis width dynamically

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -55,6 +55,7 @@ import {
 } from 'recharts/types/component/DefaultTooltipContent';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
+import { useDynamicYAxisWidth } from '../../hooks/useDynamicYAxisWidth';
 import { MetricPeekDatePicker } from '../MetricPeekDatePicker';
 import { MetricsVisualizationEmptyState } from '../MetricsVisualizationEmptyState';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
@@ -164,6 +165,7 @@ const MetricsVisualization: FC<Props> = ({
     comparison,
     isFetching,
 }) => {
+    const { yAxisWidth, setChartRef } = useDynamicYAxisWidth();
     const canManageExplore = useAppSelector(
         (state) => state.metricsCatalog.abilities.canManageExplore,
     );
@@ -288,10 +290,11 @@ const MetricsVisualization: FC<Props> = ({
 
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart
+                            ref={(instance) => setChartRef(instance)}
                             data={activeData}
                             margin={{
                                 right: 40,
-                                left: 60,
+                                left: 10,
                                 top: 10,
                             }}
                             onMouseDown={handleMouseDown}
@@ -329,7 +332,7 @@ const MetricsVisualization: FC<Props> = ({
                                 axisLine={false}
                                 tickLine={false}
                                 fontSize={11}
-                                width={8}
+                                width={yAxisWidth}
                                 domain={['dataMin - 1', 'dataMax + 1']}
                                 allowDataOverflow={false}
                                 label={
@@ -338,7 +341,6 @@ const MetricsVisualization: FC<Props> = ({
                                               value: results?.metric.label,
                                               angle: -90,
                                               position: 'left',
-                                              offset: 50,
                                               dy: -60,
                                               style: {
                                                   fontSize: 13,

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import type { LineChart } from 'recharts';
+
+const PADDING = 20;
+const TICK_VALUE_SELECTOR = '.recharts-cartesian-axis-tick-value';
+
+type ChartRef =
+    | ({
+          container?: HTMLElement;
+      } & Partial<typeof LineChart>)
+    | null;
+
+/**
+ * This hook is used to dynamically set the width of the y-axis based on the width of the tick values.
+ * This is used to ensure that the y-axis labels (and tick) are not cut off.
+ */
+export const useDynamicYAxisWidth = () => {
+    const [yAxisWidth, setYAxisWidth] = useState<number | undefined>(undefined);
+
+    const setChartRef = useCallback((chartRef: ChartRef) => {
+        if (chartRef && chartRef.container) {
+            const tickValueElements: NodeListOf<Element> =
+                chartRef.container.querySelectorAll(TICK_VALUE_SELECTOR);
+            const highestWidth = Array.from(tickValueElements).reduce(
+                (maxWidth, el) => {
+                    const width = el.getBoundingClientRect().width;
+                    return Math.max(maxWidth, width);
+                },
+                0,
+            );
+
+            setYAxisWidth(highestWidth + PADDING);
+        }
+    }, []);
+
+    return { yAxisWidth, setChartRef };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12784

### Description:

Added hook to calculate y axis width dynamically based on a selector, with inspiration from:https://github.com/recharts/recharts/issues/2027#issuecomment-1282172412

Before

<img width="919" alt="image" src="https://github.com/user-attachments/assets/3500590d-cbaa-414b-b66d-4fc73ece2ba3" />


After
<img width="1364" alt="Screenshot 2024-12-11 at 15 09 38" src="https://github.com/user-attachments/assets/824bce53-e5ee-4281-931b-c66712482a54" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
