### PR TITLE
fix: have legend icon variants on metrics explorer

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -73,7 +73,6 @@ const LegendIcon = ({
 export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
     ...props
 }) => {
-    console.log('props', props);
     const [activePage, setActivePage] = useState(1);
     const { ref: containerRef, width: containerWidth } = useElementSize();
 

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -1,6 +1,11 @@
 import { ActionIcon, Flex, Group, Text, Tooltip } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import {
+    IconBackslash,
+    IconChevronLeft,
+    IconChevronRight,
+    IconLineDashed,
+} from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { type LegendProps } from 'recharts';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -19,9 +24,56 @@ interface MetricExploreLegendProps extends Pick<LegendProps, 'payload'> {
     onClick?: (value: string) => void;
 }
 
+enum LegendIconVariant {
+    SQUARE = 'square',
+    LINE = 'line',
+    DASHED = 'dashed',
+}
+
+const getLegendIconVariant = (value: string) => {
+    switch (value) {
+        case 'metric':
+            return LegendIconVariant.LINE;
+        case 'compareMetric':
+            return LegendIconVariant.DASHED;
+        default:
+            return LegendIconVariant.SQUARE;
+    }
+};
+
+const LegendIcon = ({
+    color,
+    variant,
+}: {
+    color: string | undefined;
+    variant: LegendIconVariant;
+}) => {
+    switch (variant) {
+        case LegendIconVariant.SQUARE:
+            return <SquareBadge color={color} size={12} />;
+        case LegendIconVariant.LINE:
+            return (
+                <MantineIcon
+                    icon={IconBackslash}
+                    color={color}
+                    size={12}
+                    // react-tabler doesn't have an horizontal line icon
+                    style={{ transform: 'rotate(125deg)' }}
+                />
+            );
+        case LegendIconVariant.DASHED:
+            return (
+                <MantineIcon icon={IconLineDashed} color={color} size={12} />
+            );
+        default:
+            return null;
+    }
+};
+
 export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
     ...props
 }) => {
+    console.log('props', props);
     const [activePage, setActivePage] = useState(1);
     const { ref: containerRef, width: containerWidth } = useElementSize();
 
@@ -132,7 +184,10 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
             >
                 {visibleItems?.map((item) => (
                     <Group key={item.value} spacing={4} noWrap>
-                        <SquareBadge color={item.color} size={12} />
+                        <LegendIcon
+                            color={item.color}
+                            variant={getLegendIconVariant(item.value)}
+                        />
                         <Tooltip label={item.value}>
                             <Text
                                 span


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12964 

### Description:


<img width="791" alt="Screenshot 2024-12-19 at 09 34 45" src="https://github.com/user-attachments/assets/fa9c5081-99c3-40d3-a572-2392e29587fd" />
<img width="799" alt="Screenshot 2024-12-19 at 09 34 52" src="https://github.com/user-attachments/assets/405346d1-9741-4168-be71-339572edd9a7" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
