### PR TITLE
fix: always set y axis width to default in metrics explorer

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDynamicYAxisWidth.tsx
@@ -48,7 +48,7 @@ export const useDynamicYAxisWidth = () => {
                     const leftHighestWidth = leftTickArray.reduce(
                         (maxWidth, el) => {
                             const width = el.getBoundingClientRect().width;
-                            return Math.max(maxWidth, width);
+                            return Math.round(Math.max(maxWidth, width));
                         },
                         0,
                     );
@@ -63,7 +63,7 @@ export const useDynamicYAxisWidth = () => {
                     const rightHighestWidth = rightTickArray.reduce(
                         (maxWidth, el) => {
                             const width = el.getBoundingClientRect().width;
-                            return Math.max(maxWidth, width);
+                            return Math.round(Math.max(maxWidth, width));
                         },
                         0,
                     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After merging [#13000 ](https://github.com/lightdash/lightdash/pull/13087), and when comparing another metric (which means it has a second axis on the right side, its width isn't being set properly. Now, just set it to the default value and on subsequent re-renders it will calculate it dynamically. 




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
