### PR TITLE
fix: split chart usage query into count and select for single chart

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -666,7 +666,7 @@ export class SavedChartModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid);
     }
 
-    async getChartCountForFieldIds(projectUuid: string, fieldIds: string[]) {
+    async getChartCountPerField(projectUuid: string) {
         const chartSummaryQuery = this.getChartSummaryQuery().clearSelect();
         const results = await chartSummaryQuery
             .select({
@@ -686,7 +686,6 @@ export class SavedChartModel {
                 `${SavedChartVersionsTableName}.saved_queries_version_id`,
                 `${SavedChartVersionFieldsTableName}.saved_queries_version_id`,
             )
-            .whereIn(`${SavedChartVersionFieldsTableName}.name`, fieldIds)
             .where(
                 // filter by last version
                 `${SavedChartVersionsTableName}.saved_queries_version_id`,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -641,12 +641,40 @@ export class SavedChartModel {
         return savedChart;
     }
 
-    async getChartUsageByFieldId(
-        projectUuid: string,
-        fieldIds: string[],
-    ): Promise<Record<string, ChartSummary[]>> {
-        const results = await this.getChartSummaryQuery()
-            .select(`${SavedChartVersionFieldsTableName}.name as fieldId`)
+    async getChartSummariesForFieldId(projectUuid: string, fieldId: string) {
+        return this.getChartSummaryQuery()
+            .leftJoin(
+                SavedChartVersionsTableName,
+                `${SavedChartsTableName}.saved_query_id`,
+                `${SavedChartVersionsTableName}.saved_query_id`,
+            )
+            .leftJoin(
+                SavedChartVersionFieldsTableName,
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                `${SavedChartVersionFieldsTableName}.saved_queries_version_id`,
+            )
+            .where(`${SavedChartVersionFieldsTableName}.name`, fieldId)
+            .where(
+                // filter by last version
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                this.database.raw(`(select saved_queries_version_id
+                                           from ${SavedChartVersionsTableName}
+                                           where saved_queries.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
+                                           order by ${SavedChartVersionsTableName}.created_at desc
+                                           limit 1)`),
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+    }
+
+    async getChartCountForFieldIds(projectUuid: string, fieldIds: string[]) {
+        const chartSummaryQuery = this.getChartSummaryQuery().clearSelect();
+        return chartSummaryQuery
+            .select({
+                fieldId: `${SavedChartVersionFieldsTableName}.name`,
+            })
+            .count<{ fieldId: string; count: number }[]>(
+                `${SavedChartsTableName}.saved_query_uuid`,
+            )
             .leftJoin(
                 SavedChartVersionsTableName,
                 `${SavedChartsTableName}.saved_query_id`,
@@ -662,22 +690,13 @@ export class SavedChartModel {
                 // filter by last version
                 `${SavedChartVersionsTableName}.saved_queries_version_id`,
                 this.database.raw(`(select saved_queries_version_id
-                                           from ${SavedChartVersionsTableName}
-                                           where saved_queries.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
-                                           order by ${SavedChartVersionsTableName}.created_at desc
-                                           limit 1)`),
+                               from ${SavedChartVersionsTableName}
+                               where saved_queries.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
+                               order by ${SavedChartVersionsTableName}.created_at desc
+                               limit 1)`),
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
-
-        // Group results by fieldId
-        return results.reduce<Record<string, ChartSummary[]>>((acc, chart) => {
-            const { fieldId, ...chartSummary } = chart;
-            if (!acc[fieldId]) {
-                acc[fieldId] = [];
-            }
-            acc[fieldId].push(chartSummary);
-            return acc;
-        }, {});
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .groupBy(`${SavedChartVersionFieldsTableName}.name`);
     }
 
     async get(

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -767,10 +767,7 @@ export class CatalogService<
         catalogFieldMap: CatalogFieldMap,
     ) {
         const chartUsagesForFields =
-            await this.savedChartModel.getChartCountForFieldIds(
-                projectUuid,
-                Object.keys(catalogFieldMap),
-            );
+            await this.savedChartModel.getChartCountPerField(projectUuid);
 
         const chartUsageUpdates = chartUsagesForFields
             .map<ChartUsageIn | undefined>(({ fieldId, count }) => {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -776,7 +776,7 @@ export class CatalogService<
             .map<ChartUsageIn | undefined>(({ fieldId, count }) => {
                 const catalogField = catalogFieldMap[fieldId];
 
-                if (!catalogField) {
+                if (!catalogField || Number.isNaN(count)) {
                     return undefined;
                 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#2647](https://github.com/lightdash/lightdash-internal-work/issues/2647)

### Description:

- Splits `getChartUsageByFieldId` into:
    - `getChartSummariesForFieldId` - gets all summaries for a single field, used in the explorer when clicking usage
    - `getChartCountForFieldIds` - count query for multiple fields, used when backfilling chart usage count

- SQL when backfilling usage:

```sql
select "saved_queries_version_fields"."name" as "fieldId", count("saved_queries"."saved_query_uuid") from "saved_queries" left join "dashboards" on "dashboards"."dashboard_uuid" = "saved_queries"."dashboard_uuid" inner join "spaces" on "spaces"."space_id" = "dashboards"."space_id" or "spaces"."space_id" = "saved_queries"."space_id" left join "projects" on "spaces"."project_id" = "projects"."project_id" left join "organizations" on "organizations"."organization_id" = "projects"."organization_id" left join "pinned_chart" on "pinned_chart"."saved_chart_uuid" = "saved_queries"."saved_query_uuid" left join "pinned_list" on "pinned_list"."pinned_list_uuid" = "pinned_chart"."pinned_list_uuid" left join "saved_queries_versions" on "saved_queries"."saved_query_id" = "saved_queries_versions"."saved_query_id" left join "saved_queries_version_fields" on "saved_queries_versions"."saved_queries_version_id" = "saved_queries_version_fields"."saved_queries_version_id" where "saved_queries_version_fields"."name" in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) and "saved_queries_versions"."saved_queries_version_id" = (select saved_queries_version_id
from saved_queries_versions
where saved_queries.saved_query_id = saved_queries_versions.saved_query_id
order by saved_queries_versions.created_at desc
limit 1) and "projects"."project_uuid" = ? group by "saved_queries_version_fields"."name"
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
