### PR TITLE
feat: show different color for incomplete period

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -6,7 +6,8 @@ import {
     IconChevronRight,
     IconLineDashed,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { uniqBy } from 'lodash';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type LegendProps } from 'recharts';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { SquareBadge } from './MetricExploreTooltip';
@@ -124,16 +125,24 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
         [containerWidth, getItemWidth, getLegendItemText],
     );
 
-    const itemsPerRow = calculateItemsPerRow(props.payload || []);
+    const uniqPayload = useMemo(() => {
+        return uniqBy(props.payload, function (payload) {
+            return `${payload.value}-${payload.dataKey}`;
+        });
+    }, [props.payload]);
+
+    const itemsPerRow = calculateItemsPerRow(uniqPayload || []);
     const itemsPerPage = itemsPerRow * ROWS;
 
-    const totalPages = Math.ceil((props.payload?.length ?? 0) / itemsPerPage);
+    const totalPages = Math.ceil((uniqPayload?.length ?? 0) / itemsPerPage);
     const requiresPagination = totalPages > 1;
 
-    const visibleItems = props.payload?.slice(
-        (activePage - 1) * itemsPerPage,
-        activePage * itemsPerPage,
-    );
+    const visibleItems = useMemo(() => {
+        return uniqPayload?.slice(
+            (activePage - 1) * itemsPerPage,
+            activePage * itemsPerPage,
+        );
+    }, [activePage, itemsPerPage, uniqPayload]);
 
     useEffect(
         function resetPagination() {

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -6,7 +6,6 @@ import {
     IconChevronRight,
     IconLineDashed,
 } from '@tabler/icons-react';
-import { uniqBy } from 'lodash';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type LegendProps } from 'recharts';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -125,25 +124,25 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
         [containerWidth, getItemWidth, getLegendItemText],
     );
 
