### PR TITLE
feat: restrict dashboard tabs to one line

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -3,7 +3,8 @@ import type { DashboardTab } from '@lightdash/common';
 import { ActionIcon, Box, Menu, Tabs, Title, Tooltip } from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
 import { IconGripVertical, IconPencil, IconTrash } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { type Dispatch, type FC, type SetStateAction } from 'react';
+import { useIsTruncated } from '../../hooks/useIsTruncated';
 import MantineIcon from '../common/MantineIcon';
 
 type DraggableTabProps = {
@@ -13,8 +14,8 @@ type DraggableTabProps = {
     sortedTabs: DashboardTab[];
     currentTabHasTiles: boolean;
     isActive: boolean;
-    setEditingTab: (value: React.SetStateAction<boolean>) => void;
-    setDeletingTab: (value: React.SetStateAction<boolean>) => void;
+    setEditingTab: Dispatch<SetStateAction<boolean>>;
+    setDeletingTab: Dispatch<SetStateAction<boolean>>;
     handleDeleteTab: (tabUuid: string) => void;
 };
 
@@ -30,7 +31,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
     setDeletingTab,
 }) => {
     const { hovered: isHovered, ref: hoverRef } = useHover();
-    const [isTruncated, setTruncated] = useState(false);
+    const { ref, isTruncated } = useIsTruncated();
 
     return (
         <Draggable key={tab.uuid} draggableId={tab.uuid} index={idx}>
@@ -43,8 +44,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
                     <Tabs.Tab
                         key={idx}
                         value={tab.uuid}
-                        mr="xs"
-                        bg={isActive ? 'white' : 'var(--mantine-color-gray-0)'}
+                        bg={isActive ? 'white' : 'gray.0'}
                         icon={
                             isEditMode ? (
                                 <Box {...provided.dragHandleProps} w={'sm'}>
@@ -116,23 +116,17 @@ const DraggableTab: FC<DraggableTabProps> = ({
                             disabled={!isTruncated}
                             label={tab.name}
                             withinPortal
+                            variant="xs"
                         >
                             <Title
+                                ref={ref}
                                 order={6}
                                 fw={500}
                                 color="gray.7"
-                                truncate={true}
-                                sx={{
-                                    maxWidth: `calc(${
-                                        100 / (sortedTabs?.length || 1)
-                                    }vw)`,
-                                }}
-                                onMouseEnter={(evt) =>
-                                    setTruncated(
-                                        evt.currentTarget.offsetWidth <
-                                            evt.currentTarget.scrollWidth,
-                                    )
-                                }
+                                truncate
+                                maw={`calc(${
+                                    100 / (sortedTabs?.length || 1)
+                                }vw)`}
                             >
                                 {tab.name}
                             </Title>

--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -1,14 +1,9 @@
 import { Draggable } from '@hello-pangea/dnd';
 import type { DashboardTab } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Tabs, Title } from '@mantine/core';
+import { ActionIcon, Box, Menu, Tabs, Title, Tooltip } from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
-import {
-    IconDots,
-    IconGripVertical,
-    IconPencil,
-    IconTrash,
-} from '@tabler/icons-react';
-import type { FC } from 'react';
+import { IconGripVertical, IconPencil, IconTrash } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 
 type DraggableTabProps = {
@@ -35,6 +30,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
     setDeletingTab,
 }) => {
     const { hovered: isHovered, ref: hoverRef } = useHover();
+    const [isTruncated, setTruncated] = useState(false);
 
     return (
         <Draggable key={tab.uuid} draggableId={tab.uuid} index={idx}>
@@ -72,7 +68,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
                                     <Menu.Target>
                                         <ActionIcon variant="subtle" size="xs">
                                             <MantineIcon
-                                                icon={IconDots}
+                                                icon={IconPencil}
                                                 display={
                                                     isHovered ? 'block' : 'none'
                                                 }
@@ -116,9 +112,31 @@ const DraggableTab: FC<DraggableTabProps> = ({
                             ) : null
                         }
                     >
-                        <Title order={6} fw={500} color="gray.7">
-                            {tab.name}
-                        </Title>
+                        <Tooltip
+                            disabled={!isTruncated}
+                            label={tab.name}
+                            withinPortal
+                        >
+                            <Title
+                                order={6}
+                                fw={500}
+                                color="gray.7"
+                                truncate={true}
+                                sx={{
+                                    maxWidth: `calc(${
+                                        100 / (sortedTabs?.length || 1)
+                                    }vw)`,
+                                }}
+                                onMouseEnter={(evt) =>
+                                    setTruncated(
+                                        evt.currentTarget.offsetWidth <
+                                            evt.currentTarget.scrollWidth,
+                                    )
+                                }
+                            >
+                                {tab.name}
+                            </Title>
+                        </Tooltip>
                     </Tabs.Tab>
                 </div>
             )}

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -4,7 +4,7 @@ import {
     type DashboardTab,
     type DashboardTile,
 } from '@lightdash/common';
-import { ActionIcon, Group, Tabs } from '@mantine/core';
+import { ActionIcon, Group, ScrollArea, Tabs } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import cloneDeep from 'lodash/cloneDeep';
 import { useMemo, useState, type FC } from 'react';
@@ -240,6 +240,13 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                               backgroundColor: 'white',
                                               flexGrow: 1,
                                           },
+                                          tabsList: {
+                                              flexWrap: 'nowrap',
+                                          },
+                                          tab: {
+                                              borderBottom:
+                                                  '1px solid var(--mantine-color-gray-3)',
+                                          },
                                       }
                                     : undefined
                             }
@@ -247,31 +254,65 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                         >
                             {sortedTabs && sortedTabs?.length > 0 && (
                                 <Tabs.List bg="gray.0" px="lg">
-                                    {sortedTabs?.map((tab, idx) => {
-                                        return (
-                                            <DraggableTab
-                                                key={tab.uuid}
-                                                idx={idx}
-                                                tab={tab}
-                                                isEditMode={isEditMode}
-                                                sortedTabs={sortedTabs}
-                                                currentTabHasTiles={
-                                                    currentTabHasTiles
-                                                }
-                                                isActive={
-                                                    activeTab?.uuid === tab.uuid
-                                                }
-                                                setEditingTab={setEditingTab}
-                                                handleDeleteTab={
-                                                    handleDeleteTab
-                                                }
-                                                setDeletingTab={setDeletingTab}
-                                            />
-                                        );
-                                    })}
+                                    <ScrollArea
+                                        scrollbarSize={6}
+                                        type="hover"
+                                        scrollHideDelay={200}
+                                        styles={(theme) => ({
+                                            scrollbar: {
+                                                '&[data-orientation="horizontal"] .mantine-ScrollArea-thumb':
+                                                    {
+                                                        backgroundColor:
+                                                            theme.fn.rgba(
+                                                                theme.colors
+                                                                    .gray[6],
+                                                                0.3,
+                                                            ),
+                                                    },
+                                                '&:not([data-disabled]):hover':
+                                                    {
+                                                        background:
+                                                            'transparent',
+                                                    },
+                                            },
+                                            root: {
+                                                marginBottom: -1,
+                                            },
+                                        })}
+                                    >
+                                        <Group noWrap>
+                                            {sortedTabs?.map((tab, idx) => {
+                                                return (
+                                                    <DraggableTab
+                                                        key={tab.uuid}
+                                                        idx={idx}
+                                                        tab={tab}
+                                                        isEditMode={isEditMode}
+                                                        sortedTabs={sortedTabs}
+                                                        currentTabHasTiles={
+                                                            currentTabHasTiles
+                                                        }
+                                                        isActive={
+                                                            activeTab?.uuid ===
+                                                            tab.uuid
+                                                        }
+                                                        setEditingTab={
+                                                            setEditingTab
+                                                        }
+                                                        handleDeleteTab={
+                                                            handleDeleteTab
+                                                        }
+                                                        setDeletingTab={
+                                                            setDeletingTab
+                                                        }
+                                                    />
+                                                );
+                                            })}
+                                        </Group>
+                                    </ScrollArea>
                                     {provided.placeholder}
                                     {isEditMode && (
-                                        <Group>
+                                        <Group pl="md">
                                             <ActionIcon
                                                 size="xs"
                                                 variant="light"

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -255,32 +255,18 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                             {sortedTabs && sortedTabs?.length > 0 && (
                                 <Tabs.List bg="gray.0" px="lg">
                                     <ScrollArea
-                                        scrollbarSize={6}
                                         type="hover"
+                                        offsetScrollbars
                                         scrollHideDelay={200}
-                                        styles={(theme) => ({
-                                            scrollbar: {
-                                                '&[data-orientation="horizontal"] .mantine-ScrollArea-thumb':
-                                                    {
-                                                        backgroundColor:
-                                                            theme.fn.rgba(
-                                                                theme.colors
-                                                                    .gray[6],
-                                                                0.3,
-                                                            ),
-                                                    },
-                                                '&:not([data-disabled]):hover':
-                                                    {
-                                                        background:
-                                                            'transparent',
-                                                    },
+                                        variant="primary"
+                                        scrollbarSize={6}
+                                        styles={{
+                                            viewport: {
+                                                paddingBottom: 0,
                                             },
-                                            root: {
-                                                marginBottom: -1,
-                                            },
-                                        })}
+                                        }}
                                     >
-                                        <Group noWrap>
+                                        <Group noWrap spacing={0}>
                                             {sortedTabs?.map((tab, idx) => {
                                                 return (
                                                     <DraggableTab


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/11220

### Description:
Restrict dashboard tabs to one line. Maximum tab width is `1 / num_tabs`. Overflowing tab titles are truncated with and ellipsis, and a tooltip displays on mouseover for these. Gray scrollbar appears below tabs if parent container width exceeded.

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/601e7c4e-dea7-4dd9-b4f0-bbe407e62cda" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
