### PR TITLE
feat: `--skip-dbt-compile` and `--skip-warehouse-catalog` to `compile`

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -282,7 +282,16 @@ program
     .option('--state <state>')
     .option('--full-refresh')
     .option('--verbose', undefined, false)
-
+    .option(
+        '--skip-warehouse-catalog',
+        'Skip fetch warehouse catalog and use types in yml',
+        false,
+    )
+    .option(
+        '--skip-dbt-compile',
+        'Skip `dbt compile` and deploy from the existing ./target/manifest.json',
+        false,
+    )
     .action(compileHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: NA

Please let me know if I should open the issue.

### Description:

It would be great to boost local development by adding the `--skip-dbt-compile` and `--skip-warehouse-catalog` options to `lightdash compile` as some other commands do. Those options may be for advanced developers who understand the internal behavior of Lightdash CLI. However, they would be very useful to quickly check dimensions and metrics, though the result with the options isn't 100% reliable due to the lack of required information. 

- The `--skip-dbt-compile` option enable us to use the existing `manifest.json`. Sometimes, we don't need to re-generate `manifest.json` every time when running `lightdash compile` in local development.
- The `--skip-warehouse-catalog` option enables us to skip fetching warehouse catalog. If we clearly define types in schema YAML files, it might be ok to skip the process in local development.

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