-    // ! This is a workaround to ensure that the legend items are unique because we duplicate the name for the incomplete period line
-    const uniqPayload = useMemo(() => {
-        return uniqBy(props.payload, function (payload) {
-            return `${payload.value}-${payload.dataKey}`;
+    // ! When type of legend is none, don't render it
+    const legendItems = useMemo(() => {
+        return props.payload?.filter((payload) => {
+            return payload.type !== 'none';
         });
     }, [props.payload]);
 
-    const itemsPerRow = calculateItemsPerRow(uniqPayload || []);
+    const itemsPerRow = calculateItemsPerRow(legendItems || []);
     const itemsPerPage = itemsPerRow * ROWS;
 
-    const totalPages = Math.ceil((uniqPayload?.length ?? 0) / itemsPerPage);
+    const totalPages = Math.ceil((legendItems?.length ?? 0) / itemsPerPage);
     const requiresPagination = totalPages > 1;
 
     const visibleItems = useMemo(() => {
-        return uniqPayload?.slice(
+        return legendItems?.slice(
             (activePage - 1) * itemsPerPage,
             activePage * itemsPerPage,
         );
-    }, [activePage, itemsPerPage, uniqPayload]);
+    }, [activePage, itemsPerPage, legendItems]);
 
     useEffect(
         function resetPagination() {

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -125,6 +125,7 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
         [containerWidth, getItemWidth, getLegendItemText],
     );
 
+    // ! This is a workaround to ensure that the legend items are unique because we duplicate the name for the incomplete period line
     const uniqPayload = useMemo(() => {
         return uniqBy(props.payload, function (payload) {
             return `${payload.value}-${payload.dataKey}`;

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -126,7 +126,7 @@ const MetricsVisualization: FC<Props> = ({
         (state) => state.metricsCatalog.abilities.canManageExplore,
     );
 
-    const { colors, fn: themeFn } = useMantineTheme();
+    const { colors } = useMantineTheme();
 
     const data = useMemo(() => {
         if (!results?.results) return [];
@@ -699,21 +699,6 @@ const MetricsVisualization: FC<Props> = ({
                                 const incompletePeriodKey = `${key}-incomplete-period`;
 
                                 return [
-                                    <defs key={`${key}-gradient`}>
-                                        <linearGradient id={`${key}-gradient`}>
-                                            <stop
-                                                offset="0%"
-                                                stopColor={segment.color}
-                                            />
-                                            <stop
-                                                offset={`${100}%`}
-                                                stopColor={themeFn.lighten(
-                                                    segment.color,
-                                                    0.8,
-                                                )}
-                                            />
-                                        </linearGradient>
-                                    </defs>,
                                     <Line
                                         key={completedPeriodKey}
                                         {...getLineProps(key)}
@@ -733,11 +718,11 @@ const MetricsVisualization: FC<Props> = ({
                                         yAxisId="metric"
                                         data={segment.incompletePeriodData}
                                         dataKey="metric.value"
-                                        stroke={`url(#${key}-gradient)`}
+                                        stroke={segment.color}
                                         dot={false}
                                         legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}
-                                        strokeDasharray={'5 5'}
+                                        opacity={0.4}
                                     />,
                                 ];
                             })}
@@ -771,12 +756,35 @@ const MetricsVisualization: FC<Props> = ({
                                         }
                                         type="linear"
                                         dataKey="compareMetric.value"
-                                        data={segmentedData[0].data}
+                                        data={
+                                            splitSegments[0]
+                                                ?.completedPeriodData ?? []
+                                        }
                                         stroke={colors.indigo[9]}
                                         strokeDasharray={'3 4'}
                                         dot={false}
                                         legendType="plainline"
                                         isAnimationActive={false}
+                                    />
+                                    <Line
+                                        {...getLineProps('compareMetric')}
+                                        yAxisId={
+                                            shouldSplitYAxis
+                                                ? 'compareMetric'
+                                                : 'metric'
+                                        }
+                                        type="linear"
+                                        dataKey="compareMetric.value"
+                                        data={
+                                            splitSegments[0]
+                                                ?.incompletePeriodData ?? []
+                                        }
+                                        stroke={colors.indigo[9]}
+                                        dot={false}
+                                        legendType="none"
+                                        isAnimationActive={false}
+                                        opacity={0.4}
+                                        strokeDasharray={'3 4'}
                                     />
                                 </>
                             )}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -126,8 +126,7 @@ const MetricsVisualization: FC<Props> = ({
         (state) => state.metricsCatalog.abilities.canManageExplore,
     );
 
-    const theme = useMantineTheme();
-    const colors = theme.colors;
+    const { colors } = useMantineTheme();
 
     const data = useMemo(() => {
         if (!results?.results) return [];

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -126,7 +126,7 @@ const MetricsVisualization: FC<Props> = ({
         (state) => state.metricsCatalog.abilities.canManageExplore,
     );
 
-    const { colors } = useMantineTheme();
+    const { colors, fn: themeFn } = useMantineTheme();
 
     const data = useMemo(() => {
         if (!results?.results) return [];
@@ -699,6 +699,21 @@ const MetricsVisualization: FC<Props> = ({
                                 const incompletePeriodKey = `${key}-incomplete-period`;
 
                                 return [
+                                    <defs key={`${key}-gradient`}>
+                                        <linearGradient id={`${key}-gradient`}>
+                                            <stop
+                                                offset="0%"
+                                                stopColor={segment.color}
+                                            />
+                                            <stop
+                                                offset={`${100}%`}
+                                                stopColor={themeFn.lighten(
+                                                    segment.color,
+                                                    0.8,
+                                                )}
+                                            />
+                                        </linearGradient>
+                                    </defs>,
                                     <Line
                                         key={completedPeriodKey}
                                         {...getLineProps(key)}
@@ -718,7 +733,7 @@ const MetricsVisualization: FC<Props> = ({
                                         yAxisId="metric"
                                         data={segment.incompletePeriodData}
                                         dataKey="metric.value"
-                                        stroke={segment.color}
+                                        stroke={`url(#${key}-gradient)`}
                                         dot={false}
                                         legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -818,7 +818,7 @@ const MetricsVisualization: FC<Props> = ({
                                         }
                                         stroke={colors.indigo[9]}
                                         dot={false}
-                                        legendType="none"
+                                        legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}
                                         opacity={
                                             compareMetricIncompletePeriodOpacity

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -721,7 +721,7 @@ const MetricsVisualization: FC<Props> = ({
                                             dataKey="metric.value"
                                             stroke={segment.color}
                                             dot={false}
-                                            legendType="plainline"
+                                            legendType="none" // Don't render legend for the incomplete period line
                                             isAnimationActive={false}
                                             strokeDasharray={'5 5'}
                                         />

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -693,40 +693,38 @@ const MetricsVisualization: FC<Props> = ({
                                 isAnimationActive={false}
                             />
 
-                            {splitSegments.map((segment) => {
+                            {splitSegments.flatMap((segment) => {
                                 const key = segment.segment ?? 'metric';
                                 const completedPeriodKey = `${key}-completed-period`;
                                 const incompletePeriodKey = `${key}-incomplete-period`;
 
-                                return (
-                                    <>
-                                        <Line
-                                            key={completedPeriodKey}
-                                            {...getLineProps(key)}
-                                            type="linear"
-                                            yAxisId="metric"
-                                            data={segment.completedPeriodData}
-                                            dataKey="metric.value"
-                                            stroke={segment.color}
-                                            dot={false}
-                                            legendType="plainline"
-                                            isAnimationActive={false}
-                                        />
-                                        <Line
-                                            key={incompletePeriodKey}
-                                            {...getLineProps(key)}
-                                            type="linear"
-                                            yAxisId="metric"
-                                            data={segment.incompletePeriodData}
-                                            dataKey="metric.value"
-                                            stroke={segment.color}
-                                            dot={false}
-                                            legendType="none" // Don't render legend for the incomplete period line
-                                            isAnimationActive={false}
-                                            strokeDasharray={'5 5'}
-                                        />
-                                    </>
-                                );
+                                return [
+                                    <Line
+                                        key={completedPeriodKey}
+                                        {...getLineProps(key)}
+                                        type="linear"
+                                        yAxisId="metric"
+                                        data={segment.completedPeriodData}
+                                        dataKey="metric.value"
+                                        stroke={segment.color}
+                                        dot={false}
+                                        legendType="plainline"
+                                        isAnimationActive={false}
+                                    />,
+                                    <Line
+                                        key={incompletePeriodKey}
+                                        {...getLineProps(key)}
+                                        type="linear"
+                                        yAxisId="metric"
+                                        data={segment.incompletePeriodData}
+                                        dataKey="metric.value"
+                                        stroke={segment.color}
+                                        dot={false}
+                                        legendType="none" // Don't render legend for the incomplete period line
+                                        isAnimationActive={false}
+                                        strokeDasharray={'5 5'}
+                                    />,
+                                ];
                             })}
 
                             {results.compareMetric && (

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -555,7 +555,7 @@ const MetricsVisualization: FC<Props> = ({
         }
     }, [query.comparison, segmentedData, splitSegments]);
 
-    const compareMetricOpacity = useMemo(() => {
+    const compareMetricIncompletePeriodOpacity = useMemo(() => {
         return query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
             ? 0.4
             : 1;
@@ -820,7 +820,9 @@ const MetricsVisualization: FC<Props> = ({
                                         dot={false}
                                         legendType="none"
                                         isAnimationActive={false}
-                                        opacity={compareMetricOpacity}
+                                        opacity={
+                                            compareMetricIncompletePeriodOpacity
+                                        }
                                         strokeDasharray={'3 4'}
                                     />
                                 </>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -502,12 +502,18 @@ const MetricsVisualization: FC<Props> = ({
                 }
             });
 
-            const lastCompletedPeriodData = completedPeriodData.sort(
+            const lastCompletedPeriodDataPoint = completedPeriodData.sort(
                 (a, b) => b.date.getTime() - a.date.getTime(),
             )[0];
 
             // Add the last completed period data to the incomplete period data, this will fill in the gap between the last completed period and the first incomplete period
-            incompletePeriodData.push(lastCompletedPeriodData);
+            // Only do this if there is an incomplete period
+            if (
+                incompletePeriodData.length > 0 &&
+                lastCompletedPeriodDataPoint
+            ) {
+                incompletePeriodData.push(lastCompletedPeriodDataPoint);
+            }
 
             return {
                 ...rest,

--- a/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricPeekDate.tsx
@@ -345,3 +345,26 @@ export const is5YearDateRange = (
     const preset = getMatchingPresetLabel(dateRange, timeInterval);
     return preset === '5Y';
 };
+
+export const isInCurrentTimeFrame = (
+    date: Date,
+    timeInterval: TimeFrames | undefined,
+): boolean => {
+    if (!timeInterval) {
+        return false;
+    }
+
+    const now = dayjs();
+    switch (timeInterval) {
+        case TimeFrames.DAY:
+            return dayjs(date).isSame(now, 'day');
+        case TimeFrames.WEEK:
+            return dayjs(date).isSame(now, 'week');
+        case TimeFrames.MONTH:
+            return dayjs(date).isSame(now, 'month');
+        case TimeFrames.YEAR:
+            return dayjs(date).isSame(now, 'year');
+        default:
+            return assertUnimplementedTimeframe(timeInterval);
+    }
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12959 

### Description:

- Adds dashed line for incomplete period
- Calculate uniq legend payload since now we duplicate the line name for the incomplete period to keep legend interactions

https://github.com/user-attachments/assets/62f590a4-afa5-4cd8-b6bb-dc47e934e41f

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
