### PR TITLE
fix: fetch segments to prevent long running query when segmenting

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -256,14 +256,14 @@ export class MetricsExplorerService<
         );
     }
 
-    private async _getFirstNSegments(
+    private async _getTopNSegments(
         user: SessionUser,
         projectUuid: string,
         exploreName: string,
         segmentDimension: string | null,
         metricQuery: MetricQuery,
     ) {
-        if (!segmentDimension) {
+        if (!segmentDimension || !metricQuery.metrics.length) {
             return [];
         }
 
@@ -271,7 +271,7 @@ export class MetricsExplorerService<
             ...metricQuery,
             exploreName,
             dimensions: [segmentDimension],
-            sorts: [{ fieldId: segmentDimension, descending: true }],
+            sorts: [{ fieldId: metricQuery.metrics[0], descending: true }],
             limit: MAX_SEGMENT_DIMENSION_UNIQUE_VALUES,
             tableCalculations: [],
         };
@@ -370,7 +370,7 @@ export class MetricsExplorerService<
             limit: this.maxQueryLimit,
         };
 
-        const segments = await this._getFirstNSegments(
+        const segments = await this._getTopNSegments(
             user,
             projectUuid,
             exploreName,

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -172,6 +172,22 @@ export const getGrainForDateRange = (
     return TimeFrames.YEAR;
 };
 
+export const getMetricsExplorerSegmentFilters = (
+    segmentDimension: string | null,
+    segments: string[],
+): FilterRule[] => {
+    if (!segmentDimension || segments.length === 0) return [];
+
+    return [
+        {
+            id: uuidv4(),
+            target: { fieldId: segmentDimension },
+            operator: ConditionalOperator.EQUALS,
+            values: segments,
+        },
+    ];
+};
+
 export const getMetricExplorerDateRangeFilters = (
     timeDimensionConfig: TimeDimensionConfig,
     dateRange: MetricExplorerDateRange,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fetches top `MAX_SEGMENT_DIMENSION_UNIQUE_VALUES` segments by metric before running the query so that a filter can be applied to reduce amount of results.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
