### PR TITLE
fix: sql runner edit-mode buttons get the right state

### DIFF
--- a/packages/common/src/visualizations/TableDataModel.ts
+++ b/packages/common/src/visualizations/TableDataModel.ts
@@ -75,7 +75,6 @@ export class TableDataModel {
                     reference: key,
                     label: this.columnsConfig?.[key]?.label ?? key,
                     frozen: this.columnsConfig?.[key]?.frozen ?? false,
-                    order: this.columnsConfig?.[key]?.order,
                 },
             }),
             {},

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -223,20 +223,30 @@ export const HeaderEdit: FC = () => {
                             </HoverCard.Dropdown>
                         </HoverCard>
 
-                        <Tooltip
-                            variant="xs"
-                            label="Back to view page"
-                            position="bottom"
-                        >
-                            <ActionIcon
-                                data-testid="back-to-view-page-button"
+                        {hasChanges ? (
+                            <Button
+                                size="xs"
                                 variant="default"
-                                size="md"
                                 onClick={handleGoBackToViewPage}
                             >
-                                <MantineIcon icon={IconArrowBack} />
-                            </ActionIcon>
-                        </Tooltip>
+                                Cancel
+                            </Button>
+                        ) : (
+                            <Tooltip
+                                variant="xs"
+                                label="Back to view page"
+                                position="bottom"
+                            >
+                                <ActionIcon
+                                    data-testid="back-to-view-page-button"
+                                    variant="default"
+                                    size="md"
+                                    onClick={handleGoBackToViewPage}
+                                >
+                                    <MantineIcon icon={IconArrowBack} />
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
                         <Menu
                             position="bottom"
                             withArrow


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11967 
### Description:

Makes the SQL runner edit mode buttons consistently match spec as per #11967, with one exception: when there are no edits, the icon button remains. It felt a bit odd to have a 'Cancel' button with no alternative. Now it looks like

**Edit mode, no changes**
<img width="186" alt="Screenshot 2025-01-06 at 18 09 25" src="https://github.com/user-attachments/assets/b1cf3860-7b78-454f-9a85-089f2337693f" />

**Edit mode with changes**
<img width="186" alt="Screenshot 2025-01-06 at 18 09 34" src="https://github.com/user-attachments/assets/d0df30fd-e479-4362-bfec-fd233b64acbf" />

The missing green state was only a problem on tables. Now fixed. 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
