### PR TITLE
fix: sidebar resizing to allow showing long field labels

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -13,7 +13,6 @@ import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import {
     SIDEBAR_DEFAULT_WIDTH,
-    SIDEBAR_MAX_WIDTH,
     SIDEBAR_MIN_WIDTH,
     SIDEBAR_RESIZE_HANDLE_WIDTH,
 } from './constants';
@@ -44,13 +43,11 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     const {
         defaultWidth = SIDEBAR_DEFAULT_WIDTH,
         minWidth = SIDEBAR_MIN_WIDTH,
-        maxWidth = SIDEBAR_MAX_WIDTH,
     } = widthProps;
     const { sidebarRef, sidebarWidth, isResizing, startResizing } =
         useSidebarResize({
             defaultWidth,
             minWidth,
-            maxWidth,
             position,
             mainWidth,
             onResizeStart,

--- a/packages/frontend/src/components/common/Page/constants.ts
+++ b/packages/frontend/src/components/common/Page/constants.ts
@@ -14,6 +14,5 @@ export const PAGE_MIN_CONTENT_WIDTH = 600;
 
 export const SIDEBAR_DEFAULT_WIDTH = 400;
 export const SIDEBAR_MIN_WIDTH = 300;
-export const SIDEBAR_MAX_WIDTH = 600;
 
 export const SIDEBAR_RESIZE_HANDLE_WIDTH = 6;

--- a/packages/frontend/src/hooks/useSidebarResize.ts
+++ b/packages/frontend/src/hooks/useSidebarResize.ts
@@ -1,3 +1,4 @@
+import { useViewportSize } from '@mantine/hooks';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { PAGE_MIN_CONTENT_WIDTH } from '../components/common/Page/constants';
 import { SidebarPosition } from '../components/common/Page/types';
@@ -5,7 +6,6 @@ import { SidebarPosition } from '../components/common/Page/types';
 type Args = {
     defaultWidth: number;
     minWidth: number;
-    maxWidth: number;
     position: SidebarPosition;
     mainWidth?: number;
     onResizeStart?: () => void;
@@ -13,7 +13,6 @@ type Args = {
 };
 
 const useSidebarResize = ({
-    maxWidth,
     minWidth,
     defaultWidth,
     position,
@@ -34,6 +33,10 @@ const useSidebarResize = ({
         setIsResizing(false);
         onResizeEnd?.();
     }, [onResizeEnd, setIsResizing]);
+
+    const { width: viewportWidth } = useViewportSize();
+
+    const maxWidth = viewportWidth / 2;
 
     const resize = useCallback(
         // mouse event on div
@@ -58,8 +61,14 @@ const useSidebarResize = ({
 
             setSidebarWidth(Math.min(maxWidth, Math.max(minWidth, newWidth)));
         },
-        [isResizing, position, maxWidth, minWidth, mainWidth],
+        [isResizing, position, minWidth, mainWidth, maxWidth],
     );
+
+    useLayoutEffect(() => {
+        if (sidebarWidth > maxWidth && maxWidth > minWidth) {
+            setSidebarWidth(maxWidth);
+        }
+    }, [maxWidth, minWidth, sidebarWidth]);
 
     useLayoutEffect(() => {
         if (!isResizing) return;


### PR DESCRIPTION


Closes: https://github.com/lightdash/lightdash/issues/13124

### Description:

allows resizing sidebar half the screen size. taking into account window resize as well - when you resize the window the sidebar sizes down too

https://github.com/user-attachments/assets/fe3f939a-0ae2-4a68-b17b-66c71b0c9b27



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
