### PR TITLE
fix: remove fields bottom padding, change sql viewer tab style

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -117,7 +117,7 @@ export const TableFields: FC = () => {
     });
 
     return (
-        <Stack spacing="xs" h="calc(100% - 20px)" pt="sm" py="xs">
+        <Stack spacing="xs" h="100%" pt="sm">
             {activeTable ? (
                 <Box px="sm">
                     <Text fz="sm" fw={600} c="gray.7">

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -92,9 +92,13 @@ const ViewSqlChart = () => {
                     <Group position="apart">
                         <Group position="apart">
                             <SegmentedControl
-                                color="dark"
+                                styles={(theme) => ({
+                                    root: {
+                                        backgroundColor: theme.colors.gray[2],
+                                    },
+                                })}
                                 size="sm"
-                                radius="sm"
+                                radius="md"
                                 disabled={isChartResultsLoading}
                                 data={[
                                     {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11468, #11966 

### Description:

A couple small changes from tidying up the SQL Runner backlog:
- Remove bottom padding on the fields list
- Make the view page segmented control style match the edit page

#### Before:
<img width="416" alt="Screenshot 2024-12-30 at 13 59 24" src="https://github.com/user-attachments/assets/9466e84e-bc88-4639-b58c-6bedea5bdbd7" />
<img width="618" alt="Screenshot 2024-12-30 at 13 53 02" src="https://github.com/user-attachments/assets/73635992-b372-4319-bd9a-1b5875a93767" />

#### After:
<img width="421" alt="Screenshot 2024-12-30 at 13 58 45" src="https://github.com/user-attachments/assets/c46c56bd-d894-4a7c-91ab-37e6b91e494a" />
<img width="558" alt="Screenshot 2024-12-30 at 13 51 25" src="https://github.com/user-attachments/assets/f8152b2d-4adb-4e07-ac24-f5a2600664be" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
