### PR TITLE
style: let tag input grow vertically in metric filter

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -213,69 +213,62 @@ export const MetricExploreFilter: FC<Props> = ({
                     borderRadius: theme.radius.md,
                 }}
             >
-                <Select
-                    placeholder="Filter by"
-                    icon={<MantineIcon icon={IconFilter} />}
-                    searchable
-                    radius="md"
-                    size="xs"
-                    data={
-                        dimensions?.map((dimension) => ({
-                            value: getItemId(dimension),
-                            label: dimension.label,
-                        })) ?? []
-                    }
-                    disabled={dimensions?.length === 0}
-                    value={filterState.fieldId}
-                    itemComponent={SelectItem}
-                    onChange={handleDimensionChange}
-                    data-selected={!!filterState.fieldId}
-                    classNames={filterSelectClasses}
-                />
+                <Group spacing={0} noWrap>
+                    <Select
+                        placeholder="Filter by"
+                        icon={<MantineIcon icon={IconFilter} />}
+                        searchable
+                        radius="md"
+                        size="xs"
+                        data={
+                            dimensions?.map((dimension) => ({
+                                value: getItemId(dimension),
+                                label: dimension.label,
+                            })) ?? []
+                        }
+                        disabled={dimensions?.length === 0}
+                        value={filterState.fieldId}
+                        itemComponent={SelectItem}
+                        onChange={handleDimensionChange}
+                        data-selected={!!filterState.fieldId}
+                        data-no-values={!showValuesSection}
+                        classNames={filterSelectClasses}
+                    />
 
-                {filterState.fieldId && (
-                    <Group spacing={0} noWrap>
+                    {filterState.fieldId && (
                         <Select
-                            w={showValuesSection ? 70 : '100%'}
-                            maw={showValuesSection ? 70 : '100%'}
                             placeholder="Condition"
                             data={operatorOptions}
                             value={filterState.operator}
                             onChange={handleOperatorChange}
                             size="xs"
                             radius="md"
-                            classNames={{
-                                input: operatorSelectClasses.input,
-                                item: operatorSelectClasses.item,
-                                dropdown: operatorSelectClasses.dropdown,
-                                rightSection:
-                                    operatorSelectClasses.rightSection,
-                            }}
+                            classNames={operatorSelectClasses}
+                            data-no-values={!showValuesSection}
                             data-full-width={
                                 !showValuesSection ? 'true' : 'false'
                             }
                         />
-                        {showValuesSection && (
-                            <TagInput
-                                placeholder={
-                                    filterState.operator
-                                        ? 'Type values...'
-                                        : undefined
-                                }
-                                value={filterState.values}
-                                disabled={!filterState.operator}
-                                onChange={(values) =>
-                                    setFilterState((prev) => ({
-                                        ...prev,
-                                        values,
-                                    }))
-                                }
-                                radius="md"
-                                size="xs"
-                                classNames={tagInputClasses}
-                            />
-                        )}
-                    </Group>
+                    )}
+                </Group>
+
+                {showValuesSection && filterState.fieldId && (
+                    <TagInput
+                        placeholder={
+                            filterState.operator ? 'Type values...' : undefined
+                        }
+                        value={filterState.values}
+                        disabled={!filterState.operator}
+                        onChange={(values) =>
+                            setFilterState((prev) => ({
+                                ...prev,
+                                values,
+                            }))
+                        }
+                        radius="md"
+                        size="xs"
+                        classNames={tagInputClasses}
+                    />
                 )}
             </Stack>
             {filterState.fieldId && dimensionMetadata?.requiresValues && (

--- a/packages/frontend/src/features/metricsCatalog/styles/useFilterStyles.ts
+++ b/packages/frontend/src/features/metricsCatalog/styles/useFilterStyles.ts
@@ -39,16 +39,33 @@ const baseStyles = (theme: MantineTheme) => ({
 export const useFilterSelectStyles = createStyles((theme) => {
     const base = baseStyles(theme);
     return {
+        root: {
+            flexGrow: 1,
+        },
         input: {
             ...base.baseInput,
             padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
             borderRadius: theme.radius.md,
+            minWidth: 200,
+            // truncate text
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            maxWidth: '100%',
+
             '&[value=""]': {
                 border: `1px dashed ${theme.colors.gray[4]}`,
             },
             '&[data-selected="true"]': {
-                borderBottomLeftRadius: 0,
                 borderBottomRightRadius: 0,
+                borderBottomLeftRadius: theme.radius.md,
+                borderTopRightRadius: 0,
+            },
+            '&[data-no-values="true"]': {
+                borderBottomLeftRadius: theme.radius.md,
+            },
+            '&[data-no-values="false"]': {
+                borderBottomLeftRadius: 0,
             },
         },
         item: base.baseItem,
@@ -69,26 +86,30 @@ export const useOperatorSelectStyles = createStyles((theme: MantineTheme) => {
                 flexGrow: 1,
             },
         },
-
         input: {
             ...base.baseInput,
-            padding: `${theme.spacing.xxs} ${theme.spacing.sm}`,
+            padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
+            borderRadius: theme.radius.md,
+            width: 100,
+            minWidth: 100,
+            maxWidth: 100,
+            marginLeft: -1,
             borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
-            borderTop: 0,
-            paddingRight: 8,
-            paddingLeft: 8,
-
+            borderBottomLeftRadius: 0,
+            '&[data-no-values="true"]': {
+                borderBottomRightRadius: theme.radius.md,
+            },
+            '&[data-no-values="false"]': {
+                borderBottomRightRadius: 0,
+            },
             '&[data-full-width="true"]': {
                 width: '100%',
                 maxWidth: '100%',
-                borderBottomRightRadius: theme.radius.md,
             },
         },
         item: base.baseItem,
         dropdown: {
-            minWidth: 60,
+            minWidth: 100,
         },
         rightSection: {
             pointerEvents: 'none',
@@ -105,10 +126,9 @@ export const useFilterTagInputStyles = createStyles((theme: MantineTheme) => {
         input: {
             ...base.baseInput,
             padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
-            '&[data-disabled="true"]': {
-                border: `1px dashed ${theme.colors.gray[4]}`,
-                borderLeft: 0,
-            },
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
+            height: 'auto',
         },
         tagInput: {
             fontWeight: 500,
@@ -124,17 +144,17 @@ export const useFilterTagInputStyles = createStyles((theme: MantineTheme) => {
             border: `1px solid ${theme.colors.gray[2]}`,
         },
         values: {
-            maxHeight: 32,
+            minHeight: 24,
+            height: 'auto',
         },
         tagInputContainer: {
             ...base.baseInput,
             borderRadius: theme.radius.md,
             borderTopRightRadius: 0,
             borderTopLeftRadius: 0,
-            borderBottomLeftRadius: 0,
-            borderLeft: 0,
+            borderLeft: `1px solid ${theme.colors.gray[2]}`,
             borderTop: 0,
-            overflow: 'scroll',
+            overflow: 'visible',
         },
         rightSection: {
             pointerEvents: 'none',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13177](https://github.com/lightdash/lightdash/issues/13177)

### Description:

Operator is on the same row as the dimension to filter by
type values / tag input component is on its own row and grows vertically

demo

<img width="342" alt="Screenshot 2025-01-13 at 10 36 33" src="https://github.com/user-attachments/assets/5ea7380b-f841-4305-8a55-e3a02fb5ef1b" />
<img width="362" alt="Screenshot 2025-01-13 at 10 36 40" src="https://github.com/user-attachments/assets/bdb10a15-4dd6-40ba-b4d9-08a630e091c9" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
