### PR TITLE
fix: dbt cloud manifest version

### DIFF
--- a/packages/backend/src/dbt/DbtMetadataApiClient.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.ts
@@ -1,6 +1,7 @@
 import {
     DbtModelNode,
     DbtNode,
+    getLatestSupportedDbtManifestVersion,
     isSupportedDbtAdapterType,
     ParseError,
     SupportedDbtAdapter,
@@ -161,7 +162,7 @@ export class DbtMetadataApiClient implements DbtClient {
                 metadata: {
                     adapter_type: results.environment.adapterType,
                     generated_at: results.environment.applied.lastUpdatedAt,
-                    dbt_schema_version: 'graphql-v2',
+                    dbt_schema_version: `/${getLatestSupportedDbtManifestVersion()}.json`,
                 },
                 metrics: {},
                 docs: {},

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -545,6 +545,11 @@ export const getDbtManifestVersion = (
     throw new Error(`Unsupported dbt manifest version: ${version}`);
 };
 
+export const getLatestSupportedDbtManifestVersion = (): DbtManifestVersion => {
+    const versions = Object.values(DbtManifestVersion);
+    return versions[versions.length - 1];
+};
+
 export enum DbtExposureType {
     DASHBOARD = 'dashboard',
     NOTEBOOK = 'notebook',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13104](https://github.com/lightdash/lightdash/issues/13104)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem introduced by: https://github.com/lightdash/lightdash/commit/f5700418f719faf53ed2fd0db696fb6ee273274d

We need to simulate/mock the manifest version when fetching the model data via the dbt cloud graphql API. 

Before:
<img width="1193" alt="Screenshot 2025-01-06 at 15 31 49" src="https://github.com/user-attachments/assets/f3dd08cb-9595-4e8c-8470-124455c54950" />

After:

<img width="1196" alt="Screenshot 2025-01-06 at 15 40 08" src="https://github.com/user-attachments/assets/558da7da-3796-4857-a5eb-43efa8922d0c" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging


