### PR TITLE
feat: option to use latest dbt version

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -2,7 +2,6 @@ import {
     CreatePostgresCredentials,
     DbtLocalProjectConfig,
     DbtProjectType,
-    DefaultSupportedDbtVersion,
     generateSlug,
     OrganizationMemberRole,
     SEED_ORG_1,
@@ -15,6 +14,7 @@ import {
     SEED_ORG_2_ADMIN_PASSWORD,
     SEED_PROJECT,
     SEED_SPACE,
+    SupportedDbtVersions,
     WarehouseTypes,
 } from '@lightdash/common';
 import bcrypt from 'bcrypt';
@@ -114,7 +114,7 @@ export async function seed(knex: Knex): Promise<void> {
             ...SEED_PROJECT,
             organization_id: organizationId,
             dbt_connection: encryptedProjectSettings,
-            dbt_version: DefaultSupportedDbtVersion,
+            dbt_version: SupportedDbtVersions.V1_4,
             semantic_layer_connection: null,
             created_by_user_uuid: user.user_uuid,
         })
@@ -183,7 +183,7 @@ export async function seed(knex: Knex): Promise<void> {
                 warehouseCatalog: undefined,
                 onWarehouseCatalogChange: () => {},
             },
-            DefaultSupportedDbtVersion,
+            SupportedDbtVersions.V1_4,
         );
         const explores = await adapter.compileAllExplores();
         await new ProjectModel({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6742,6 +6742,23 @@ const models: TsoaRoute.Models = {
         enums: ['v1.4', 'v1.5', 'v1.6', 'v1.7', 'v1.8', 'v1.9'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtVersionOptionLatest: {
+        dataType: 'refEnum',
+        enums: ['latest'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtVersionOption: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'SupportedDbtVersions' },
+                { ref: 'DbtVersionOptionLatest' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'SemanticLayerType.DBT': {
         dataType: 'refEnum',
         enums: ['DBT'],
@@ -6806,7 +6823,7 @@ const models: TsoaRoute.Models = {
                 },
                 schedulerTimezone: { dataType: 'string', required: true },
                 semanticLayerConnection: { ref: 'SemanticLayerConnection' },
-                dbtVersion: { ref: 'SupportedDbtVersions', required: true },
+                dbtVersion: { ref: 'DbtVersionOption', required: true },
                 upstreamProjectUuid: { dataType: 'string' },
                 pinnedListUuid: { dataType: 'string' },
                 warehouseConnection: { ref: 'WarehouseCredentials' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7217,6 +7217,20 @@
                 "enum": ["v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9"],
                 "type": "string"
             },
+            "DbtVersionOptionLatest": {
+                "enum": ["latest"],
+                "type": "string"
+            },
+            "DbtVersionOption": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/SupportedDbtVersions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtVersionOptionLatest"
+                    }
+                ]
+            },
             "SemanticLayerType.DBT": {
                 "enum": ["DBT"],
                 "type": "string"
@@ -7281,7 +7295,7 @@
                         "$ref": "#/components/schemas/SemanticLayerConnection"
                     },
                     "dbtVersion": {
-                        "$ref": "#/components/schemas/SupportedDbtVersions"
+                        "$ref": "#/components/schemas/DbtVersionOption"
                     },
                     "upstreamProjectUuid": {
                         "type": "string"
@@ -12889,7 +12903,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1428.1",
+        "version": "0.1434.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -34,7 +34,7 @@ export const projectAdapterFromConfig = async (
     Logger.debug(`Initialize project adaptor of type ${configType}`);
 
     const dbtVersion: SupportedDbtVersions =
-        dbtVersionOption === DbtVersionOptionLatest
+        dbtVersionOption === DbtVersionOptionLatest.LATEST
             ? getLatestSupportDbtVersion()
             : dbtVersionOption;
 

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -2,6 +2,9 @@ import {
     CreateWarehouseCredentials,
     DbtProjectConfig,
     DbtProjectType,
+    DbtVersionOption,
+    DbtVersionOptionLatest,
+    getLatestSupportDbtVersion,
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
@@ -19,7 +22,7 @@ export const projectAdapterFromConfig = async (
     config: DbtProjectConfig,
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
-    dbtVersion: SupportedDbtVersions,
+    dbtVersionOption: DbtVersionOption,
     useDbtLs: boolean = true,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
@@ -29,6 +32,11 @@ export const projectAdapterFromConfig = async (
         warehouseClientFromCredentials(warehouseCredentials);
     const configType = config.type;
     Logger.debug(`Initialize project adaptor of type ${configType}`);
+
+    const dbtVersion: SupportedDbtVersions =
+        dbtVersionOption === DbtVersionOptionLatest
+            ? getLatestSupportDbtVersion()
+            : dbtVersionOption;
 
     switch (config.type) {
         case DbtProjectType.DBT:

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -202,7 +202,18 @@ export enum SupportedDbtVersions {
     V1_9 = 'v1.9',
 }
 
-export const DefaultSupportedDbtVersion = SupportedDbtVersions.V1_4;
+export const DbtVersionOptionLatest = 'latest' as const;
+
+export type DbtVersionOption =
+    | SupportedDbtVersions
+    | typeof DbtVersionOptionLatest;
+
+export const getLatestSupportDbtVersion = (): SupportedDbtVersions => {
+    const versions = Object.values(SupportedDbtVersions);
+    return versions[versions.length - 1];
+};
+
+export const DefaultSupportedDbtVersion = DbtVersionOptionLatest;
 
 export interface DbtProjectCompilerBase extends DbtProjectConfigBase {
     target?: string;
@@ -304,7 +315,7 @@ export type Project = {
     warehouseConnection?: WarehouseCredentials;
     pinnedListUuid?: string;
     upstreamProjectUuid?: string;
-    dbtVersion: SupportedDbtVersions;
+    dbtVersion: DbtVersionOption;
     semanticLayerConnection?: SemanticLayerConnection;
     schedulerTimezone: string;
     createdByUserUuid: string | null;

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -202,18 +202,19 @@ export enum SupportedDbtVersions {
     V1_9 = 'v1.9',
 }
 
-export const DbtVersionOptionLatest = 'latest' as const;
+// Make it an enum to avoid TSOA errors
+export enum DbtVersionOptionLatest {
+    LATEST = 'latest',
+}
 
-export type DbtVersionOption =
-    | SupportedDbtVersions
-    | typeof DbtVersionOptionLatest;
+export type DbtVersionOption = SupportedDbtVersions | DbtVersionOptionLatest;
 
 export const getLatestSupportDbtVersion = (): SupportedDbtVersions => {
     const versions = Object.values(SupportedDbtVersions);
     return versions[versions.length - 1];
 };
 
-export const DefaultSupportedDbtVersion = DbtVersionOptionLatest;
+export const DefaultSupportedDbtVersion = DbtVersionOptionLatest.LATEST;
 
 export interface DbtProjectCompilerBase extends DbtProjectConfigBase {
     target?: string;

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -184,7 +184,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                             label="dbt version"
                             data={[
                                 {
-                                    value: DbtVersionOptionLatest,
+                                    value: DbtVersionOptionLatest.LATEST,
                                     label: `latest (${getLatestSupportDbtVersion()})`,
                                 },
                                 ...Object.values(SupportedDbtVersions)

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -2,11 +2,11 @@ import {
     assertUnreachable,
     DbtProjectType,
     DbtProjectTypeLabels,
-    DbtVersionOption,
     DbtVersionOptionLatest,
     DefaultSupportedDbtVersion,
     FeatureFlags,
     getLatestSupportDbtVersion,
+    SupportedDbtVersions,
     WarehouseTypes,
 } from '@lightdash/common';
 import { Select, Stack, TextInput } from '@mantine/core';
@@ -182,15 +182,18 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                     render={({ field }) => (
                         <Select
                             label="dbt version"
-                            data={Object.values(DbtVersionOption).map(
-                                (version) => ({
-                                    value: version,
-                                    label:
-                                        version === DbtVersionOptionLatest
-                                            ? `latest (${getLatestSupportDbtVersion()})`
-                                            : version,
-                                }),
-                            )}
+                            data={[
+                                {
+                                    value: DbtVersionOptionLatest,
+                                    label: `latest (${getLatestSupportDbtVersion()})`,
+                                },
+                                ...Object.values(SupportedDbtVersions)
+                                    .reverse()
+                                    .map((version) => ({
+                                        value: version,
+                                        label: version,
+                                    })),
+                            ]}
                             value={field.value}
                             onChange={field.onChange}
                             disabled={disabled}

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -2,9 +2,11 @@ import {
     assertUnreachable,
     DbtProjectType,
     DbtProjectTypeLabels,
+    DbtVersionOption,
+    DbtVersionOptionLatest,
     DefaultSupportedDbtVersion,
     FeatureFlags,
-    SupportedDbtVersions,
+    getLatestSupportDbtVersion,
     WarehouseTypes,
 } from '@lightdash/common';
 import { Select, Stack, TextInput } from '@mantine/core';
@@ -180,10 +182,13 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                     render={({ field }) => (
                         <Select
                             label="dbt version"
-                            data={Object.values(SupportedDbtVersions).map(
+                            data={Object.values(DbtVersionOption).map(
                                 (version) => ({
                                     value: version,
-                                    label: version,
+                                    label:
+                                        version === DbtVersionOptionLatest
+                                            ? `latest (${getLatestSupportDbtVersion()})`
+                                            : version,
                                 }),
                             )}
                             value={field.value}

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -5,7 +5,7 @@ import {
     ProjectType,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
-    type SupportedDbtVersions,
+    type DbtVersionOption,
     type WarehouseTypes,
 } from '@lightdash/common';
 import {
@@ -53,7 +53,7 @@ type ProjectConnectionForm = {
     dbt: DbtProjectConfig;
 
     warehouse?: CreateWarehouseCredentials;
-    dbtVersion: SupportedDbtVersions;
+    dbtVersion: DbtVersionOption;
 };
 
 interface Props {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#10848](https://github.com/lightdash/lightdash/issues/10848)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
<img width="885" alt="Screenshot 2025-01-03 at 15 22 56" src="https://github.com/user-attachments/assets/2ab27835-9a1a-49b7-b979-1c47f3bb1a06" />

We save 'latest' in the database and when we need to execute a dbt command we find the latest supported version.
<img width="1360" alt="Screenshot 2025-01-03 at 15 25 53" src="https://github.com/user-attachments/assets/5c945252-317c-4c07-9c43-f1ca52e462f9" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
