### PR TITLE
feat: pie chart legend max length

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -79,6 +79,8 @@ export type PieChartLegendPosition = keyof typeof PieChartLegendPositions;
 export const PieChartLegendPositionDefault = Object.keys(
     PieChartLegendPositions,
 )[0] as PieChartLegendPosition;
+export const PieChartLegendLabelMaxLengthDefault = 30;
+export const PieChartTooltipLabelMaxLength = 40;
 
 export type SeriesMetadata = {
     color: string;
@@ -96,6 +98,7 @@ export type PieChart = {
     groupSortOverrides?: string[];
     showLegend?: boolean;
     legendPosition?: PieChartLegendPosition;
+    legendMaxItemLength?: number;
     metadata?: Record<string, SeriesMetadata>;
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartDisplayConfig.tsx
@@ -1,4 +1,5 @@
 import {
+    PieChartLegendLabelMaxLengthDefault,
     PieChartLegendPositions,
     type PieChartLegendPosition,
 } from '@lightdash/common';
@@ -8,6 +9,7 @@ import {
     SegmentedControl,
     Stack,
     Switch,
+    TextInput,
 } from '@mantine/core';
 import React from 'react';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/VisualizationConfigPie';
@@ -24,6 +26,8 @@ export const Display: React.FC = () => {
         toggleShowLegend,
         legendPosition,
         legendPositionChange,
+        legendMaxItemLength,
+        legendMaxItemLengthChange,
     } = visualizationConfig.chartConfig;
 
     return (
@@ -36,22 +40,43 @@ export const Display: React.FC = () => {
             </Config>
 
             <Collapse in={showLegend}>
-                <Group spacing="xs">
-                    <Config.Label>Orientation</Config.Label>
-                    <SegmentedControl
-                        name="orient"
-                        value={legendPosition}
-                        onChange={(val: PieChartLegendPosition) =>
-                            legendPositionChange(val)
-                        }
-                        data={Object.entries(PieChartLegendPositions).map(
-                            ([position, label]) => ({
-                                label,
-                                value: position,
-                            }),
-                        )}
-                    />
-                </Group>
+                <Stack spacing="xs">
+                    <Group spacing="xs">
+                        <Config.Label>Orientation</Config.Label>
+                        <SegmentedControl
+                            name="orient"
+                            value={legendPosition}
+                            onChange={(val: PieChartLegendPosition) =>
+                                legendPositionChange(val)
+                            }
+                            data={Object.entries(PieChartLegendPositions).map(
+                                ([position, label]) => ({
+                                    label,
+                                    value: position,
+                                }),
+                            )}
+                        />
+                    </Group>
+                    <Group>
+                        <Config.Label>Label max length</Config.Label>
+                        <TextInput
+                            type="number"
+                            value={legendMaxItemLength}
+                            placeholder={PieChartLegendLabelMaxLengthDefault.toString()}
+                            onChange={(e) => {
+                                const parsedNumber = Number.parseInt(
+                                    e.target.value,
+                                    10,
+                                );
+                                legendMaxItemLengthChange(
+                                    !Number.isNaN(parsedNumber)
+                                        ? parsedNumber
+                                        : undefined,
+                                );
+                            }}
+                        />
+                    </Group>
+                </Stack>
             </Collapse>
         </Stack>
     );

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -1,5 +1,7 @@
 import {
     formatItemValue,
+    PieChartLegendLabelMaxLengthDefault,
+    PieChartTooltipLabelMaxLength,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
@@ -137,7 +139,15 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                         value,
                     );
 
-                    return `${marker} <b>${name}</b><br />${percent}% - ${formattedValue}`;
+                    const truncatedName =
+                        name.length > PieChartTooltipLabelMaxLength
+                            ? `${name.slice(
+                                  0,
+                                  PieChartTooltipLabelMaxLength,
+                              )}...`
+                            : name;
+
+                    return `${marker} <b>${truncatedName}</b><br />${percent}% - ${formattedValue}`;
                 },
             },
         };
