### PR TITLE
fix: show the sidebar when switching to the viz tab

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -8,7 +8,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
-import { type Dispatch, type FC, type SetStateAction } from 'react';
+import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { VisualizationConfigPanel } from '../../../components/DataViz/VisualizationConfigPanel';
 import { useRefreshTables } from '../hooks/useTables';
@@ -17,7 +17,7 @@ import { setSelectedChartType, SidebarTabs } from '../store/sqlRunnerSlice';
 import { TablesPanel } from './TablesPanel';
 
 type Props = {
-    setSidebarOpen: Dispatch<SetStateAction<boolean>>;
+    setSidebarOpen: (isOpen: boolean) => void;
 };
 
 export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -120,6 +120,7 @@ export interface SqlRunnerState {
             isOpen: boolean;
         };
     };
+    isLeftSidebarOpen: boolean;
     quoteChar: string;
     warehouseConnectionType: WarehouseTypes | undefined;
     sqlColumns: VizColumn[] | undefined;
@@ -172,6 +173,7 @@ export const initialState: SqlRunnerState = {
             isOpen: false,
         },
     },
+    isLeftSidebarOpen: true,
     quoteChar: '"',
     warehouseConnectionType: undefined,
     sqlColumns: undefined,
@@ -271,6 +273,10 @@ export const sqlRunnerSlice = createSlice({
                 if (state.selectedChartType === undefined) {
                     state.selectedChartType = ChartKind.VERTICAL_BAR;
                 }
+                // Show the sidebar when switching to the chart tab
+                if (!state.isLeftSidebarOpen) {
+                    state.isLeftSidebarOpen = true;
+                }
             }
             if (action.payload === EditorTabs.SQL) {
                 state.activeSidebarTab = SidebarTabs.TABLES;
@@ -309,6 +315,9 @@ export const sqlRunnerSlice = createSlice({
         ) => {
             state.modals[action.payload].isOpen =
                 !state.modals[action.payload].isOpen;
+        },
+        setSidebarOpen: (state, action: PayloadAction<boolean>) => {
+            state.isLeftSidebarOpen = action.payload;
         },
         setQuoteChar: (state, action: PayloadAction<string>) => {
             state.quoteChar = action.payload;
@@ -416,6 +425,7 @@ export const {
     setSavedChartData,
     setSelectedChartType,
     toggleModal,
+    setSidebarOpen,
     resetState,
     setQuoteChar,
     setWarehouseConnectionType,

--- a/packages/frontend/src/pages/SqlRunnerNew.tsx
+++ b/packages/frontend/src/pages/SqlRunnerNew.tsx
@@ -1,7 +1,7 @@
 import { getFieldQuoteChar } from '@lightdash/common';
 import { ActionIcon, Group, Paper, Stack, Tooltip } from '@mantine/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMount, useUnmount } from 'react-use';
@@ -29,6 +29,7 @@ import {
     setProjectUuid,
     setQuoteChar,
     setSavedChartData,
+    setSidebarOpen,
     setSql,
     setState,
     setWarehouseConnectionType,
@@ -57,7 +58,9 @@ const SqlRunnerNew = ({
     const location = useLocation<{ sql?: string }>();
     const history = useHistory();
 
-    const [isLeftSidebarOpen, setLeftSidebarOpen] = useState(true);
+    const isLeftSidebarOpen = useAppSelector(
+        (state) => state.sqlRunner.isLeftSidebarOpen,
+    );
     const { data: project } = useProject(projectUuid);
     const { showToastError } = useToaster();
 
@@ -147,6 +150,10 @@ const SqlRunnerNew = ({
         }
     }, [dispatch, project?.warehouseConnection?.type]);
 
+    const handleSetSidebarOpen = (isOpen: boolean) => {
+        dispatch(setSidebarOpen(isOpen));
+    };
+
     if (chartError) {
         return <ErrorState error={chartError.error} />;
     }
@@ -164,7 +171,7 @@ const SqlRunnerNew = ({
                 )
             }
             isSidebarOpen={isLeftSidebarOpen}
-            sidebar={<Sidebar setSidebarOpen={setLeftSidebarOpen} />}
+            sidebar={<Sidebar setSidebarOpen={handleSetSidebarOpen} />}
             noSidebarPadding
         >
             <Group
@@ -191,7 +198,7 @@ const SqlRunnerNew = ({
                             >
                                 <ActionIcon
                                     size="sm"
-                                    onClick={() => setLeftSidebarOpen(true)}
+                                    onClick={() => handleSetSidebarOpen(true)}
                                 >
                                     <MantineIcon
                                         icon={IconLayoutSidebarLeftExpand}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #11518 

### Description:

This does two things:
- Moves sidebar state to the slice, making it possible to control it in other parts of the page
- Opens the sidebar (if it was closed) when switching to the viz tab. This mitigates the issue mentioned in the linked ticket (#11518) where it's confusing to switch to the viz tab and see no cahrt config. We could potentially improve this behavior in the future, but this seems better than what we have. And moving sidebar state to the slice will be necessary for whatever else we do there. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
