### PR TITLE
feat: Enable to specify path of `lightdasah {download,upload}`

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -28,8 +28,13 @@ export type DownloadHandlerOptions = {
     path?: string; // New optional path parameter
 };
 
-const getDownloadFolder = (customPath?: string): string =>
-    customPath || path.join(process.cwd(), 'lightdash');
+const getDownloadFolder = (customPath?: string): string => {
+    if (customPath) {
+        return path.isAbsolute(customPath) ? customPath : path.join(process.cwd(), customPath);
+    } else {
+        return path.join(process.cwd(), 'lightdash');
+    }
+};
 
 /*
     This function is used to parse the content filters.

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -30,10 +30,11 @@ export type DownloadHandlerOptions = {
 
 const getDownloadFolder = (customPath?: string): string => {
     if (customPath) {
-        return path.isAbsolute(customPath) ? customPath : path.join(process.cwd(), customPath);
-    } else {
-        return path.join(process.cwd(), 'lightdash');
+        return path.isAbsolute(customPath)
+            ? customPath
+            : path.join(process.cwd(), customPath);
     }
+    return path.join(process.cwd(), 'lightdash');
 };
 
 /*
@@ -329,9 +330,9 @@ const getPromoteAction = (action: PromotionAction) => {
         case PromotionAction.NO_CHANGES:
             return 'skipped';
         default:
-            // eslint-disable-next-line consistent-return
             assertUnreachable(action, `Unknown promotion action: ${action}`);
     }
+    return 'skipped';
 };
 
 const storeUploadChanges = (

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -4,7 +4,6 @@ import {
     ApiChartAsCodeListResponse,
     ApiChartAsCodeUpsertResponse,
     ApiDashboardAsCodeListResponse,
-    assertUnreachable,
     AuthorizationError,
     ChartAsCode,
     DashboardAsCode,
@@ -20,15 +19,18 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 
-const DOWNLOAD_FOLDER = 'lightdash';
 export type DownloadHandlerOptions = {
     verbose: boolean;
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
     force: boolean;
+    path?: string; // New optional path parameter
 };
 
-/* 
+const getDownloadFolder = (customPath?: string): string =>
+    customPath || path.join(process.cwd(), 'lightdash');
+
+/*
     This function is used to parse the content filters.
     It can be slugs, uuids or urls
     We remove the URL part (if any) and return a list of `slugs or uuids` that can be used in the API call
@@ -51,8 +53,9 @@ const parseContentFilters = (items: string[]): string => {
 const dumpIntoFiles = async (
     folder: 'charts' | 'dashboards',
     items: (ChartAsCode | DashboardAsCode)[],
+    customPath?: string,
 ) => {
-    const outputDir = path.join(process.cwd(), DOWNLOAD_FOLDER, folder);
+    const outputDir = path.join(getDownloadFolder(customPath), folder);
 
     GlobalState.debug(`Writing ${items.length} ${folder} into ${outputDir}`);
     // Make directory
@@ -70,8 +73,9 @@ const dumpIntoFiles = async (
 
 const readCodeFiles = async <T extends ChartAsCode | DashboardAsCode>(
     folder: 'charts' | 'dashboards',
+    customPath?: string,
 ): Promise<(T & { needsUpdating: boolean })[]> => {
-    const inputDir = path.join(process.cwd(), DOWNLOAD_FOLDER, folder);
+    const inputDir = path.join(getDownloadFolder(customPath), folder);
 
     console.info(`Reading ${folder} from ${inputDir}`);
     const items: (T & { needsUpdating: boolean })[] = [];
@@ -128,6 +132,7 @@ export const downloadContent = async (
     ids: string[], // slug, uuid or url
     type: 'charts' | 'dashboards',
     projectId: string,
+    customPath?: string,
 ): Promise<[number, string[]]> => {
     const spinner = GlobalState.getActiveSpinner();
     const contentFilters = parseContentFilters(ids);
@@ -157,7 +162,11 @@ export const downloadContent = async (
         });
 
         if ('dashboards' in contentAsCode) {
-            await dumpIntoFiles('dashboards', contentAsCode.dashboards);
+            await dumpIntoFiles(
+                'dashboards',
+                contentAsCode.dashboards,
+                customPath,
+            );
             // Extract chart slugs from dashboards
             chartSlugs = contentAsCode.dashboards.reduce<string[]>(
                 (acc, dashboard) => {
@@ -176,7 +185,7 @@ export const downloadContent = async (
                 chartSlugs,
             );
         } else {
-            await dumpIntoFiles('charts', contentAsCode.charts);
+            await dumpIntoFiles('charts', contentAsCode.charts, customPath);
         }
         offset = contentAsCode.offset;
     } while (contentAsCode.offset < contentAsCode.total);
@@ -234,6 +243,7 @@ export const downloadHandler = async (
                 options.charts,
                 'charts',
                 projectId,
+                options.path,
             );
             spinner.succeed(`Downloaded ${chartTotal} charts`);
         }
@@ -250,6 +260,7 @@ export const downloadHandler = async (
                 options.dashboards,
                 'dashboards',
                 projectId,
+                options.path,
             );
 
             spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
@@ -265,6 +276,7 @@ export const downloadHandler = async (
                     chartSlugs,
                     'charts',
                     projectId,
+                    options.path,
                 );
 
                 spinner.succeed(
@@ -298,8 +310,6 @@ export const downloadHandler = async (
             },
         });
     }
-
-    // TODO delete files if chart don't exist ?*/
 };
 
 const getPromoteAction = (action: PromotionAction) => {
@@ -313,10 +323,10 @@ const getPromoteAction = (action: PromotionAction) => {
         case PromotionAction.NO_CHANGES:
             return 'skipped';
         default:
-            assertUnreachable(action, `Unknown promotion action: ${action}`);
+            return 'skipped';
     }
-    return 'skipped';
 };
