### PR TITLE
chore: force avoid worker when formatting for metrics catalog

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -116,6 +116,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 adjustedMetricQuery,
+                true,
             );
 
         // Comparison uses the same dimension as the base metric
@@ -207,6 +208,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 query.metric.table,
                 metricQuery,
+                true,
             );
 
         const dimension = fields[metricQuery.dimensions[0]];
@@ -343,6 +345,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 metricQuery,
+                true,
             );
 
         let allFields = fields;
@@ -559,6 +562,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 metricQuery,
+                true,
             );
 
         let compareRows: ResultRow[] | undefined;
@@ -588,6 +592,7 @@ export class MetricsExplorerService<
                     projectUuid,
                     exploreName,
                     compareMetricQuery,
+                    true,
                 )
             ).rows;
         }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1613,6 +1613,7 @@ export class ProjectService extends BaseService {
         explore: validExplore,
         granularity,
         chartUuid,
+        forceAvoidWorker,
     }: {
         user: SessionUser;
         metricQuery: MetricQuery;
@@ -1625,6 +1626,7 @@ export class ProjectService extends BaseService {
         explore?: Explore;
         granularity?: DateGranularity;
         chartUuid: string | undefined;
+        forceAvoidWorker?: boolean;
     }): Promise<ApiQueryResults> {
         return wrapSentryTransaction(
             'ProjectService.runQueryAndFormatRows',
@@ -1664,7 +1666,9 @@ export class ProjectService extends BaseService {
                         warehouse: warehouseConnection?.type,
                     },
                     async (formatRowsSpan) => {
-                        const useWorker = rows.length > 500;
+                        const useWorker =
+                            rows.length > 500 && !forceAvoidWorker;
+
                         return measureTime(
                             async () => {
                                 formatRowsSpan.setAttribute(
@@ -1710,6 +1714,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         exploreName: string,
         metricQuery: MetricQuery,
+        forceAvoidWorker?: boolean,
     ) {
         return measureTime(
             () =>
@@ -1722,6 +1727,7 @@ export class ProjectService extends BaseService {
                     context: QueryExecutionContext.METRICS_EXPLORER,
                     queryTags: {},
                     chartUuid: undefined,
+                    forceAvoidWorker,
                 }),
             'runQueryAndFormatRows',
             this.logger,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12981 

### Description:

Avoids using the worker for metrics catalog as this is impacting the duration of the `formatRows` execution, testing

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
