### PR TITLE
feat: show conditional format field name and color in list

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -14,7 +14,7 @@ interface Props {
     color?: string;
     defaultColor?: string;
     swatches: string[];
-    onColorChange: (newColor: string) => void;
+    onColorChange?: (newColor: string) => void;
 }
 
 const ColorSelector: FC<Props> = ({
@@ -26,13 +26,13 @@ const ColorSelector: FC<Props> = ({
     const isValidHexColor = color && isHexCodeColor(color);
 
     return (
-        <Popover shadow="md" withArrow>
+        <Popover shadow="md" withArrow disabled={!onColorChange}>
             <Popover.Target>
                 <ColorSwatch
                     size={20}
                     color={isValidHexColor ? color : defaultColor}
                     sx={{
-                        cursor: 'pointer',
+                        cursor: onColorChange ? 'pointer' : 'default',
                         transition: 'opacity 100ms ease',
                         '&:hover': { opacity: 0.8 },
                     }}
@@ -47,7 +47,11 @@ const ColorSelector: FC<Props> = ({
                         swatches={swatches}
                         swatchesPerRow={8}
                         value={color ?? defaultColor}
-                        onChange={(newColor) => onColorChange(newColor)}
+                        onChange={(newColor) => {
+                            if (onColorChange) {
+                                onColorChange(newColor);
+                            }
+                        }}
                     />
 
                     <TextInput
@@ -62,9 +66,11 @@ const ColorSelector: FC<Props> = ({
                         value={(color ?? '').replace('#', '')}
                         onChange={(event) => {
                             const newColor = event.currentTarget.value;
-                            onColorChange(
-                                newColor === '' ? newColor : `#${newColor}`,
-                            );
+                            if (onColorChange) {
+                                onColorChange(
+                                    newColor === '' ? newColor : `#${newColor}`,
+                                );
+                            }
                         }}
                     />
                 </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -6,7 +6,7 @@ import {
     createConditionalFormattingConfigWithSingleColor,
     getConditionalFormattingConfigType,
     getItemId,
-    getItemLabel,
+    getItemLabelWithoutTableName,
     hasPercentageFormat,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
@@ -249,7 +249,9 @@ export const ConditionalFormattingItem: FC<Props> = ({
     return (
         <Accordion.Item value={accordionValue}>
             <AccordionControl
-                label={field ? getItemLabel(field) : controlLabel}
+                label={
+                    field ? getItemLabelWithoutTableName(field) : controlLabel
+                }
                 extraControlElements={
                     <ColorSelector
                         color={

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -6,6 +6,7 @@ import {
     createConditionalFormattingConfigWithSingleColor,
     getConditionalFormattingConfigType,
     getItemId,
+    getItemLabel,
     hasPercentageFormat,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
@@ -248,7 +249,17 @@ export const ConditionalFormattingItem: FC<Props> = ({
     return (
         <Accordion.Item value={accordionValue}>
             <AccordionControl
-                label={controlLabel}
+                label={field ? getItemLabel(field) : controlLabel}
+                extraControlElements={
+                    <ColorSelector
+                        color={
+                            isConditionalFormattingConfigWithSingleColor(config)
+                                ? config.color
+                                : config.color.start
+                        }
+                        swatches={colorPalette}
+                    />
+                }
                 onControlClick={onControlClick}
                 onRemove={handleRemove}
             />

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -66,7 +66,7 @@ export const AccordionControl: FC<Props> = ({
                 </ActionIcon>
             </Tooltip>
             <Accordion.Control onClick={onControlClick} {...props}>
-                <Text fw={500} size="xs">
+                <Text fw={500} size="xs" truncate>
                     {label}
                 </Text>
             </Accordion.Control>

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -2,6 +2,7 @@ import {
     Accordion,
     ActionIcon,
     Box,
+    Flex,
     Group,
     Text,
     Tooltip,
@@ -30,12 +31,12 @@ export const AccordionControl: FC<Props> = ({
     const { ref, hovered } = useHover<HTMLDivElement>();
 
     return (
-        <Group
-            noWrap
+        <Flex
             ref={ref}
-            spacing="xs"
             px="xs"
             pos="relative"
+            align="center"
+            gap="xs"
             sx={(theme) => ({
                 borderRadius: theme.radius.sm,
                 '&:hover': {
@@ -48,28 +49,38 @@ export const AccordionControl: FC<Props> = ({
                     {extraControlElements}
                 </Box>
             )}
-            <Tooltip
-                variant="xs"
-                label={`Remove ${label}`}
-                position="left"
-                withinPortal
+            <Text
+                fw={500}
+                size="xs"
+                truncate
+                sx={{ flex: 1 }}
+                onClick={onControlClick}
             >
-                <ActionIcon
-                    onClick={onRemove}
-                    pos="absolute"
-                    right={40}
-                    sx={{
-                        visibility: hovered ? 'visible' : 'hidden',
-                    }}
+                {label}
+            </Text>
+            <Group noWrap ml="sm" spacing="lg">
+                <Tooltip
+                    variant="xs"
+                    label={`Remove ${label}`}
+                    position="right"
+                    withinPortal
                 >
-                    <MantineIcon icon={IconTrash} />
-                </ActionIcon>
-            </Tooltip>
-            <Accordion.Control onClick={onControlClick} {...props}>
-                <Text fw={500} size="xs" truncate>
-                    {label}
-                </Text>
-            </Accordion.Control>
-        </Group>
+                    <ActionIcon
+                        onClick={onRemove}
+                        sx={{
+                            visibility: hovered ? 'visible' : 'hidden',
+                        }}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
+                </Tooltip>
+                <Accordion.Control
+                    w="sm"
+                    sx={{ flex: 0 }}
+                    onClick={onControlClick}
+                    {...props}
+                />
+            </Group>
+        </Flex>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12657 

### Description:

Shows the color and the column name in conditional formatting list (before it was a rule number).

Now:
<img width="400" alt="Screenshot 2024-12-16 at 18 35 19" src="https://github.com/user-attachments/assets/3bd1bdf3-574e-4edc-8f3b-bcd2336d22cb" />

Before:
<img width="393" alt="Screenshot 2024-12-16 at 18 35 51" src="https://github.com/user-attachments/assets/7b60adc1-9c3e-48ef-a14c-d14547f5dedd" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
