### PR TITLE
fix: use 2 space tabs instead of 4 in sql runner

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -46,6 +46,7 @@ const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
     quickSuggestions: true,
     contextmenu: false,
     automaticLayout: true,
+    tabSize: 2,
 };
 
 const getLanguage = (warehouseType?: WarehouseTypes): string => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11805 

### Description:

Tab will now indent by 2 spaces instead of 4 in the SQL runner. Working through some SQL runner UX tickets. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
