### PR TITLE
feat: show reference line label in list

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -324,7 +324,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
     return (
         <Accordion.Item value={accordionValue}>
             <AccordionControl
-                label={controlLabel}
+                label={label || controlLabel}
                 onControlClick={onControlClick}
                 onRemove={() => removeReferenceLine(lineId)}
                 extraControlElements={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Quick fix to show reference line labels in the list of lines instead of 'Line 1', 'Line 2', etc. We recently made a change to accordion control to do this for conditional formatting rules, so it was easy and made sense to add it here.

Before
<img width="390" alt="Screenshot 2024-12-19 at 10 44 24" src="https://github.com/user-attachments/assets/3afd115e-2f0f-4cb9-a113-fabd2b007bca" />

After
<img width="393" alt="Screenshot 2024-12-19 at 10 44 01" src="https://github.com/user-attachments/assets/ea336e94-cd69-4ce1-8bcd-82b95db15f57" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
