### PR TITLE
fix: skip cache for explore queries

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1598,6 +1598,7 @@ export class ProjectService extends BaseService {
             queryTags,
             granularity: dateZoomGranularity,
             chartUuid: undefined,
+            invalidateCache: true, // Do not cache results for explore queries
         });
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/12697

Simply skip cache if query comes from explore: `{explore}/runQuery`

- view chart uses `/saved/{uuid}/results`
- dashboard uses `/saved/{uuid}/chart-and-results`
- calculate total from explore does not have any cache  (calculateTotalFromSavedChart does) 
- scheduler doesn't rely on this explore method 

### Next steps 

We could add a new argument `skipCache` that will also skip the step of uploading results to cloud storage. 
This can be done on this PR, or on a separate PR ( I can make a ticket for it) . 

We'll have to add this argument to multiple methods, and cascade the value from the explore results method until getResultsFromCacheOrWarehouse

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
