### PR TITLE
Chore/improve catalog search query

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -379,8 +379,6 @@ export class CatalogModel {
             return acc;
         }, {} as Record<string, Pick<Tag, 'tagUuid' | 'name' | 'color'>[]>);
 
-        console.log(tagsPerItem);
-
         const catalog = await wrapSentryTransaction(
             'CatalogModel.search.parse',
             {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Improves the performance of the search catalog query by doing the tags catalog tags aggregation on a second query after the catalog items query has finished. This helps because when aggregating we would have to group by which became very expensive.

Tests were done with 200000+ metrics:

**Before**
![image](https://github.com/user-attachments/assets/735e6ba9-e118-4b22-9086-4edd1de2bd56)


**After**
![image](https://github.com/user-attachments/assets/7067428e-a681-491e-bc28-4cf032240153)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
