### PR TITLE
feat: format metric explorer and tree values on the frontend instead of backend

### DIFF
--- a/packages/backend/src/controllers/metricsExplorerController.ts
+++ b/packages/backend/src/controllers/metricsExplorerController.ts
@@ -87,6 +87,8 @@ export class MetricsExplorerController extends BaseController {
         @Path() metric: string,
         @Request() req: express.Request,
         @Query() timeFrame: TimeFrames,
+        @Query() startDate: string,
+        @Query() endDate: string,
         @Body()
         body?: {
             comparisonType?: MetricTotalComparisonType;
@@ -102,6 +104,8 @@ export class MetricsExplorerController extends BaseController {
                 explore,
                 metric,
                 timeFrame,
+                startDate,
+                endDate,
                 body?.comparisonType,
             );
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4130,7 +4130,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },
-                        { dataType: 'undefined' },
+                        { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
                 },
@@ -4138,7 +4138,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'double' },
-                        { dataType: 'undefined' },
+                        { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
                 },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3915,14 +3915,6 @@ const models: TsoaRoute.Models = {
                             ],
                             required: true,
                         },
-                        formatted: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
                         value: {
                             dataType: 'union',
                             subSchemas: [
@@ -3938,14 +3930,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         label: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        formatted: {
                             dataType: 'union',
                             subSchemas: [
                                 { dataType: 'string' },
@@ -4133,27 +4117,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResultValue: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                formatted: { dataType: 'string', required: true },
-                raw: { dataType: 'any', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricTotalResults: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                metric: {
+                    ref: 'MetricWithAssociatedTimeDimension',
+                    required: true,
+                },
                 comparisonValue: {
                     dataType: 'union',
                     subSchemas: [
-                        { ref: 'ResultValue' },
+                        { dataType: 'double' },
                         { dataType: 'undefined' },
                     ],
                     required: true,
@@ -4161,7 +4137,7 @@ const models: TsoaRoute.Models = {
                 value: {
                     dataType: 'union',
                     subSchemas: [
-                        { ref: 'ResultValue' },
+                        { dataType: 'double' },
                         { dataType: 'undefined' },
                     ],
                     required: true,
@@ -5749,7 +5725,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SupportedDbtVersions: {
         dataType: 'refEnum',
-        enums: ['v1.4', 'v1.5', 'v1.6', 'v1.7', 'v1.8'],
+        enums: ['v1.4', 'v1.5', 'v1.6', 'v1.7', 'v1.8', 'v1.9'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'SemanticLayerType.DBT': {
@@ -14126,6 +14102,18 @@ export function RegisterRoutes(app: express.Router) {
                     name: 'timeFrame',
                     required: true,
                     ref: 'TimeFrames',
+                },
+                startDate: {
+                    in: 'query',
+                    name: 'startDate',
+                    required: true,
+                    dataType: 'string',
+                },
+                endDate: {
+                    in: 'query',
+                    name: 'endDate',
+                    required: true,
+                    dataType: 'string',
                 },
                 body: {
                     in: 'body',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4421,17 +4421,13 @@
                                 "type": "string",
                                 "nullable": true
                             },
-                            "formatted": {
-                                "type": "string",
-                                "nullable": true
-                            },
                             "value": {
                                 "type": "number",
                                 "format": "double",
                                 "nullable": true
                             }
                         },
-                        "required": ["label", "formatted", "value"],
+                        "required": ["label", "value"],
                         "type": "object"
                     },
                     "metric": {
@@ -4440,17 +4436,13 @@
                                 "type": "string",
                                 "nullable": true
                             },
-                            "formatted": {
-                                "type": "string",
-                                "nullable": true
-                            },
                             "value": {
                                 "type": "number",
                                 "format": "double",
                                 "nullable": true
                             }
                         },
-                        "required": ["label", "formatted", "value"],
+                        "required": ["label", "value"],
                         "type": "object"
                     },
                     "segment": {
@@ -4618,25 +4610,21 @@
                     }
                 ]
             },
-            "ResultValue": {
-                "properties": {
-                    "formatted": {
-                        "type": "string"
-                    },
-                    "raw": {}
-                },
-                "required": ["formatted", "raw"],
-                "type": "object"
-            },
             "MetricTotalResults": {
                 "properties": {
+                    "metric": {
+                        "$ref": "#/components/schemas/MetricWithAssociatedTimeDimension"
+                    },
                     "comparisonValue": {
-                        "$ref": "#/components/schemas/ResultValue"
+                        "type": "number",
+                        "format": "double"
                     },
                     "value": {
-                        "$ref": "#/components/schemas/ResultValue"
+                        "type": "number",
+                        "format": "double"
                     }
                 },
+                "required": ["metric"],
                 "type": "object"
             },
             "ApiMetricsExplorerTotalResults": {
@@ -6423,7 +6411,7 @@
                 ]
             },
             "SupportedDbtVersions": {
-                "enum": ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8"],
+                "enum": ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9"],
                 "type": "string"
             },
             "SemanticLayerType.DBT": {
@@ -12445,7 +12433,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1422.0",
+        "version": "0.1426.3",
         "description": "Open API documentation for all public Lightdash API endpoints.  # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -14931,6 +14919,22 @@
                         "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/TimeFrames"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "startDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "endDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4617,14 +4617,16 @@
                     },
                     "comparisonValue": {
                         "type": "number",
-                        "format": "double"
+                        "format": "double",
+                        "nullable": true
                     },
                     "value": {
                         "type": "number",
-                        "format": "double"
+                        "format": "double",
+                        "nullable": true
                     }
                 },
-                "required": ["metric"],
+                "required": ["metric", "comparisonValue", "value"],
                 "type": "object"
             },
             "ApiMetricsExplorerTotalResults": {

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -588,15 +588,14 @@ export class MetricsExplorerService<
                 },
             };
 
-            const compareResults =
+            compareRows = (
                 await this.projectService.runMetricExplorerQuery(
                     user,
                     projectUuid,
                     exploreName,
                     compareMetricQuery,
-                );
-
-            compareRows = compareResults.rows;
+                )
+            ).rows;
         }
 
         return {

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -21,6 +21,7 @@ import {
     isDimension,
     MetricExplorerComparison,
     MetricTotalComparisonType,
+    parseMetricValue,
     TimeFrames,
     type MetricExplorerDateRange,
     type MetricQuery,
@@ -599,8 +600,10 @@ export class MetricsExplorerService<
         }
 
         return {
-            value: currentRows[0]?.[getItemId(metric)] ?? undefined,
-            comparisonValue: compareRows?.[0]?.[getItemId(metric)] ?? undefined,
+            value: parseMetricValue(currentRows[0]?.[getItemId(metric)]),
+            comparisonValue: parseMetricValue(
+                compareRows?.[0]?.[getItemId(metric)],
+            ),
             metric,
         };
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1713,7 +1713,7 @@ export class ProjectService extends BaseService {
     ) {
         return measureTime(
             () =>
-                this.runQueryAndFormatRows({
+                this.runMetricQuery({
                     user,
                     metricQuery,
                     projectUuid,
@@ -1723,7 +1723,7 @@ export class ProjectService extends BaseService {
                     queryTags: {},
                     chartUuid: undefined,
                 }),
-            'runQueryAndFormatRows',
+            'runMetricQuery',
             this.logger,
             {
                 exploreName,

--- a/packages/common/src/types/metricsExplorer.ts
+++ b/packages/common/src/types/metricsExplorer.ts
@@ -64,8 +64,8 @@ export enum MetricTotalComparisonType {
 }
 
 export type MetricTotalResults = {
-    value: number | undefined;
-    comparisonValue: number | undefined;
+    value: number | null;
+    comparisonValue: number | null;
     metric: MetricWithAssociatedTimeDimension; // For now only previous period is supported in total query, so we only need the metric
 };
 

--- a/packages/common/src/types/metricsExplorer.ts
+++ b/packages/common/src/types/metricsExplorer.ts
@@ -1,6 +1,5 @@
 import { type MetricWithAssociatedTimeDimension } from './catalog';
 import type { Dimension, ItemsMap } from './field';
-import type { ResultValue } from './results';
 
 export enum MetricExplorerComparison {
     NONE = 'none',
@@ -33,12 +32,10 @@ export type MetricExploreDataPoint = {
     segment: string | null;
     metric: {
         value: number | null;
-        formatted: string | null;
         label: string | null;
     };
     compareMetric: {
         value: number | null;
-        formatted: string | null;
         label: string | null;
     };
 };
@@ -67,8 +64,9 @@ export enum MetricTotalComparisonType {
 }
 
 export type MetricTotalResults = {
-    value: ResultValue | undefined;
-    comparisonValue: ResultValue | undefined;
+    value: number | undefined;
+    comparisonValue: number | undefined;
+    metric: MetricWithAssociatedTimeDimension; // For now only previous period is supported in total query, so we only need the metric
 };
 
 export type ApiMetricsExplorerTotalResults = {

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -197,7 +197,7 @@ export const getMetricExplorerDateRangeFilters = (
 };
 
 // Parse the metric value to a number, returning null if it's not a number
-const parseMetricValue = (value: unknown): number | null => {
+export const parseMetricValue = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;
     const parsed = Number(value);
     return Number.isNaN(parsed) ? null : parsed;

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -196,7 +196,6 @@ export const getMetricExplorerDateRangeFilters = (
     ];
 };
 
-// TODO: Should we just use the formatted value instead?
 // Parse the metric value to a number, returning null if it's not a number
 const parseMetricValue = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;
@@ -216,7 +215,7 @@ export const MAX_SEGMENT_DIMENSION_UNIQUE_VALUES = 10;
 export const getMetricExplorerDataPoints = (
     dimension: Dimension,
     metric: MetricWithAssociatedTimeDimension,
-    metricRows: ResultRow[],
+    metricRows: Record<string, any>[],
     segmentDimensionId: string | null,
 ): {
     dataPoints: Array<MetricExploreDataPoint>;
@@ -229,43 +228,39 @@ export const getMetricExplorerDataPoints = (
     let isSegmentDimensionFiltered = false;
     if (segmentDimensionId) {
         const countUniqueValues = new Set(
-            metricRows.map((row) => row[segmentDimensionId]?.value.raw),
+            metricRows.map((row) => row[segmentDimensionId]),
         ).size;
 
         if (countUniqueValues > MAX_SEGMENT_DIMENSION_UNIQUE_VALUES) {
             isSegmentDimensionFiltered = true;
             const first10Values = Array.from(
-                new Set(
-                    metricRows.map((row) => row[segmentDimensionId]?.value.raw),
-                ),
+                new Set(metricRows.map((row) => row[segmentDimensionId])),
             ).slice(0, MAX_SEGMENT_DIMENSION_UNIQUE_VALUES);
             filteredMetricRows = metricRows.filter((row) =>
-                first10Values.includes(row[segmentDimensionId]?.value.raw),
+                first10Values.includes(row[segmentDimensionId]),
             );
         }
     }
 
     const groupByMetricRows = groupBy(filteredMetricRows, (row) =>
-        new Date(String(row[dimensionId].value.raw)).toISOString(),
+        new Date(String(row[dimensionId])).toISOString(),
     );
 
     const dataPoints = Object.entries(groupByMetricRows).flatMap(
         ([date, rows]) =>
             rows.map((row) => {
                 const segmentValue = segmentDimensionId
-                    ? parseDimensionValue(row[segmentDimensionId]?.value.raw)
+                    ? parseDimensionValue(row[segmentDimensionId])
                     : null;
 
                 return {
                     date: new Date(date),
                     segment: segmentValue,
                     metric: {
-                        value: parseMetricValue(row[metricId]?.value.raw),
-                        formatted: row[metricId]?.value.formatted,
+                        value: parseMetricValue(row[metricId]),
                         label: segmentValue ?? metric.label ?? metric.name,
                     },
                     compareMetric: {
-                        formatted: null,
                         value: null,
                         label: null,
                     },
@@ -305,8 +300,8 @@ export const getMetricExplorerDataPointsWithCompare = (
     dimension: Dimension,
     compareDimension: Dimension,
     metric: MetricWithAssociatedTimeDimension,
-    metricRows: ResultRow[],
-    compareMetricRows: ResultRow[],
+    metricRows: Record<string, any>[],
+    compareMetricRows: Record<string, any>[],
     query: MetricExplorerQuery,
     timeFrame: TimeFrames,
 ): {
@@ -322,10 +317,10 @@ export const getMetricExplorerDataPointsWithCompare = (
     const compareDimensionId = getItemId(compareDimension);
 
     const groupByMetricRows = groupBy(metricRows, (row) =>
-        new Date(String(row[dimensionId].value.raw)).toISOString(),
+        new Date(String(row[dimensionId])).toISOString(),
     );
     const groupByCompareMetricRows = groupBy(compareMetricRows, (row) =>
-        new Date(String(row[compareDimensionId].value.raw)).toISOString(),
+        new Date(String(row[compareDimensionId])).toISOString(),
     );
 
     const offsetGroupByCompareMetricRows = mapKeys(
@@ -371,20 +366,12 @@ export const getMetricExplorerDataPointsWithCompare = (
         date: new Date(date),
         segment: null,
         metric: {
-            formatted:
-                groupByMetricRows[date]?.[0]?.[metricId]?.value.formatted,
-            value: parseMetricValue(
-                groupByMetricRows[date]?.[0]?.[metricId]?.value.raw,
-            ),
+            value: parseMetricValue(groupByMetricRows[date]?.[0]?.[metricId]),
             label: metric.label ?? metric.name,
         },
         compareMetric: {
-            formatted:
-                offsetGroupByCompareMetricRows[date]?.[0]?.[compareMetricId]
-                    ?.value.formatted,
             value: parseMetricValue(
-                offsetGroupByCompareMetricRows[date]?.[0]?.[compareMetricId]
-                    ?.value.raw,
+                offsetGroupByCompareMetricRows[date]?.[0]?.[compareMetricId],
             ),
             label: comparisonMetricLabel,
         },
@@ -430,23 +417,32 @@ export const getDefaultDateRangeFromInterval = (
     }
 };
 
-export const getDefaultDateRangeForMetricTotal = (
+export const getDefaultMetricTreeNodeDateRange = (
     timeFrame: TimeFrames,
 ): MetricExplorerDateRange => {
     const now = dayjs();
 
     switch (timeFrame) {
         case TimeFrames.DAY:
-            return [now.startOf('day').toDate(), now.endOf('day').toDate()];
+            return [
+                now.startOf('day').subtract(1, 'day').toDate(),
+                now.endOf('day').subtract(1, 'day').toDate(),
+            ];
         case TimeFrames.WEEK:
             return [
-                now.startOf('isoWeek').toDate(),
-                now.endOf('isoWeek').toDate(),
+                now.startOf('isoWeek').subtract(1, 'week').toDate(),
+                now.endOf('isoWeek').subtract(1, 'week').toDate(),
             ];
         case TimeFrames.MONTH:
-            return [now.startOf('month').toDate(), now.endOf('month').toDate()];
+            return [
+                now.startOf('month').subtract(1, 'month').toDate(),
+                now.endOf('month').subtract(1, 'month').toDate(),
+            ];
         case TimeFrames.YEAR:
-            return [now.startOf('year').toDate(), now.endOf('year').toDate()];
+            return [
+                now.startOf('year').subtract(1, 'year').toDate(),
+                now.endOf('year').subtract(1, 'year').toDate(),
+            ];
         default:
             return assertUnimplementedTimeframe(timeFrame);
     }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeConnectedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/MetricTreeConnectedNode.tsx
@@ -2,8 +2,8 @@ import {
     applyCustomFormat,
     ComparisonFormatTypes,
     CustomFormatType,
+    formatItemValue,
     friendlyName,
-    getCustomFormat,
     getDefaultMetricTreeNodeDateRange,
     MetricTotalComparisonType,
     type TimeFrames,
@@ -86,8 +86,10 @@ const MetricTreeConnectedNode: React.FC<
 
     const formattedValue = useMemo(() => {
         if (totalQuery.data) {
-            const customFormat = getCustomFormat(totalQuery.data.metric);
-            return applyCustomFormat(totalQuery.data.value, customFormat);
+            return formatItemValue(
+                totalQuery.data.metric,
+                totalQuery.data.value,
+            );
         }
         return '-';
     }, [totalQuery.data]);

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -31,7 +31,7 @@ import {
     getGranularityLabel,
     getGranularitySublabel,
 } from '../../utils/metricPeekDate';
-import type { FormatConfig } from './types';
+import type { MetricVisualizationFormatConfig } from './types';
 
 type RechartsTooltipPropsPayload = NonNullable<
     TooltipProps<ValueType, NameType>['payload']
@@ -47,7 +47,7 @@ interface MetricExploreTooltipProps extends TooltipProps<ValueType, NameType> {
     is5YearDateRangePreset: boolean;
     payload?: CustomTooltipPropsPayload[];
     dateRange?: MetricExplorerDateRange;
-    formatConfig: FormatConfig;
+    formatConfig: MetricVisualizationFormatConfig;
 }
 
 /**
@@ -211,7 +211,7 @@ const TooltipEntry: FC<{
     comparison: MetricExplorerQuery;
     date: string | undefined;
     is5YearDateRangePreset: boolean;
-    formatConfig: FormatConfig;
+    formatConfig: MetricVisualizationFormatConfig;
     dateRange?: MetricExplorerDateRange;
 }> = (props) => {
     const { entry } = props;

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -52,7 +52,7 @@ import { MetricExploreLegend } from './MetricExploreLegend';
 import { MetricExploreTooltip } from './MetricExploreTooltip';
 import { MetricPeekDatePicker } from './MetricPeekDatePicker';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
-import { FORMATS } from './types';
+import { FORMATS, type FormatConfig } from './types';
 // REMOVE COMMENTS TO ENABLE CHART ZOOM
 // import { useChartZoom } from './useChartZoom';
 
@@ -317,7 +317,7 @@ const MetricsVisualization: FC<Props> = ({
         is5YearDateRangePreset,
     ]);
 
-    const formatConfig = useMemo(() => {
+    const formatConfig = useMemo<FormatConfig>(() => {
         return {
             metric: getCustomFormat(results?.metric),
             compareMetric: getCustomFormat(results?.compareMetric ?? undefined),
@@ -609,6 +609,7 @@ const MetricsVisualization: FC<Props> = ({
                                             is5YearDateRangePreset
                                         }
                                         dateRange={dateRange}
+                                        formatConfig={formatConfig}
                                     />
                                 }
                                 cursor={{

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -52,27 +52,27 @@ import { MetricExploreLegend } from './MetricExploreLegend';
 import { MetricExploreTooltip } from './MetricExploreTooltip';
 import { MetricPeekDatePicker } from './MetricPeekDatePicker';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
-import { FORMATS, type FormatConfig } from './types';
+import { DATE_FORMATS, type MetricVisualizationFormatConfig } from './types';
 // REMOVE COMMENTS TO ENABLE CHART ZOOM
 // import { useChartZoom } from './useChartZoom';
 
 const tickFormatter = (date: Date) => {
     return (
         timeSecond(date) < date
-            ? FORMATS.millisecond
+            ? DATE_FORMATS.millisecond
             : timeMinute(date) < date
-            ? FORMATS.second
+            ? DATE_FORMATS.second
             : timeHour(date) < date
-            ? FORMATS.minute
+            ? DATE_FORMATS.minute
             : timeDay(date) < date
-            ? FORMATS.hour
+            ? DATE_FORMATS.hour
             : timeMonth(date) < date
             ? timeWeek(date) < date
-                ? FORMATS.day
-                : FORMATS.week
+                ? DATE_FORMATS.day
+                : DATE_FORMATS.week
             : timeYear(date) < date
-            ? FORMATS.month
-            : FORMATS.year
+            ? DATE_FORMATS.month
+            : DATE_FORMATS.year
     )(date);
 };
 
@@ -317,7 +317,7 @@ const MetricsVisualization: FC<Props> = ({
         is5YearDateRangePreset,
     ]);
 
-    const formatConfig = useMemo<FormatConfig>(() => {
+    const formatConfig = useMemo<MetricVisualizationFormatConfig>(() => {
         return {
             metric: getCustomFormat(results?.metric),
             compareMetric: getCustomFormat(results?.compareMetric ?? undefined),

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
@@ -1,3 +1,4 @@
+import type { CustomFormat } from '@lightdash/common';
 import dayjs from 'dayjs';
 
 export const FORMATS = {
@@ -9,4 +10,9 @@ export const FORMATS = {
     week: (date: Date) => dayjs(date).format('MMM D'),
     month: (date: Date) => dayjs(date).format('MMM'),
     year: (date: Date) => dayjs(date).format('YYYY'),
+};
+
+export type FormatConfig = {
+    metric: CustomFormat | undefined;
+    compareMetric: CustomFormat | undefined;
 };

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
@@ -1,7 +1,7 @@
 import type { CustomFormat } from '@lightdash/common';
 import dayjs from 'dayjs';
 
-export const FORMATS = {
+export const DATE_FORMATS = {
     millisecond: (date: Date) => dayjs(date).format('HH:mm:ss.SSS'),
     second: (date: Date) => dayjs(date).format('HH:mm:ss'),
     minute: (date: Date) => dayjs(date).format('HH:mm'),
@@ -12,7 +12,7 @@ export const FORMATS = {
     year: (date: Date) => dayjs(date).format('YYYY'),
 };
 
-export type FormatConfig = {
+export type MetricVisualizationFormatConfig = {
     metric: CustomFormat | undefined;
     compareMetric: CustomFormat | undefined;
 };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -163,7 +163,16 @@ export const useRunMetricTotal = ({
     options?: UseQueryOptions<ApiMetricsExplorerTotalResults['results']>;
 }) => {
     return useQuery({
-        queryKey: ['runMetricTotal', projectUuid, exploreName, metricName],
+        queryKey: [
+            'runMetricTotal',
+            projectUuid,
+            exploreName,
+            metricName,
+            dateRange?.[0],
+            dateRange?.[1],
+            timeFrame,
+            comparisonType,
+        ],
         queryFn: () =>
             postRunMetricTotal({
                 projectUuid: projectUuid!,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12997 

### Description:

- Formats result values on the frontend instead of backend
- Fix tree total query to use data range query params, previously they were being ignored

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