@@ -147,7 +157,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         if (!chartConfig || !pieSeriesOption) return;
 
         const {
-            validConfig: { showLegend, legendPosition },
+            validConfig: { showLegend, legendPosition, legendMaxItemLength },
         } = chartConfig;
 
         return {
@@ -155,6 +165,21 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                 show: showLegend,
                 orient: legendPosition,
                 type: 'scroll',
+                formatter: (name) => {
+                    return name.length >
+                        (legendMaxItemLength ??
+                            PieChartLegendLabelMaxLengthDefault)
+                        ? `${name.slice(
+                              0,
+                              legendMaxItemLength ??
+                                  PieChartLegendLabelMaxLengthDefault,
+                          )}...`
+                        : name;
+                },
+                tooltip: {
+                    show: true, // show tooltip for truncated legend items
+                    trigger: 'item',
+                },
                 ...(legendPosition === 'vertical'
                     ? {
                           left: 'left',

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -3,6 +3,7 @@ import {
     isField,
     isMetric,
     isTableCalculation,
+    PieChartLegendLabelMaxLengthDefault,
     PieChartLegendPositionDefault,
     type ApiQueryResults,
     type CustomDimension,
@@ -71,7 +72,8 @@ type PieChartConfig = {
     toggleShowLegend: () => void;
     legendPosition: PieChartLegendPosition;
     legendPositionChange: (position: PieChartLegendPosition) => void;
-
+    legendMaxItemLength: number | undefined;
+    legendMaxItemLengthChange: (length: number | undefined) => void;
     data: {
         name: string;
         value: number;
@@ -152,6 +154,13 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const [legendPosition, setLegendPosition] = useState(
         pieChartConfig?.legendPosition ?? PieChartLegendPositionDefault,
+    );
+
+    const [legendMaxItemLength, setLegendMaxItemLength] = useState<
+        number | undefined
+    >(
+        pieChartConfig?.legendMaxItemLength ??
+            PieChartLegendLabelMaxLengthDefault,
     );
 
     const dimensionIds = useMemo(() => Object.keys(dimensions), [dimensions]);
@@ -449,6 +458,7 @@ const usePieChartConfig: PieChartConfigFn = (
             ),
             showLegend,
             legendPosition,
+            legendMaxItemLength,
         }),
         [
             groupFieldIds,
@@ -464,6 +474,7 @@ const usePieChartConfig: PieChartConfigFn = (
             groupSortOverrides,
             showLegend,
             legendPosition,
+            legendMaxItemLength,
         ],
     );
 
@@ -508,7 +519,8 @@ const usePieChartConfig: PieChartConfigFn = (
         toggleShowLegend: () => setShowLegend((prev) => !prev),
         legendPosition,
         legendPositionChange: handleLegendPositionChange,
-
+        legendMaxItemLength,
+        legendMaxItemLengthChange: setLegendMaxItemLength,
         data,
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12801](https://github.com/lightdash/lightdash/issues/12801)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Problem: large series labels would cause the legend to overlap the chart and the tooltip to be partially hidden.

Changes:
- truncate legend labels by default
- truncate tooltip labels by default
- allow to change legend label max length ( no option to change tooltip for now )

---

### Before:
<img width="1074" alt="Screenshot 2024-12-16 at 16 59 50" src="https://github.com/user-attachments/assets/6bbad974-7e16-4a5b-9164-9ce66623431f" />
<img width="1070" alt="Screenshot 2024-12-16 at 16 59 38" src="https://github.com/user-attachments/assets/7528f417-19fc-4826-a062-14b660a0be78" />

---

### After:
<img width="1505" alt="Screenshot 2024-12-16 at 16 56 48" src="https://github.com/user-attachments/assets/26d4445b-daa9-46da-90c1-02d6192aa05a" />
<img width="447" alt="Screenshot 2024-12-16 at 16 56 55" src="https://github.com/user-attachments/assets/2aa55ed5-52ab-445d-995b-19154d6e8f4e" />
g
<img width="1505" alt="Screenshot 2024-12-16 at 16 57 14" src="https://github.com/user-attachments/assets/aa0d48c4-040b-4c67-b98f-16cd94b21665" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

