### PR TITLE
fix: get correct key on previous period

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -190,7 +190,11 @@ const PreviousPeriodTooltip: FC<{
                 </Text>
             </Group>
             <TooltipBadge
-                value={entry.payload.metric.formatted}
+                value={
+                    entry.name === 'metric'
+                        ? entry.payload.metric.formatted
+                        : entry.payload.compareMetric?.formatted
+                }
                 variant="comparison"
             />
         </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

gets correct key

<img width="406" alt="Screenshot 2024-12-20 at 14 51 12" src="https://github.com/user-attachments/assets/d353218e-bece-4cb0-bbad-324f5825f836" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
