### PR TITLE
chore: log and measure operations for metrics explorer/trees

### DIFF
--- a/packages/backend/src/logging/measureTime.ts
+++ b/packages/backend/src/logging/measureTime.ts
@@ -1,0 +1,22 @@
+import { type Logger } from 'winston';
+
+export const measureTime = async <T, C>(
+    fn: () => Promise<T>,
+    name: string,
+    logger: Logger,
+    context?: C,
+): Promise<T> => {
+    const start = performance.now();
+    const result = await fn();
+    const end = performance.now();
+    const duration = end - start;
+
+    logger.info(
+        `${name} - operation completed in ${duration.toFixed(
+            2,
+        )}ms - Context: ${JSON.stringify(context)}`,
+        { name, duration, context },
+    );
+
+    return result;
+};

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -33,6 +33,7 @@ import {
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import type { LightdashConfig } from '../../config/parseConfig';
+import { measureTime } from '../../logging/measureTime';
 import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../BaseService';
@@ -222,6 +223,39 @@ export class MetricsExplorerService<
     }
 
     async runMetricExplorerQuery(
+        user: SessionUser,
+        projectUuid: string,
+        exploreName: string,
+        metricName: string,
+        startDate: string,
+        endDate: string,
+        query: MetricExplorerQuery,
+        timeDimensionOverride: TimeDimensionConfig | undefined,
+    ): Promise<MetricsExplorerQueryResults> {
+        return measureTime(
+            () =>
+                this._runMetricExplorerQuery(
+                    user,
+                    projectUuid,
+                    exploreName,
+                    metricName,
+                    startDate,
+                    endDate,
+                    query,
+                    timeDimensionOverride,
+                ),
+            'runMetricExplorerQuery',
+            this.logger,
+            {
+                query,
+                startDate,
+                endDate,
+                timeDimensionOverride,
+            },
+        );
+    }
+
+    private async _runMetricExplorerQuery(
         user: SessionUser,
         projectUuid: string,
         exploreName: string,
@@ -451,6 +485,33 @@ export class MetricsExplorerService<
     }
 
     async getMetricTotal(
+        user: SessionUser,
+        projectUuid: string,
+        exploreName: string,
+        metricName: string,
+        timeFrame: TimeFrames,
+        comparisonType: MetricTotalComparisonType = MetricTotalComparisonType.NONE,
+    ): Promise<MetricTotalResults> {
+        return measureTime(
+            () =>
+                this._getMetricTotal(
+                    user,
+                    projectUuid,
+                    exploreName,
+                    metricName,
+                    timeFrame,
+                    comparisonType,
+                ),
+            'getMetricTotal',
+            this.logger,
+            {
+                timeFrame,
+                comparisonType,
+            },
+        );
+    }
+
+    private async _getMetricTotal(
         user: SessionUser,
         projectUuid: string,
         exploreName: string,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/12970

### Description:

- logs operation duration of main function calls to render a chart on the metrics explorer
- same for metric trees' nodes metric total 
- this also includes logs for the metric query against the warehouse, format rows logic, and getting results from cache 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
