### PR TITLE
feat: allow tree urls to be shared

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -8,6 +8,7 @@ import NavBar from './components/NavBar';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
 import UserCompletionModal from './components/UserCompletionModal';
+import { MetricCatalogView } from './features/metricsCatalog/types';
 import AuthPopupResult from './pages/AuthPopupResult';
 import Catalog from './pages/Catalog';
 import ChartHistory from './pages/ChartHistory';
@@ -365,6 +366,19 @@ const METRICS_ROUTES: RouteObject[] = [
                 <NavBar />
                 <TrackPage name={PageName.METRICS_CATALOG}>
                     <MetricsCatalog />
+                </TrackPage>
+            </>
+        ),
+    },
+    {
+        path: '/projects/:projectUuid/metrics/tree',
+        element: (
+            <>
+                <NavBar />
+                <TrackPage name={PageName.METRICS_CATALOG}>
+                    <MetricsCatalog
+                        metricCatalogView={MetricCatalogView.TREE}
+                    />
                 </TrackPage>
             </>
         ),

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -31,8 +31,12 @@ import {
     setCategoryFilters,
     setOrganizationUuid,
     setProjectUuid,
+    setSearch,
+    setTableSorting,
     toggleMetricExploreModal,
+    toggleMetricPeekModal,
 } from '../store/metricsCatalogSlice';
+import { type MetricCatalogView } from '../types';
 import { MetricChartUsageModal } from './MetricChartUsageModal';
 import { MetricsTable } from './MetricsTable';
 
@@ -156,7 +160,13 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['sx'] }> = ({
     );
 };
 
