### PR TITLE
fix: handle empty string timezone in FE

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -285,7 +285,7 @@ const Schedulers: FC<SchedulersProps> = ({
                                   <Text fz="xs" color="gray.6">
                                       {getHumanReadableCronExpression(
                                           item.cron,
-                                          item.timezone ??
+                                          item.timezone ||
                                               project.schedulerTimezone,
                                       )}
                                   </Text>

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -58,7 +58,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                         <Text color="gray" size={12}>
                             {getHumanReadableCronExpression(
                                 scheduler.cron,
-                                scheduler.timezone ?? project.schedulerTimezone,
+                                scheduler.timezone || project.schedulerTimezone,
                             )}
                         </Text>
 

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -104,7 +104,7 @@ export const SyncModalView: FC<{ chartUuid: string }> = ({ chartUuid }) => {
                                             <Text span size="xs" color="gray.6">
                                                 {getHumanReadableCronExpression(
                                                     sync.cron,
-                                                    sync.timezone ??
+                                                    sync.timezone ||
                                                         project.schedulerTimezone,
                                                 )}
                                             </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixes an issue where saved empty strings in Scheduled deliveries timezones cause the list page to crash

<img width="1239" alt="Screenshot 2025-01-07 at 17 15 44" src="https://github.com/user-attachments/assets/e8d067c5-74c5-49e1-88f4-945271e71892" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