+
 const storeUploadChanges = (
     changes: Record<string, number>,
     promoteChanges: PromotionChanges,
@@ -352,6 +362,7 @@ const storeUploadChanges = (
 
     return updatedChanges;
 };
+
 const logUploadChanges = (changes: Record<string, number>) => {
     Object.entries(changes).forEach(([key, value]) => {
         console.info(`Total ${key}: ${value} `);
@@ -368,10 +379,11 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     changes: Record<string, number>,
     force: boolean,
     slugs: string[],
+    customPath?: string,
 ): Promise<{ changes: Record<string, number>; total: number }> => {
     const config = await getConfig();
 
-    const items = await readCodeFiles<T>(type);
+    const items = await readCodeFiles<T>(type, customPath);
 
     console.info(`Found ${items.length} ${type} files`);
 
@@ -498,6 +510,7 @@ export const uploadHandler = async (
                     changes,
                     options.force,
                     options.charts,
+                    options.path,
                 );
             changes = chartChanges;
             chartTotal = total;
@@ -515,6 +528,7 @@ export const uploadHandler = async (
                     changes,
                     options.force,
                     options.dashboards,
+                    options.path,
                 );
             changes = dashboardChanges;
             dashboardTotal = total;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -4,6 +4,7 @@ import {
     ApiChartAsCodeListResponse,
     ApiChartAsCodeUpsertResponse,
     ApiDashboardAsCodeListResponse,
+    assertUnreachable,
     AuthorizationError,
     ChartAsCode,
     DashboardAsCode,
@@ -323,7 +324,8 @@ const getPromoteAction = (action: PromotionAction) => {
         case PromotionAction.NO_CHANGES:
             return 'skipped';
         default:
-            return 'skipped';
+            assertUnreachable(action, `Unknown promotion action: ${action}`);
+            return ''; // Added return statement to satisfy consistent-return rule
     }
 };
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -324,8 +324,8 @@ const getPromoteAction = (action: PromotionAction) => {
         case PromotionAction.NO_CHANGES:
             return 'skipped';
         default:
+            // eslint-disable-next-line consistent-return
             assertUnreachable(action, `Unknown promotion action: ${action}`);
-            return ''; // Added return statement to satisfy consistent-return rule
     }
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -445,7 +445,7 @@ program
         [],
     )
     .option(
-        '--path <path>',
+        '-p, --path <path>',
         'specify a custom path to download charts and dashboards',
         undefined,
     )
@@ -471,7 +471,7 @@ program
         false,
     )
     .option(
-        '--path <path>',
+        '-p, --path <path>',
         'specify a custom path to upload charts and dashboards from',
         undefined,
     )

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -444,7 +444,13 @@ program
         'specify dashboard slugs, uuids or urls to download',
         [],
     )
+    .option(
+        '--path <path>',
+        'specify a custom path to download charts and dashboards',
+        undefined,
+    )
     .action(downloadHandler);
+
 program
     .command('upload')
     .description('Uploads charts and dashboards as code')
@@ -463,6 +469,11 @@ program
         '--force',
         'Force upload even if local files have not changed, use this when you want to upload files to a new project',
         false,
+    )
+    .option(
+        '--path <path>',
+        'specify a custom path to upload charts and dashboards from',
+        undefined,
     )
     .action(uploadHandler);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13157

