### PR TITLE
fix: capture all errors from gsheet, disable scheduler and notify

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -2,6 +2,7 @@ import {
     CustomDimension,
     DimensionType,
     Field,
+    ForbiddenError,
     formatDate,
     getItemLabel,
     getItemLabelWithoutTableName,
@@ -9,7 +10,9 @@ import {
     isField,
     ItemsMap,
     Metric,
+    MissingConfigError,
     TableCalculation,
+    UnexpectedGoogleSheetsError,
 } from '@lightdash/common';
 import { google, sheets_v4 } from 'googleapis';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -45,7 +48,7 @@ export class GoogleDriveClient {
                 authClient,
             });
         } catch (err) {
-            throw new Error(`Failed to get credentials: ${err}`);
+            throw new ForbiddenError(`Failed to get credentials: ${err}`);
         }
     }
 
@@ -79,7 +82,7 @@ export class GoogleDriveClient {
 
     async createNewTab(refreshToken: string, fileId: string, tabName: string) {
         if (!this.isEnabled) {
-            throw new Error('Google Drive is not enabled');
+            throw new MissingConfigError('Google Drive is not enabled');
         }
         const auth = await this.getCredentials(refreshToken);
         const sheets = google.sheets({ version: 'v4', auth });
@@ -110,7 +113,7 @@ export class GoogleDriveClient {
                         `Google sheet tab already exist, we will overwrite it: ${error.errors[0]?.message}`,
                     );
                 } else {
-                    throw new Error(error);
+                    throw new UnexpectedGoogleSheetsError(error);
                 }
             });
 
@@ -119,7 +122,7 @@ export class GoogleDriveClient {
 
     async createNewSheet(refreshToken: string, title: string) {
         if (!this.isEnabled) {
-            throw new Error('Google Drive is not enabled');
+            throw new MissingConfigError('Google Drive is not enabled');
         }
         const auth = await this.getCredentials(refreshToken);
         const sheets = google.sheets({ version: 'v4', auth });
@@ -142,7 +145,7 @@ export class GoogleDriveClient {
         reportUrl?: string,
     ) {
         if (!this.isEnabled) {
-            throw new Error('Google Drive is not enabled');
+            throw new MissingConfigError('Google Drive is not enabled');
         }
 
         const metadataTabName = 'metadata';
@@ -190,7 +193,7 @@ export class GoogleDriveClient {
                 const firstSheetName =
                     spreadsheet.data.sheets?.[0].properties?.title;
                 if (!firstSheetName) {
-                    throw new Error(
+                    throw new UnexpectedGoogleSheetsError(
                         'Unable to find the first sheet name in the spreadsheet',
                     );
                 }
@@ -209,6 +212,7 @@ export class GoogleDriveClient {
             }
         } catch (error) {
             Logger.error('Unable to clear the sheet', error);
+            // Silently ignore this error
         }
     }
 
@@ -263,7 +267,7 @@ export class GoogleDriveClient {
         hiddenFields: string[] = [],
     ) {
         if (!this.isEnabled) {
-            throw new Error('Google Drive is not enabled');
+            throw new MissingConfigError('Google Drive is not enabled');
         }
 
         if (csvContent.length === 0) {
@@ -312,7 +316,7 @@ export class GoogleDriveClient {
         tabName?: string,
     ) {
         if (!this.isEnabled) {
-            throw new Error('Google Drive is not enabled');
+            throw new MissingConfigError('Google Drive is not enabled');
         }
 
         if (results.length === 0) {

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -349,3 +349,17 @@ export class SlackInstallationNotFoundError extends LightdashError {
         });
     }
 }
+
+export class UnexpectedGoogleSheetsError extends LightdashError {
+    constructor(
+        message = 'Unexpected error in Google sheets client',
+        data: { [key: string]: any } = {},
+    ) {
+        super({
+            message,
+            name: 'UnexpectedGoogleSheetsError',
+            statusCode: 400,
+            data,
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12825

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
We were already disabling some google sheet schedulers on specific errors 
- invalid_grant : integration with gsheets was removed https://myaccount.google.com/connections
- request entity: file was removed from gdrive 

Now I'm throwing a new error type, and capturing all errorrs to disable schedulers. 
And sending a notification to slack 

Disabling gsheets
![Screenshot from 2024-12-12 09-04-03](https://github.com/user-attachments/assets/94b7b54a-b9a8-4f88-8c1f-bbe1c1a5cba0)

<!-- Even better add a screenshot / gif / loom -->
slack notification: 

![Screenshot from 2024-12-12 09-18-10](https://github.com/user-attachments/assets/59945438-fa06-4618-b8da-7df99b086de6)

### Reviewer actions


- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
