### PR TITLE
fix: remove orange state from SQL runner

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -349,6 +349,7 @@ export const ContentPanel: FC = () => {
                                                 >
                                                     <Group spacing={4} noWrap>
                                                         <MantineIcon
+                                                            color="gray.6"
                                                             icon={
                                                                 IconCodeCircle
                                                             }

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -349,24 +349,11 @@ export const ContentPanel: FC = () => {
                                                 >
                                                     <Group spacing={4} noWrap>
                                                         <MantineIcon
-                                                            color={
-                                                                hasUnrunChanges
-                                                                    ? 'yellow.7'
-                                                                    : 'gray.6'
-                                                            }
                                                             icon={
                                                                 IconCodeCircle
                                                             }
                                                         />
-                                                        <Text
-                                                            color={
-                                                                hasUnrunChanges
-                                                                    ? 'yellow.7'
-                                                                    : 'gray.6'
-                                                            }
-                                                        >
-                                                            SQL
-                                                        </Text>
+                                                        <Text>SQL</Text>
                                                     </Group>
                                                 </Tooltip>
                                             ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11894 

### Description:

I saw this ticket when looking for something else in the SQL runner and it was easy enough to pick up. 

Removes the orange warning color from unrun SQL as the linked ticket calls for. 

Before
<img width="395" alt="Screenshot 2024-12-27 at 16 55 58" src="https://github.com/user-attachments/assets/e681be77-1cf3-44c4-879a-a38dc63dabb8" />

After
<img width="506" alt="Screenshot 2024-12-27 at 16 56 31" src="https://github.com/user-attachments/assets/72c7f2e4-3bba-4599-9217-f7a8299f6def" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
