### PR TITLE
fix: echarts overlapping labels

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -369,7 +369,12 @@ export const timeFrameConfigs: Record<TimeFrames, TimeFrameConfig> = {
         getDimensionType: () => DimensionType.DATE,
         getSql: getSqlForTruncatedDate,
         getAxisMinInterval: () => null,
-        getAxisLabelFormatter: () => ({ hour: '' }),
+        getAxisLabelFormatter: () => ({
+            year: '{bold|{yyyy}}',
+            month: '{bold|{MMM}}',
+            day: '{d}',
+            hour: '',
+        }),
     },
     WEEK: {
         getLabel: () => 'Week',

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,7 +67,7 @@
         "cronstrue": "^2.22.0",
         "csv-stringify": "^6.5.1",
         "dayjs": "^1.11.10",
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.1",
         "echarts-for-react": "^3.0.2",
         "emoji-picker-react": "^4.12.0",
         "fuse.js": "^6.5.3",

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -948,16 +948,19 @@ const getEchartAxes = ({
             (isField(axisItem) &&
                 (axisItem.format || axisItem.round || axisItem.compact)) ||
             (axisItem && isTableCalculation(axisItem) && axisItem.format);
+
         const axisMinInterval =
             isDimension(axisItem) &&
             axisItem.timeInterval &&
             isTimeInterval(axisItem.timeInterval) &&
             timeFrameConfigs[axisItem.timeInterval].getAxisMinInterval();
+
         const axisLabelFormatter =
             isDimension(axisItem) &&
             axisItem.timeInterval &&
             isTimeInterval(axisItem.timeInterval) &&
             timeFrameConfigs[axisItem.timeInterval].getAxisLabelFormatter();
+
         const axisConfig: Record<string, any> = {};
 
         if (axisItem && (hasFormattingConfig || axisMinInterval)) {
@@ -976,6 +979,11 @@ const getEchartAxes = ({
         } else if (axisLabelFormatter) {
             axisConfig.axisLabel = {
                 formatter: axisLabelFormatter,
+                rich: {
+                    bold: {
+                        fontWeight: 'bold',
+                    },
+                },
             };
             axisConfig.axisPointer = {
                 label: {
@@ -1045,7 +1053,11 @@ const getEchartAxes = ({
             axisConfig.axisLabel.rotate = rotate;
             axisConfig.axisLabel.margin = 12;
             axisConfig.nameGap = oppositeSide + 15;
+        } else {
+            axisConfig.axisLabel = axisConfig.axisLabel || {};
+            axisConfig.axisLabel.hideOverlap = true;
         }
+
         return axisConfig;
     };
 
@@ -1839,7 +1851,11 @@ const useEchartsCartesianConfig = (
                             const tooltipValue = (
                                 value as Record<string, unknown>
                             )[dim];
-                            if (typeof value === 'object' && dim in value) {
+                            if (
+                                value &&
+                                typeof value === 'object' &&
+                                dim in value
+                            ) {
                                 return `
                             <tr>
                                 <td>${marker}</td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10815,13 +10815,13 @@ echarts-for-react@^3.0.2:
     fast-deep-equal "^3.1.3"
     size-sensor "^1.0.1"
 
-echarts@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz"
-  integrity sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==
+echarts@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.5.1.tgz#8dc9c68d0c548934bedcb5f633db07ed1dd2101c"
+  integrity sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.4.4"
+    zrender "5.6.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -22276,10 +22276,10 @@ zod@^3.23.3:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.3.tgz#eeb068f83acb55310174673dee631dfa0be5510d"
   integrity sha512-tPvq1B/2Yu/dh2uAIH2/BhUlUeLIUvAjr6dpL/75I0pCYefHgjhXk1o1Kob3kTU8C7yU1j396jFHlsVWFi9ogg==
 
-zrender@5.4.4:
-  version "5.4.4"
-  resolved "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz"
-  integrity sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==
+zrender@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.0.tgz#01325b0bb38332dd5e87a8dbee7336cafc0f4a5b"
+  integrity sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==
   dependencies:
     tslib "2.3.0"
 


### PR DESCRIPTION
Closes: [#4431](https://github.com/lightdash/lightdash/issues/4431)

### Description:

⚠️ this required an upgrade to the latest version of echarts
⚠️ I tried to hide the ticks for the hidden labels but could not succeed.
ℹ️ for better readability, when the granularity is `day` I make the year and month labels bold to distinguish it easily for days when they are close.

#### BEFORE

##### very small

![CleanShot 2024-12-18 at 21 54 57@2x](https://github.com/user-attachments/assets/8035ff6b-4b19-4602-b5ea-62adf9411d20)

##### small

![CleanShot 2024-12-18 at 21 54 50@2x](https://github.com/user-attachments/assets/9d8b07cf-0765-472b-ab20-feac63c1f700)

##### normal

![CleanShot 2024-12-18 at 21 54 41@2x](https://github.com/user-attachments/assets/2aca262f-55dc-4946-ba34-170b32f7a658)


---


#### AFTER

##### very small

![CleanShot 2024-12-18 at 21 50 48@2x](https://github.com/user-attachments/assets/2cf6c8a2-5f09-4a74-b63c-daff23f1dd1d)

##### small

![CleanShot 2024-12-18 at 21 39 22@2x](https://github.com/user-attachments/assets/bbb60ae9-239e-41da-a17d-36247417fc08)

##### normal

![CleanShot 2024-12-18 at 21 39 37@2x](https://github.com/user-attachments/assets/8ff68ff0-6e35-4476-a322-e9b675f23577)





### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