### Description:
I want to add the `--path` option to `lightdash download` and `lightdash upload` respectively so that we can specify the path to manage Lightdash charts and dashboards. If we don't pass the `--path` option, Lightdash CLI manage charts and dashboards in the default directory `lightdash` as today.

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

### Test

#### Execute `lightdash doanload` and `lightdash upload` without the `--path` option

```shell
# Download charts and dashboards to the default directory
$ node /Users/yu/local/src/github/lightdash/packages/cli/dist/index.js download 
⠙ Downloading charts
Created new folder: /Users/yu/local/src/github/jaffle_shop/lightdash/charts 
✔ Downloaded 5 charts
⠇ Downloading dashboards
Created new folder: /Users/yu/local/src/github/jaffle_shop/lightdash/dashboards 
✔ Downloaded 2 dashboards
Done 🕶

# Show the download charts and dashboards in the default directory
$ tree lightdash/
lightdash/
├── charts
│   ├── -orders-day.yml
│   ├── -orders-month.yml
│   ├── copy-of-orders-day-1734323467623.yml
│   ├── orders-by-coupon-consumption.yml
│   └── sum-of-order-amount-customer.yml
└── dashboards
    ├── test-dashboard-1.yml
    └── test-dashboard.yml

3 directories, 7 files

# Upload charts and dashboards from the default directory
$ node /Users/yu/local/src/github/lightdash/packages/cli/dist/index.js upload 
Reading charts from /Users/yu/local/src/github/jaffle_shop/lightdash/charts
Found 5 charts files
Reading dashboards from /Users/yu/local/src/github/jaffle_shop/lightdash/dashboards
Found 2 dashboards files
Total charts skipped: 5 
Total dashboards skipped: 2 
Done 🕶
```

#### Execute `lightdash doanload` and `lightdash upload` with the `--path` option

```shell
# Download charts and dashboards to path/to/jaffle_shop
$ node /Users/yu/local/src/github/lightdash/packages/cli/dist/index.js download --path path/to/jaffle_shop
⠙ Downloading charts
Created new folder: path/to/jaffle_shop/charts 
✔ Downloaded 5 charts
⠦ Downloading dashboards
Created new folder: path/to/jaffle_shop/dashboards 
✔ Downloaded 2 dashboards
Done 🕶

# Show the download charts and dashboards in path/to/jaffle_shop
$ tree path/to/jaffle_shop/
path/to/jaffle_shop/
├── charts
│   ├── -orders-day.yml
│   ├── -orders-month.yml
│   ├── copy-of-orders-day-1734323467623.yml
│   ├── orders-by-coupon-consumption.yml
│   └── sum-of-order-amount-customer.yml
└── dashboards
    ├── test-dashboard-1.yml
    └── test-dashboard.yml

3 directories, 7 files

3 directories, 7 files

# Upload charts and dashboards from path/to/jaffle_shop
$ node /Users/yu/local/src/github/lightdash/packages/cli/dist/index.js upload --path path/to/jaffle_shop/
Reading charts from path/to/jaffle_shop/charts
Found 5 charts files
Reading dashboards from path/to/jaffle_shop/dashboards
Found 2 dashboards files
Total charts skipped: 5 
Total dashboards skipped: 2 
Done 🕶
```