### PR TITLE
fix: redirect to view mode when dashboard is saved

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -206,7 +206,7 @@ const DASHBOARD_ROUTES: RouteObject[] = [
                 element: <DashboardPageWrapper keyParam={'dashboardUuid'} />,
             },
             {
-                path: '/projects/:projectUuid/dashboards/:dashboardUuid:mode/tabs/:tabUuid?',
+                path: '/projects/:projectUuid/dashboards/:dashboardUuid/:mode/tabs/:tabUuid?',
                 element: <DashboardPageWrapper keyParam={'tabUuid'} />,
             },
         ],

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -273,7 +273,7 @@ const Dashboard: FC = () => {
                 );
             } else {
                 void navigate(
-                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/`,
+                    `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
                     { replace: true },
                 );
             }
@@ -435,7 +435,7 @@ const Dashboard: FC = () => {
             );
         } else {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/`,
+                `/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
                 { replace: true },
             );
         }

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -17,7 +17,7 @@ import {
 import min from 'lodash/min';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
-import { useMount } from 'react-use';
+import { useDeepCompareEffect, useMount } from 'react-use';
 import { getConditionalRuleLabel } from '../../components/common/Filters/FilterInputs/utils';
 import { hasSavedFilterValueChanged } from '../../components/DashboardFilter/FilterConfiguration/utils';
 import {
@@ -210,8 +210,8 @@ const DashboardProvider: React.FC<
         }
     }, [dashboard, dashboardFilters, overridesForSavedDashboardFilters]);
 
-    // Updates url with temp and overridden filters
-    useEffect(() => {
+    // Updates url with temp and overridden filters and deep compare to avoid unnecessary re-renders for dashboardTemporaryFilters
+    useDeepCompareEffect(() => {
         const newParams = new URLSearchParams(search);
         if (
             dashboardTemporaryFilters?.dimensions?.length === 0 &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13095 

### Description:

To replicate see issue ^ 

Underlying issue: 
- When we save a dashboard, we navigate back to /view
- The use Effect in dashboard provider for temp filters was running unnecessarily bc the reference was not stable (dashboardTempFilters). I introduced the useDeepCompareEffect to avoid unnecessary re-renders. Before, it would not wait for the navigate in Dashboard.tsx to update the pathname, and a redirect to back to previous pathname (edit mode) would happen. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
