### PR TITLE
fix: use requestAnimationFrame to avoid infinite loop

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
@@ -17,21 +17,30 @@ type ChartRef =
 export const useDynamicYAxisWidth = () => {
     const [yAxisWidth, setYAxisWidth] = useState<number | undefined>(undefined);
 
-    const setChartRef = useCallback((chartRef: ChartRef) => {
-        if (chartRef && chartRef.container) {
-            const tickValueElements: NodeListOf<Element> =
-                chartRef.container.querySelectorAll(TICK_VALUE_SELECTOR);
-            const highestWidth = Array.from(tickValueElements).reduce(
-                (maxWidth, el) => {
-                    const width = el.getBoundingClientRect().width;
-                    return Math.max(maxWidth, width);
-                },
-                0,
-            );
+    const setChartRef = useCallback(
+        (chartRef: ChartRef) => {
+            if (!chartRef?.container) return;
 
-            setYAxisWidth(highestWidth + PADDING);
-        }
-    }, []);
+            requestAnimationFrame(() => {
+                const tickValueElements: NodeListOf<Element> =
+                    chartRef.container!.querySelectorAll(TICK_VALUE_SELECTOR);
+
+                const highestWidth = Array.from(tickValueElements).reduce(
+                    (maxWidth, el) => {
+                        const width = el.getBoundingClientRect().width;
+                        return Math.max(maxWidth, width);
+                    },
+                    0,
+                );
+
+                const newWidth = highestWidth + PADDING;
+                if (newWidth !== yAxisWidth) {
+                    setYAxisWidth(newWidth);
+                }
+            });
+        },
+        [yAxisWidth],
+    );
 
     return { yAxisWidth, setChartRef };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After merging this; https://github.com/lightdash/lightdash/pull/12831 there would be a infinite render issue when going from unique_payment_count 12M to 5Y for example

Now it uses `requestAnimationFrame` to stabilise the setting of the y axis width. 




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
