### PR TITLE
fix: show loading spinner in between empty states

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -496,23 +496,18 @@ const MetricsVisualization: FC<Props> = ({
                 </Tooltip> */}
             </Group>
 
-            {showEmptyState && !isFetching && (
-                <Flex sx={{ flex: 1, position: 'relative' }}>
-                    <MetricsVisualizationEmptyState />
-                </Flex>
-            )}
+            <Flex mih={0} sx={{ flex: 1, position: 'relative' }}>
+                <LoadingOverlay
+                    visible={isFetching}
+                    loaderProps={{
+                        size: 'sm',
+                        color: 'dark',
+                        variant: 'dots',
+                    }}
+                />
+                {showEmptyState && <MetricsVisualizationEmptyState />}
 
-            {!showEmptyState && results && (
-                <Flex mih={0} sx={{ flex: 1, position: 'relative' }}>
-                    <LoadingOverlay
-                        visible={isFetching}
-                        loaderProps={{
-                            size: 'sm',
-                            color: 'dark',
-                            variant: 'dots',
-                        }}
-                    />
-
+                {!showEmptyState && results && (
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart
                             ref={(instance) => setChartRef(instance)}
@@ -689,8 +684,8 @@ const MetricsVisualization: FC<Props> = ({
                             */}
                         </LineChart>
                     </ResponsiveContainer>
-                </Flex>
-            )}
+                )}
+            </Flex>
             <Group
                 position="center"
                 mt="auto"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

In metrics explorer, run 2 queries that return no results and show empty state. Go between date ranges and see the loading spinner. Before this PR, we weren't showing the spinner at all, which for longer queries, wouldn't be sufficient feedback to the user.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
