### PR TITLE
style: get accurate styles for comparison types of metrics exploration

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -1,21 +1,22 @@
+import {
+    MetricExplorerComparison,
+    type MetricExplorerQuery,
+} from '@lightdash/common';
 import { ActionIcon, Flex, Group, Text, Tooltip } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
-import {
-    IconBackslash,
-    IconChevronLeft,
-    IconChevronRight,
-    IconLineDashed,
-} from '@tabler/icons-react';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type LegendProps } from 'recharts';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { SquareBadge } from './MetricExploreTooltip';
+import { COMPARISON_OPACITY } from './types';
 
 interface MetricExploreLegendProps extends Pick<LegendProps, 'payload'> {
     legendConfig: Record<
         string | 'metric' | 'compareMetric',
         { name: string; label: string }
     > | null;
+    comparison: MetricExplorerQuery;
     getLegendProps: (value: string) => {
         opacity: number;
     };
@@ -24,50 +25,14 @@ interface MetricExploreLegendProps extends Pick<LegendProps, 'payload'> {
     onClick?: (value: string) => void;
 }
 
-enum LegendIconVariant {
-    SQUARE = 'square',
-    LINE = 'line',
-    DASHED = 'dashed',
-}
-
-const getLegendIconVariant = (value: string) => {
-    switch (value) {
-        case 'metric':
-            return LegendIconVariant.LINE;
-        case 'compareMetric':
-            return LegendIconVariant.DASHED;
-        default:
-            return LegendIconVariant.SQUARE;
-    }
-};
-
 const LegendIcon = ({
     color,
-    variant,
+    opacity,
 }: {
     color: string | undefined;
-    variant: LegendIconVariant;
+    opacity: number;
 }) => {
-    switch (variant) {
-        case LegendIconVariant.SQUARE:
-            return <SquareBadge color={color} size={12} />;
-        case LegendIconVariant.LINE:
-            return (
-                <MantineIcon
-                    icon={IconBackslash}
-                    color={color}
-                    size={12}
-                    // react-tabler doesn't have an horizontal line icon
-                    style={{ transform: 'rotate(125deg)' }}
-                />
-            );
-        case LegendIconVariant.DASHED:
-            return (
-                <MantineIcon icon={IconLineDashed} color={color} size={12} />
-            );
-        default:
-            return null;
-    }
+    return <SquareBadge color={color} size={12} opacity={opacity} />;
 };
 
 export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
@@ -151,6 +116,17 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
         [props.legendConfig],
     );
 
