### PR TITLE
fix: use isoWeek and offset weeks correctly on PoP

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -87,7 +87,10 @@ export class MetricsExplorerService<
         fields: ItemsMap;
         dimension: Dimension;
     }> {
-        const oneYearBack = getDateCalcUtils(TimeFrames.YEAR).back;
+        const oneYearBack = getDateCalcUtils(
+            TimeFrames.YEAR,
+            timeDimensionConfig.interval,
+        ).back;
         const forwardBackDateRange: MetricExplorerDateRange = [
             oneYearBack(dateRange[0]),
             oneYearBack(dateRange[1]),
@@ -427,6 +430,7 @@ export class MetricsExplorerService<
                     currentResults,
                     comparisonResults,
                     query,
+                    timeDimensionConfig.interval,
                 );
 
             dataPoints = metricExplorerDataPointsWithCompare;

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -98,30 +98,29 @@ export const getFieldIdForDateDimension = (
 
 export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
     switch (timeFrame) {
-        case TimeFrames.DAY:
-            return {
-                forward: (date: Date) => dayjs(date).add(1, 'day').toDate(),
-                back: (date: Date) => dayjs(date).subtract(1, 'day').toDate(),
-            };
-        case TimeFrames.WEEK:
-            return {
-                forward: (date: Date) => dayjs(date).add(1, 'week').toDate(),
-                back: (date: Date) => dayjs(date).subtract(1, 'week').toDate(),
-            };
         case TimeFrames.MONTH:
+            if (grain)
+                throw new Error(
+                    `Timeframe "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
+                );
             return {
                 forward: (date: Date) => dayjs(date).add(1, 'month').toDate(),
                 back: (date: Date) => dayjs(date).subtract(1, 'month').toDate(),
             };
         case TimeFrames.YEAR:
-            // Handle week shift for previous year comparison
+            // Handle week shift for previous year comparison and subtract what the amount of weeks is in a year
             if (grain === TimeFrames.WEEK) {
                 return {
                     forward: (date: Date) =>
-                        dayjs(date).add(1, 'year').startOf('isoWeek').toDate(),
+                        dayjs(date)
+                            // 52 weeks in a year
+                            .add(52, 'weeks')
+                            .startOf('isoWeek')
+                            .toDate(),
                     back: (date: Date) =>
                         dayjs(date)
-                            .subtract(1, 'year')
+                            // 52 weeks in a year
+                            .subtract(52, 'weeks')
                             .startOf('isoWeek')
                             .toDate(),
                 };
@@ -130,6 +129,9 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
                 forward: (date: Date) => dayjs(date).add(1, 'year').toDate(),
                 back: (date: Date) => dayjs(date).subtract(1, 'year').toDate(),
             };
+        case TimeFrames.DAY:
+        case TimeFrames.WEEK:
+            throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         default:
             return assertUnimplementedTimeframe(timeFrame);
     }

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -279,9 +279,9 @@ export const getMetricExplorerDataPoints = (
     };
 };
 
-function adjustCompareDates(
+function offsetWeekCompareDates(
     groupByCompareMetricRows: Dictionary<ResultRow[]>,
-    timeFrame: TimeFrames,
+    timeFrame: TimeFrames.WEEK,
 ) {
     return Object.fromEntries(
         Object.keys(groupByCompareMetricRows).map((compareDate) => {
@@ -333,7 +333,7 @@ export const getMetricExplorerDataPointsWithCompare = (
         (_, date) => {
             if (query.comparison === MetricExplorerComparison.PREVIOUS_PERIOD) {
                 if (timeFrame === TimeFrames.WEEK) {
-                    return adjustCompareDates(
+                    return offsetWeekCompareDates(
                         groupByCompareMetricRows,
                         timeFrame,
                     )[date];

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -11,8 +11,11 @@ import {
     type YearPickerProps,
 } from '@mantine/dates';
 import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatDate, getDateRangePresets } from '../utils/metricPeekDate';
+
+dayjs.extend(isoWeek);
 
 type DateRange = MetricExplorerPartialDateRange;
 
@@ -314,10 +317,10 @@ export const useDateRangePicker = ({
 
                             const getWeekBoundaries = (date: Date) => {
                                 const weekStart = dayjs(date)
-                                    .startOf('week')
+                                    .startOf('isoWeek')
                                     .toDate();
                                 const weekEnd = dayjs(date)
-                                    .endOf('week')
+                                    .endOf('isoWeek')
                                     .toDate();
                                 return { weekStart, weekEnd };
                             };
@@ -367,26 +370,31 @@ export const useDateRangePicker = ({
                             }
                         },
                         numberOfColumns: 2,
-                        firstDayOfWeek: 0,
+                        firstDayOfWeek: 1,
                         hideOutsideDates: true,
                         // Highlight the week of the selected date
                         getDayProps: (date) => {
+                            const today = dayjs().endOf('day');
+                            const isInFuture = dayjs(date).isAfter(today);
+
                             const isSelected = Boolean(
                                 tempDateRange[0] &&
                                     tempDateRange[1] &&
                                     date >=
                                         dayjs(tempDateRange[0])
-                                            .startOf('week')
+                                            .startOf('isoWeek')
                                             .toDate() &&
                                     date <=
                                         dayjs(tempDateRange[1])
-                                            .endOf('week')
-                                            .toDate(),
+                                            .endOf('isoWeek')
+                                            .toDate() &&
+                                    !isInFuture, // Don't highlight future dates
                             );
+
                             return {
                                 inRange: isSelected,
-                                firstInRange: date.getDay() === 0 && isSelected, // Highlight the first day of the week
-                                lastInRange: date.getDay() === 6 && isSelected, // Highlight the last day of the week
+                                firstInRange: date.getDay() === 1 && isSelected,
+                                lastInRange: date.getDay() === 0 && isSelected,
                             };
                         },
                         styles: getCommonCalendarStyles,

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -5,8 +5,11 @@ import {
     type MetricExplorerPartialDateRange,
 } from '@lightdash/common';
 import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
 import { type NameType } from 'recharts/types/component/DefaultTooltipContent';
 import { type DateRangePreset } from '../hooks/useDateRangePicker';
+
+dayjs.extend(isoWeek);
 
 const DATE_FORMAT = 'MMM D, YYYY';
 export const formatDate = (date: Date | null): string | undefined => {
@@ -96,7 +99,7 @@ export const getDateRangePresets = (
                     label: 'This week',
                     controlLabel: 'This week',
                     getValue: () => [
-                        today.startOf('week').toDate(),
+                        today.startOf('isoWeek').toDate(),
                         now.toDate(),
                     ],
                 },
@@ -104,7 +107,7 @@ export const getDateRangePresets = (
                     label: 'Past 1 week',
                     controlLabel: '1W',
                     getValue: () => [
-                        today.subtract(1, 'week').startOf('week').toDate(),
+                        today.subtract(1, 'week').startOf('isoWeek').toDate(),
                         now.toDate(),
                     ],
                 },
@@ -112,7 +115,7 @@ export const getDateRangePresets = (
                     label: 'Past 4 weeks',
                     controlLabel: '4W',
                     getValue: () => [
-                        today.subtract(4, 'week').startOf('week').toDate(),
+                        today.subtract(4, 'week').startOf('isoWeek').toDate(),
                         now.toDate(),
                     ],
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12893](https://github.com/lightdash/lightdash/issues/12893)

### Description:

When comparing to previous year, on a week granularity, there was no offset applied to the start of the week, now we address that and values align with the previous year's relative week. 

Also, have used isoWeek plugin so that the it matches the isoString usage we have - thoughts?


Demo:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/00273e10-fe34-417b-8cc1-422c016f5ccb" />


<img width="1502" alt="image" src="https://github.com/user-attachments/assets/e33fbd48-a434-4a02-ac18-ef6285cd0452" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
