### PR TITLE
fix: generate jobs starting at midnight, even when scheduler is delayed

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -424,13 +424,20 @@ export class SchedulerClient {
     async generateDailyJobsForScheduler(
         scheduler: SchedulerAndTargets,
         defaultTimezone: string,
+        // startingDateTime specifies that time after which to generate jobs.
+        // If not provided, it will generate job after now, which is the desired
+        // behavior for new schedulers and updates.
+        startingDateTime?: Date,
     ): Promise<void> {
         if (scheduler.enabled === false) return; // Do not add jobs for disabled schedulers
 
-        const dates = getDailyDatesFromCron({
-            cron: scheduler.cron,
-            timezone: scheduler.timezone ?? defaultTimezone,
-        });
+        const dates = getDailyDatesFromCron(
+            {
+                cron: scheduler.cron,
+                timezone: scheduler.timezone ?? defaultTimezone,
+            },
+            startingDateTime,
+        );
 
         try {
             const promises = dates.map((date: Date) =>

--- a/packages/backend/src/scheduler/SchedulerWorker.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.test.ts
@@ -42,6 +42,28 @@ describe('Cron converter', () => {
         expect(executionDates[0]).toStrictEqual(new Date(2023, 0, 1, 0, 0, 0)); // First execution should be at midnight
     });
 
+    test('Make sure we can schedule at midnight by passing the start of the day', () => {
+        const when = new Date(2023, 0, 1, 0, 0, 0);
+        const executionDates = getDailyDatesFromCron(
+            { cron: '0 * * * *', timezone: 'UTC' }, // Every hour
+            when,
+        );
+
+        expect(executionDates[0]).toStrictEqual(new Date(2023, 0, 1, 0, 0, 0)); // First execution should be at midnight
+    });
+
+    test('When no start time is provided, it should generate jobs after now', () => {
+        // A minute and a half after midnight
+        const when = new Date(2023, 0, 1, 0, 1, 30);
+        const executionDates = getDailyDatesFromCron(
+            { cron: '0 0 * * *', timezone: 'UTC' }, // At midnight
+            when,
+        );
+
+        // We should not generate jobs for today
+        expect(executionDates.length).toStrictEqual(0);
+    });
+
     test('Beginning and end of workday', () => {
         const when = new Date(2023, 0, 1, 0, 0, 30); // Beggining of the day (30 seconds after midnight)
         const executionDates = getDailyDatesFromCron(

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -162,6 +162,11 @@ export class SchedulerWorker extends SchedulerTask {
     protected getTaskList(): TaskList {
         return {
             generateDailyJobs: async () => {
+                const currentDateStartOfDay = moment()
+                    .utc()
+                    .startOf('day')
+                    .toDate();
+
                 const schedulers =
                     await this.schedulerService.getAllSchedulers();
 
@@ -174,6 +179,7 @@ export class SchedulerWorker extends SchedulerTask {
                     await this.schedulerClient.generateDailyJobsForScheduler(
                         scheduler,
                         defaultTimezone,
+                        currentDateStartOfDay,
                     );
                 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Jobs scheduled for midnight were not running when the job creating task happened after the first minute of the day. The method which finds which jobs to run rounds down to the beginning of the minute, so when it runs at 00:00:30, it catches jobs at midnight, but if it runs at 00:01:30, it misses jobs in the first minute.

This fix makes it so `generateDailyJobsForScheduler` takes an optional starting time after which to generate jobs. When we are creating the daily jobs, we now pass the start of the day `00:00:00`. So all jobs in that minute and after get added. 

Note that other calls to `generateDailyJobsForScheduler` from `create` and `update` methods DO NOT pass a start time since we want them to create jobs starting from when they are called. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
