### PR TITLE
fix: content as code download in batches

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -163,4 +163,7 @@ export const lightdashConfigMock: LightdashConfig = {
     headlessBrowser: {
         internalLightdashHost: 'https://test.lightdash.cloud',
     },
+    contentAsCode: {
+        maxDownloads: 100,
+    },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -294,6 +294,9 @@ export type LightdashConfig = {
         appName: string;
         redirectDomain: string;
     };
+    contentAsCode: {
+        maxDownloads: number;
+    };
 };
 
 export type SlackConfig = {
@@ -835,6 +838,11 @@ export const parseConfig = (): LightdashConfig => {
             redirectDomain:
                 process.env.GITHUB_REDIRECT_DOMAIN ||
                 siteUrl.split('.')[0].split('//')[1],
+        },
+        contentAsCode: {
+            maxDownloads:
+                getIntegerFromEnvironmentVariable('MAX_DOWNLOADS_AS_CODE') ||
+                100,
         },
     };
 };

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -829,13 +829,14 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
         @Query() ids?: string[],
+        @Query() offset?: number,
     ): Promise<ApiChartAsCodeListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getCoderService()
-                .getCharts(req.user!, projectUuid, ids),
+                .getCharts(req.user!, projectUuid, ids, offset),
         };
     }
 
@@ -847,13 +848,14 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
         @Query() ids?: string[],
+        @Query() offset?: number,
     ): Promise<ApiDashboardAsCodeListResponse> {
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getCoderService()
-                .getDashboards(req.user!, projectUuid, ids),
+                .getDashboards(req.user!, projectUuid, ids, offset),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7086,6 +7086,8 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        offset: { dataType: 'double', required: true },
+                        total: { dataType: 'double', required: true },
                         missingIds: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -7126,13 +7128,12 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_DashboardTile.Exclude_keyofDashboardTile.properties__': {
+    'Pick_DashboardTile.Exclude_keyofDashboardTile.properties-or-uuid__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 type: { ref: 'DashboardTileTypes', required: true },
-                uuid: { dataType: 'string' },
                 x: { dataType: 'double', required: true },
                 y: { dataType: 'double', required: true },
                 h: { dataType: 'double', required: true },
@@ -7150,10 +7151,10 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_DashboardTile.properties_': {
+    'Omit_DashboardTile.properties-or-uuid_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_DashboardTile.Exclude_keyofDashboardTile.properties__',
+            ref: 'Pick_DashboardTile.Exclude_keyofDashboardTile.properties-or-uuid__',
             validators: {},
         },
     },
@@ -7182,12 +7183,20 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'intersection',
             subSchemas: [
-                { ref: 'Omit_DashboardTile.properties_' },
+                { ref: 'Omit_DashboardTile.properties-or-uuid_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         properties: {
                             ref: 'Omit_DashboardTile-at-properties.savedChartUuid-or-savedSqlUuid-or-savedSemanticViewerChartUuid_',
+                            required: true,
+                        },
+                        uuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
                             required: true,
                         },
                     },
@@ -7234,6 +7243,8 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        offset: { dataType: 'double', required: true },
+                        total: { dataType: 'double', required: true },
                         missingIds: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -16859,6 +16870,7 @@ export function RegisterRoutes(app: express.Router) {
                     dataType: 'array',
                     array: { dataType: 'string' },
                 },
