### PR TITLE
fix: dbt version fallback prompt

### DIFF
--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -40,13 +40,13 @@ class GlobalState {
         this.verbose = verbose;
     }
 
-    getPromptAnswer<T extends keyof RememberPromptAnswer>(
+    getSavedPromptAnswer<T extends keyof RememberPromptAnswer>(
         prompt: T,
     ): RememberPromptAnswer[T] | undefined {
         return this.savedPromptAnswers[prompt];
     }
 
-    rememberPromptAnswer<T extends keyof RememberPromptAnswer>(
+    savePromptAnswer<T extends keyof RememberPromptAnswer>(
         prompt: T,
         value: RememberPromptAnswer[T],
     ) {

--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import * as styles from './styles';
 
-type RememberPromptAnswer = {
+type PromptAnswer = {
     useFallbackDbtVersion?: boolean;
 };
 
@@ -10,7 +10,7 @@ class GlobalState {
 
     private activeSpinner: ora.Ora | undefined;
 
-    private savedPromptAnswers: RememberPromptAnswer;
+    private savedPromptAnswers: PromptAnswer;
 
     constructor() {
         this.savedPromptAnswers = {};
@@ -40,17 +40,21 @@ class GlobalState {
         this.verbose = verbose;
     }
 
-    getSavedPromptAnswer<T extends keyof RememberPromptAnswer>(
+    getSavedPromptAnswer<T extends keyof PromptAnswer>(
         prompt: T,
-    ): RememberPromptAnswer[T] | undefined {
+    ): PromptAnswer[T] | undefined {
         return this.savedPromptAnswers[prompt];
     }
 
-    savePromptAnswer<T extends keyof RememberPromptAnswer>(
+    savePromptAnswer<T extends keyof PromptAnswer>(
         prompt: T,
-        value: RememberPromptAnswer[T],
+        value: PromptAnswer[T],
     ) {
         this.savedPromptAnswers[prompt] = value;
+    }
+
+    clearPromptAnswer() {
+        this.savedPromptAnswers = {};
     }
 
     debug(message: string) {

--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -1,10 +1,20 @@
 import ora from 'ora';
 import * as styles from './styles';
 
+type RememberPromptAnswer = {
+    useFallbackDbtVersion?: boolean;
+};
+
 class GlobalState {
     private verbose: boolean = false;
 
     private activeSpinner: ora.Ora | undefined;
+
+    private savedPromptAnswers: RememberPromptAnswer;
+
+    constructor() {
+        this.savedPromptAnswers = {};
+    }
 
     getActiveSpinner() {
         return this.activeSpinner;
@@ -28,6 +38,19 @@ class GlobalState {
 
     setVerbose(verbose: boolean) {
         this.verbose = verbose;
+    }
+
+    getPromptAnswer<T extends keyof RememberPromptAnswer>(
+        prompt: T,
+    ): RememberPromptAnswer[T] | undefined {
+        return this.savedPromptAnswers[prompt];
+    }
+
+    rememberPromptAnswer<T extends keyof RememberPromptAnswer>(
+        prompt: T,
+        value: RememberPromptAnswer[T],
+    ) {
+        this.savedPromptAnswers[prompt] = value;
     }
 
     debug(message: string) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -11,7 +11,6 @@ import {
     WarehouseCatalog,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
-import inquirer from 'inquirer';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
@@ -30,7 +29,7 @@ import {
     getCompiledModels,
     maybeCompileModelsAndJoins,
 } from './dbt/compile';
-import { getDbtVersion, isSupportedDbtVersion } from './dbt/getDbtVersion';
+import { getDbtVersion } from './dbt/getDbtVersion';
 
 export type CompileHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -50,33 +49,12 @@ export const compile = async (options: CompileHandlerOptions) => {
         event: 'compile.started',
         properties: {
             executionId,
-            dbtVersion,
+            dbtVersion: dbtVersion.verboseVersion,
             useDbtList: !!options.useDbtList,
             skipWarehouseCatalog: !!options.skipWarehouseCatalog,
             skipDbtCompile: !!options.skipDbtCompile,
         },
     });
-
-    if (!isSupportedDbtVersion(dbtVersion)) {
-        if (process.env.CI === 'true') {
-            console.error(
-                `Your dbt version ${dbtVersion} does not match our supported versions (1.3.* - 1.9.*), this could cause problems on compile or validation.`,
-            );
-        } else {
-            const answers = await inquirer.prompt([
-                {
-                    type: 'confirm',
-                    name: 'isConfirm',
-                    message: `${styles.warning(
-                        `Your dbt version ${dbtVersion} does not match our supported version (1.3.* - 1.9.*), this could cause problems on compile or validation.`,
-                    )}\nDo you still want to continue?`,
-                },
-            ]);
-            if (!answers.isConfirm) {
-                throw new Error(`Unsupported dbt version ${dbtVersion}`);
-            }
-        }
-    }
 
     const absoluteProjectPath = path.resolve(options.projectDir);
     const absoluteProfilesPath = path.resolve(options.profilesDir);
@@ -155,7 +133,7 @@ ${errors.join('')}`),
             event: 'compile.error',
             properties: {
                 executionId,
-                dbtVersion,
+                dbtVersion: dbtVersion.verboseVersion,
                 error: `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
             },
         });
@@ -208,7 +186,7 @@ ${errors.join('')}`),
             explores: explores.length,
             errors,
             dbtMetrics: Object.values(manifest.metrics).length,
-            dbtVersion,
+            dbtVersion: dbtVersion.verboseVersion,
         },
     });
     return explores;

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -17,7 +17,7 @@ import {
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { lightdashApi } from './dbt/apiClient';
-import { getSupportedDbtVersion } from './dbt/getDbtVersion';
+import { getDbtVersion } from './dbt/getDbtVersion';
 
 const askToRememberAnswer = async (): Promise<void> => {
     const answers = await inquirer.prompt([
@@ -78,7 +78,7 @@ type CreateProjectOptions = {
 export const createProject = async (
     options: CreateProjectOptions,
 ): Promise<ApiCreateProjectResults | undefined> => {
-    const dbtVersion = await getSupportedDbtVersion();
+    const dbtVersion = await getDbtVersion();
 
     const absoluteProjectPath = path.resolve(options.projectDir);
     const absoluteProfilesPath = path.resolve(options.profilesDir);
@@ -136,7 +136,7 @@ export const createProject = async (
             target: targetName,
         },
         upstreamProjectUuid: options.upstreamProjectUuid,
-        dbtVersion,
+        dbtVersion: dbtVersion.versionOption,
     };
 
     return lightdashApi<ApiCreateProjectResults>({

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -1,4 +1,8 @@
-import { DbtModelNode, ParseError } from '@lightdash/common';
+import {
+    DbtModelNode,
+    ParseError,
+    SupportedDbtVersions,
+} from '@lightdash/common';
 import execa from 'execa';
 import { xor } from 'lodash';
 import { loadManifest, LoadManifestArgs } from '../../dbt/manifest';
@@ -131,8 +135,8 @@ async function dbtList(options: DbtCompileOptions): Promise<string[]> {
             'unique_id',
         ];
         const version = await getDbtVersion();
-        // older dbt versions don't support --quiet flag
-        if (!version.startsWith('1.3.') && !version.startsWith('1.4.')) {
+        // only dbt 1.5 and above support --quiet flag
+        if (version.versionOption !== SupportedDbtVersions.V1_4) {
             args.push('--quiet');
         }
         GlobalState.debug(`> Running: dbt ls ${args.join(' ')}`);

--- a/packages/cli/src/handlers/dbt/getDbtVersion.mocks.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.mocks.ts
@@ -1,0 +1,57 @@
+import { ExecaError, ExecaReturnValue } from 'execa';
+
+export const cliMocks = {
+    dbt1_3: {
+        all:
+            'Core:\n' +
+            '  - installed: 1.3.0\n' +
+            '  - latest:    1.9.1 - Update available!\n',
+    } as Partial<ExecaReturnValue>,
+    dbt1_4: {
+        all:
+            'Core:\n' +
+            '  - installed: 1.4.9\n' +
+            '  - latest:    1.9.1 - Update available!\n' +
+            '\n' +
+            '  Your version of dbt-core is out of date!\n' +
+            '  You can find instructions for upgrading here:\n' +
+            '  https://docs.getdbt.com/docs/installation\n' +
+            '\n' +
+            'Plugins:\n' +
+            '  - trino:      1.4.2 - Update available!\n' +
+            '  - databricks: 1.4.3 - Update available!\n' +
+            '  - redshift:   1.4.1 - Update available!\n' +
+            '  - spark:      1.4.3 - Update available!\n' +
+            '  - bigquery:   1.4.5 - Update available!\n' +
+            '  - snowflake:  1.4.5 - Update available!\n' +
+            '  - postgres:   1.4.9 - Update available!\n' +
+            '\n' +
+            '  At least one plugin is out of date or incompatible with dbt-core.\n' +
+            '  You can find instructions for upgrading here:\n' +
+            '  https://docs.getdbt.com/docs/installation\n',
+    } as Partial<ExecaReturnValue>,
+    dbt1_9: {
+        all:
+            'Core:\n' +
+            '  - installed: 1.9.1\n' +
+            '  - latest:    1.9.1 - Up to date!\n' +
+            '\n' +
+            'Plugins:\n' +
+            '  - databricks: 1.9.1 - Up to date!\n' +
+            '  - redshift:   1.9.0 - Up to date!\n' +
+            '  - spark:      1.9.0 - Up to date!\n' +
+            '  - bigquery:   1.9.0 - Up to date!\n' +
+            '  - snowflake:  1.9.0 - Up to date!\n' +
+            '  - postgres:   1.9.0 - Up to date!\n',
+    } as Partial<ExecaReturnValue>,
+    dbt20_1: {
+        all:
+            'Core:\n' +
+            '  - installed: 20.1.0\n' +
+            '  - latest:    20.2.0 - Update available!\n',
+    } as Partial<ExecaReturnValue>,
+    error: {
+        shortMessage: 'error message',
+        all: 'all error messages',
+    } as Partial<ExecaError>,
+};

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -62,6 +62,8 @@ describe('Get dbt version', () => {
                     "We don't currently support version 1.3.0",
                 ),
             );
+            // Clear saved prompt answer
+            GlobalState.clearPromptAnswer();
             // Test for future version
             execaMock.mockImplementation(async () => cliMocks.dbt20_1);
             const version2 = await getDbtVersion();

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -1,0 +1,94 @@
+import {
+    getLatestSupportDbtVersion,
+    SupportedDbtVersions,
+} from '@lightdash/common';
+import execa from 'execa';
+import inquirer from 'inquirer';
+import { getDbtVersion } from './getDbtVersion';
+import { cliMocks } from './getDbtVersion.mocks';
+
+jest.mock('execa');
+const execaMock = execa as unknown as jest.Mock;
+jest.mock('inquirer', () => ({
+    prompt: jest.fn(),
+}));
+const promptMock = inquirer.prompt as unknown as jest.Mock;
+const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('Get dbt version', () => {
+    const { env } = process;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        jest.resetModules();
+        process.env = { ...env };
+        execaMock.mockImplementation(async () => cliMocks.dbt1_4);
+        promptMock.mockImplementation(async () => ({ isConfirm: true }));
+    });
+
+    afterEach(() => {
+        process.env = env;
+    });
+
+    describe('getDbtVersion', () => {
+        test('should return error if dbt cli is not installed', async () => {
+            execaMock.mockImplementation(async () => cliMocks.error);
+            await expect(getDbtVersion()).rejects.toThrowError();
+        });
+        test('should return supported dbt versions', async () => {
+            // Test for 1.4
+            const version = await getDbtVersion();
+            expect(version.verboseVersion).toEqual('1.4.9');
+            expect(version.versionOption).toEqual(SupportedDbtVersions.V1_4);
+            // Test for 1.9
+            execaMock.mockImplementation(async () => cliMocks.dbt1_9);
+            const version2 = await getDbtVersion();
+            expect(version2.verboseVersion).toEqual('1.9.1');
+            expect(version2.versionOption).toEqual(SupportedDbtVersions.V1_9);
+        });
+        test('when CI=true, should warn user about unsupported version and return fallback', async () => {
+            process.env.CI = 'true';
+            // Test for 1.3
+            execaMock.mockImplementation(async () => cliMocks.dbt1_3);
+            const version = await getDbtVersion();
+            expect(version.verboseVersion).toEqual('1.3.0');
+            expect(version.versionOption).toEqual(SupportedDbtVersions.V1_4);
+            expect(consoleError).toHaveBeenCalledTimes(1);
+            expect(consoleError).nthCalledWith(
+                1,
+                expect.stringContaining(
+                    "We don't currently support version 1.3.0",
+                ),
+            );
+            // Test for future version
+            execaMock.mockImplementation(async () => cliMocks.dbt20_1);
+            const version2 = await getDbtVersion();
+            expect(version2.verboseVersion).toEqual('20.1.0');
+            expect(version2.versionOption).toEqual(
+                getLatestSupportDbtVersion(),
+            );
+            expect(consoleError).toHaveBeenCalledTimes(2);
+            expect(consoleError).nthCalledWith(
+                2,
+                expect.stringContaining(
+                    "We don't currently support version 20.1.0",
+                ),
+            );
+        });
+        test('when CI=false, should return fallback version if user confirms', async () => {
+            execaMock.mockImplementation(async () => cliMocks.dbt1_3);
+            const version = await getDbtVersion();
+            expect(version.verboseVersion).toEqual('1.3.0');
+            expect(version.versionOption).toEqual(SupportedDbtVersions.V1_4);
+            expect(promptMock).toHaveBeenCalledTimes(1);
+            expect(consoleError).toHaveBeenCalledTimes(0);
+        });
+        test('when CI=false, should return error if user declines fallback', async () => {
+            execaMock.mockImplementation(async () => cliMocks.dbt1_3);
+            promptMock.mockImplementation(async () => ({ isConfirm: false }));
+            await expect(getDbtVersion()).rejects.toThrowError();
+            expect(promptMock).toHaveBeenCalledTimes(1);
+            expect(consoleError).toHaveBeenCalledTimes(0);
+        });
+    });
+});

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@lightdash/common';
 import execa from 'execa';
 import inquirer from 'inquirer';
+import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
 import { cliMocks } from './getDbtVersion.mocks';
 
@@ -24,6 +25,7 @@ describe('Get dbt version', () => {
         process.env = { ...env };
         execaMock.mockImplementation(async () => cliMocks.dbt1_4);
         promptMock.mockImplementation(async () => ({ isConfirm: true }));
+        GlobalState.clearPromptAnswer();
     });
 
     afterEach(() => {

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -78,6 +78,7 @@ describe('Get dbt version', () => {
             );
         });
         test('when CI=false, should return fallback version if user confirms', async () => {
+            process.env.CI = 'false';
             execaMock.mockImplementation(async () => cliMocks.dbt1_3);
             const version = await getDbtVersion();
             expect(version.verboseVersion).toEqual('1.3.0');
@@ -86,6 +87,7 @@ describe('Get dbt version', () => {
             expect(consoleError).toHaveBeenCalledTimes(0);
         });
         test('when CI=false, should return error if user declines fallback', async () => {
+            process.env.CI = 'false';
             execaMock.mockImplementation(async () => cliMocks.dbt1_3);
             promptMock.mockImplementation(async () => ({ isConfirm: false }));
             await expect(getDbtVersion()).rejects.toThrowError();

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -1,20 +1,23 @@
 import {
-    DefaultSupportedDbtVersion,
+    DbtVersionOption,
+    getLatestSupportDbtVersion,
     ParseError,
     SupportedDbtVersions,
 } from '@lightdash/common';
 import execa from 'execa';
+import inquirer from 'inquirer';
 import * as styles from '../../styles';
 
-export const getDbtVersion = async () => {
+const DBT_CORE_VERSION_REGEX = /installed:.*/;
+
+const getDbtCLIVersion = async () => {
     try {
         const { all } = await execa('dbt', ['--version'], {
             all: true,
             stdio: ['pipe', 'pipe', 'pipe'],
         });
         const logs = all || '';
-        const coreVersionRegex = /installed:.*/;
-        const version = await logs.match(coreVersionRegex);
+        const version = logs.match(DBT_CORE_VERSION_REGEX);
         if (version === null || version.length === 0)
             throw new ParseError(`Can't locate dbt --version: ${logs}`);
         return version[0].split(':')[1].trim();
@@ -24,8 +27,9 @@ export const getDbtVersion = async () => {
     }
 };
 
-export const getSupportedDbtVersion = async () => {
-    const version = await getDbtVersion();
+const getSupportedDbtVersionOption = (
+    version: string,
+): DbtVersionOption | null => {
     if (version.startsWith('1.4.')) return SupportedDbtVersions.V1_4;
     if (version.startsWith('1.5.')) return SupportedDbtVersions.V1_5;
     if (version.startsWith('1.6.')) return SupportedDbtVersions.V1_6;
@@ -33,25 +37,50 @@ export const getSupportedDbtVersion = async () => {
     if (version.startsWith('1.8.')) return SupportedDbtVersions.V1_8;
     if (version.startsWith('1.9.')) return SupportedDbtVersions.V1_9;
 
-    console.error(
-        styles.warning(
-            `We don't currently support version ${version} on Lightdash, we'll be using ${DefaultSupportedDbtVersion} instead when dbt is refresh from the UI.`,
-        ),
-    );
-    return DefaultSupportedDbtVersion;
+    // No supported version found
+    return null;
 };
 
-export const isSupportedDbtVersion = (version: string) => {
-    const supportedVersions = [
-        '1.3.',
-        '1.4.',
-        '1.5.',
-        '1.6.',
-        '1.7',
-        '1.8',
-        '1.9',
-    ];
-    return supportedVersions.some((supportedVersion) =>
-        version.startsWith(supportedVersion),
-    );
+const getFallbackDbtVersionOption = (version: string): DbtVersionOption => {
+    if (version.startsWith('1.3.')) return SupportedDbtVersions.V1_4; // legacy|deprecated support for dbt 1.3
+    return getLatestSupportDbtVersion();
+};
+
+type DbtVersion = {
+    verboseVersion: string; // Verbose version returned by dbt --version
+    versionOption: DbtVersionOption; // The supported version by Lightdash
+};
+
+export const getDbtVersion = async (): Promise<DbtVersion> => {
+    const verboseVersion = await getDbtCLIVersion();
+    const supportedVersionOption = getSupportedDbtVersionOption(verboseVersion);
+    const fallbackVersionOption = getFallbackDbtVersionOption(verboseVersion);
+    const isSupported = !!supportedVersionOption;
+    if (!isSupported) {
+        const supportedVersionsRangeMessage = `1.4.* - 1.9.*`;
+        const message = `We don't currently support version ${verboseVersion} on Lightdash. We'll interpret it as version ${fallbackVersionOption} instead, which might cause unexpected errors or behavior. For the best experience, please use a supported version (${supportedVersionsRangeMessage}).`;
+        if (process.env.CI === 'true') {
+            console.error(styles.warning(message));
+        } else {
+            const answers = await inquirer.prompt([
+                {
+                    type: 'confirm',
+                    name: 'isConfirm',
+                    message: `${styles.warning(
+                        message,
+                    )}\nDo you still want to continue?`,
+                },
+            ]);
+            if (!answers.isConfirm) {
+                throw new Error(
+                    `Unsupported dbt version ${verboseVersion}. Please consider using a supported version (${supportedVersionsRangeMessage}).`,
+                );
+            }
+        }
+    }
+
+    return {
+        verboseVersion,
+        versionOption: supportedVersionOption ?? fallbackVersionOption,
+    };
 };

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -66,11 +66,11 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
             versions[versions.length - 1]
         }.*`;
         const message = `We don't currently support version ${verboseVersion} on Lightdash. We'll interpret it as version ${fallbackVersionOption} instead, which might cause unexpected errors or behavior. For the best experience, please use a supported version (${supportedVersionsRangeMessage}).`;
+        const spinner = GlobalState.getActiveSpinner();
+        spinner?.stop();
         if (process.env.CI === 'true') {
             console.error(styles.warning(message));
         } else {
-            const spinner = GlobalState.getActiveSpinner();
-            spinner?.stop();
             const answers = await inquirer.prompt([
                 {
                     type: 'confirm',
@@ -80,14 +80,14 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
                     )}\nDo you still want to continue?`,
                 },
             ]);
-            spinner?.start();
             if (!answers.isConfirm) {
                 throw new Error(
                     `Unsupported dbt version ${verboseVersion}. Please consider using a supported version (${supportedVersionsRangeMessage}).`,
                 );
             }
-            GlobalState.savePromptAnswer('useFallbackDbtVersion', true);
         }
+        spinner?.start();
+        GlobalState.savePromptAnswer('useFallbackDbtVersion', true);
     }
 
     return {

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -57,7 +57,10 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
     const supportedVersionOption = getSupportedDbtVersionOption(verboseVersion);
     const fallbackVersionOption = getFallbackDbtVersionOption(verboseVersion);
     const isSupported = !!supportedVersionOption;
-    if (!isSupported && !GlobalState.getPromptAnswer('useFallbackDbtVersion')) {
+    if (
+        !isSupported &&
+        !GlobalState.getSavedPromptAnswer('useFallbackDbtVersion')
+    ) {
         const versions = Object.values(SupportedDbtVersions);
         const supportedVersionsRangeMessage = `${versions[0]}.* - ${
             versions[versions.length - 1]
@@ -83,7 +86,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
                     `Unsupported dbt version ${verboseVersion}. Please consider using a supported version (${supportedVersionsRangeMessage}).`,
                 );
             }
-            GlobalState.rememberPromptAnswer('useFallbackDbtVersion', true);
+            GlobalState.savePromptAnswer('useFallbackDbtVersion', true);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- Refactor logic on getting dbt version and fallback
- Show warning/prompt consistently across all Lightdash commands
- Only show prompt once


### reproduce steps

```
# Create python virtual env 
python -m venv dbt-1-3
# Activate virtual env
source dbt-1-3/bin/activate
# update pip
pip install --upgrade pip
# install dbt 1.3
pip install dbt-postgres~=1.3.0
# check dbt version 
dbt --version
# if doesn't show correct version, deactivate virtual env
deactivate
# and activate again 
source dbt-1-3/bin/activate
```


#### compile command using dbt 1.3

<img width="1554" alt="Screenshot 2025-01-06 at 16 04 29" src="https://github.com/user-attachments/assets/6bb5e918-196b-4f90-887c-6c84f09f15a7" />


#### preview command using dbt 1.3

<img width="1578" alt="Screenshot 2025-01-06 at 17 03 09" src="https://github.com/user-attachments/assets/ed893236-3637-4815-a8fb-fc0dfb209c6e" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
