### PR TITLE
fix: set comparison as none if empty metric

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricPeekModal.tsx
@@ -84,13 +84,26 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose }) => {
         tableName,
     });
 
+    const queryHasEmptyMetric = useMemo(() => {
+        return (
+            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC &&
+            query.metric.name === '' &&
+            query.metric.table === ''
+        );
+    }, [query]);
+
     const metricResultsQuery = useRunMetricExplorerQuery(
         {
             projectUuid,
             exploreName: tableName,
             metricName,
             dateRange: dateRange ?? undefined,
-            query,
+            query: queryHasEmptyMetric
+                ? {
+                      comparison: MetricExplorerComparison.NONE,
+                      segmentDimension: null,
+                  }
+                : query,
             timeDimensionOverride,
         },
         {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12862](https://github.com/lightdash/lightdash/issues/12862)

### Description:

sets comparison as none if its comparing a different metric but that is still empty

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
