### PR TITLE
fix: make tree container min height same as the table

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -318,7 +318,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
             ref: tableContainerRef,
             sx: {
                 maxHeight: 'calc(100dvh - 350px)',
-                minHeight: '600px',
+                minHeight: 600,
                 display: 'flex',
                 flexDirection: 'column',
             },
@@ -632,7 +632,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                         />
                         <Divider color="gray.2" />
                     </Box>
-                    <Box w="100%" h="calc(100dvh - 350px)">
+                    <Box w="100%" h="calc(100dvh - 350px)" mih={600}>
                         <ReactFlowProvider>
                             {isValidMetricsTree ? (
                                 <MetricTree


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12993 

### Description:

Sets the min height of the tree container to the same value as the table

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
