### PR TITLE
fix: use correct placeholder for virtual views

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -17,7 +17,7 @@ import {
     IconLink,
     IconTableAlias,
 } from '@tabler/icons-react';
-import { useCallback, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { cartesianChartSelectors } from '../../../../components/DataViz/store/selectors';
 import { EditableText } from '../../../../components/VisualizationConfigs/common/EditableText';
@@ -29,7 +29,6 @@ import { CreateVirtualViewModal } from '../../../virtualView';
 import { useCreateSqlRunnerShareUrl } from '../../hooks/useSqlRunnerShareUrl';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
-    DEFAULT_NAME,
     EditorTabs,
     setActiveEditorTab,
     toggleModal,
@@ -40,6 +39,9 @@ import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
 
 type CtaAction = 'save' | 'createVirtualView' | 'writeBackToDbt';
+
+const DEFAULT_SQL_NAME = 'Untitled SQL query';
+const DEFAULT_NAME_VIRTUAL_VIEW = 'Untitled virtual view';
 
 export const HeaderCreate: FC = () => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
@@ -134,6 +136,14 @@ export const HeaderCreate: FC = () => {
                 return <MantineIcon icon={IconBrandGithub} />;
         }
     }, []);
+
+    const untitledName = useMemo(() => {
+        if (ctaAction === 'createVirtualView') {
+            return DEFAULT_NAME_VIRTUAL_VIEW;
+        }
+        return DEFAULT_SQL_NAME;
+    }, [ctaAction]);
+
     const clipboard = useClipboard({ timeout: 500 });
     const { showToastSuccess } = useToaster();
     const createShareUrl = useCreateSqlRunnerShareUrl();
@@ -144,6 +154,8 @@ export const HeaderCreate: FC = () => {
         showToastSuccess({ title: 'Shared URL copied to clipboard!' });
     }, [createShareUrl, clipboard, showToastSuccess]);
 
+    console.log('ctaAction', ctaAction);
+
     return (
         <>
             <Paper shadow="none" radius={0} px="md" py="xs" withBorder>
@@ -152,7 +164,7 @@ export const HeaderCreate: FC = () => {
                         <EditableText
                             size="md"
                             w={400}
-                            placeholder={DEFAULT_NAME}
+                            placeholder={untitledName}
                             value={name}
                             onChange={(e) =>
                                 dispatch(updateName(e.currentTarget.value))

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -154,8 +154,6 @@ export const HeaderCreate: FC = () => {
         showToastSuccess({ title: 'Shared URL copied to clipboard!' });
     }, [createShareUrl, clipboard, showToastSuccess]);
 
-    console.log('ctaAction', ctaAction);
-
     return (
         <>
             <Paper shadow="none" radius={0} px="md" py="xs" withBorder>

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -79,8 +79,6 @@ export const compareSqlQueries = (
     );
 };
 
-export const DEFAULT_NAME = 'Untitled SQL Query';
-
 export interface SqlRunnerState {
     projectUuid: string;
     activeTable: string | undefined;

--- a/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
@@ -33,6 +33,9 @@ export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const columns = useAppSelector((state) => state.sqlRunner.sqlColumns);
+
+    const name = useAppSelector((state) => state.sqlRunner.name);
+
     const {
         mutateAsync: createVirtualView,
         isLoading: isLoadingVirtual,
@@ -42,7 +45,7 @@ export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
     });
     const form = useForm<FormValues>({
         initialValues: {
-            name: '',
+            name: name || '',
         },
         validate: zodResolver(validationSchema),
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11895 

### Description:

Use correct name placeholders for virtual view
- Untitled placeholder when no name is entered 
<img width="587" alt="Screenshot 2025-01-02 at 13 43 19" src="https://github.com/user-attachments/assets/4eb992c4-ca3b-4683-a655-32e3348a6141" />

- Default to the name entered on the page in the virtual view dialog (it was empty)
<img width="915" alt="Screenshot 2025-01-02 at 13 44 36" src="https://github.com/user-attachments/assets/462ca5e4-ce6f-438b-9373-a0a34a5d4b01" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
