### PR TITLE
chore: remove styled components from gsheets icons

### DIFF
--- a/packages/frontend/src/components/common/GSheetsIcon/index.tsx
+++ b/packages/frontend/src/components/common/GSheetsIcon/index.tsx
@@ -1,16 +1,59 @@
-import styled from 'styled-components';
+import { type TablerIconsProps } from '@tabler/icons-react';
+import { forwardRef } from 'react';
 import GsheetsFilledSvg from '../../../svgs/google-sheets-filled.svg?react';
 import GsheetsSvg from '../../../svgs/google-sheets.svg?react';
 
-export const GSheetsIcon = styled(GsheetsSvg)`
-    width: 16px;
-    height: 16px;
-`;
+const iconStyles = {
+    width: '16px',
+    height: '16px',
+};
 
-export const GSheetsIconFilled = styled(GsheetsFilledSvg)`
-    width: 16px;
-    height: 16px;
-    & path {
-        stroke-width: 4;
-    }
-`;
+const filledIconStyles = {
+    width: '16px',
+    height: '16px',
+    path: {
+        strokeWidth: 4,
+    },
+};
+
+export const GSheetsIcon = forwardRef<SVGSVGElement, TablerIconsProps>(
+    (props, ref) => {
+        // Convert numeric stroke values to strings
+        const svgProps = {
+            ...props,
+            stroke: props.stroke?.toString(),
+            strokeWidth: props.strokeWidth?.toString(),
+        };
+
+        return (
+            <GsheetsSvg
+                {...svgProps}
+                ref={ref}
+                style={{ ...iconStyles, ...props.style }}
+            />
+        );
+    },
+);
+
+export const GSheetsIconFilled = forwardRef<SVGSVGElement, TablerIconsProps>(
+    (props, ref) => {
+        // Convert numeric stroke values to strings
+        const svgProps = {
+            ...props,
+            stroke: props.stroke?.toString(),
+            strokeWidth: props.strokeWidth?.toString(),
+        };
+
+        return (
+            <GsheetsFilledSvg
+                {...svgProps}
+                ref={ref}
+                style={{ ...filledIconStyles, ...props.style }}
+            />
+        );
+    },
+);
+
+// Add display names for better debugging
+GSheetsIcon.displayName = 'GSheetsIcon';
+GSheetsIconFilled.displayName = 'GSheetsIconFilled';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removing styled components to reduce our reliance on them. 

Here are screenshots of everywhere these icons are used I took with this change applied

**Explorer table sync**
<img width="560" alt="Screenshot 2025-01-07 at 16 53 09" src="https://github.com/user-attachments/assets/75f7bf5b-0dbb-4965-b753-b11816fea0b7" />

**Sync dialog**
<img width="817" alt="Screenshot 2025-01-07 at 17 13 48" src="https://github.com/user-attachments/assets/c08e02f1-2878-41de-be45-bc4765d20b7e" />


**Deliveries list**
<img width="449" alt="Screenshot 2025-01-07 at 17 31 34" src="https://github.com/user-attachments/assets/c7d0b47b-2d11-4ab1-ab4c-1b6031f44cbd" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
