### PR TITLE
fix: only set border bottom to none when theres scroll and is last row

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -403,6 +403,10 @@ export const MetricsTable = () => {
                 props.table.getAllColumns().length - 1;
 
             const isLastRow = flatData.length === props.row.index + 1;
+            const hasScroll = tableContainerRef.current
+                ? tableContainerRef.current.scrollHeight >
+                  tableContainerRef.current.clientHeight
+                : false;
 
             return {
                 h: 72,
@@ -413,9 +417,10 @@ export const MetricsTable = () => {
                         ? 'none'
                         : `1px solid ${theme.colors.gray[2]}`,
                     // This is needed to remove the bottom border of the last row when there are rows
-                    borderBottom: isLastRow
-                        ? 'none'
-                        : `1px solid ${theme.colors.gray[2]}`,
+                    borderBottom:
+                        isLastRow && hasScroll
+                            ? 'none'
+                            : `1px solid ${theme.colors.gray[2]}`,
                     borderTop: 'none',
                     borderLeft: 'none',
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

- when there's no scroll it means that there won't be overlap with footer, so we don't set border bottom to `none`
![image](https://github.com/user-attachments/assets/d479010e-ed86-46a0-9651-18c186e8961b)

- when there's scroll, we set it to `none` so there's no double borders
![image](https://github.com/user-attachments/assets/57df222f-8999-429d-8357-53b77978acca)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
