### PR TITLE
feat: enable SQL runner to save to a table when no viz is selected

### DIFF
--- a/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
@@ -179,7 +179,7 @@ describe('SQL Runner (new)', () => {
         ).should('exist');
     });
 
-    it('Should save a chart', () => {
+    it.only('Should save a chart', () => {
         // Verify that the Run query button is disabled by default
         cy.contains('Run query').should('be.disabled');
 
@@ -193,6 +193,9 @@ describe('SQL Runner (new)', () => {
         );
         cy.contains('Run query').click();
         cy.get('table thead th').eq(0).should('contain.text', 'customer_id');
+
+        // View chart
+        cy.contains('label', 'Chart').click();
 
         // Verify that the chart is saved
         cy.contains('Save').click();

--- a/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
@@ -30,21 +30,25 @@ describe('SQL Runner (new)', () => {
         // Verify that the query is run and the results are displayed
         cy.contains('Run query').click();
 
-        cy.get('table thead th').should('have.length', 12);
-        cy.get('table thead th').eq(0).should('contain.text', 'order_id');
-        cy.get('table thead th').eq(1).should('contain.text', 'customer_id');
-        cy.get('table thead th').eq(2).should('contain.text', 'order_date');
-        cy.get('table thead th').eq(3).should('contain.text', 'status');
-        cy.get('table tbody tr')
-            .first()
-            .within(() => {
-                cy.get('td').eq(0).should('contain.text', '1');
-                cy.get('td').eq(1).should('contain.text', '1');
-                cy.get('td')
-                    .eq(2)
-                    .should('contain.text', '2018-01-01T00:00:00.000Z');
-                cy.get('td').eq(3).should('contain.text', 'returned');
-            });
+        cy.get('#sql-runner-panel-results').within(() => {
+            cy.get('table thead th').should('have.length', 12);
+            cy.get('table thead th').eq(0).should('contain.text', 'order_id');
+            cy.get('table thead th')
+                .eq(1)
+                .should('contain.text', 'customer_id');
+            cy.get('table thead th').eq(2).should('contain.text', 'order_date');
+            cy.get('table thead th').eq(3).should('contain.text', 'status');
+            cy.get('table tbody tr')
+                .first()
+                .within(() => {
+                    cy.get('td').eq(0).should('contain.text', '1');
+                    cy.get('td').eq(1).should('contain.text', '1');
+                    cy.get('td')
+                        .eq(2)
+                        .should('contain.text', '2018-01-01T00:00:00.000Z');
+                    cy.get('td').eq(3).should('contain.text', 'returned');
+                });
+        });
 
         // Verify that the query is saved in the draft history
         cy.get('button[data-testid="sql-query-history-button"]').click();

--- a/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunnerNew.cy.ts
@@ -179,7 +179,7 @@ describe('SQL Runner (new)', () => {
         ).should('exist');
     });
 
-    it.only('Should save a chart', () => {
+    it('Should save a chart', () => {
         // Verify that the Run query button is disabled by default
         cy.contains('Run query').should('be.disabled');
 

--- a/packages/frontend/src/components/DataViz/store/selectors.ts
+++ b/packages/frontend/src/components/DataViz/store/selectors.ts
@@ -147,20 +147,6 @@ export const selectCompleteConfigByKind = createSelector(
     },
 );
 
-export const selectCurrentVizConfig = createSelector(
-    [
-        (state) => state.sqlRunner.selectedChartType,
-        (state) => state.sqlRunner.userHasSelectedChartType,
-        (state) => state,
-    ],
-    (selectedChartType, userHasSelectedChartType, state) => {
-        const chartKind = userHasSelectedChartType
-            ? selectedChartType
-            : ChartKind.TABLE;
-        return selectCompleteConfigByKind(state, chartKind);
-    },
-);
-
 export const selectCurrentCartesianChartState = createSelector(
     [
         (state, chartKind) => chartKind,

--- a/packages/frontend/src/components/DataViz/store/selectors.ts
+++ b/packages/frontend/src/components/DataViz/store/selectors.ts
@@ -147,6 +147,20 @@ export const selectCompleteConfigByKind = createSelector(
     },
 );
 
+export const selectCurrentVizConfig = createSelector(
+    [
+        (state) => state.sqlRunner.selectedChartType,
+        (state) => state.sqlRunner.userHasSelectedChartType,
+        (state) => state,
+    ],
+    (selectedChartType, userHasSelectedChartType, state) => {
+        const chartKind = userHasSelectedChartType
+            ? selectedChartType
+            : ChartKind.TABLE;
+        return selectCompleteConfigByKind(state, chartKind);
+    },
+);
+
 export const selectCurrentCartesianChartState = createSelector(
     [
         (state, chartKind) => chartKind,

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -580,7 +580,7 @@ export const ContentPanel: FC = () => {
                                                                             }
                                                                             style={{
                                                                                 height: inputSectionHeight,
-                                                                                flex: 1,
+                                                                                flex: inputSectionWidth,
                                                                             }}
                                                                             onChartReady={(
                                                                                 instance,

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -24,7 +24,10 @@ import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SaveToSpaceForm from '../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
 import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateModal/types';
-import { selectCompleteConfigByKind } from '../../../components/DataViz/store/selectors';
+import {
+    selectCompleteConfigByKind,
+    selectCurrentVizConfig,
+} from '../../../components/DataViz/store/selectors';
 import {
     useCreateMutation as useSpaceCreateMutation,
     useSpaceSummaries,
@@ -58,9 +61,7 @@ const SaveChartForm: FC<
 
     const name = useAppSelector((state) => state.sqlRunner.name);
     const description = useAppSelector((state) => state.sqlRunner.description);
-    const selectedChartType = useAppSelector(
-        (state) => state.sqlRunner.selectedChartType,
-    );
+
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const limit = useAppSelector((state) => state.sqlRunner.limit);
 
@@ -69,7 +70,7 @@ const SaveChartForm: FC<
     );
 
     const currentVizConfig = useAppSelector((state) =>
-        selectCompleteConfigByKind(state, selectedChartType),
+        selectCurrentVizConfig(state),
     );
 
     // TODO: this sometimes runs `/api/v1/projects//spaces` request
@@ -128,6 +129,11 @@ const SaveChartForm: FC<
             : undefined;
         const spaceUuid =
             newSpace?.uuid || form.values.spaceUuid || spaces[0].uuid;
+
+        console.log('currentVizConfig', {
+            currentVizConfig,
+            defaultChartConfig,
+        });
 
         const currentConfig = currentVizConfig ?? defaultChartConfig;
 

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -61,6 +61,11 @@ const SaveChartForm: FC<
 
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const limit = useAppSelector((state) => state.sqlRunner.limit);
+
+    const selectedChartType = useAppSelector(
+        (state) => state.sqlRunner.selectedChartType,
+    );
+
     const activeEditorTab = useAppSelector(
         (state) => state.sqlRunner.activeEditorTab,
     );
@@ -70,7 +75,7 @@ const SaveChartForm: FC<
             state,
             activeEditorTab === EditorTabs.SQL
                 ? ChartKind.TABLE
-                : ChartKind.VERTICAL_BAR,
+                : selectedChartType,
         ),
     );
 

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
@@ -1,3 +1,4 @@
+import { ChartKind } from '@lightdash/common';
 import { isAnyOf } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { setChartOptionsAndConfig } from '../../../components/DataViz/store/actions/commonChartActions';
@@ -40,7 +41,19 @@ export const addSqlRunnerQueryListener = (
                 completeConfigByKind,
             );
 
+            const tableConfig = selectCompleteConfigByKind(
+                state,
+                ChartKind.TABLE,
+            );
+
+            const tableResultOptions = getChartConfigAndOptions(
+                resultsRunner,
+                ChartKind.TABLE,
+                tableConfig,
+            );
+
             listenerApi.dispatch(setChartOptionsAndConfig(chartResultOptions));
+            listenerApi.dispatch(setChartOptionsAndConfig(tableResultOptions));
 
             await listenerApi.dispatch(prepareAndFetchChartData());
         },

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -148,7 +148,7 @@ export const initialState: SqlRunnerState = {
     limit: 500,
     activeSidebarTab: SidebarTabs.TABLES,
     activeEditorTab: EditorTabs.SQL,
-    selectedChartType: ChartKind.TABLE,
+    selectedChartType: ChartKind.VERTICAL_BAR,
     userHasSelectedChartType: false,
     resultsTableConfig: undefined,
     modals: {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -272,6 +272,7 @@ export const sqlRunnerSlice = createSlice({
                 state.activeSidebarTab = SidebarTabs.VISUALIZATION;
                 if (!state.userHasSelectedChartType) {
                     state.selectedChartType = ChartKind.VERTICAL_BAR;
+                    state.userHasSelectedChartType = true;
                 }
             }
             if (action.payload === EditorTabs.SQL) {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -96,6 +96,7 @@ export interface SqlRunnerState {
     activeSidebarTab: SidebarTabs;
     activeEditorTab: EditorTabs;
     selectedChartType: ChartKind | undefined;
+    userHasSelectedChartType: boolean;
     resultsTableConfig: VizTableColumnsConfig | undefined;
     modals: {
         saveChartModal: {
@@ -147,7 +148,8 @@ export const initialState: SqlRunnerState = {
     limit: 500,
     activeSidebarTab: SidebarTabs.TABLES,
     activeEditorTab: EditorTabs.SQL,
-    selectedChartType: ChartKind.VERTICAL_BAR,
+    selectedChartType: ChartKind.TABLE,
+    userHasSelectedChartType: false,
     resultsTableConfig: undefined,
     modals: {
         saveChartModal: {
@@ -176,7 +178,7 @@ export const initialState: SqlRunnerState = {
     warehouseConnectionType: undefined,
     sqlColumns: undefined,
     sqlRows: undefined,
-    activeConfigs: [ChartKind.VERTICAL_BAR],
+    activeConfigs: [ChartKind.TABLE, ChartKind.VERTICAL_BAR],
     fetchResultsOnLoad: false,
     queryIsLoading: false,
     queryError: undefined,
@@ -268,7 +270,7 @@ export const sqlRunnerSlice = createSlice({
             }
             if (action.payload === EditorTabs.VISUALIZATION) {
                 state.activeSidebarTab = SidebarTabs.VISUALIZATION;
-                if (state.selectedChartType === undefined) {
+                if (!state.userHasSelectedChartType) {
                     state.selectedChartType = ChartKind.VERTICAL_BAR;
                 }
             }
@@ -290,6 +292,7 @@ export const sqlRunnerSlice = createSlice({
         },
         setSelectedChartType: (state, action: PayloadAction<ChartKind>) => {
             state.selectedChartType = action.payload;
+            state.userHasSelectedChartType = true;
             if (!state.activeConfigs.includes(action.payload)) {
                 state.activeConfigs.push(action.payload);
             }

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -96,7 +96,6 @@ export interface SqlRunnerState {
     activeSidebarTab: SidebarTabs;
     activeEditorTab: EditorTabs;
     selectedChartType: ChartKind | undefined;
-    userHasSelectedChartType: boolean;
     resultsTableConfig: VizTableColumnsConfig | undefined;
     modals: {
         saveChartModal: {
@@ -149,7 +148,6 @@ export const initialState: SqlRunnerState = {
     activeSidebarTab: SidebarTabs.TABLES,
     activeEditorTab: EditorTabs.SQL,
     selectedChartType: ChartKind.VERTICAL_BAR,
-    userHasSelectedChartType: false,
     resultsTableConfig: undefined,
     modals: {
         saveChartModal: {
@@ -270,9 +268,8 @@ export const sqlRunnerSlice = createSlice({
             }
             if (action.payload === EditorTabs.VISUALIZATION) {
                 state.activeSidebarTab = SidebarTabs.VISUALIZATION;
-                if (!state.userHasSelectedChartType) {
+                if (!state.selectedChartType) {
                     state.selectedChartType = ChartKind.VERTICAL_BAR;
-                    state.userHasSelectedChartType = true;
                 }
             }
             if (action.payload === EditorTabs.SQL) {
@@ -293,7 +290,6 @@ export const sqlRunnerSlice = createSlice({
         },
         setSelectedChartType: (state, action: PayloadAction<ChartKind>) => {
             state.selectedChartType = action.payload;
-            state.userHasSelectedChartType = true;
             if (!state.activeConfigs.includes(action.payload)) {
                 state.activeConfigs.push(action.payload);
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13013 

### Description:

This fixes a bug and makes a behavior change:
- **bug:** sql runner cant save when there is only one column
- **change:** when saving from the SQL tab, the viz will be saved as a table, the current view

The implementation does the following
- Populates both table and chart config when data loads (it used to be just the chart config)
- If the user saves while viewing the results table, the table viz will be saved

To test:
- Run a query with one column
- Save from the SQL tab
- A table is saved

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
