### PR TITLE
chore: track when searching metrics catalog

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -39,7 +39,10 @@ import SuboptimalState from '../../../components/common/SuboptimalState/Suboptim
 import { useTracking } from '../../../providers/TrackingProvider';
 import { EventName } from '../../../types/Events';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
-import { useMetricsCatalog } from '../hooks/useMetricsCatalog';
+import {
+    MIN_METRICS_CATALOG_SEARCH_LENGTH,
+    useMetricsCatalog,
+} from '../hooks/useMetricsCatalog';
 import { useMetricsTree } from '../hooks/useMetricsTree';
 import {
     setCategoryFilters,
@@ -114,6 +117,22 @@ export const MetricsTable = () => {
             sortDirection: sorting[0].desc ? 'desc' : 'asc',
         }),
     });
+
+    useEffect(() => {
+        if (
+            deferredSearch &&
+            deferredSearch.length > MIN_METRICS_CATALOG_SEARCH_LENGTH &&
+            data
+        ) {
+            track({
+                name: EventName.METRICS_CATALOG_SEARCH_APPLIED,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                },
+            });
+        }
+    }, [deferredSearch, track, organizationUuid, projectUuid, data]);
 
     // Check if we are mutating any of the icons or categories related mutations
     // TODO: Move this to separate hook and utilise constants so this scales better

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -16,6 +16,8 @@ type UseMetricsCatalogOptions = {
     sortDirection?: ApiSort['order'];
 };
 
+export const MIN_METRICS_CATALOG_SEARCH_LENGTH = 2;
+
 const getMetricsCatalog = async ({
     projectUuid,
     search,
@@ -95,7 +97,11 @@ export const useMetricsCatalog = ({
                     : undefined;
             }
         },
-        enabled: !!projectUuid && (!!search ? search.length > 2 : true),
+        enabled:
+            !!projectUuid &&
+            (!!search
+                ? search.length > MIN_METRICS_CATALOG_SEARCH_LENGTH
+                : true),
         keepPreviousData: true,
     });
 };

--- a/packages/frontend/src/providers/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/TrackingProvider.tsx
@@ -75,7 +75,8 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_EXPLORE_DATE_FILTER_APPLIED
         | EventName.METRICS_CATALOG_EXPLORE_GRANULARITY_APPLIED
         | EventName.METRICS_CATALOG_EXPLORE_SEGMENT_BY_APPLIED
-        | EventName.METRICS_CATALOG_EXPLORE_TIME_DIMENSION_OVERRIDE_APPLIED;
+        | EventName.METRICS_CATALOG_EXPLORE_TIME_DIMENSION_OVERRIDE_APPLIED
+        | EventName.METRICS_CATALOG_SEARCH_APPLIED;
     properties?: {};
 };
 
@@ -327,6 +328,14 @@ type MetricsCatalogExploreTimeDimensionOverrideAppliedEvent = {
     };
 };
 
+type MetricsCatalogSearchAppliedEvent = {
+    name: EventName.METRICS_CATALOG_SEARCH_APPLIED;
+    properties: {
+        organizationId: string;
+        projectId: string;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | FormClickedEvent
@@ -353,7 +362,8 @@ export type EventData =
     | MetricsCatalogExploreDateFilterAppliedEvent
     | MetricsCatalogExploreGranularityAppliedEvent
     | MetricsCatalogExploreSegmentByAppliedEvent
-    | MetricsCatalogExploreTimeDimensionOverrideAppliedEvent;
+    | MetricsCatalogExploreTimeDimensionOverrideAppliedEvent
+    | MetricsCatalogSearchAppliedEvent;
 
 type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -121,6 +121,7 @@ export enum EventName {
 
     // Metrics Catalog
     METRICS_CATALOG_CLICKED = 'metrics_catalog.clicked',
+    METRICS_CATALOG_SEARCH_APPLIED = 'metrics_catalog_search.applied',
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',
     METRICS_CATALOG_CHART_USAGE_CHART_CLICKED = 'metrics_catalog_chart_usage_chart.clicked',
     METRICS_CATALOG_EXPLORE_CLICKED = 'metrics_catalog_explore.clicked',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Tracks when user searches the metrics catalog

<img width="1903" alt="Screenshot 2024-12-13 at 17 10 24" src="https://github.com/user-attachments/assets/29b4d055-d10c-4450-9a8a-131d77f0fea3" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
