### PR TITLE
fix: [SQL runner] make field select style match other dropdowns

### DIFF
--- a/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
@@ -23,7 +23,15 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
                 },
                 item: {
                     '&[data-selected="true"]': {
+                        color: theme.colors.gray[7],
                         fontWeight: 500,
+                        backgroundColor: theme.colors.gray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.gray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.gray[1],
                     },
                 },
             })}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11896 

### Description:

Make the field select style match other dropdowns. 

The selected element is now gray. 

<img width="391" alt="Screenshot 2025-01-02 at 13 54 35" src="https://github.com/user-attachments/assets/3bc03343-312e-462b-a746-34fc5fdeb375" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
