### PR TITLE
fix: metrics explorer y label align center

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -802,8 +802,10 @@ const MetricsVisualization: FC<Props> = ({
                                               value: results?.metric.label,
                                               angle: -90,
                                               position: 'left',
-                                              dy: -60,
+                                              // hardcoded value to align the label when the legend is shown
+                                              dy: showLegend ? -25 : 0,
                                               style: {
+                                                  textAnchor: 'middle',
                                                   fontSize: 14,
                                                   fill: colors.gray[7],
                                                   fontWeight: 500,


### PR DESCRIPTION
Closes: #12888 

### Description:


https://github.com/user-attachments/assets/5063e9e4-8ea4-4557-be9a-9384dbb1a861



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
