### PR TITLE
fix: metrics explorer segment compare select loading states

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekComparison.tsx
@@ -17,7 +17,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { IconCalendar, IconChevronDown, IconStack } from '@tabler/icons-react';
+import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import {
     forwardRef,
@@ -214,16 +214,17 @@ export const MetricPeekComparison: FC<Props> = ({
                                             value={getItemId(query.metric)}
                                             onChange={handleMetricChange}
                                             itemComponent={FieldItem}
+                                            // this does not work as expected in Mantine 6
+                                            data-disabled={
+                                                !metricsWithTimeDimensionsQuery.isSuccess
+                                            }
                                             rightSection={
                                                 metricsWithTimeDimensionsQuery.isLoading ? (
-                                                    <Loader size="xs" />
-                                                ) : (
-                                                    <MantineIcon
-                                                        color="dark.2"
-                                                        icon={IconChevronDown}
-                                                        size={12}
+                                                    <Loader
+                                                        size="xs"
+                                                        color="gray.5"
                                                     />
-                                                )
+                                                ) : undefined
                                             }
                                             classNames={{
                                                 input: classes.input,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -15,6 +15,7 @@ import {
     Button,
     Divider,
     Group,
+    Loader,
     LoadingOverlay,
     Modal,
     Select,
@@ -283,7 +284,15 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
                                             : null
                                     }
                                     onChange={handleSegmentDimensionChange}
-                                    disabled={!segmentDimensionsQuery.isSuccess}
+                                    // this does not work as expected in Mantine 6
+                                    data-disabled={
+                                        !segmentDimensionsQuery.isSuccess
+                                    }
+                                    rightSection={
+                                        segmentDimensionsQuery.isLoading ? (
+                                            <Loader size="xs" color="gray.5" />
+                                        ) : undefined
+                                    }
                                     classNames={{
                                         input: classes.input,
                                         item: classes.item,


### PR DESCRIPTION
Closes: [#12844](https://github.com/lightdash/lightdash/issues/12844)

### Description:

mantine's disabled prop hides the right section

and

data-disabled prop does not get forwarded to the input

this is fixed in mantine 7 but have not found a way to make it work with mantine 6, thus I removed disabled state completely and left a comment

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
