### PR TITLE
chore: get manifest version from manifest metadata

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -9,7 +9,7 @@ import {
     Explore,
     ExploreError,
     friendlyName,
-    GetDbtManifestVersion,
+    getDbtManifestVersion,
     getSchemaStructureFromDbtModels,
     InlineError,
     InlineErrorType,
@@ -90,7 +90,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         const models = Object.values(manifest.nodes).filter(
             (node: any) => node.resource_type === 'model' && node.meta, // check that node.meta exists
         ) as DbtRawModelNode[];
-        const manifestVersion = GetDbtManifestVersion(this.dbtVersion);
+        const manifestVersion = getDbtManifestVersion(manifest);
         Logger.debug(
             `Validate ${models.length} models in manifest with version ${manifestVersion}`,
         );

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,10 +40,10 @@ Lightdash login
 node ./packages/cli/dist/index.js login http://localhost:3000
 ```
 
-Dbt compile
+Lightdash compile
 
 ```
-dbt compile --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
+node ./packages/cli/dist/index.js compile --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
 ```
 
 Lightdash generate

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,23 +1,10 @@
-import { DbtManifest, DbtManifestVersion } from '@lightdash/common';
+import { DbtManifest } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import globalState from '../globalState';
-import { getDbtVersion } from '../handlers/dbt/getDbtVersion';
 
 export type LoadManifestArgs = {
     targetDir: string;
-};
-
-export const getDbtManifest = async (): Promise<DbtManifestVersion> => {
-    const version = await getDbtVersion();
-    if (version.startsWith('1.3.')) return DbtManifestVersion.V7;
-    if (version.startsWith('1.5.')) return DbtManifestVersion.V9;
-    if (version.startsWith('1.6.')) return DbtManifestVersion.V10;
-    if (version.startsWith('1.7.')) return DbtManifestVersion.V11;
-    if (version.startsWith('1.8.')) return DbtManifestVersion.V12;
-    if (version.startsWith('1.9.')) return DbtManifestVersion.V12;
-
-    return DbtManifestVersion.V8;
 };
 
 export const getManifestPath = async (targetDir: string): Promise<string> =>

--- a/packages/cli/src/dbt/validation.ts
+++ b/packages/cli/src/dbt/validation.ts
@@ -8,9 +8,9 @@ import {
     ManifestValidator,
     normaliseModelDatabase,
     SupportedDbtAdapter,
+    type DbtManifestVersion,
 } from '@lightdash/common';
 import GlobalState from '../globalState';
-import { getDbtManifest } from './manifest';
 
 type DbtModelsGroupedByState = {
     valid: DbtModelNode[];
@@ -19,10 +19,10 @@ type DbtModelsGroupedByState = {
 };
 export const validateDbtModel = async (
     adapterType: string,
+    manifestVersion: DbtManifestVersion,
     models: DbtRawModelNode[],
 ): Promise<DbtModelsGroupedByState> => {
     GlobalState.debug(`> Validating ${models.length} models from dbt manifest`);
-    const manifestVersion = await getDbtManifest();
 
     GlobalState.debug(
         `> Validating models using dbt manifest version ${manifestVersion}`,

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -525,6 +525,26 @@ export enum DbtManifestVersion {
     V12 = 'v12',
 }
 
+export const getDbtManifestVersion = (
+    manifest: DbtManifest,
+): DbtManifestVersion => {
+    const version =
+        manifest.metadata.dbt_schema_version.match(/\/(v\d+).json/)?.[1];
+    if (!version) {
+        throw new Error(
+            `Could not determine dbt manifest version from ${manifest.metadata.dbt_schema_version}`,
+        );
+    }
+    if (
+        Object.values(DbtManifestVersion).includes(
+            version as DbtManifestVersion,
+        )
+    ) {
+        return version as DbtManifestVersion;
+    }
+    throw new Error(`Unsupported dbt manifest version: ${version}`);
+};
+
 export enum DbtExposureType {
     DASHBOARD = 'dashboard',
     NOTEBOOK = 'notebook',

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1,6 +1,4 @@
-import assertUnreachable from '../utils/assertUnreachable';
 import { type WeekDay } from '../utils/timeFrames';
-import { DbtManifestVersion } from './dbt';
 import { type ProjectGroupAccess } from './projectGroupAccess';
 
 export enum ProjectType {
@@ -203,30 +201,6 @@ export enum SupportedDbtVersions {
     V1_8 = 'v1.8',
     V1_9 = 'v1.9',
 }
-
-export const GetDbtManifestVersion = (
-    dbtVersion: SupportedDbtVersions,
-): DbtManifestVersion => {
-    switch (dbtVersion) {
-        case SupportedDbtVersions.V1_4:
-            return DbtManifestVersion.V8;
-        case SupportedDbtVersions.V1_5:
-            return DbtManifestVersion.V9;
-        case SupportedDbtVersions.V1_6:
-            return DbtManifestVersion.V10;
-        case SupportedDbtVersions.V1_7:
-            return DbtManifestVersion.V11;
-        case SupportedDbtVersions.V1_8:
-        case SupportedDbtVersions.V1_9:
-            return DbtManifestVersion.V12;
-        default:
-            assertUnreachable(
-                dbtVersion,
-                'Missing dbt version manifest mapping',
-            );
-    }
-    return DbtManifestVersion.V8;
-};
 
 export const DefaultSupportedDbtVersion = SupportedDbtVersions.V1_4;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#9025](https://github.com/lightdash/lightdash/issues/9025)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Get manifest version from manifest metadata. 
Benefits:
- detach manifest version logic from dbt version ( + future support for dbt cloud cli )
- less code changes when adding support for a new dbt core version

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
