### PR TITLE
fix: render markdown on clamped description

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
@@ -6,7 +6,9 @@ import {
     px,
     useMantineTheme,
 } from '@mantine/core';
-import MarkdownPreview from '@uiw/react-markdown-preview';
+import MarkdownPreview, {
+    type MarkdownPreviewProps,
+} from '@uiw/react-markdown-preview';
 import { type MRT_TableInstance } from 'mantine-react-table';
 import { useEffect, useRef, type FC } from 'react';
 import { useLockScroll } from '../../../hooks/useLockScroll';
@@ -17,6 +19,7 @@ type Props = {
     content: string;
     cellRef: React.RefObject<HTMLDivElement>;
     table: MRT_TableInstance<CatalogField>;
+    markdownPreviewProps?: Omit<MarkdownPreviewProps, 'source'>;
 };
 
 export const MetricCatalogCellOverlay: FC<Props> = ({
@@ -25,6 +28,7 @@ export const MetricCatalogCellOverlay: FC<Props> = ({
     content,
     cellRef,
     table,
+    markdownPreviewProps,
 }) => {
     const theme = useMantineTheme();
     const overlayRef = useRef<HTMLDivElement>(null);
@@ -88,31 +92,13 @@ export const MetricCatalogCellOverlay: FC<Props> = ({
                 }}
             >
                 <MarkdownPreview
+                    {...markdownPreviewProps}
                     source={content}
                     style={{
-                        fontSize: theme.fontSizes.sm,
-                        color: theme.colors.dark[4],
-                        fontFamily: 'Inter',
+                        ...markdownPreviewProps?.style,
                         backgroundColor: theme.fn.lighten(
                             theme.colors.violet[1],
                             0.8,
-                        ),
-                    }}
-                    components={{
-                        h1: ({ children }) => (
-                            <h1 style={{ fontWeight: 600 }}>{children}</h1>
-                        ),
-                        h2: ({ children }) => (
-                            <h2 style={{ fontWeight: 600 }}>{children}</h2>
-                        ),
-                        h3: ({ children }) => (
-                            <h3 style={{ fontWeight: 600 }}>{children}</h3>
-                        ),
-                        p: ({ children }) => (
-                            <p style={{ fontWeight: 400 }}>{children}</p>
-                        ),
-                        li: ({ children }) => (
-                            <li style={{ fontWeight: 400 }}>{children}</li>
                         ),
                     }}
                 />

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -1,5 +1,8 @@
 import { type CatalogField } from '@lightdash/common';
-import { Box, Highlight } from '@mantine/core';
+import { Box, Text, useMantineTheme } from '@mantine/core';
+import MarkdownPreview, {
+    type MarkdownPreviewProps,
+} from '@uiw/react-markdown-preview';
 import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
 import { useRef, useState, type FC } from 'react';
 import { useIsLineClamped } from '../../../hooks/useIsLineClamped';
@@ -13,6 +16,7 @@ type Props = {
 };
 
 export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
+    const theme = useMantineTheme();
     const dispatch = useAppDispatch();
     const cellRef = useRef<HTMLDivElement>(null);
     const { ref: highlightRef, isLineClamped } =
@@ -27,9 +31,33 @@ export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
         (state) => state.metricsCatalog.popovers.description.isClosing,
     );
 
+    const markdownPreviewProps: MarkdownPreviewProps = {
+        style: {
+            fontSize: theme.fontSizes.sm,
+            color: theme.colors.dark[4],
+            fontFamily: 'Inter',
+            backgroundColor: 'inherit',
+        },
+        components: {
+            h1: ({ children }) => (
+                <h1 style={{ fontWeight: 600 }}>{children}</h1>
+            ),
+            h2: ({ children }) => (
+                <h2 style={{ fontWeight: 600 }}>{children}</h2>
+            ),
+            h3: ({ children }) => (
+                <h3 style={{ fontWeight: 600 }}>{children}</h3>
+            ),
+            p: ({ children }) => <p style={{ fontWeight: 400 }}>{children}</p>,
+            li: ({ children }) => (
+                <li style={{ fontWeight: 400 }}>{children}</li>
+            ),
+        },
+    };
+
     return (
         <Box ref={cellRef}>
-            <Highlight
+            <Text
                 ref={highlightRef}
                 c={row.original.description ? 'dark.4' : 'dark.1'}
                 fz="sm"
@@ -46,15 +74,17 @@ export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
                         setIsOpen(true);
                     }
                 }}
-                highlight={table.getState().globalFilter || ''}
                 lineClamp={2}
                 sx={{
                     cursor: canOpen ? 'pointer' : 'default',
                     color: row.original.description ? 'dark.4' : 'dark.1',
                 }}
             >
-                {row.original.description ?? '-'}
-            </Highlight>
+                <MarkdownPreview
+                    source={row.original.description ?? '-'}
+                    {...markdownPreviewProps}
+                />
+            </Text>
 
             <MetricCatalogCellOverlay
                 isOpen={isOpen}
@@ -74,6 +104,7 @@ export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
                 content={row.original.description || ''}
                 cellRef={cellRef}
                 table={table}
+                markdownPreviewProps={markdownPreviewProps}
             />
         </Box>
     );

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -81,7 +81,7 @@ export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
                 }}
             >
                 <MarkdownPreview
-                    source={row.original.description ?? '-'}
+                    source={row.original.description ?? '\\-'}
                     {...markdownPreviewProps}
                 />
             </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13057 

### Description:

- Adds ability to preview clamped markdown

**Note:** Removed ability to display highlight for description when searching 

**Before**
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/0e9ca604-059a-421f-9034-ab3e9440b960" />

**After**
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/4ccfbb0f-e647-4908-a8cb-cb58c1212045" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
