### PR TITLE
fix: downloading a specific dashboard also downloads all associated charts

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -241,19 +241,15 @@ export const downloadHandler = async (
         } else {
             const spinner = GlobalState.startSpinner(`Downloading dashboards`);
             [dashboardTotal, chartSlugs] = await downloadContent(
-                options.charts,
+                options.dashboards,
                 'dashboards',
                 projectId,
             );
 
             spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
 
-            // If chart filters were not provided, we download all charts for these dashboard
-            if (
-                hasFilters &&
-                options.charts.length === 0 &&
-                chartSlugs.length > 0
-            ) {
+            // If any filter is provided, we download all charts for these dashboard
+            if (hasFilters) {
                 spinner.start(
                     `Downloading ${chartSlugs.length} charts linked to dashboards`,
                 );

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -202,7 +202,6 @@ export const downloadHandler = async (
     // For analytics
     let chartTotal: number | undefined;
     let dashboardTotal: number | undefined;
-    let chartSlugs: string[] = [];
     const start = Date.now();
 
     await LightdashAnalytics.track({
@@ -240,6 +239,8 @@ export const downloadHandler = async (
             );
         } else {
             const spinner = GlobalState.startSpinner(`Downloading dashboards`);
+            let chartSlugs: string[] = [];
+
             [dashboardTotal, chartSlugs] = await downloadContent(
                 options.dashboards,
                 'dashboards',
@@ -249,6 +250,7 @@ export const downloadHandler = async (
             spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
 
             // If any filter is provided, we download all charts for these dashboard
+            // We don't need to do this if we download everything (no filters)
             if (hasFilters) {
                 spinner.start(
                     `Downloading ${chartSlugs.length} charts linked to dashboards`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12903

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2024-12-18 17-09-52](https://github.com/user-attachments/assets/65f13b58-6820-42bd-a4d8-983229b04157)

Another example (creating folders) 

![image](https://github.com/user-attachments/assets/7ac9be7c-b01c-4090-886c-ff6c51b8c9ac)

i’d expect that the dashboard selector would always download charts linked to the dashboard (even if I added a chart selector as well).

![image](https://github.com/user-attachments/assets/b03687d2-a96a-45d7-b5a8-3494376c2c19)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
