### PR TITLE
feat: dbt cloud CLI

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -560,7 +560,21 @@ export class ProjectService extends BaseService {
 
         await this.validateProjectCreationPermissions(user, data);
 
-        const createProject = await this._resolveWarehouseClientSshKeys(data);
+        const newProjectData = data;
+        if (
+            newProjectData.type === ProjectType.PREVIEW &&
+            data.copyWarehouseConnectionFromUpstreamProject &&
+            data.upstreamProjectUuid
+        ) {
+            newProjectData.warehouseConnection =
+                await this.projectModel.getWarehouseCredentialsForProject(
+                    data.upstreamProjectUuid,
+                );
+        }
+
+        const createProject = await this._resolveWarehouseClientSshKeys(
+            newProjectData,
+        );
         const projectUuid = await this.projectModel.create(
             user.userUuid,
             user.organizationUuid,

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -313,6 +313,7 @@ export const getModelsFromManifest = (
             node.resource_type === 'model' &&
             node.config?.materialized !== 'ephemeral',
     ) as DbtRawModelNode[];
+
     if (!isSupportedDbtAdapter(manifest.metadata)) {
         throw new ParseError(
             `dbt adapter not supported. Lightdash does not support adapter ${manifest.metadata.adapter_type}`,
@@ -345,7 +346,7 @@ export const getCompiledModels = async (
     if (args.select || args.exclude) {
         const spinner = GlobalState.startSpinner(`Filtering models`);
         try {
-            const { stdout, command } = await execa('dbt', [
+            const { stdout } = await execa('dbt', [
                 'ls',
                 ...(args.projectDir ? ['--project-dir', args.projectDir] : []),
                 ...(args.target ? ['--target', args.target] : []),
@@ -356,7 +357,6 @@ export const getCompiledModels = async (
                 '--resource-type=model',
                 '--output=json',
             ]);
-            GlobalState.debug(`> Compiled models: ${command}`);
             const filteredModelIds = stdout
                 .split('\n')
                 .map((l) => l.trim())

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -336,6 +336,7 @@ export const getCompiledModels = async (
         select: string[] | undefined;
         exclude: string[] | undefined;
         projectDir: string | undefined;
+        profilesDir: string | undefined;
         target: string | undefined;
         profile: string | undefined;
         vars: string | undefined;
@@ -349,6 +350,9 @@ export const getCompiledModels = async (
             const { stdout } = await execa('dbt', [
                 'ls',
                 ...(args.projectDir ? ['--project-dir', args.projectDir] : []),
+                ...(args.profilesDir
+                    ? ['--profiles-dir', args.profilesDir]
+                    : []),
                 ...(args.target ? ['--target', args.target] : []),
                 ...(args.profile ? ['--profile', args.profile] : []),
                 ...(args.select ? ['--select', args.select.join(' ')] : []),

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -349,8 +349,8 @@ export const getCompiledModels = async (
         try {
             const { stdout } = await execa('dbt', [
                 'ls',
-                '--profiles-dir',
-                args.profilesDir,
+                // '--profiles-dir',
+                // args.profilesDir,
                 '--project-dir',
                 args.projectDir,
                 ...(args.target ? ['--target', args.target] : []),

--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -3,6 +3,7 @@ import * as styles from './styles';
 
 type PromptAnswer = {
     useFallbackDbtVersion?: boolean;
+    useExperimentalDbtCloudCLI?: boolean;
 };
 
 class GlobalState {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -1,31 +1,21 @@
 import {
     attachTypesToModels,
     convertExplores,
-    CreateBigqueryCredentials,
-    DbtManifest,
     DbtManifestVersion,
-    Explore,
-    ExploreError,
     getDbtManifestVersion,
     getSchemaStructureFromDbtModels,
     isExploreError,
     isSupportedDbtAdapter,
-    isWeekDay,
     ParseError,
+    SupportedDbtAdapter,
     WarehouseCatalog,
-    WarehouseTypes,
 } from '@lightdash/common';
-import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getDbtContext } from '../dbt/context';
 import { loadManifest } from '../dbt/manifest';
 import { getModelsFromManifest } from '../dbt/models';
-import {
-    loadDbtTarget,
-    warehouseCredentialsFromDbtTarget,
-} from '../dbt/profile';
 import { validateDbtModel } from '../dbt/validation';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
@@ -35,6 +25,7 @@ import {
     maybeCompileModelsAndJoins,
 } from './dbt/compile';
 import { getDbtVersion } from './dbt/getDbtVersion';
+import getWarehouseClient from './dbt/getWarehouseClient';
 
 export type CompileHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -46,177 +37,7 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     startOfWeek?: number;
 };
 
-type DbtCloudCompileHandlerOptions = DbtCompileOptions & {
-    startOfWeek?: number;
-};
-
-type CompileResult = {
-    explores: (Explore | ExploreError)[];
-    errors: number;
-    manifest: DbtManifest;
-};
-
-export const compileDbtCloud = async (
-    options: DbtCloudCompileHandlerOptions,
-): Promise<CompileResult> => {
-    const dbtVersion = await getDbtVersion();
-    GlobalState.debug(`> dbt version ${dbtVersion.verboseVersion}`);
-    const executionId = uuidv4();
-    await LightdashAnalytics.track({
-        event: 'compile.started',
-        properties: {
-            executionId,
-            dbtVersion: dbtVersion.verboseVersion,
-            useDbtList: !!options.useDbtList,
-            skipWarehouseCatalog: !!options.skipWarehouseCatalog,
-            skipDbtCompile: !!options.skipDbtCompile,
-        },
-    });
-
-    const absoluteProjectPath = path.resolve('.');
-
-    GlobalState.debug(`> Compiling with project dir ${absoluteProjectPath}`);
-
-    const context = await getDbtContext({ projectDir: absoluteProjectPath });
-
-    const compiledModelIds: string[] | undefined =
-        await maybeCompileModelsAndJoins(
-            { targetDir: context.targetDir },
-            options,
-        );
-
-    const profileName = options.profile || context.profileName;
-
-    GlobalState.debug(`> Compiling with profile ${profileName}`);
-
-    // TODO: Implement this
-    const mockDbtCloudCredentials: CreateBigqueryCredentials = {
-        type: WarehouseTypes.BIGQUERY,
-        project: '',
-        dataset: '',
-        keyfileContents: {},
-        location: undefined,
-        maximumBytesBilled: undefined,
-        priority: undefined,
-        retries: undefined,
-        timeoutSeconds: undefined,
-    };
-
-    const warehouseClient = warehouseClientFromCredentials({
-        ...mockDbtCloudCredentials,
-        startOfWeek: isWeekDay(options.startOfWeek)
-            ? options.startOfWeek
-            : undefined,
-    });
-
-    const manifest = await loadManifest({ targetDir: context.targetDir });
-    const manifestVersion = getDbtManifestVersion(manifest);
-    const manifestModels = getModelsFromManifest(manifest);
-    const compiledModels = getCompiledModels(manifestModels, compiledModelIds);
-
-    const adapterType = manifest.metadata.adapter_type;
-    const { valid: validModels, invalid: failedExplores } =
-        await validateDbtModel(adapterType, manifestVersion, compiledModels);
-
-    if (failedExplores.length > 0) {
-        const errors = failedExplores.map((failedExplore) =>
-            failedExplore.errors.map(
-                (error) => `- ${failedExplore.name}: ${error.message}\n`,
-            ),
-        );
-        console.error(
-            styles.warning(`Found ${
-                failedExplores.length
-            } errors when validating dbt models:
-${errors.join('')}`),
-        );
-    }
-
-    // Skipping assumes yml has the field types.
-    const catalog: WarehouseCatalog = {};
-    // if (!options.skipWarehouseCatalog) {
-    //     GlobalState.debug('> Fetching warehouse catalog');
-    //     catalog = await warehouseClient.getCatalog(
-    //         getSchemaStructureFromDbtModels(validModels),
-    //     );
-    // } else {
-    //     GlobalState.debug('> Skipping warehouse catalog');
-    // }
-
-    const validModelsWithTypes = attachTypesToModels(
-        validModels,
-        catalog,
-        false,
-    );
-
-    if (!isSupportedDbtAdapter(manifest.metadata)) {
-        await LightdashAnalytics.track({
-            event: 'compile.error',
-            properties: {
-                executionId,
-                dbtVersion: dbtVersion.verboseVersion,
-                error: `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
-            },
-        });
-        throw new ParseError(
-            `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
-        );
-    }
-
-    GlobalState.debug(
-        `> Converting explores with adapter: ${manifest.metadata.adapter_type}`,
-    );
-    const validExplores = await convertExplores(
-        validModelsWithTypes,
-        false,
-        manifest.metadata.adapter_type,
-        [
-            DbtManifestVersion.V10,
-            DbtManifestVersion.V11,
-            DbtManifestVersion.V12,
-        ].includes(manifestVersion)
-            ? []
-            : Object.values(manifest.metrics),
-        warehouseClient,
-    );
-    console.error('');
-
-    const explores = [...validExplores, ...failedExplores];
-
-    explores.forEach((e) => {
-        const status = isExploreError(e)
-            ? styles.error('ERROR')
-            : styles.success('SUCCESS');
-        const errors = isExploreError(e)
-            ? `: ${styles.error(e.errors.map((err) => err.message).join(', '))}`
-            : '';
-        console.error(`- ${status}> ${e.name} ${errors}`);
-    });
-    console.error('');
-    const errors = explores.filter((e) => isExploreError(e)).length;
-    console.error(
-        `Compiled ${explores.length} explores, SUCCESS=${
-            explores.length - errors
-        } ERRORS=${errors}`,
-    );
-
-    await LightdashAnalytics.track({
-        event: 'compile.completed',
-        properties: {
-            executionId,
-            explores: explores.length,
-            errors,
-            dbtMetrics: Object.values(manifest.metrics).length,
-            dbtVersion: dbtVersion.verboseVersion,
-        },
-    });
-    return {
-        explores,
-        errors,
-        manifest,
-    };
-};
-export const compileDbtCore = async (options: CompileHandlerOptions) => {
+export const compile = async (options: CompileHandlerOptions) => {
     const dbtVersion = await getDbtVersion();
     GlobalState.debug(`> dbt version ${dbtVersion}`);
     const executionId = uuidv4();
@@ -231,17 +52,9 @@ export const compileDbtCore = async (options: CompileHandlerOptions) => {
         },
     });
 
-    if (!options.projectDir || !options.profilesDir) {
-        throw new Error(
-            'project dir and profiles dir are required for dbt core',
-        );
-    }
-
     const absoluteProjectPath = path.resolve(options.projectDir);
-    const absoluteProfilesPath = path.resolve(options.profilesDir);
 
     GlobalState.debug(`> Compiling with project dir ${absoluteProjectPath}`);
-    GlobalState.debug(`> Compiling with profiles dir ${absoluteProfilesPath}`);
 
     const context = await getDbtContext({ projectDir: absoluteProjectPath });
 
@@ -251,25 +64,15 @@ export const compileDbtCore = async (options: CompileHandlerOptions) => {
             options,
         );
 
-    const profileName = options.profile || context.profileName;
-    const { target } = await loadDbtTarget({
-        profilesDir: absoluteProfilesPath,
-        profileName,
-        targetName: options.target,
-    });
-
-    GlobalState.debug(`> Compiling with profile ${profileName}`);
-    GlobalState.debug(`> Compiling with target ${target}`);
-
-    const credentials = await warehouseCredentialsFromDbtTarget(target);
-    const warehouseClient = warehouseClientFromCredentials({
-        ...credentials,
-        startOfWeek: isWeekDay(options.startOfWeek)
-            ? options.startOfWeek
-            : undefined,
-    });
-
     const manifest = await loadManifest({ targetDir: context.targetDir });
+    const warehouseClient = await getWarehouseClient({
+        isDbtCloudCLI: dbtVersion.isDbtCloudCLI,
+        dbtAdaptorType: manifest.metadata.adapter_type as SupportedDbtAdapter,
+        profilesDir: options.profilesDir,
+        profile: options.profile || context.profileName,
+        target: options.target,
+        startOfWeek: options.startOfWeek,
+    });
     const manifestVersion = getDbtManifestVersion(manifest);
     const manifestModels = getModelsFromManifest(manifest);
     const compiledModels = getCompiledModels(manifestModels, compiledModelIds);
@@ -370,21 +173,6 @@ ${errors.join('')}`),
             dbtVersion: dbtVersion.verboseVersion,
         },
     });
-    return {
-        explores,
-        errors,
-        manifest,
-    };
-};
-export const compile = async (options: CompileHandlerOptions) => {
-    const dbtVersion = await getDbtVersion();
-    const { explores } = dbtVersion.isDbtCloudCLI
-        ? await compileDbtCloud({
-              ...options,
-              projectDir: undefined,
-              profilesDir: undefined,
-          })
-        : await compileDbtCore(options);
     return explores;
 };
 export const compileHandler = async (options: CompileHandlerOptions) => {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -1,7 +1,11 @@
 import {
     attachTypesToModels,
     convertExplores,
+    CreateBigqueryCredentials,
+    DbtManifest,
     DbtManifestVersion,
+    Explore,
+    ExploreError,
     getDbtManifestVersion,
     getSchemaStructureFromDbtModels,
     isExploreError,
@@ -9,6 +13,7 @@ import {
     isWeekDay,
     ParseError,
     WarehouseCatalog,
+    WarehouseTypes,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import path from 'path';
@@ -41,7 +46,177 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     startOfWeek?: number;
 };
 
-export const compile = async (options: CompileHandlerOptions) => {
+type DbtCloudCompileHandlerOptions = DbtCompileOptions & {
+    startOfWeek?: number;
+};
+
+type CompileResult = {
+    explores: (Explore | ExploreError)[];
+    errors: number;
+    manifest: DbtManifest;
+};
+
+export const compileDbtCloud = async (
+    options: DbtCloudCompileHandlerOptions,
+): Promise<CompileResult> => {
+    const dbtVersion = await getDbtVersion();
+    GlobalState.debug(`> dbt version ${dbtVersion.verboseVersion}`);
+    const executionId = uuidv4();
+    await LightdashAnalytics.track({
+        event: 'compile.started',
+        properties: {
+            executionId,
+            dbtVersion: dbtVersion.verboseVersion,
+            useDbtList: !!options.useDbtList,
+            skipWarehouseCatalog: !!options.skipWarehouseCatalog,
+            skipDbtCompile: !!options.skipDbtCompile,
+        },
+    });
+
+    const absoluteProjectPath = path.resolve('.');
+
+    GlobalState.debug(`> Compiling with project dir ${absoluteProjectPath}`);
+
+    const context = await getDbtContext({ projectDir: absoluteProjectPath });
+
+    const compiledModelIds: string[] | undefined =
+        await maybeCompileModelsAndJoins(
+            { targetDir: context.targetDir },
+            options,
+        );
+
+    const profileName = options.profile || context.profileName;
+
+    GlobalState.debug(`> Compiling with profile ${profileName}`);
+
+    // TODO: Implement this
+    const mockDbtCloudCredentials: CreateBigqueryCredentials = {
+        type: WarehouseTypes.BIGQUERY,
+        project: '',
+        dataset: '',
+        keyfileContents: {},
+        location: undefined,
+        maximumBytesBilled: undefined,
+        priority: undefined,
+        retries: undefined,
+        timeoutSeconds: undefined,
+    };
+
+    const warehouseClient = warehouseClientFromCredentials({
+        ...mockDbtCloudCredentials,
+        startOfWeek: isWeekDay(options.startOfWeek)
+            ? options.startOfWeek
+            : undefined,
+    });
+
+    const manifest = await loadManifest({ targetDir: context.targetDir });
+    const manifestVersion = getDbtManifestVersion(manifest);
+    const manifestModels = getModelsFromManifest(manifest);
+    const compiledModels = getCompiledModels(manifestModels, compiledModelIds);
+
+    const adapterType = manifest.metadata.adapter_type;
+    const { valid: validModels, invalid: failedExplores } =
+        await validateDbtModel(adapterType, manifestVersion, compiledModels);
+
+    if (failedExplores.length > 0) {
+        const errors = failedExplores.map((failedExplore) =>
+            failedExplore.errors.map(
+                (error) => `- ${failedExplore.name}: ${error.message}\n`,
+            ),
+        );
+        console.error(
+            styles.warning(`Found ${
+                failedExplores.length
+            } errors when validating dbt models:
+${errors.join('')}`),
+        );
+    }
+
+    // Skipping assumes yml has the field types.
+    const catalog: WarehouseCatalog = {};
+    // if (!options.skipWarehouseCatalog) {
+    //     GlobalState.debug('> Fetching warehouse catalog');
+    //     catalog = await warehouseClient.getCatalog(
+    //         getSchemaStructureFromDbtModels(validModels),
+    //     );
+    // } else {
+    //     GlobalState.debug('> Skipping warehouse catalog');
+    // }
+
+    const validModelsWithTypes = attachTypesToModels(
+        validModels,
+        catalog,
+        false,
+    );
+
+    if (!isSupportedDbtAdapter(manifest.metadata)) {
+        await LightdashAnalytics.track({
+            event: 'compile.error',
+            properties: {
+                executionId,
+                dbtVersion: dbtVersion.verboseVersion,
+                error: `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
+            },
+        });
+        throw new ParseError(
+            `Dbt adapter ${manifest.metadata.adapter_type} is not supported`,
+        );
+    }
+
+    GlobalState.debug(
+        `> Converting explores with adapter: ${manifest.metadata.adapter_type}`,
+    );
+    const validExplores = await convertExplores(
+        validModelsWithTypes,
+        false,
+        manifest.metadata.adapter_type,
+        [
+            DbtManifestVersion.V10,
+            DbtManifestVersion.V11,
+            DbtManifestVersion.V12,
+        ].includes(manifestVersion)
+            ? []
+            : Object.values(manifest.metrics),
+        warehouseClient,
+    );
+    console.error('');
+
+    const explores = [...validExplores, ...failedExplores];
+
+    explores.forEach((e) => {
+        const status = isExploreError(e)
+            ? styles.error('ERROR')
+            : styles.success('SUCCESS');
+        const errors = isExploreError(e)
+            ? `: ${styles.error(e.errors.map((err) => err.message).join(', '))}`
+            : '';
+        console.error(`- ${status}> ${e.name} ${errors}`);
+    });
+    console.error('');
+    const errors = explores.filter((e) => isExploreError(e)).length;
+    console.error(
+        `Compiled ${explores.length} explores, SUCCESS=${
+            explores.length - errors
+        } ERRORS=${errors}`,
+    );
+
+    await LightdashAnalytics.track({
+        event: 'compile.completed',
+        properties: {
+            executionId,
+            explores: explores.length,
+            errors,
+            dbtMetrics: Object.values(manifest.metrics).length,
+            dbtVersion: dbtVersion.verboseVersion,
+        },
+    });
+    return {
+        explores,
+        errors,
+        manifest,
+    };
+};
+export const compileDbtCore = async (options: CompileHandlerOptions) => {
     const dbtVersion = await getDbtVersion();
     GlobalState.debug(`> dbt version ${dbtVersion}`);
     const executionId = uuidv4();
@@ -55,6 +230,12 @@ export const compile = async (options: CompileHandlerOptions) => {
             skipDbtCompile: !!options.skipDbtCompile,
         },
     });
+
+    if (!options.projectDir || !options.profilesDir) {
+        throw new Error(
+            'project dir and profiles dir are required for dbt core',
+        );
+    }
 
     const absoluteProjectPath = path.resolve(options.projectDir);
     const absoluteProfilesPath = path.resolve(options.profilesDir);
@@ -189,6 +370,21 @@ ${errors.join('')}`),
             dbtVersion: dbtVersion.verboseVersion,
         },
     });
+    return {
+        explores,
+        errors,
+        manifest,
+    };
+};
+export const compile = async (options: CompileHandlerOptions) => {
+    const dbtVersion = await getDbtVersion();
+    const { explores } = dbtVersion.isDbtCloudCLI
+        ? await compileDbtCloud({
+              ...options,
+              projectDir: undefined,
+              profilesDir: undefined,
+          })
+        : await compileDbtCore(options);
     return explores;
 };
 export const compileHandler = async (options: CompileHandlerOptions) => {

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -1,7 +1,6 @@
 import {
     CreateProject,
     DbtProjectType,
-    isWeekDay,
     ProjectType,
     WarehouseTypes,
     type ApiCreateProjectResults,
@@ -10,14 +9,12 @@ import inquirer from 'inquirer';
 import path from 'path';
 import { getConfig, setAnswer } from '../config';
 import { getDbtContext } from '../dbt/context';
-import {
-    loadDbtTarget,
-    warehouseCredentialsFromDbtTarget,
-} from '../dbt/profile';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { lightdashApi } from './dbt/apiClient';
+import getDbtProfileTargetName from './dbt/getDbtProfileTargetName';
 import { getDbtVersion } from './dbt/getDbtVersion';
+import getWarehouseClient from './dbt/getWarehouseClient';
 
 const askToRememberAnswer = async (): Promise<void> => {
     const answers = await inquirer.prompt([
@@ -81,20 +78,27 @@ export const createProject = async (
     const dbtVersion = await getDbtVersion();
 
     const absoluteProjectPath = path.resolve(options.projectDir);
-    const absoluteProfilesPath = path.resolve(options.profilesDir);
     const context = await getDbtContext({ projectDir: absoluteProjectPath });
-    const profileName = options.profile || context.profileName;
-    const { target, name: targetName } = await loadDbtTarget({
-        profilesDir: absoluteProfilesPath,
-        profileName,
-        targetName: options.target,
+    const targetName = await getDbtProfileTargetName({
+        isDbtCloudCLI: dbtVersion.isDbtCloudCLI,
+        profilesDir: options.profilesDir,
+        profile: options.profile || context.profileName,
+        target: options.target,
     });
     const canStoreWarehouseCredentials =
         await askPermissionToStoreWarehouseCredentials();
     if (!canStoreWarehouseCredentials) {
         return undefined;
     }
-    const credentials = await warehouseCredentialsFromDbtTarget(target);
+
+    const { credentials } = await getWarehouseClient({
+        isDbtCloudCLI: dbtVersion.isDbtCloudCLI,
+        profilesDir: options.profilesDir,
+        profile: options.profile || context.profileName,
+        target: options.target,
+        startOfWeek: options.startOfWeek,
+    });
+
     if (
         credentials.type === WarehouseTypes.BIGQUERY &&
         'project_id' in credentials.keyfileContents &&
@@ -125,12 +129,7 @@ export const createProject = async (
     const project: CreateProject = {
         name: options.name,
         type: options.type,
-        warehouseConnection: {
-            ...credentials,
-            startOfWeek: isWeekDay(options.startOfWeek)
-                ? options.startOfWeek
-                : undefined,
-        },
+        warehouseConnection: credentials,
         dbtConnection: {
             type: DbtProjectType.NONE,
             target: targetName,

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -130,6 +130,7 @@ export const createProject = async (
         name: options.name,
         type: options.type,
         warehouseConnection: credentials,
+        copyWarehouseConnectionFromUpstreamProject: dbtVersion.isDbtCloudCLI,
         dbtConnection: {
             type: DbtProjectType.NONE,
             target: targetName,

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -145,7 +145,12 @@ async function dbtList(options: DbtCompileOptions): Promise<string[]> {
             .split('\n')
             .map<string>((line) => {
                 try {
-                    return JSON.parse(line).unique_id;
+                    // remove prefixed time in dbt cloud cli output
+                    const lineWithoutPrefixedTime = line.replace(
+                        /^\d{2}:\d{2}:\d{2}\s*/,
+                        '',
+                    );
+                    return JSON.parse(lineWithoutPrefixedTime).unique_id;
                 } catch {
                     // ignore non-json lines
                     return '';

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -165,8 +165,18 @@ async function dbtList(options: DbtCompileOptions): Promise<string[]> {
 
 export async function maybeCompileModelsAndJoins(
     loadManifestOpts: LoadManifestArgs,
-    options: DbtCompileOptions,
+    initialOptions: DbtCompileOptions,
 ): Promise<string[] | undefined> {
+    const dbtVersion = await getDbtVersion();
+    let options = initialOptions;
+    if (dbtVersion.isDbtCloudCLI) {
+        options = {
+            ...initialOptions,
+            projectDir: undefined,
+            profilesDir: undefined,
+        };
+    }
+
     // Skipping assumes manifest.json already exists.
     if (options.skipDbtCompile) {
         GlobalState.debug('> Skipping dbt compile');

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -11,8 +11,8 @@ import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
 
 export type DbtCompileOptions = {
-    profilesDir: string;
-    projectDir: string;
+    profilesDir: string | undefined;
+    projectDir: string | undefined;
     target: string | undefined;
     profile: string | undefined;
     select: string[] | undefined;

--- a/packages/cli/src/handlers/dbt/getDbtProfileTargetName.ts
+++ b/packages/cli/src/handlers/dbt/getDbtProfileTargetName.ts
@@ -1,0 +1,55 @@
+import { ParseError } from '@lightdash/common';
+import execa from 'execa';
+import path from 'path';
+import { loadDbtTarget } from '../../dbt/profile';
+import GlobalState from '../../globalState';
+
+const DBT_CLOUD_TARGET_NAME_REGEX = /Target name\s+(\w+)/;
+
+const getDbtCloudTargetName = async (): Promise<string> => {
+    try {
+        const { all } = await execa('dbt', ['environment', 'show'], {
+            all: true,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        const logs = all || '';
+        const targetName = logs.match(DBT_CLOUD_TARGET_NAME_REGEX);
+        if (targetName === null || targetName.length === 0) {
+            throw new ParseError(
+                `Can't locate profile target name in 'dbt environment show' response`,
+            );
+        }
+        return targetName[1];
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '-';
+        throw new ParseError(`Failed to get profile target name:\n  ${msg}`);
+    }
+};
+
+type GetDbtProfileTargetNameOptions = {
+    isDbtCloudCLI: boolean;
+    profilesDir: string;
+    profile: string;
+    target?: string;
+};
+
+export default async function getDbtProfileTargetName(
+    options: GetDbtProfileTargetNameOptions,
+): Promise<string> {
+    let targetName;
+    if (options.isDbtCloudCLI) {
+        targetName = await getDbtCloudTargetName();
+    } else {
+        const absoluteProfilesPath = path.resolve(options.profilesDir);
+        GlobalState.debug(
+            `> Using profiles dir ${absoluteProfilesPath} and profile ${options.profile}`,
+        );
+        const { name } = await loadDbtTarget({
+            profilesDir: absoluteProfilesPath,
+            profileName: options.profile,
+            targetName: options.target,
+        });
+        targetName = name;
+    }
+    return targetName;
+}

--- a/packages/cli/src/handlers/dbt/getDbtVersion.mocks.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.mocks.ts
@@ -44,6 +44,9 @@ export const cliMocks = {
             '  - snowflake:  1.9.0 - Up to date!\n' +
             '  - postgres:   1.9.0 - Up to date!\n',
     } as Partial<ExecaReturnValue>,
+    dbtCloud: {
+        all: 'dbt Cloud CLI - 0.38.22 (1183c2abdb6003083b0fa91fcd89cd5feb25f9f7 2024-11-20T15:49:01Z)',
+    } as Partial<ExecaReturnValue>,
     dbt20_1: {
         all:
             'Core:\n' +

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -1,4 +1,5 @@
 import {
+    DbtVersionOptionLatest,
     getLatestSupportDbtVersion,
     SupportedDbtVersions,
 } from '@lightdash/common';
@@ -47,6 +48,16 @@ describe('Get dbt version', () => {
             const version2 = await getDbtVersion();
             expect(version2.verboseVersion).toEqual('1.9.1');
             expect(version2.versionOption).toEqual(SupportedDbtVersions.V1_9);
+        });
+        test('should return latest for dbt cloud', async () => {
+            execaMock.mockImplementation(async () => cliMocks.dbtCloud);
+            const version3 = await getDbtVersion();
+            expect(version3.verboseVersion).toEqual(
+                expect.stringContaining('dbt Cloud CLI'),
+            );
+            expect(version3.versionOption).toEqual(
+                DbtVersionOptionLatest.LATEST,
+            );
         });
         test('when CI=true, should warn user about unsupported version and return fallback', async () => {
             process.env.CI = 'true';

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -89,12 +89,15 @@ describe('Get dbt version', () => {
             expect(consoleError).toHaveBeenCalledTimes(0);
         });
         test('when CI=false, should return error if user declines fallback', async () => {
+            const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
             process.env.CI = 'false';
             execaMock.mockImplementation(async () => cliMocks.dbt1_3);
             promptMock.mockImplementation(async () => ({ isConfirm: false }));
-            await expect(getDbtVersion()).rejects.toThrowError();
+            await getDbtVersion();
             expect(promptMock).toHaveBeenCalledTimes(1);
-            expect(consoleError).toHaveBeenCalledTimes(0);
+            expect(consoleError).toHaveBeenCalledTimes(1);
+            expect(exitSpy).toHaveBeenCalledWith(1);
+            exitSpy.mockRestore();
         });
     });
 });

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -93,9 +93,12 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
                 },
             ]);
             if (!answers.isConfirm) {
-                throw new Error(
-                    `Unsupported dbt version ${verboseVersion}. Please consider using a supported version (${supportedVersionsRangeMessage}).`,
+                console.error(
+                    styles.error(
+                        `Unsupported dbt version ${verboseVersion}. Please consider using a supported version (${supportedVersionsRangeMessage}).`,
+                    ),
                 );
+                process.exit(1);
             }
         }
         spinner?.start();
@@ -122,9 +125,12 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
                 },
             ]);
             if (!answers.isConfirm) {
-                throw new Error(
-                    `Unsupported dbt version ${verboseVersion}. Please consider using dbt core CLI for the best experience.`,
+                console.error(
+                    styles.error(
+                        `Command using dbt cloud CLI has been canceled. Please consider using dbt core CLI for the best experience.`,
+                    ),
                 );
+                process.exit(1);
             }
         }
         spinner?.start();

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -1,5 +1,6 @@
 import {
     DbtVersionOption,
+    DbtVersionOptionLatest,
     getLatestSupportDbtVersion,
     ParseError,
     SupportedDbtVersions,
@@ -10,6 +11,7 @@ import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 
 const DBT_CORE_VERSION_REGEX = /installed:.*/;
+export const DBT_CLOUD_CLI_REGEX = /dbt Cloud CLI.*/;
 
 const getDbtCLIVersion = async () => {
     try {
@@ -18,6 +20,10 @@ const getDbtCLIVersion = async () => {
             stdio: ['pipe', 'pipe', 'pipe'],
         });
         const logs = all || '';
+        const cloudVersion = logs.match(DBT_CLOUD_CLI_REGEX);
+        if (cloudVersion) {
+            return cloudVersion[0];
+        }
         const version = logs.match(DBT_CORE_VERSION_REGEX);
         if (version === null || version.length === 0)
             throw new ParseError(`Can't locate dbt --version: ${logs}`);
@@ -28,9 +34,14 @@ const getDbtCLIVersion = async () => {
     }
 };
 
+const isDbtCloudCLI = (version: string): boolean =>
+    version.match(DBT_CLOUD_CLI_REGEX) !== null;
+
 const getSupportedDbtVersionOption = (
     version: string,
 ): DbtVersionOption | null => {
+    if (version.match(DBT_CLOUD_CLI_REGEX))
+        return DbtVersionOptionLatest.LATEST;
     if (version.startsWith('1.4.')) return SupportedDbtVersions.V1_4;
     if (version.startsWith('1.5.')) return SupportedDbtVersions.V1_5;
     if (version.startsWith('1.6.')) return SupportedDbtVersions.V1_6;
@@ -50,6 +61,7 @@ const getFallbackDbtVersionOption = (version: string): DbtVersionOption => {
 type DbtVersion = {
     verboseVersion: string; // Verbose version returned by dbt --version
     versionOption: DbtVersionOption; // The supported version by Lightdash
+    isDbtCloudCLI: boolean; // Whether the version is dbt Cloud CLI
 };
 
 export const getDbtVersion = async (): Promise<DbtVersion> => {
@@ -92,6 +104,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
 
     return {
         verboseVersion,
+        isDbtCloudCLI: isDbtCloudCLI(verboseVersion),
         versionOption: supportedVersionOption ?? fallbackVersionOption,
     };
 };

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -106,7 +106,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
         isDbtCloudCLI(verboseVersion) &&
         !GlobalState.getSavedPromptAnswer('useExperimentalDbtCloudCLI')
     ) {
-        const message = `Support for dbt Cloud CLI is still experimental and might not work as expected. Please consider using dbt core CLI for the best experience.`;
+        const message = `Support for dbt Cloud CLI is still experimental and might not work as expected.`;
         const spinner = GlobalState.getActiveSpinner();
         spinner?.stop();
         if (process.env.CI === 'true') {
@@ -123,7 +123,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
             ]);
             if (!answers.isConfirm) {
                 throw new Error(
-                    `Unsupported dbt version ${verboseVersion}. Please consider using dbt core CLI.`,
+                    `Unsupported dbt version ${verboseVersion}. Please consider using dbt core CLI for the best experience.`,
                 );
             }
         }

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -21,7 +21,6 @@ import {
 import GlobalState from '../../globalState';
 import { lightdashApi } from './apiClient';
 
-// /api/v1/projects/b5c8914d-ff8b-41b0-ba1b-4e7403451f53/sqlRunner/fields?tableName=events_partitioned&schemaName=e2e_jaffle_shop
 type GetTableCatalogProps = {
     projectUuid: string;
     tableName: string;

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -1,0 +1,177 @@
+import {
+    assertUnreachable,
+    CreateWarehouseCredentials,
+    isWeekDay,
+    SupportedDbtAdapter,
+    WarehouseTypes,
+} from '@lightdash/common';
+import { warehouseClientFromCredentials } from '@lightdash/warehouses';
+import path from 'path';
+import {
+    loadDbtTarget,
+    warehouseCredentialsFromDbtTarget,
+} from '../../dbt/profile';
+import GlobalState from '../../globalState';
+
+function getMockCredentials(
+    dbtAdaptorType: SupportedDbtAdapter,
+): CreateWarehouseCredentials {
+    let credentials: CreateWarehouseCredentials;
+    switch (dbtAdaptorType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            credentials = {
+                type: WarehouseTypes.BIGQUERY,
+                project: '',
+                dataset: '',
+                timeoutSeconds: undefined,
+                priority: undefined,
+                keyfileContents: {},
+                retries: undefined,
+                location: undefined,
+                maximumBytesBilled: undefined,
+            };
+            break;
+        case SupportedDbtAdapter.POSTGRES:
+            credentials = {
+                type: WarehouseTypes.POSTGRES,
+                host: '',
+                user: '',
+                password: '',
+                port: 5432,
+                dbname: '',
+                schema: '',
+            };
+            break;
+        case SupportedDbtAdapter.REDSHIFT:
+            credentials = {
+                type: WarehouseTypes.REDSHIFT,
+                host: '',
+                user: '',
+                password: '',
+                port: 5432,
+                dbname: '',
+                schema: '',
+            };
+            break;
+        case SupportedDbtAdapter.SNOWFLAKE:
+            credentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: '',
+                user: '',
+                password: '',
+                warehouse: '',
+                database: '',
+                schema: '',
+                role: '',
+            };
+            break;
+
+        case SupportedDbtAdapter.DATABRICKS:
+            credentials = {
+                type: WarehouseTypes.DATABRICKS,
+                catalog: '',
+                database: '',
+                serverHostName: '',
+                httpPath: '',
+                personalAccessToken: '',
+            };
+            break;
+        case SupportedDbtAdapter.TRINO:
+            credentials = {
+                type: WarehouseTypes.TRINO,
+                host: '',
+                user: '',
+                password: '',
+                port: 5432,
+                dbname: '',
+                schema: '',
+                http_scheme: '',
+            };
+            break;
+        default:
+            assertUnreachable(
+                dbtAdaptorType,
+                `Unsupported dbt adaptor type ${dbtAdaptorType}`,
+            );
+    }
+    return credentials;
+}
+
+type GetWarehouseClientOptions = {
+    isDbtCloudCLI: boolean;
+    dbtAdaptorType: SupportedDbtAdapter;
+    profilesDir: string;
+    profile: string;
+    target?: string;
+    startOfWeek?: number;
+};
+
+export default async function getWarehouseClient(
+    options: GetWarehouseClientOptions,
+) {
+    let warehouseClient;
+    if (options.isDbtCloudCLI) {
+        GlobalState.debug(`> Using ${options.dbtAdaptorType} client mock`);
+        warehouseClient = warehouseClientFromCredentials({
+            ...getMockCredentials(options.dbtAdaptorType),
+            startOfWeek: isWeekDay(options.startOfWeek)
+                ? options.startOfWeek
+                : undefined,
+        });
+        // Overwrite methods that need to connect to the warehouse
+        warehouseClient.getCatalog = async () => {
+            GlobalState.debug(
+                `> WarehouseClient.getCatalog() is not supported with dbt Cloud CLI. An empty catalog will be used.`,
+            );
+            return {};
+        };
+        warehouseClient.streamQuery = async (_query, streamCallback) => {
+            GlobalState.debug(
+                `> WarehouseClient.streamQuery() is not supported with dbt Cloud CLI. An empty result will be used.`,
+            );
+            return streamCallback({ fields: {}, rows: [] });
+        };
+        warehouseClient.runQuery = async () => {
+            GlobalState.debug(
+                `> WarehouseClient.runQuery() is not supported with dbt Cloud CLI. An empty result will be used.`,
+            );
+            return { fields: {}, rows: [] };
+        };
+        warehouseClient.test = async () => {
+            GlobalState.debug(
+                `> WarehouseClient.test() is not supported with dbt Cloud CLI. No test will be run.`,
+            );
+        };
+        warehouseClient.getAllTables = async () => {
+            GlobalState.debug(
+                `> WarehouseClient.getAllTables() is not supported with dbt Cloud CLI. An empty result will be used.`,
+            );
+            return [];
+        };
+        warehouseClient.getFields = async () => {
+            GlobalState.debug(
+                `> WarehouseClient.getFields() is not supported with dbt Cloud CLI. An empty result will be used.`,
+            );
+            return { fields: {} };
+        };
+    } else {
+        const absoluteProfilesPath = path.resolve(options.profilesDir);
+        GlobalState.debug(
+            `> Using profiles dir ${absoluteProfilesPath} and profile ${options.profile}`,
+        );
+        const { target } = await loadDbtTarget({
+            profilesDir: absoluteProfilesPath,
+            profileName: options.profile,
+            targetName: options.target,
+        });
+        GlobalState.debug(`> Using target ${target}`);
+        const credentials = await warehouseCredentialsFromDbtTarget(target);
+        warehouseClient = warehouseClientFromCredentials({
+            ...credentials,
+            startOfWeek: isWeekDay(options.startOfWeek)
+                ? options.startOfWeek
+                : undefined,
+        });
+    }
+    return warehouseClient;
+}

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -194,7 +194,7 @@ export default async function getWarehouseClient(
                     const fields = await getTableSchema({
                         projectUuid: config.context.project,
                         tableName: ref.table,
-                        schemaName: 'e2e_jaffle_shop', // ref.schema,
+                        schemaName: ref.schema,
                     });
                     acc[ref.database] = {
                         [ref.schema]: {

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -7,6 +7,8 @@ import { generateHandler } from '../generate';
 import { DbtCompileOptions } from './compile';
 
 type DbtRunHandlerOptions = DbtCompileOptions & {
+    profilesDir: string;
+    projectDir: string;
     excludeMeta: boolean;
     verbose: boolean;
     assumeYes: boolean;

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -1,5 +1,4 @@
 import { ParseError } from '@lightdash/common';
-import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import { promises as fs } from 'fs';
 import inquirer from 'inquirer';
 import * as yaml from 'js-yaml';
@@ -14,15 +13,13 @@ import {
     getModelsFromManifest,
     getWarehouseTableForModel,
 } from '../dbt/models';
-import {
-    loadDbtTarget,
-    warehouseCredentialsFromDbtTarget,
-} from '../dbt/profile';
 import { getFileHeadComments } from '../dbt/schema';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { CompileHandlerOptions } from './compile';
 import { checkLightdashVersion } from './dbt/apiClient';
+import { getDbtVersion } from './dbt/getDbtVersion';
+import getWarehouseClient from './dbt/getWarehouseClient';
 
 type GenerateHandlerOptions = CompileHandlerOptions & {
     select: string[] | undefined;
@@ -65,40 +62,31 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     });
 
     const absoluteProjectPath = path.resolve(options.projectDir);
-    const absoluteProfilesPath = path.resolve(options.profilesDir);
 
     const context = await getDbtContext({
         projectDir: absoluteProjectPath,
     });
     const profileName = options.profile || context.profileName;
 
-    GlobalState.debug(
-        `> Loading profiles from directory: ${absoluteProfilesPath}`,
-    );
-
-    const { target } = await loadDbtTarget({
-        profilesDir: absoluteProfilesPath,
-        profileName,
-        targetName: options.target,
+    const dbtVersion = await getDbtVersion();
+    const { warehouseClient } = await getWarehouseClient({
+        isDbtCloudCLI: dbtVersion.isDbtCloudCLI,
+        profilesDir: options.profilesDir,
+        profile: options.profile || context.profileName,
+        target: options.target,
+        startOfWeek: options.startOfWeek,
     });
-
-    GlobalState.debug(`> Loaded target from profiles: ${target.type}`);
-
-    const credentials = await warehouseCredentialsFromDbtTarget(target);
-    const warehouseClient = warehouseClientFromCredentials(credentials);
     const manifest = await loadManifest({ targetDir: context.targetDir });
     const models = getModelsFromManifest(manifest);
-
+    console.error('models 3', models.length);
     const compiledModels = await getCompiledModels(models, {
-        projectDir: absoluteProjectPath,
-        profilesDir: absoluteProfilesPath,
-        profile: profileName,
+        projectDir: dbtVersion.isDbtCloudCLI ? undefined : absoluteProjectPath,
+        profile: dbtVersion.isDbtCloudCLI ? undefined : profileName,
         target: options.target,
         select: options.select || options.models,
         exclude: options.exclude,
         vars: options.vars || undefined,
     });
-
     GlobalState.debug(`> Compiled models: ${compiledModels.length}`);
 
     console.info(styles.info(`Generated .yml files:`));

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -80,6 +80,9 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     const models = getModelsFromManifest(manifest);
     const compiledModels = await getCompiledModels(models, {
         projectDir: dbtVersion.isDbtCloudCLI ? undefined : absoluteProjectPath,
+        profilesDir: dbtVersion.isDbtCloudCLI
+            ? undefined
+            : path.resolve(options.profilesDir),
         profile: dbtVersion.isDbtCloudCLI ? undefined : profileName,
         target: options.target,
         select: options.select || options.models,

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -78,7 +78,6 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     });
     const manifest = await loadManifest({ targetDir: context.targetDir });
     const models = getModelsFromManifest(manifest);
-    console.error('models 3', models.length);
     const compiledModels = await getCompiledModels(models, {
         projectDir: dbtVersion.isDbtCloudCLI ? undefined : absoluteProjectPath,
         profile: dbtVersion.isDbtCloudCLI ? undefined : profileName,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -889,6 +889,7 @@ export type CreateProject = Omit<
     | 'createdByUserUuid'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
+    copyWarehouseConnectionFromUpstreamProject?: boolean;
 };
 
 export type UpdateProject = Omit<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#9025](https://github.com/lightdash/lightdash/issues/9025)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Adding experimental support for dbt cloud CLI in the Lightdash CLI.

**Known limitation:**
1. dbt cloud doesn't expose credentials to the warehouse so for some commands we rely on the warehouse credentials from the active project. That means the credentials from the project should have access to all development/staging schemas.
Affected commands: `lightdash generate`, `lightdash preview` and `lightdash start-preview` 

2. Warehouse credentials will be empty when creating a new project that is not a preview. Upon creation, the user needs to update the project settings.

### Main code changes

- Move logic on how to get the warehouse client and target/profile data to separate functions which now handles the dbt cloud scenario.
- Adjust dbt commands to not have project and profile arguments as they are not supported in dbt cloud
- Allow previews to copy upstream warehouse credentials
- Handle "wrong" output from dbt cloud which prefixes json logs with timestamps

### How to test

1. First install dbt cloud CLI in a python virtual env to avoid issues with dbt core CLI
```
# Create python virtual env 
python -m venv dbt-cloud-env

# Activate virtual env
source dbt-cloud-env/bin/activate

# update pip
pip install --upgrade pip

# install dbt cloud CLI
pip install dbt

# check dbt version 
dbt --version

# if doesn't show correct version, deactivate virtual env
deactivate

# and activate again 
source dbt-cloud-env/bin/activate
```

2. Teach out to me for dbt cloud credentials.


### Demo
#### `lightdash preview` with new metric
<img width="1105" alt="Screenshot 2025-01-09 at 16 29 22" src="https://github.com/user-attachments/assets/c0f83785-c573-4d6e-9005-6b500b323051" />
<img width="464" alt="Screenshot 2025-01-09 at 16 29 33" src="https://github.com/user-attachments/assets/4d79cd6f-06fa-4039-9846-725a67f8239b" />
<img width="1322" alt="Screenshot 2025-01-09 at 16 29 49" src="https://github.com/user-attachments/assets/7378d1ff-4c6d-42bb-81a3-5f8b85e30d94" />

#### `lightdash compile` 
<img width="997" alt="Screenshot 2025-01-09 at 16 30 31" src="https://github.com/user-attachments/assets/0f9d1bd4-38fb-4ccf-9943-ad306afc197e" />

#### `lightdash generate` 
<img width="996" alt="Screenshot 2025-01-09 at 16 31 01" src="https://github.com/user-attachments/assets/6cb95a16-6798-4260-ae85-71c096ab816b" />

#### `lightdash deploy` 
<img width="982" alt="Screenshot 2025-01-09 at 17 45 12" src="https://github.com/user-attachments/assets/e76bebc1-70bd-4fc4-b81f-65d29b7d65ae" />

#### `lightdash deploy --create` 
<img width="1059" alt="Screenshot 2025-01-09 at 17 57 53" src="https://github.com/user-attachments/assets/2c004a22-6a12-49c9-8ddb-3fae23ff62e3" />

#### `lightdash validate` 
<img width="1007" alt="Screenshot 2025-01-09 at 18 00 29" src="https://github.com/user-attachments/assets/e684d49a-73f8-4859-a4f9-858c86e735cf" />

#### `lightdash start-preview` 
<img width="1248" alt="Screenshot 2025-01-09 at 18 03 40" src="https://github.com/user-attachments/assets/fe45a81a-ed61-4111-b36d-022c885695cc" />

#### Saying no to the prompt
<img width="981" alt="Screenshot 2025-01-09 at 18 31 20" src="https://github.com/user-attachments/assets/95489b87-c06c-4653-a63c-e425759ad756" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