+    const getOpacity = useCallback(
+        (value: string) => {
+            return value === 'compareMetric' &&
+                props.comparison.comparison ===
+                    MetricExplorerComparison.PREVIOUS_PERIOD
+                ? COMPARISON_OPACITY
+                : 1;
+        },
+        [props.comparison],
+    );
+
     return (
         <Flex
             w="100%"
@@ -194,7 +170,7 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
                     <Group key={item.value} spacing={4} noWrap>
                         <LegendIcon
                             color={item.color}
-                            variant={getLegendIconVariant(item.value)}
+                            opacity={getOpacity(item.value)}
                         />
                         <Tooltip label={item.value}>
                             <Text

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -16,7 +16,6 @@ import {
     Text,
     type DefaultMantineColor,
 } from '@mantine/core';
-import { IconLineDashed, IconMinus } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { uniqBy } from 'lodash';
 import { memo, useMemo, type FC } from 'react';
@@ -25,13 +24,15 @@ import {
     type NameType,
     type ValueType,
 } from 'recharts/types/component/DefaultTooltipContent';
-import MantineIcon from '../../../../components/common/MantineIcon';
 import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
 import {
     getGranularityLabel,
     getGranularitySublabel,
 } from '../../utils/metricExploreDate';
-import type { MetricVisualizationFormatConfig } from './types';
+import {
+    COMPARISON_OPACITY,
+    type MetricVisualizationFormatConfig,
+} from './types';
 
 type RechartsTooltipPropsPayload = NonNullable<
     TooltipProps<ValueType, NameType>['payload']
@@ -104,13 +105,15 @@ const TooltipBadge: FC<{
 export const SquareBadge: FC<{
     color?: DefaultMantineColor;
     size?: number;
-}> = ({ color, size = 10 }) => (
+    opacity?: number;
+}> = ({ color, size = 10, opacity = 1 }) => (
     <Box
         sx={{
             width: size,
             height: size,
             borderRadius: 2,
             backgroundColor: color ?? 'indigo.6',
+            opacity,
         }}
     />
 );
@@ -189,12 +192,15 @@ const PreviousPeriodTooltip: FC<{
                 : `${startYear - 1}-${currentPeriodYear - 1}`;
     }
 
+    const opacity = entry.name === 'compareMetric' ? COMPARISON_OPACITY : 1;
+
     return (
         <Group position="apart">
             <Group spacing={4}>
-                <MantineIcon
+                <SquareBadge
                     color={color ?? 'indigo.6'}
-                    icon={entry.name === 'metric' ? IconMinus : IconLineDashed}
+                    size={12}
+                    opacity={opacity}
                 />
                 <Text c="gray.8" fz={13} fw={500}>
                     {label}
@@ -271,14 +277,16 @@ const TooltipEntry: FC<{
             return (
                 <Group position="apart">
                     <Group spacing={4}>
-                        <MantineIcon
+                        <SquareBadge color={props.color} size={12} />
+                        {/* <MantineIcon
                             color={props.color ?? 'indigo.6'}
-                            icon={
-                                entry.name === 'metric'
-                                    ? IconMinus
-                                    : IconLineDashed
+                            icon={IconMinus}
+                            opacity={
+                                entry.name === 'compareMetric'
+                                    ? COMPARISON_OPACITY
+                                    : 1
                             }
-                        />
+                        /> */}
                         <Text c="gray.8" fz={13} fw={500}>
                             {entryData.label}
                         </Text>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -59,7 +59,11 @@ import { MetricExploreDatePicker } from './MetricExploreDatePicker';
 import { MetricExploreLegend } from './MetricExploreLegend';
 import { MetricExploreTooltip } from './MetricExploreTooltip';
 import { TimeDimensionPicker } from './TimeDimensionPicker';
-import { DATE_FORMATS, type MetricVisualizationFormatConfig } from './types';
+import {
+    COMPARISON_OPACITY,
+    DATE_FORMATS,
+    type MetricVisualizationFormatConfig,
+} from './types';
 import { useChartZoom } from './useChartZoom';
 
 const tickFormatter = (date: Date) => {
@@ -398,7 +402,7 @@ const MetricsVisualization: FC<Props> = ({
 
             let opacity = 1;
             if (hoveringLegend && hoveredIsActive) {
-                opacity = name === hoveringLegend ? 1 : 0.3;
+                opacity = name === hoveringLegend ? 1 : COMPARISON_OPACITY;
             }
 
             return {
@@ -418,7 +422,7 @@ const MetricsVisualization: FC<Props> = ({
                 opacity:
                     activeLegends.length === 0 || activeLegends.includes(name)
                         ? 1
-                        : 0.3,
+                        : COMPARISON_OPACITY,
             };
         },
         [activeLegends],
@@ -552,12 +556,6 @@ const MetricsVisualization: FC<Props> = ({
         }
     }, [query.comparison, segmentedData, splitSegments]);
 
-    const compareMetricIncompletePeriodOpacity = useMemo(() => {
-        return query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
-            ? 0.4
-            : 1;
-    }, [query.comparison]);
-
     const chartCursor = useMemo<React.CSSProperties['cursor']>(() => {
         return zoomState.refAreaLeft || zoomState.refAreaRight
             ? 'grabbing'
@@ -654,6 +652,7 @@ const MetricsVisualization: FC<Props> = ({
                                     content={
                                         <MetricExploreLegend
                                             legendConfig={legendConfig}
+                                            comparison={query}
                                             getLegendProps={getLegendProps}
                                             onMouseEnter={setHoveringLegend}
                                             onMouseLeave={() => {
@@ -764,7 +763,8 @@ const MetricsVisualization: FC<Props> = ({
                                         dot={false}
                                         legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}
-                                        opacity={0.4}
+                                        opacity={COMPARISON_OPACITY}
+                                        strokeDasharray="3 4"
                                     />,
                                 ];
                             })}
@@ -801,11 +801,21 @@ const MetricsVisualization: FC<Props> = ({
                                         data={
                                             compareMetricSplitSegment.completedPeriodData
                                         }
-                                        stroke={colors.indigo[9]}
-                                        strokeDasharray={'3 4'}
+                                        stroke={
+                                            query.comparison ===
+                                            MetricExplorerComparison.DIFFERENT_METRIC
+                                                ? colors.teal[5]
+                                                : colors.indigo[4]
+                                        }
                                         dot={false}
                                         legendType="plainline"
                                         isAnimationActive={false}
+                                        opacity={
+                                            query.comparison ===
+                                            MetricExplorerComparison.DIFFERENT_METRIC
+                                                ? 1
+                                                : COMPARISON_OPACITY
+                                        }
                                     />
                                     <Line
                                         {...getLineProps('compareMetric')}
@@ -823,10 +833,8 @@ const MetricsVisualization: FC<Props> = ({
                                         dot={false}
                                         legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}
-                                        opacity={
-                                            compareMetricIncompletePeriodOpacity
-                                        }
-                                        strokeDasharray={'3 4'}
+                                        opacity={COMPARISON_OPACITY}
+                                        strokeDasharray="3 4"
                                     />
                                 </>
                             )}
@@ -837,7 +845,7 @@ const MetricsVisualization: FC<Props> = ({
                                         yAxisId={'metric'}
                                         x1={zoomState.refAreaLeft}
                                         x2={zoomState.refAreaRight}
-                                        strokeOpacity={0.3}
+                                        strokeOpacity={COMPARISON_OPACITY}
                                         fill={colors.gray[3]}
                                     />
                                 )}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -829,7 +829,12 @@ const MetricsVisualization: FC<Props> = ({
                                         data={
                                             compareMetricSplitSegment.incompletePeriodData
                                         }
-                                        stroke={colors.indigo[9]}
+                                        stroke={
+                                            query.comparison ===
+                                            MetricExplorerComparison.DIFFERENT_METRIC
+                                                ? colors.teal[9]
+                                                : colors.indigo[9]
+                                        }
                                         dot={false}
                                         legendType="none" // Don't render legend for the incomplete period line
                                         isAnimationActive={false}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
@@ -12,6 +12,8 @@ export const DATE_FORMATS = {
     year: (date: Date) => dayjs(date).format('YYYY'),
 };
 
+export const COMPARISON_OPACITY = 0.3;
+
 export type MetricVisualizationFormatConfig = {
     metric: CustomFormat | undefined;
     compareMetric: CustomFormat | undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13227

### Description:

Reviewed by @PriPatel 

(btw, there's definitely room for improvement and consistency throughout, but will do that in a separate PR)

<img width="1011" alt="Screenshot 2025-01-13 at 12 19 19" src="https://github.com/user-attachments/assets/6c3aef1b-db94-464f-b949-8e5f976df39e" />
<img width="960" alt="Screenshot 2025-01-13 at 12 19 28" src="https://github.com/user-attachments/assets/807ba8a9-d5db-4f65-bf65-b76875bed869" />
alm
<img width="985" alt="Screenshot 2025-01-13 at 12 19 35" src="https://github.com/user-attachments/assets/5d8ffc8c-e2dd-4020-a2d3-07ed208364d5" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
