### PR TITLE
fix: remove tile uuid from dashboard as code

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -124,7 +124,7 @@ export class CoderService extends BaseService {
                     ...tile,
                     properties: { ...tile.properties },
                 };
-
+                delete tileWithoutUuid.uuid;
                 if ('savedChartUuid' in tileWithoutUuid.properties) {
                     delete tileWithoutUuid.properties.savedChartUuid;
                 }

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -36,7 +36,11 @@ export type ApiChartAsCodeUpsertResponse = {
     results: PromotionChanges;
 };
 
-export type DashboardTileWithoutUuids = Omit<DashboardTile, 'properties'> & {
+export type DashboardTileWithoutUuids = Omit<
+    DashboardTile,
+    'properties' | 'uuid'
+> & {
+    uuid: DashboardTile['uuid'] | undefined; // Allows us to remove the uuid from the object
     properties: Omit<
         DashboardTile['properties'],
         'savedChartUuid' | 'savedSqlUuid' | 'savedSemanticViewerChartUuid'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Thread: https://lightdash.slack.com/archives/C07UA0AC2G2/p1734084141684769?thread_ts=1734029192.374489&cid=C07UA0AC2G2
### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Removes tile uuid from dashboard as code, it was not used, but it was causing confusion to users. 
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
