### PR TITLE
refactor: replace peek references with explore

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate } from 'react-router';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
-import { toggleMetricPeekModal } from '../store/metricsCatalogSlice';
+import { toggleMetricExploreModal } from '../store/metricsCatalogSlice';
 
 type Props = {
     row: MRT_Row<CatalogField>;
@@ -43,7 +43,7 @@ export const ExploreMetricButton = ({ row }: Props) => {
         });
 
         dispatch(
-            toggleMetricPeekModal({
+            toggleMetricExploreModal({
                 name: row.original.name,
                 tableName: row.original.tableName,
             }),

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
@@ -42,15 +42,15 @@ import { useCatalogSegmentDimensions } from '../hooks/useCatalogSegmentDimension
 import { useMetric } from '../hooks/useMetricsCatalog';
 import { useRunMetricExplorerQuery } from '../hooks/useRunMetricExplorerQuery';
 import { MetricExploreFilter } from './visualization/MetricExploreFilter';
-import { MetricPeekComparison } from './visualization/MetricPeekComparison';
-import { MetricPeekSegmentationPicker } from './visualization/MetricPeekSegmentationPicker';
+import { MetricExploreComparison } from './visualization/MetricExploreComparison';
+import { MetricExploreSegmentationPicker } from './visualization/MetricExploreSegmentationPicker';
 import MetricsVisualization from './visualization/MetricsVisualization';
 
 type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
     metrics: CatalogField[];
 };
 
-export const MetricPeekModal: FC<Props> = ({ opened, onClose, metrics }) => {
+export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
     const { track } = useTracking();
 
     const organizationUuid = useAppSelector(
@@ -525,7 +525,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                 onFilterApply={handleFilterApply}
                                 key={`${tableName}-${metricName}`}
                             />
-                            <MetricPeekSegmentationPicker
+                            <MetricExploreSegmentationPicker
                                 query={query}
                                 onSegmentDimensionChange={
                                     handleSegmentDimensionChange
@@ -585,7 +585,7 @@ export const MetricPeekModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                     </Button>
                                 </Group>
 
-                                <MetricPeekComparison
+                                <MetricExploreComparison
                                     baseMetricLabel={metricQuery.data?.label}
                                     query={query}
                                     onQueryChange={setQuery}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
@@ -41,8 +41,8 @@ import { useCatalogMetricsWithTimeDimensions } from '../hooks/useCatalogMetricsW
 import { useCatalogSegmentDimensions } from '../hooks/useCatalogSegmentDimensions';
 import { useMetric } from '../hooks/useMetricsCatalog';
 import { useRunMetricExplorerQuery } from '../hooks/useRunMetricExplorerQuery';
-import { MetricExploreFilter } from './visualization/MetricExploreFilter';
 import { MetricExploreComparison } from './visualization/MetricExploreComparison';
+import { MetricExploreFilter } from './visualization/MetricExploreFilter';
 import { MetricExploreSegmentationPicker } from './visualization/MetricExploreSegmentationPicker';
 import MetricsVisualization from './visualization/MetricsVisualization';
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -31,7 +31,7 @@ import {
     setCategoryFilters,
     setOrganizationUuid,
     setProjectUuid,
-    toggleMetricPeekModal,
+    toggleMetricExploreModal,
 } from '../store/metricsCatalogSlice';
 import { MetricChartUsageModal } from './MetricChartUsageModal';
 import { MetricsTable } from './MetricsTable';
@@ -270,10 +270,10 @@ export const MetricsCatalogPanel = () => {
     );
 
     useEffect(
-        function openMetricPeekModal() {
+        function openMetricExploreModal() {
             if (tableName && metricName) {
                 dispatch(
-                    toggleMetricPeekModal({
+                    toggleMetricExploreModal({
                         name: metricName,
                         tableName,
                     }),

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -48,10 +48,10 @@ import {
 import { useMetricsTree } from '../hooks/useMetricsTree';
 import {
     setCategoryFilters,
-    toggleMetricPeekModal,
+    toggleMetricExploreModal,
 } from '../store/metricsCatalogSlice';
 import { MetricCatalogView } from '../types';
-import { MetricPeekModal } from './MetricPeekModal';
+import { MetricExploreModal } from './MetricExploreModal';
 import { MetricsCatalogColumns } from './MetricsCatalogColumns';
 import { MetricsTableTopToolbar } from './MetricsTableTopToolbar';
 import MetricTree from './MetricTree';
@@ -73,8 +73,8 @@ export const MetricsTable = () => {
     const { canManageTags, canManageMetricsTree } = useAppSelector(
         (state) => state.metricsCatalog.abilities,
     );
-    const isMetricPeekModalOpen = useAppSelector(
-        (state) => state.metricsCatalog.modals.metricPeekModal.isOpen,
+    const isMetricExploreModalOpen = useAppSelector(
+        (state) => state.metricsCatalog.modals.metricExploreModal.isOpen,
     );
     const metricCatalogView = useAppSelector(
         (state) => state.metricsCatalog.view,
@@ -97,8 +97,8 @@ export const MetricsTable = () => {
 
     const [sorting, setSorting] = useState<MRT_SortingState>(initialSorting);
 
-    const onCloseMetricPeekModal = () => {
-        dispatch(toggleMetricPeekModal(undefined));
+    const onCloseMetricExploreModal = () => {
+        dispatch(toggleMetricExploreModal(undefined));
     };
 
     const {
@@ -595,10 +595,10 @@ export const MetricsTable = () => {
             return (
                 <>
                     <MantineReactTable table={table} />
-                    {isMetricPeekModalOpen && (
-                        <MetricPeekModal
-                            opened={isMetricPeekModalOpen}
-                            onClose={onCloseMetricPeekModal}
+                    {isMetricExploreModalOpen && (
+                        <MetricExploreModal
+                            opened={isMetricExploreModalOpen}
+                            onClose={onCloseMetricExploreModal}
                             metrics={flatData}
                         />
                     )}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -33,7 +33,7 @@ type Props = {
     >;
 };
 
-export const MetricPeekComparison: FC<Props> = ({
+export const MetricExploreComparison: FC<Props> = ({
     baseMetricLabel,
     query,
     onQueryChange,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -23,7 +23,7 @@ import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import { useDateRangePicker } from '../../hooks/useDateRangePicker';
-import { getMatchingPresetLabel } from '../../utils/metricPeekDate';
+import { getMatchingPresetLabel } from '../../utils/metricExploreDate';
 import { TimeDimensionIntervalPicker } from './TimeDimensionIntervalPicker';
 
 type Props = {
@@ -39,7 +39,7 @@ type Props = {
     isFetching: boolean;
 };
 
-export const MetricPeekDatePicker: FC<Props> = ({
+export const MetricExploreDatePicker: FC<Props> = ({
     dateRange,
     onChange,
     showTimeDimensionIntervalPicker,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -30,7 +30,7 @@ type Props = {
     hasFilteredSeries: boolean;
 };
 
-export const MetricPeekSegmentationPicker: FC<Props> = ({
+export const MetricExploreSegmentationPicker: FC<Props> = ({
     query,
     onSegmentDimensionChange,
     segmentByData,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -30,7 +30,7 @@ import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
 import {
     getGranularityLabel,
     getGranularitySublabel,
-} from '../../utils/metricPeekDate';
+} from '../../utils/metricExploreDate';
 import type { MetricVisualizationFormatConfig } from './types';
 
 type RechartsTooltipPropsPayload = NonNullable<

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -53,11 +53,11 @@ import { useDynamicYAxisWidth } from '../../hooks/useDynamicYAxisWidth';
 import {
     is5YearDateRange,
     isInCurrentTimeFrame,
-} from '../../utils/metricPeekDate';
+} from '../../utils/metricExploreDate';
 import { MetricsVisualizationEmptyState } from '../MetricsVisualizationEmptyState';
 import { MetricExploreLegend } from './MetricExploreLegend';
 import { MetricExploreTooltip } from './MetricExploreTooltip';
-import { MetricPeekDatePicker } from './MetricPeekDatePicker';
+import { MetricExploreDatePicker } from './MetricExploreDatePicker';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
 import { DATE_FORMATS, type MetricVisualizationFormatConfig } from './types';
 import { useChartZoom } from './useChartZoom';
@@ -568,7 +568,7 @@ const MetricsVisualization: FC<Props> = ({
         <Stack spacing="sm" w="100%" h="100%">
             <Group spacing="sm" noWrap>
                 {dateRange && results?.metric.timeDimension && (
-                    <MetricPeekDatePicker
+                    <MetricExploreDatePicker
                         dateRange={dateRange}
                         onChange={onDateRangeChange}
                         showTimeDimensionIntervalPicker={

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -55,9 +55,9 @@ import {
     isInCurrentTimeFrame,
 } from '../../utils/metricExploreDate';
 import { MetricsVisualizationEmptyState } from '../MetricsVisualizationEmptyState';
+import { MetricExploreDatePicker } from './MetricExploreDatePicker';
 import { MetricExploreLegend } from './MetricExploreLegend';
 import { MetricExploreTooltip } from './MetricExploreTooltip';
-import { MetricExploreDatePicker } from './MetricExploreDatePicker';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
 import { DATE_FORMATS, type MetricVisualizationFormatConfig } from './types';
 import { useChartZoom } from './useChartZoom';

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -13,7 +13,7 @@ import {
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { formatDate, getDateRangePresets } from '../utils/metricPeekDate';
+import { formatDate, getDateRangePresets } from '../utils/metricExploreDate';
 
 dayjs.extend(isoWeek);
 

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -7,7 +7,7 @@ type MetricsCatalogState = {
         chartUsageModal: {
             isOpen: boolean;
         };
-        metricPeekModal: {
+        metricExploreModal: {
             isOpen: boolean;
             metric: Pick<CatalogField, 'name' | 'tableName'> | undefined;
         };
@@ -49,7 +49,7 @@ const initialState: MetricsCatalogState = {
         chartUsageModal: {
             isOpen: false,
         },
-        metricPeekModal: {
+        metricExploreModal: {
             isOpen: false,
             metric: undefined,
         },
@@ -109,14 +109,14 @@ export const metricsCatalogSlice = createSlice({
         ) => {
             state.popovers.description.isClosing = action.payload;
         },
-        toggleMetricPeekModal: (
+        toggleMetricExploreModal: (
             state,
             action: PayloadAction<
                 Pick<CatalogField, 'name' | 'tableName'> | undefined
             >,
         ) => {
-            state.modals.metricPeekModal.isOpen = Boolean(action.payload);
-            state.modals.metricPeekModal.metric = action.payload;
+            state.modals.metricExploreModal.isOpen = Boolean(action.payload);
+            state.modals.metricExploreModal.metric = action.payload;
         },
         setMetricCatalogView: (
             state,
@@ -135,6 +135,6 @@ export const {
     setAbility,
     setCategoryPopoverIsClosing,
     setDescriptionPopoverIsClosing,
-    toggleMetricPeekModal,
+    toggleMetricExploreModal,
     setMetricCatalogView,
 } = metricsCatalogSlice.actions;

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
@@ -17,7 +17,7 @@ export const formatDate = (date: Date | null): string | undefined => {
 };
 
 /**
- * Get the date range presets for the metric peek date picker
+ * Get the date range presets for the metric explore date picker
  * @param timeInterval - The timeframe for which to get the date range presets
  * @returns The date range presets
  */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Keep /peek url path
Keep peek word references in backend - thats fine

Rename occurrences of "peek" on the frontend bc it was getting confusing - there was a mix of "peek" and "explore"

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
