### PR TITLE
fix: load pylon script through hook

### DIFF
--- a/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
+++ b/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
@@ -1,26 +1,70 @@
 import { LightdashMode } from '@lightdash/common';
 import { PostHogProvider, usePostHog } from 'posthog-js/react';
-import { useEffect, type FC } from 'react';
+import { useCallback, useEffect, type FC } from 'react';
 import { IntercomProvider } from 'react-use-intercom';
 import { Intercom } from '../components/Intercom';
 import useSentry from '../hooks/thirdPartyServices/useSentry';
 import useApp from './App/useApp';
 
-const Pylon = () => {
+const usePylon = () => {
     const { user, health } = useApp();
-    useEffect(() => {
-        if (health.data?.pylon?.appId && user.data) {
-            // @ts-ignore
-            window.pylon = {
-                chat_settings: {
-                    app_id: health.data.pylon.appId,
-                    email: user.data.email,
-                    name: `${user.data.firstName} ${user.data.lastName}`,
-                    email_hash: health.data.pylon.verificationHash,
-                },
-            };
-            // @ts-ignore
-            if (window.Pylon) {
+
+    // REFERENCE: https://docs.usepylon.com/pylon-docs/in-app-chat/chat-setup
+    const initPylonWidget = useCallback((appId: string) => {
+        const PYLON_WIDGET_URL = 'https://widget.usepylon.com/widget/';
+        const e = window;
+        const t = document;
+        const n = function () {
+            n.e(arguments); // eslint-disable-line
+        };
+        n.q = [] as unknown[];
+        n.e = function (e: unknown) {
+            n.q.push(e);
+        };
+        // @ts-ignore
+        e.Pylon = n;
+        const r = function () {
+            const e = t.createElement('script');
+            e.setAttribute('type', 'text/javascript');
+            e.setAttribute('async', 'true');
+            e.setAttribute('src', `${PYLON_WIDGET_URL}${appId}`);
+            const n = t.getElementsByTagName('script')[0];
+            if (n.parentNode) {
+                n.parentNode.insertBefore(e, n);
+            }
+        };
+        if (t.readyState === 'complete') {
+            r();
+        } else if (e.addEventListener) {
+            e.addEventListener('load', r, false);
+        }
+    }, []);
+
+    useEffect(
+        function initPylon() {
+            if (health.data?.pylon?.appId && user.data) {
+                // @ts-ignore
+                window.pylon = {
+                    chat_settings: {
+                        app_id: health.data.pylon.appId,
+                        email: user.data.email,
+                        name: `${user.data.firstName} ${user.data.lastName}`,
+                        email_hash: health.data.pylon.verificationHash,
+                    },
+                };
+
+                // @ts-ignore
+                if (!window.Pylon) {
+                    initPylonWidget(health.data.pylon.appId);
+                }
+            }
+        },
+        [user, health],
+    );
+
+    useEffect(
+        function setNewIssueCustomFields() {
+            if (health.data?.pylon?.appId && user.data) {
                 // @ts-ignore
                 window.Pylon('setNewIssueCustomFields', {
                     user_uuid: user.data.userUuid,
@@ -29,17 +73,8 @@ const Pylon = () => {
                     user_role: user.data.role,
                 });
             }
-        }
-    }, [user, health]);
-
-    if (!health.data?.pylon?.appId) {
-        return null;
-    }
-
-    return (
-        <script type="text/javascript">
-            {`(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${health.data.pylon.appId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`}
-        </script>
+        },
+        [user, health],
     );
 };
 
@@ -91,6 +126,7 @@ const ThirdPartyServicesEnabledProvider: FC<React.PropsWithChildren<{}>> = ({
     const { health, user } = useApp();
 
     useSentry(health?.data?.sentry, user.data);
+    usePylon();
 
     return (
         <IntercomProvider
@@ -109,7 +145,6 @@ const ThirdPartyServicesEnabledProvider: FC<React.PropsWithChildren<{}>> = ({
             >
                 <PosthogIdentified>
                     <Intercom />
-                    <Pylon />
                     <Clarity />
                     {children}
                 </PosthogIdentified>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13118 

### Description:

Followed this example: https://github.com/rilldata/rill/pull/4861/files

Added hook `usePylon` to load script with ts rather than using `script` element - couldn't make it work

How to test: 
- set app id env var
- go to update HelpMenu.tsx to have {isCloudCustomer || true && (
 
<img width="464" alt="Screenshot 2025-01-07 at 13 50 08" src="https://github.com/user-attachments/assets/e3914fc6-d0de-4390-b12d-694a95f89aa4" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
