### PR TITLE
fix: keep custom metric formatting in BigValue

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -8,6 +8,7 @@ import {
     getCustomFormatFromLegacy,
     getItemId,
     getItemLabel,
+    hasFormatOptions,
     isField,
     isMetric,
     isNumericItem,
@@ -251,6 +252,23 @@ const useBigNumberConfig = (
             );
         } else if (item !== undefined && isTableCalculation(item)) {
             return formatItemValue(item, firstRowValueRaw);
+        } else if (item !== undefined && hasFormatOptions(item)) {
+            // Custom metrics case
+
+            // If the custom metric has no format, but the big number has
+            // compact, treat the custom metric as a number
+            const type =
+                item.formatOptions?.type === CustomFormatType.DEFAULT
+                    ? bigNumberStyle
+                        ? CustomFormatType.NUMBER
+                        : CustomFormatType.DEFAULT
+                    : item.formatOptions?.type;
+
+            return applyCustomFormat(firstRowValueRaw, {
+                ...item.formatOptions,
+                type,
+                compact: bigNumberStyle,
+            });
         } else {
             return applyCustomFormat(
                 firstRowValueRaw,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12707 

### Description:

Use custom metric formatting in big number viz. Specifically:
- Uses a custom metric's formatting in Big Number
- If the user sets the 'compact' formatting in big number config, the compact formatting is overriden. 
- Compact formatting is *not* overriden for percentages -- the formatting functions for percentage ignore compact, we could potentially add it there, but it looks intentionally ignored. There will be broader implications. 

To test:
- Add a custom metric with formatting
- Make a big number viz
- Check that format is preserved
- Check that you can change the 'Format' options in the viz config, which just affect 'compact' styles

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