+                offset: { in: 'query', name: 'offset', dataType: 'double' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -16921,6 +16933,7 @@ export function RegisterRoutes(app: express.Router) {
                     dataType: 'array',
                     array: { dataType: 'string' },
                 },
+                offset: { in: 'query', name: 'offset', dataType: 'double' },
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7919,6 +7919,14 @@
                 "properties": {
                     "results": {
                         "properties": {
+                            "offset": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "total": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "missingIds": {
                                 "items": {
                                     "type": "string"
@@ -7932,7 +7940,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["missingIds", "charts"],
+                        "required": ["offset", "total", "missingIds", "charts"],
                         "type": "object"
                     },
                     "status": {
@@ -7973,13 +7981,10 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Pick_DashboardTile.Exclude_keyofDashboardTile.properties__": {
+            "Pick_DashboardTile.Exclude_keyofDashboardTile.properties-or-uuid__": {
                 "properties": {
                     "type": {
                         "$ref": "#/components/schemas/DashboardTileTypes"
-                    },
-                    "uuid": {
-                        "type": "string"
                     },
                     "x": {
                         "type": "number",
@@ -8005,8 +8010,8 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_DashboardTile.properties_": {
-                "$ref": "#/components/schemas/Pick_DashboardTile.Exclude_keyofDashboardTile.properties__",
+            "Omit_DashboardTile.properties-or-uuid_": {
+                "$ref": "#/components/schemas/Pick_DashboardTile.Exclude_keyofDashboardTile.properties-or-uuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "Pick_DashboardTile-at-properties.Exclude_keyofDashboardTile-at-properties.savedChartUuid-or-savedSqlUuid-or-savedSemanticViewerChartUuid__": {
@@ -8025,12 +8030,15 @@
             "DashboardTileWithoutUuids": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Omit_DashboardTile.properties_"
+                        "$ref": "#/components/schemas/Omit_DashboardTile.properties-or-uuid_"
                     },
                     {
                         "properties": {
                             "properties": {
                                 "$ref": "#/components/schemas/Omit_DashboardTile-at-properties.savedChartUuid-or-savedSqlUuid-or-savedSemanticViewerChartUuid_"
+                            },
+                            "uuid": {
+                                "type": "string"
                             }
                         },
                         "required": ["properties"],
@@ -8072,6 +8080,14 @@
                 "properties": {
                     "results": {
                         "properties": {
+                            "offset": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "total": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "missingIds": {
                                 "items": {
                                     "type": "string"
@@ -8085,7 +8101,12 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["missingIds", "dashboards"],
+                        "required": [
+                            "offset",
+                            "total",
+                            "missingIds",
+                            "dashboards"
+                        ],
                         "type": "object"
                     },
                     "status": {
@@ -12408,7 +12429,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1413.3",
+        "version": "0.1419.0",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -17122,6 +17143,15 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
                     }
                 ]
             }
@@ -17171,6 +17201,15 @@
                             "items": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -43,8 +43,6 @@ type CoderServiceArguments = {
     promoteService: PromoteService;
 };
 
-const MAX_RESULTS = 10;
-
 export class CoderService extends BaseService {
     lightdashConfig: LightdashConfig;
 
@@ -301,17 +299,15 @@ export class CoderService extends BaseService {
             };
         }
 
-        // TODO
-        // We need to get the dashboards and all the dashboards config
-        // At the moment we are going to fetch them all in individual queries
-        // But in the future we should fetch them in a single query for optimization purposes
         const dashboardSummaries = await this.dashboardModel.find({
             projectUuid,
             slugs,
         });
+
+        const maxResults = this.lightdashConfig.contentAsCode.maxDownloads;
         const offsetIndex = offset || 0;
         const newOffset = Math.min(
-            offsetIndex + MAX_RESULTS,
+            offsetIndex + maxResults,
             dashboardSummaries.length,
         );
         const limitedDashboardSummaries = dashboardSummaries.slice(
@@ -386,20 +382,17 @@ export class CoderService extends BaseService {
             };
         }
 
-        // TODO
-        // We need to get the charts and all the chart config
-        // At the moment we are going to fetch them all in individual queries
-        // But in the future we should fetch them in a single query for optimiziation purposes
-
         const chartSummaries = await this.savedChartModel.find({
             projectUuid,
             slugs,
+            excludeChartsSavedInDashboard: false,
         });
+        const maxResults = this.lightdashConfig.contentAsCode.maxDownloads;
 
         // Apply offset and limit to chart summaries
         const offsetIndex = offset || 0;
         const newOffset = Math.min(
-            offsetIndex + MAX_RESULTS,
+            offsetIndex + maxResults,
             chartSummaries.length,
         );
         const limitedChartSummaries = chartSummaries.slice(
@@ -450,6 +443,7 @@ export class CoderService extends BaseService {
         const [chart] = await this.savedChartModel.find({
             slug,
             projectUuid,
+            excludeChartsSavedInDashboard: false,
         });
 
         // If chart does not exist, we can't use promoteService,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -169,7 +169,9 @@ export const downloadHandler = async (
                 `Downloaded ${chartsAsCode.offset} of ${chartsAsCode.total} charts`,
             );
             chartsAsCode.missingIds.forEach((missingId) => {
-                console.warn(styles.warning(`No chart with id "${missingId}"`));
+                console.warn(
+                    styles.warning(`\nNo chart with id "${missingId}"`),
+                );
             });
 
             await dumpIntoFiles('charts', chartsAsCode.charts);
@@ -209,7 +211,7 @@ export const downloadHandler = async (
 
             dashboardsAsCode.missingIds.forEach((missingId) => {
                 console.warn(
-                    styles.warning(`No dashboard with id "${missingId}"`),
+                    styles.warning(`\nNo dashboard with id "${missingId}"`),
                 );
             });
             spinner?.start(

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -28,7 +28,12 @@ export type ChartAsCode = Pick<
 
 export type ApiChartAsCodeListResponse = {
     status: 'ok';
-    results: { charts: ChartAsCode[]; missingIds: string[] };
+    results: {
+        charts: ChartAsCode[];
+        missingIds: string[];
+        total: number;
+        offset: number;
+    };
 };
 
 export type ApiChartAsCodeUpsertResponse = {
@@ -59,7 +64,12 @@ export type DashboardAsCode = Pick<
 
 export type ApiDashboardAsCodeListResponse = {
     status: 'ok';
-    results: { dashboards: DashboardAsCode[]; missingIds: string[] };
+    results: {
+        dashboards: DashboardAsCode[];
+        missingIds: string[];
+        total: number;
+        offset: number;
+    };
 };
 export type ApiDashboardAsCodeUpsertResponse = {
     status: 'ok';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12856

### Description:
<!-- Add a description of the changes proposed in the pull request. -->


[Screencast from 2024-12-17 09-23-58.webm](https://github.com/user-attachments/assets/96a20ce6-c8a4-473e-a7b1-18765778fe87)


I tried stress loading this a bit, it seems to be working as expected 

We can increase the max concurrent charts if we like. 

![Screenshot from 2024-12-16 16-51-53](https://github.com/user-attachments/assets/a740fb43-a929-4b39-b10b-e43415cf42d6)

178 charts + 39 dashboards takes 2 seconds to download in batches 

![image](https://github.com/user-attachments/assets/89f9f20e-66aa-4d44-ac85-5a730a6849b1)

### Load tests

I created thousand of charts and dashboards, some charts were charts within dashboards

I allowed 1000 simultaneous charts (aka 1000 queries to the database) 

The old listing of charts and dashboards in the UI breaks with a few hundreds

Some charts were as big as 119kb (4351 lines) 

Memory increased  a small amount per call 

![image](https://github.com/user-attachments/assets/291e4a25-5c85-4d31-a6b6-925fce9ec220)

Command took 12 seconds 

![image](https://github.com/user-attachments/assets/e705dc24-4d23-47c3-a459-0a280d4d7be0)


Conclusion: 1000 simultaneous requests are manageable, however, I think having a limit of 100 charts per query makes sense. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
