### PR TITLE
feat: empty state links to docs when there are no metrics

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -4,7 +4,9 @@ import {
     type CatalogItem,
 } from '@lightdash/common';
 import {
+    Anchor,
     Box,
+    Center,
     Divider,
     Group,
     Paper,
@@ -271,6 +273,17 @@ export const MetricsTable = () => {
         return flatData.some((item) => item.categories?.length);
     }, [flatData]);
 
+    const noMeticsAvailable = useMemo(() => {
+        return (
+            flatData.length === 0 &&
+            !isLoading &&
+            !isFetching &&
+            !hasNextPage &&
+            !search &&
+            categoryFilters.length === 0
+        );
+    }, [flatData, isLoading, isFetching, search, categoryFilters, hasNextPage]);
+
     const table = useMantineReactTable({
         columns: MetricsCatalogColumns,
         data: flatData,
@@ -491,6 +504,30 @@ export const MetricsTable = () => {
                 )}
             </Box>
         ),
+        renderEmptyRowsFallback: () => {
+            return noMeticsAvailable ? (
+                <SuboptimalState
+                    title="No metrics defined in this project"
+                    action={
+                        <Text>
+                            To learn how to define metrics, check out our{' '}
+                            <Anchor
+                                target="_blank"
+                                href="https://docs.lightdash.com/references/metrics/"
+                            >
+                                documentation
+                            </Anchor>
+                        </Text>
+                    }
+                />
+            ) : (
+                <Center>
+                    <Text fs="italic" color="gray">
+                        No results found
+                    </Text>
+                </Center>
+            );
+        },
         icons: {
             IconArrowsSort: () => (
                 <MantineIcon icon={IconArrowsSort} size="md" color="gray.5" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12991 

### Description:

Shows an empty state with link to the metrics docs when no metrics are present. The empty state for 'No results found' when searching is unchanged. 

To test, you have to have no metrics. Locally you can reset the db or return no data in some other way. 

The ticket didn't specify copy, but I made a guess. 

<img width="1416" alt="Screenshot 2025-01-03 at 10 28 37" src="https://github.com/user-attachments/assets/9acb2fc9-34e3-49c4-bfe1-7a7d2538278a" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
