### PR TITLE
fix: metric tree nodes not loading edges when changing filters

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -174,17 +174,19 @@ const getNodeLayout = (
                 label: 'Unconnected nodes',
             },
             position: {
-                x: isNaN(unconnectedGroupX) ? 0 : unconnectedGroupX,
-                y: isNaN(unconnectedGroupY) ? 0 : unconnectedGroupY,
+                x: isFinite(unconnectedGroupX) ? unconnectedGroupX : 0,
+                y: isFinite(unconnectedGroupY) ? unconnectedGroupY : 0,
             },
             style: {
                 backgroundColor: theme.fn.lighten(theme.colors.gray[0], 0.7),
                 border: `1px solid ${theme.colors.gray[3]}`,
                 boxShadow: theme.shadows.subtle,
-                height: isNaN(unconnectedGroupHeight)
-                    ? 0
-                    : unconnectedGroupHeight,
-                width: isNaN(unconnectedGroupWidth) ? 0 : unconnectedGroupWidth,
+                height: isFinite(unconnectedGroupHeight)
+                    ? unconnectedGroupHeight
+                    : 0,
+                width: isFinite(unconnectedGroupWidth)
+                    ? unconnectedGroupWidth
+                    : 0,
                 pointerEvents: 'none' as const,
                 borderRadius: theme.radius.md,
                 padding: theme.spacing.md,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -167,33 +167,43 @@ const getNodeLayout = (
     const unconnectedGroupWidth = right - left + mainPadding * 2;
     const unconnectedGroupHeight = bottom - top + mainPadding * 2;
 
-    const groups = [
-        {
-            id: STATIC_NODE_TYPES.UNCONNECTED,
-            data: {
-                label: 'Unconnected nodes',
-            },
-            position: {
-                x: isFinite(unconnectedGroupX) ? unconnectedGroupX : 0,
-                y: isFinite(unconnectedGroupY) ? unconnectedGroupY : 0,
-            },
-            style: {
-                backgroundColor: theme.fn.lighten(theme.colors.gray[0], 0.7),
-                border: `1px solid ${theme.colors.gray[3]}`,
-                boxShadow: theme.shadows.subtle,
-                height: isFinite(unconnectedGroupHeight)
-                    ? unconnectedGroupHeight
-                    : 0,
-                width: isFinite(unconnectedGroupWidth)
-                    ? unconnectedGroupWidth
-                    : 0,
-                pointerEvents: 'none' as const,
-                borderRadius: theme.radius.md,
-                padding: theme.spacing.md,
-            },
-            type: 'group',
-        },
-    ] satisfies MetricTreeNode[];
+    const groups =
+        free.length > 0
+            ? ([
+                  {
+                      id: STATIC_NODE_TYPES.UNCONNECTED,
+                      data: {
+                          label: 'Unconnected nodes',
+                      },
+                      position: {
+                          x: isFinite(unconnectedGroupX)
+                              ? unconnectedGroupX
+                              : 0,
+                          y: isFinite(unconnectedGroupY)
+                              ? unconnectedGroupY
+                              : 0,
+                      },
+                      style: {
+                          backgroundColor: theme.fn.lighten(
+                              theme.colors.gray[0],
+                              0.7,
+                          ),
+                          border: `1px solid ${theme.colors.gray[3]}`,
+                          boxShadow: theme.shadows.subtle,
+                          height: isFinite(unconnectedGroupHeight)
+                              ? unconnectedGroupHeight
+                              : 0,
+                          width: isFinite(unconnectedGroupWidth)
+                              ? unconnectedGroupWidth
+                              : 0,
+                          pointerEvents: 'none' as const,
+                          borderRadius: theme.radius.md,
+                          padding: theme.spacing.md,
+                      },
+                      type: 'group',
+                  },
+              ] satisfies MetricTreeNode[])
+            : [];
 
     return {
         nodes: [...groups, ...tree, ...free],

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -162,19 +162,31 @@ const getNodeLayout = (
         };
     });
 
+    const unconnectedGroupX = isNaN(left) ? 0 : left - mainPadding;
+    const unconnectedGroupY = isNaN(top) ? 0 : top - mainPadding;
+    const unconnectedGroupWidth = isNaN(right)
+        ? 0
+        : right - left + mainPadding * 2;
+    const unconnectedGroupHeight = isNaN(bottom)
+        ? 0
+        : bottom - top + mainPadding * 2;
+
     const groups = [
         {
             id: STATIC_NODE_TYPES.UNCONNECTED,
             data: {
                 label: 'Unconnected nodes',
             },
-            position: { x: left - mainPadding, y: top - mainPadding },
+            position: {
+                x: unconnectedGroupX,
+                y: unconnectedGroupY,
+            },
             style: {
                 backgroundColor: theme.fn.lighten(theme.colors.gray[0], 0.7),
                 border: `1px solid ${theme.colors.gray[3]}`,
                 boxShadow: theme.shadows.subtle,
-                height: bottom - top + mainPadding * 2,
-                width: right - left + mainPadding * 2,
+                height: unconnectedGroupHeight,
+                width: unconnectedGroupWidth,
                 pointerEvents: 'none' as const,
                 borderRadius: theme.radius.md,
                 padding: theme.spacing.md,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -162,14 +162,10 @@ const getNodeLayout = (
         };
     });
 
-    const unconnectedGroupX = isNaN(left) ? 0 : left - mainPadding;
-    const unconnectedGroupY = isNaN(top) ? 0 : top - mainPadding;
-    const unconnectedGroupWidth = isNaN(right)
-        ? 0
-        : right - left + mainPadding * 2;
-    const unconnectedGroupHeight = isNaN(bottom)
-        ? 0
-        : bottom - top + mainPadding * 2;
+    const unconnectedGroupX = left - mainPadding;
+    const unconnectedGroupY = top - mainPadding;
+    const unconnectedGroupWidth = right - left + mainPadding * 2;
+    const unconnectedGroupHeight = bottom - top + mainPadding * 2;
 
     const groups = [
         {
@@ -178,15 +174,17 @@ const getNodeLayout = (
                 label: 'Unconnected nodes',
             },
             position: {
-                x: unconnectedGroupX,
-                y: unconnectedGroupY,
+                x: isNaN(unconnectedGroupX) ? 0 : unconnectedGroupX,
+                y: isNaN(unconnectedGroupY) ? 0 : unconnectedGroupY,
             },
             style: {
                 backgroundColor: theme.fn.lighten(theme.colors.gray[0], 0.7),
                 border: `1px solid ${theme.colors.gray[3]}`,
                 boxShadow: theme.shadows.subtle,
-                height: unconnectedGroupHeight,
-                width: unconnectedGroupWidth,
+                height: isNaN(unconnectedGroupHeight)
+                    ? 0
+                    : unconnectedGroupHeight,
+                width: isNaN(unconnectedGroupWidth) ? 0 : unconnectedGroupWidth,
                 pointerEvents: 'none' as const,
                 borderRadius: theme.radius.md,
                 padding: theme.spacing.md,
@@ -202,6 +200,14 @@ const getNodeLayout = (
 };
 
 const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
+    useEffect(() => {
+        console.log({
+            metrics,
+            edges,
+            viewOnly,
+        });
+    }, [metrics, edges, viewOnly]);
+
     const theme = useMantineTheme();
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -223,7 +223,7 @@ const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
     const nodesInitialized = useNodesInitialized();
     const [layoutState, setLayoutState] = useState({
         isReady: false,
-        shouldFitView: false,
+        shouldFitView: true,
     });
 
     const initialEdges = useMemo<Edge[]>(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13050 

### Description:

**Before**

https://github.com/user-attachments/assets/49611e29-efcc-4f4e-937d-7de343428fdc

**After**

https://github.com/user-attachments/assets/d0c8a8a1-189a-4384-a282-9d603eefd22f

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
