### PR TITLE
fix: SQL runner share url

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -25,8 +25,8 @@ import { EditableText } from '../../../../components/VisualizationConfigs/common
 import useHealth from '../../../../hooks/health/useHealth';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useProject } from '../../../../hooks/useProject';
-import { useCreateShareMutation } from '../../../../hooks/useShare';
 import { CreateVirtualViewModal } from '../../../virtualView';
+import { useCreateSqlRunnerShareUrl } from '../../hooks/useSqlRunnerShareUrl';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
     DEFAULT_NAME,
@@ -52,9 +52,6 @@ export const HeaderCreate: FC = () => {
         (state) => state.sqlRunner.modals.saveChartModal.isOpen,
     );
     const health = useHealth();
-    const sqlRunnerState = useAppSelector((state) => state.sqlRunner);
-    const { mutateAsync: createShareUrl } = useCreateShareMutation();
-
     const isGithubIntegrationEnabled =
         health?.data?.hasGithub &&
         project?.dbtConnection.type === DbtProjectType.GITHUB;
@@ -139,17 +136,13 @@ export const HeaderCreate: FC = () => {
     }, []);
     const clipboard = useClipboard({ timeout: 500 });
     const { showToastSuccess } = useToaster();
+    const createShareUrl = useCreateSqlRunnerShareUrl();
 
     const handleCreateShareUrl = useCallback(async () => {
-        const path = window.location.pathname;
-        const shareUrl = await createShareUrl({
-            path,
-            params: JSON.stringify(sqlRunnerState),
-        });
-        const fullUrl = `${window.location.origin}${window.location.pathname}?share=${shareUrl.nanoid}`;
+        const fullUrl = await createShareUrl();
         clipboard.copy(fullUrl);
         showToastSuccess({ title: 'Shared URL copied to clipboard!' });
-    }, [createShareUrl, sqlRunnerState, clipboard, showToastSuccess]);
+    }, [createShareUrl, clipboard, showToastSuccess]);
 
     return (
         <>

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlRunnerShareUrl.ts
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlRunnerShareUrl.ts
@@ -1,0 +1,123 @@
+import { type AllVizChartConfig } from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { selectCompleteConfigByKind } from '../../../components/DataViz/store/selectors';
+import { useCreateShareMutation, useGetShare } from '../../../hooks/useShare';
+import { useAppSelector } from '../store/hooks';
+import {
+    initialState,
+    selectActiveChartType,
+    type SqlRunnerState,
+} from '../store/sqlRunnerSlice';
+
+const EXCLUDED_KEYS_FROM_SHARE_STATE = [
+    'savedSqlChart',
+    'fileUrl',
+    'successfulSqlQueries',
+    'hasUnrunChanges',
+    'modals',
+    'sqlColumns',
+    'queryIsLoading',
+    'queryError',
+    'editorHighlightError',
+    'fetchResultsOnLoad',
+] as const;
+
+type ExcludedKeysFromShareState = typeof EXCLUDED_KEYS_FROM_SHARE_STATE[number];
+
+type SqlRunnerStateWithoutExcludedKeys = Omit<
+    SqlRunnerState,
+    ExcludedKeysFromShareState
+>;
+
+type SqlRunnerShareParams = {
+    sqlRunnerState: SqlRunnerStateWithoutExcludedKeys;
+    chartConfig: AllVizChartConfig | undefined;
+};
+
+function isSqlRunnerShareParams(value: unknown): value is SqlRunnerShareParams {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'sqlRunnerState' in value &&
+        'chartConfig' in value
+    );
+}
+
+export const useCreateSqlRunnerShareUrl = () => {
+    const sqlRunnerState = useAppSelector((state) => state.sqlRunner);
+    const selectedChartType = useAppSelector(selectActiveChartType);
+    const config = useAppSelector((state) =>
+        selectCompleteConfigByKind(state, selectedChartType),
+    );
+    const { mutateAsync: createShareUrl } = useCreateShareMutation();
+    return useCallback(async () => {
+        const path = window.location.pathname;
+        // Exclude sql runner state keys that should not be shared
+        const sqlRunnerStateWithoutExcludedKeys = Object.fromEntries(
+            Object.entries(sqlRunnerState).filter(
+                ([key]) =>
+                    !EXCLUDED_KEYS_FROM_SHARE_STATE.includes(
+                        key as ExcludedKeysFromShareState,
+                    ),
+            ),
+        ) as SqlRunnerStateWithoutExcludedKeys;
+
+        const shareStateParams: SqlRunnerShareParams = {
+            sqlRunnerState: sqlRunnerStateWithoutExcludedKeys,
+            chartConfig: config,
+        };
+
+        const shareUrl = await createShareUrl({
+            path,
+            params: JSON.stringify(shareStateParams),
+        });
+        return `${window.location.origin}${path}?share=${shareUrl.nanoid}`;
+    }, [createShareUrl, sqlRunnerState, config]);
+};
+
+type SqlRunnerShare = {
+    sqlRunnerState: SqlRunnerState | undefined;
+    chartConfig: AllVizChartConfig | undefined;
+    error: Error | null;
+};
+
+export const useSqlRunnerShareUrl = (
+    share: string | undefined,
+): SqlRunnerShare => {
+    const { data, error: apiError } = useGetShare(share || undefined);
+
+    return useMemo(() => {
+        let error: Error | null = apiError
+            ? new Error(apiError.error.message)
+            : null;
+        let sqlRunnerState: SqlRunnerState | undefined;
+        let chartConfig: AllVizChartConfig | undefined;
+        if (data?.params) {
+            try {
+                const sqlRunnerParams = JSON.parse(data.params);
+                console.log('before', sqlRunnerParams);
+                if (isSqlRunnerShareParams(sqlRunnerParams)) {
+                    console.log('new');
+                    sqlRunnerState = {
+                        ...initialState,
+                        ...sqlRunnerParams.sqlRunnerState,
+                    };
+                    chartConfig = sqlRunnerParams.chartConfig;
+                } else {
+                    // handle legacy share links where params are just the sql runner state
+                    sqlRunnerState = {
+                        ...initialState,
+                        ...sqlRunnerParams,
+                    };
+                }
+            } catch (e) {
+                error = new Error('Unable to parse SQL runner state json');
+            }
+        }
+        return {
+            sqlRunnerState,
+            chartConfig,
+            error,
+        };
+    }, [data, apiError]);
+};

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -132,7 +132,7 @@ export interface SqlRunnerState {
     editorHighlightError: MonacoHighlightChar | undefined;
 }
 
-const initialState: SqlRunnerState = {
+export const initialState: SqlRunnerState = {
     mode: 'default',
     projectUuid: '',
     activeTable: undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12829](https://github.com/lightdash/lightdash/issues/12829) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problems:
- we were storing results and other state properties that should not be part of a share url
- we had to rerun the query on load
- we were not storing the viz config in the share url

Changes:
- move all logic around share URL to hooks
- only save relevant properties in share url
- save viz config in share url
- handle legacy URLs


https://github.com/user-attachments/assets/3ccb5ea1-7678-427b-bb86-b8f94c8b6234



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
