### PR TITLE
fix: different sidebar spacing between saved and unsaved explores

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -145,7 +145,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     }
 
     return (
-        <>
+        <Stack h="100%" sx={{ flexGrow: 1 }}>
             <Group position="apart">
                 <PageBreadcrumbs
                     size="md"
@@ -230,7 +230,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     projectUuid={projectUuid}
                 />
             )}
-        </>
+        </Stack>
     );
 });
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -235,13 +235,7 @@ const ExploreSideBar = memo(() => {
 
     return (
         <TrackSection name={SectionName.SIDEBAR}>
-            <Stack h="100%" sx={{ flexGrow: 1 }}>
-                {!tableName ? (
-                    <BasePanel />
-                ) : (
-                    <ExplorePanel onBack={handleBack} />
-                )}
-            </Stack>
+            {!tableName ? <BasePanel /> : <ExplorePanel onBack={handleBack} />}
         </TrackSection>
     );
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12115

### Description:

The spacing in the sidebar was different between saved and unsaved Explores. The components return fragments which were being wrapped in a stack in unsaved explores and not in saved ones. This just moves the stack to the imported component. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
