### PR TITLE
chore: add composite index for project_uuid and catalog_search_uuid

### DIFF
--- a/packages/backend/src/database/migrations/20250108140928_create-project-uuid-catalog-search-uuid-index.ts
+++ b/packages/backend/src/database/migrations/20250108140928_create-project-uuid-catalog-search-uuid-index.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const CatalogTableName = 'catalog_search';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table.index(['project_uuid', 'catalog_search_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table.dropIndex(['project_uuid', 'catalog_search_uuid']);
+    });
+}

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -11,7 +11,6 @@ import {
     type ApiCatalogSearch,
     type ApiSort,
     type CatalogFieldMap,
-    type CatalogFieldWhere,
     type CatalogItem,
     type CatalogItemSummary,
     type CatalogItemWithTagUuids,

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -857,16 +857,24 @@ export class CatalogModel {
             })
             .innerJoin(
                 { source_metric: CatalogTableName },
-                `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
-                `source_metric.catalog_search_uuid`,
+                function joinSource() {
+                    void this.on(
+                        `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
+                        '=',
+                        `source_metric.catalog_search_uuid`,
+                    ).andOnVal('source_metric.project_uuid', '=', projectUuid);
+                },
             )
             .innerJoin(
                 { target_metric: CatalogTableName },
-                `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
-                `target_metric.catalog_search_uuid`,
-            )
-            .where('source_metric.project_uuid', projectUuid)
-            .andWhere('target_metric.project_uuid', projectUuid);
+                function joinTarget() {
+                    void this.on(
+                        `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
+                        '=',
+                        `target_metric.catalog_search_uuid`,
+                    ).andOnVal('target_metric.project_uuid', '=', projectUuid);
+                },
+            );
 
         return edges.map((e) => ({
             source: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#2647](https://github.com/lightdash/lightdash-internal-work/issues/2647)

### Description:

- Adds composite index to `project_uuid` and `catalog_search_uuid` to the `catalog_search` table to help with metric tree edges query.
- Filters by project UUID on join instead of after

```typescript
await this.database(MetricsTreeEdgesTableName)
            .select<
                (DbMetricsTreeEdge & {
                    source_metric_name: string;
                    source_metric_table_name: string;
                    target_metric_name: string;
                    target_metric_table_name: string;
                })[]
            >({
                source_metric_catalog_search_uuid: `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
                target_metric_catalog_search_uuid: `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
                created_at: `${MetricsTreeEdgesTableName}.created_at`,
                created_by_user_uuid: `${MetricsTreeEdgesTableName}.created_by_user_uuid`,
                source_metric_name: `source_metric.name`,
                source_metric_table_name: `source_metric.table_name`,
                target_metric_name: `target_metric.name`,
                target_metric_table_name: `target_metric.table_name`,
            })
            .innerJoin(
                { source_metric: CatalogTableName },
                `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
                `source_metric.catalog_search_uuid`,
            )
            .innerJoin(
                { target_metric: CatalogTableName },
                `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
                `target_metric.catalog_search_uuid`,
            )
            .where('source_metric.project_uuid', projectUuid)
            .andWhere('target_metric.project_uuid', projectUuid);
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
