### PR TITLE
chore: check for isIntervalBase being present

### DIFF
--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -524,7 +524,8 @@ export const getAvailableTimeDimensionsFromTables = (
             } =>
                 (dim.type === DimensionType.DATE ||
                     dim.type === DimensionType.TIMESTAMP) &&
-                !!dim.isIntervalBase &&
+                // Some time/date dimensions might not have isIntervalBase set
+                ('isIntervalBase' in dim ? !!dim.isIntervalBase : true) &&
                 !dim.hidden,
         ),
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#12938](https://github.com/lightdash/lightdash/issues/12938)

### Description:

For the reported issue, the following happened
1. User peeks a metric
2. Metric info is returned with `undefined` `timeDimension` 
3. If it's `undefined`, then the date range is never set, which will never trigger the metric explorer query

So after investigating a bit further, realised that time/date dimensions **might** not have `isIntervalBase` so we should check if that exists, then check if truthy. otherwise, ignore



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
