### PR TITLE
chore: allow force cache for metric explorer queries

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -116,6 +116,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 adjustedMetricQuery,
+                true,
             );
 
         // Comparison uses the same dimension as the base metric
@@ -207,6 +208,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 query.metric.table,
                 metricQuery,
+                true,
             );
 
         const dimension = fields[metricQuery.dimensions[0]];
@@ -343,6 +345,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 metricQuery,
+                true,
             );
 
         let allFields = fields;
@@ -559,6 +562,7 @@ export class MetricsExplorerService<
                 projectUuid,
                 exploreName,
                 metricQuery,
+                true,
             );
 
         let compareRows: ResultRow[] | undefined;
@@ -588,6 +592,7 @@ export class MetricsExplorerService<
                     projectUuid,
                     exploreName,
                     compareMetricQuery,
+                    true,
                 )
             ).rows;
         }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1613,6 +1613,7 @@ export class ProjectService extends BaseService {
         explore: validExplore,
         granularity,
         chartUuid,
+        forceUseCache,
     }: {
         user: SessionUser;
         metricQuery: MetricQuery;
@@ -1625,6 +1626,7 @@ export class ProjectService extends BaseService {
         explore?: Explore;
         granularity?: DateGranularity;
         chartUuid: string | undefined;
+        forceUseCache?: boolean;
     }): Promise<ApiQueryResults> {
         return wrapSentryTransaction(
             'ProjectService.runQueryAndFormatRows',
@@ -1647,6 +1649,7 @@ export class ProjectService extends BaseService {
                         explore,
                         granularity,
                         chartUuid,
+                        forceUseCache,
                     });
                 span.setAttribute('rows', rows.length);
 
@@ -1710,6 +1713,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         exploreName: string,
         metricQuery: MetricQuery,
+        forceUseCache?: boolean,
     ) {
         return measureTime(
             () =>
@@ -1722,6 +1726,7 @@ export class ProjectService extends BaseService {
                     context: QueryExecutionContext.METRICS_EXPLORER,
                     queryTags: {},
                     chartUuid: undefined,
+                    forceUseCache,
                 }),
             'runQueryAndFormatRows',
             this.logger,
@@ -1775,6 +1780,7 @@ export class ProjectService extends BaseService {
         metricQuery,
         queryTags,
         invalidateCache,
+        forceUseCache,
     }: {
         projectUuid: string;
         context: QueryExecutionContext;
@@ -1783,6 +1789,7 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery;
         queryTags: RunQueryTags;
         invalidateCache?: boolean;
+        forceUseCache?: boolean;
     }): Promise<{
         rows: Record<string, any>[];
         cacheMetadata: CacheMetadata;
@@ -1804,7 +1811,8 @@ export class ProjectService extends BaseService {
                 span.setAttribute('cacheHit', false);
 
                 if (
-                    this.lightdashConfig.resultsCache?.resultsEnabled &&
+                    (forceUseCache ||
+                        this.lightdashConfig.resultsCache?.resultsEnabled) &&
                     !invalidateCache
                 ) {
                     const cacheEntryMetadata = await this.s3CacheClient
@@ -1909,6 +1917,7 @@ export class ProjectService extends BaseService {
         explore: loadedExplore,
         granularity,
         chartUuid,
+        forceUseCache,
     }: {
         user: SessionUser;
         metricQuery: MetricQuery;
@@ -1921,6 +1930,7 @@ export class ProjectService extends BaseService {
         explore?: Explore;
         granularity?: DateGranularity;
         chartUuid: string | undefined; // for analytics
+        forceUseCache?: boolean;
     }): Promise<{
         rows: Record<string, any>[];
         cacheMetadata: CacheMetadata;
@@ -2126,6 +2136,7 @@ export class ProjectService extends BaseService {
                             query,
                             queryTags,
                             invalidateCache,
+                            forceUseCache,
                         });
                     await sshTunnel.disconnect();
                     return { rows, cacheMetadata, fields };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12969 

### Description:

Forces current caching mechanism on metrics explorer queries, cache by default expires within 24h

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