-export const MetricsCatalogPanel = () => {
+type MetricsCatalogPanelProps = {
+    metricCatalogView: MetricCatalogView;
+};
+
+export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
+    metricCatalogView,
+}) => {
     const dispatch = useAppDispatch();
     const theme = useMantineTheme();
     const { show: showIntercom } = useIntercom();
@@ -165,8 +175,16 @@ export const MetricsCatalogPanel = () => {
     );
     const navigate = useNavigate();
     const categoriesParam = useSearchParams('categories');
+    const searchParam = useSearchParams('search');
+    const sortingParam = useSearchParams('sortBy');
+    const sortDirectionParam = useSearchParams('sortDirection');
+
     const categories = useAppSelector(
         (state) => state.metricsCatalog.categoryFilters,
+    );
+    const search = useAppSelector((state) => state.metricsCatalog.search);
+    const tableSorting = useAppSelector(
+        (state) => state.metricsCatalog.tableSorting,
     );
 
     const organizationUuid = useAppSelector(
@@ -215,11 +233,40 @@ export const MetricsCatalogPanel = () => {
     useEffect(() => {
         const urlCategories =
             categoriesParam?.split(',').map(decodeURIComponent) || [];
+        const urlSearch = searchParam
+            ? decodeURIComponent(searchParam)
+            : undefined;
+        const urlSortByParam = sortingParam
+            ? decodeURIComponent(sortingParam)
+            : undefined;
+        const urlSortDirectionParam = sortDirectionParam
+            ? decodeURIComponent(sortDirectionParam)
+            : undefined;
+
         dispatch(setCategoryFilters(urlCategories));
-    }, [categoriesParam, dispatch]);
+        dispatch(setSearch(urlSearch));
+
+        if (urlSortByParam) {
+            dispatch(
+                setTableSorting([
+                    {
+                        id: urlSortByParam,
+                        desc: urlSortDirectionParam === 'desc',
+                    },
+                ]),
+            );
+        }
+    }, [
+        categoriesParam,
+        dispatch,
+        searchParam,
+        sortingParam,
+        sortDirectionParam,
+    ]);
 
     useEffect(() => {
         const queryParams = new URLSearchParams(window.location.search);
+
         if (categories.length > 0) {
             queryParams.set(
                 'categories',
@@ -228,8 +275,24 @@ export const MetricsCatalogPanel = () => {
         } else {
             queryParams.delete('categories');
         }
+
+        if (search) {
+            queryParams.set('search', encodeURIComponent(search));
+        } else {
+            queryParams.delete('search');
+        }
+
+        if (tableSorting.length > 0) {
+            // TODO: Handle multiple sorting - this needs to be enabled and handled later in the backend
+            queryParams.set('sortBy', encodeURIComponent(tableSorting[0].id));
+            queryParams.set(
+                'sortDirection',
+                encodeURIComponent(tableSorting[0].desc ? 'desc' : 'asc'),
+            );
+        }
+
         void navigate({ search: queryParams.toString() }, { replace: true });
-    }, [categories, navigate]);
+    }, [categories, search, tableSorting, navigate]);
 
     useEffect(
         function handleAbilities() {
@@ -364,7 +427,7 @@ export const MetricsCatalogPanel = () => {
                     <LearnMorePopover buttonStyles={headerButtonStyles} />
                 </Group>
             </Group>
-            <MetricsTable />
+            <MetricsTable metricCatalogView={metricCatalogView} />
             <MetricChartUsageModal
                 opened={isMetricUsageModalOpen}
                 onClose={onCloseMetricUsageModal}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -34,7 +34,6 @@ import {
     setSearch,
     setTableSorting,
     toggleMetricExploreModal,
-    toggleMetricPeekModal,
 } from '../store/metricsCatalogSlice';
 import { type MetricCatalogView } from '../types';
 import { MetricChartUsageModal } from './MetricChartUsageModal';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -34,6 +34,7 @@ import {
     useMemo,
     useRef,
     useState,
+    type FC,
     type UIEvent,
 } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -48,6 +49,8 @@ import {
 import { useMetricsTree } from '../hooks/useMetricsTree';
 import {
     setCategoryFilters,
+    setSearch,
+    setTableSorting,
     toggleMetricExploreModal,
 } from '../store/metricsCatalogSlice';
 import { MetricCatalogView } from '../types';
@@ -56,7 +59,11 @@ import { MetricsCatalogColumns } from './MetricsCatalogColumns';
 import { MetricsTableTopToolbar } from './MetricsTableTopToolbar';
 import MetricTree from './MetricTree';
 
-export const MetricsTable = () => {
+type MetricsTableProps = {
+    metricCatalogView: MetricCatalogView;
+};
+
+export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
     const { track } = useTracking();
     const dispatch = useAppDispatch();
     const theme = useMantineTheme();
@@ -76,26 +83,19 @@ export const MetricsTable = () => {
     const isMetricExploreModalOpen = useAppSelector(
         (state) => state.metricsCatalog.modals.metricExploreModal.isOpen,
     );
-    const metricCatalogView = useAppSelector(
-        (state) => state.metricsCatalog.view,
+    const search = useAppSelector((state) => state.metricsCatalog.search);
+    const stateTableSorting = useAppSelector(
+        (state) => state.metricsCatalog.tableSorting,
     );
+    const deferredSearch = useDeferredValue(search);
     const prevView = useRef(metricCatalogView);
-
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
         useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
-    const [search, setSearch] = useState<string | undefined>(undefined);
-    const deferredSearch = useDeferredValue(search);
 
-    // Enable sorting by highest popularity(how many charts use the metric) by default
-    const initialSorting = [
-        {
-            id: 'chartUsage',
-            desc: true,
-        },
-    ];
-
-    const [sorting, setSorting] = useState<MRT_SortingState>(initialSorting);
+    // We need internal state to handle non serializable state for the updater function
+    const [internalSorting, setInternalSorting] =
+        useState<MRT_SortingState>(stateTableSorting);
 
     const onCloseMetricExploreModal = () => {
         dispatch(toggleMetricExploreModal(undefined));
@@ -114,11 +114,15 @@ export const MetricsTable = () => {
         search: deferredSearch,
         categories: categoryFilters,
         // TODO: Handle multiple sorting - this needs to be enabled and handled later in the backend
-        ...(sorting.length > 0 && {
-            sortBy: sorting[0].id as keyof CatalogItem,
-            sortDirection: sorting[0].desc ? 'desc' : 'asc',
+        ...(stateTableSorting.length > 0 && {
+            sortBy: stateTableSorting[0].id as keyof CatalogItem,
+            sortDirection: stateTableSorting[0].desc ? 'desc' : 'asc',
         }),
     });
+
+    useEffect(() => {
+        dispatch(setTableSorting(internalSorting));
+    }, [dispatch, internalSorting]);
 
     useEffect(() => {
         if (
@@ -300,13 +304,13 @@ export const MetricsTable = () => {
         enableHiding: false,
         enableGlobalFilterModes: false,
         onGlobalFilterChange: (s: string) => {
-            setSearch(s);
+            dispatch(setSearch(s));
         },
         manualFiltering: true,
         enableFilterMatchHighlighting: true,
         enableSorting: true,
         manualSorting: true,
-        onSortingChange: setSorting,
+        onSortingChange: setInternalSorting,
         enableTopToolbar: true,
         positionGlobalFilter: 'left',
         mantinePaperProps,
@@ -463,7 +467,7 @@ export const MetricsTable = () => {
             <Box>
                 <MetricsTableTopToolbar
                     search={search}
-                    setSearch={setSearch}
+                    setSearch={(s) => dispatch(setSearch(s))}
                     totalResults={totalResults}
                     selectedCategories={categoryFilters}
                     setSelectedCategories={handleSetCategoryFilters}
@@ -472,6 +476,7 @@ export const MetricsTable = () => {
                     showCategoriesFilter={canManageTags || dataHasCategories}
                     isValidMetricsTree={isValidMetricsTree}
                     segmentedControlTooltipLabel={segmentedControlTooltipLabel}
+                    metricCatalogView={metricCatalogView}
                 />
                 <Divider color="gray.2" />
             </Box>
@@ -540,7 +545,7 @@ export const MetricsTable = () => {
             ),
         },
         state: {
-            sorting,
+            sorting: stateTableSorting,
             showProgressBars: false,
             showLoadingOverlay, // show loading overlay when fetching (like search, category filtering), but hide when editing rows.
             showSkeletons: isLoading, // loading for the first time with no data
@@ -610,7 +615,7 @@ export const MetricsTable = () => {
                     <Box>
                         <MetricsTableTopToolbar
                             search={search}
-                            setSearch={setSearch}
+                            setSearch={(s) => dispatch(setSearch(s))}
                             totalResults={totalResults}
                             selectedCategories={categoryFilters}
                             setSelectedCategories={handleSetCategoryFilters}
@@ -623,6 +628,7 @@ export const MetricsTable = () => {
                             segmentedControlTooltipLabel={
                                 segmentedControlTooltipLabel
                             }
+                            metricCatalogView={metricCatalogView}
                         />
                         <Divider color="gray.2" />
                     </Box>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar.tsx
@@ -23,12 +23,12 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { TotalMetricsDot } from '../../../svgs/metricsCatalog';
-import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
+import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useProjectTags } from '../hooks/useProjectTags';
-import { setMetricCatalogView } from '../store/metricsCatalogSlice';
 import { MetricCatalogView } from '../types';
 import { CatalogCategory } from './CatalogCategory';
 
@@ -208,6 +208,7 @@ type MetricsTableTopToolbarProps = GroupProps & {
     segmentedControlTooltipLabel?: string;
     showCategoriesFilter?: boolean;
     isValidMetricsTree: boolean;
+    metricCatalogView: MetricCatalogView;
 };
 
 export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
@@ -220,12 +221,11 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
         showCategoriesFilter,
         isValidMetricsTree,
         segmentedControlTooltipLabel,
+        metricCatalogView,
         ...props
     }) => {
-        const dispatch = useAppDispatch();
-        const metricCatalogView = useAppSelector(
-            (store) => store.metricsCatalog.view,
-        );
+        const location = useLocation();
+        const navigate = useNavigate();
         const clearSearch = useCallback(() => setSearch(''), [setSearch]);
 
         const isMetricTreesFeatureFlagEnabled = useFeatureFlagEnabled(
@@ -393,11 +393,26 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                         },
                                     ]}
                                     onChange={(value) => {
-                                        dispatch(
-                                            setMetricCatalogView(
-                                                value as MetricCatalogView,
-                                            ),
-                                        );
+                                        const view = value as MetricCatalogView;
+
+                                        switch (view) {
+                                            case MetricCatalogView.LIST:
+                                                void navigate({
+                                                    pathname:
+                                                        location.pathname.replace(
+                                                            /\/tree/,
+                                                            '',
+                                                        ),
+                                                    search: location.search,
+                                                });
+                                                break;
+                                            case MetricCatalogView.TREE:
+                                                void navigate({
+                                                    pathname: `${location.pathname}/tree`,
+                                                    search: location.search,
+                                                });
+                                                break;
+                                        }
                                     }}
                                 />
                             </Tooltip>

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -1,6 +1,6 @@
 import type { CatalogField } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import { MetricCatalogView } from '../types';
+import type { MRT_SortingState } from 'mantine-react-table';
 
 type MetricsCatalogState = {
     modals: {
@@ -21,8 +21,9 @@ type MetricsCatalogState = {
     activeMetric: CatalogField | undefined;
     projectUuid: string | undefined;
     organizationUuid: string | undefined;
-    view: MetricCatalogView;
     categoryFilters: CatalogField['categories'][number]['tagUuid'][];
+    search: string | undefined;
+    tableSorting: MRT_SortingState;
     popovers: {
         category: {
             isClosing: boolean;
@@ -38,13 +39,19 @@ const initialState: MetricsCatalogState = {
     projectUuid: undefined,
     organizationUuid: undefined,
     categoryFilters: [],
+    search: undefined,
+    tableSorting: [
+        {
+            id: 'chartUsage',
+            desc: true,
+        },
+    ],
     abilities: {
         canManageTags: false,
         canRefreshCatalog: false,
         canManageExplore: false,
         canManageMetricsTree: false,
     },
-    view: MetricCatalogView.LIST,
     modals: {
         chartUsageModal: {
             isOpen: false,
@@ -89,6 +96,12 @@ export const metricsCatalogSlice = createSlice({
         ) => {
             state.categoryFilters = action.payload;
         },
+        setSearch: (state, action: PayloadAction<string | undefined>) => {
+            state.search = action.payload;
+        },
+        setTableSorting: (state, action: PayloadAction<MRT_SortingState>) => {
+            state.tableSorting = action.payload;
+        },
         setAbility: (
             state,
             action: PayloadAction<{
@@ -118,12 +131,6 @@ export const metricsCatalogSlice = createSlice({
             state.modals.metricExploreModal.isOpen = Boolean(action.payload);
             state.modals.metricExploreModal.metric = action.payload;
         },
-        setMetricCatalogView: (
-            state,
-            action: PayloadAction<MetricCatalogView>,
-        ) => {
-            state.view = action.payload;
-        },
     },
 });
 
@@ -136,5 +143,6 @@ export const {
     setCategoryPopoverIsClosing,
     setDescriptionPopoverIsClosing,
     toggleMetricExploreModal,
-    setMetricCatalogView,
+    setSearch,
+    setTableSorting,
 } = metricsCatalogSlice.actions;

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -3,10 +3,17 @@ import { type FC } from 'react';
 import { Provider } from 'react-redux';
 import Page from '../components/common/Page/Page';
 import { MetricsCatalogPanel } from '../features/metricsCatalog';
+import { MetricCatalogView } from '../features/metricsCatalog/types';
 import { store } from '../features/sqlRunner/store';
 import { getMantineThemeOverride } from '../mantineTheme';
 
-const MetricsCatalog: FC = () => {
+type MetricsCatalogProps = {
+    metricCatalogView?: MetricCatalogView;
+};
+
+const MetricsCatalog: FC<MetricsCatalogProps> = ({
+    metricCatalogView = MetricCatalogView.LIST,
+}) => {
     return (
         <Provider store={store}>
             <MantineProvider
@@ -57,7 +64,9 @@ const MetricsCatalog: FC = () => {
                     withLargeContent
                     backgroundColor="#FAFAFA"
                 >
-                    <MetricsCatalogPanel />
+                    <MetricsCatalogPanel
+                        metricCatalogView={metricCatalogView}
+                    />
                 </Page>
             </MantineProvider>
         </Provider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13049 

### Description:

- Keeps full state of catalog query in URL
- Adds `/tree` to route to the tree view

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
