### PR TITLE
feat: dashboard tab ux and style tweaks

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -36,6 +36,7 @@ const useDashboardFilterStyles = createStyles((theme) => ({
     inactiveFilter: {
         borderStyle: 'dashed',
         borderWidth: '1px',
+        borderColor: theme.fn.rgba(theme.colors.gray[5], 0.7),
         backgroundColor: theme.fn.rgba(theme.white, 0.7),
     },
 }));
@@ -145,7 +146,9 @@ const Filter: FC<Props> = ({
                 })
                 .join(', ');
             return appliedTabList
-                ? `This filter only applies to tabs: ${appliedTabList}`
+                ? `This filter only applies to tab${
+                      appliesToTabs.length === 1 ? '' : 's'
+                  }: ${appliedTabList}`
                 : 'This filter is not currently applied to any tabs';
         }
     }, [activeTabUuid, appliesToTabs, dashboardTabs]);

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -257,6 +257,7 @@ const Filter: FC<Props> = ({
                             fz="xs"
                             label={inactiveFilterInfo}
                             disabled={!inactiveFilterInfo}
+                            withinPortal
                         >
                             <Button
                                 pos="relative"

--- a/packages/frontend/src/components/DashboardTabs/AddTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTabs/AddTabModal.tsx
@@ -47,6 +47,7 @@ export const TabAddModal: FC<AddProps> = ({
                     <TextInput
                         label="Tab name"
                         placeholder="Name your tab"
+                        data-autofocus
                         required
                         {...form.getInputProps('tabName')}
                     ></TextInput>

--- a/packages/frontend/src/components/DashboardTabs/EditTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTabs/EditTabModal.tsx
@@ -50,6 +50,7 @@ export const TabEditModal: FC<AddProps> = ({
                     <TextInput
                         label="Tab name"
                         placeholder="Name your tab"
+                        data-autofocus
                         required
                         {...form.getInputProps('newTabName')}
                     ></TextInput>

--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -68,7 +68,6 @@ const DraggableTab: FC<DraggableTabProps> = ({
                                     withArrow
                                     withinPortal
                                     shadow="md"
-                                    width={200}
                                 >
                                     <Menu.Target>
                                         <ActionIcon variant="subtle" size="xs">


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/12053

### Description:

**1. Inactive filter dashed border color now slightly darker to avoid optical illusion of dashed line being lighter than solid line**
<img width="663" alt="image" src="https://github.com/user-attachments/assets/399cfeae-9020-45ff-8f1c-0fa94adf4c10" />

**2. Tooltip singular/plural tab(s) as appropriate** 
<img width="230" alt="image" src="https://github.com/user-attachments/assets/e6e77fab-9f49-40fe-aa13-1be980535d02" />

**3. Auto-focus add and edit tab modal text fields**
<img width="378" alt="image" src="https://github.com/user-attachments/assets/b06b5024-7814-45e8-b8c4-2d87b9606640" />

**4. Reduce width of dashboard tab menu**
<img width="176" alt="image" src="https://github.com/user-attachments/assets/6a0abadb-b854-4002-875e-805905b93e94" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
