### PR TITLE
fix: reset grain dropdown picker width

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
@@ -52,7 +52,11 @@ export const TimeDimensionIntervalPicker: FC<Props> = ({
             rightSection={
                 <MantineIcon color="dark.2" icon={IconChevronDown} size={12} />
             }
-            classNames={classes}
+            classNames={{
+                input: classes.input,
+                item: classes.item,
+                rightSection: classes.rightSection,
+            }}
         />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:


Before

<img width="420" alt="Screenshot 2024-12-20 at 11 20 03" src="https://github.com/user-attachments/assets/1a8886cd-8cc7-4d6e-b1f0-842450971c0e" />


After

<img width="246" alt="Screenshot 2024-12-20 at 11 18 45" src="https://github.com/user-attachments/assets/84d0d123-0a21-4a39-85b7-3a708c5cbf29" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
