### PR TITLE
feat: group fields by table label in metric catalog

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
@@ -378,6 +378,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
             segmentDimensionsQuery.data?.map((dimension) => ({
                 value: getItemId(dimension),
                 label: dimension.label,
+                group: dimension.tableLabel,
             })) ?? []
         );
     }, [segmentDimensionsQuery.data]);

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -190,6 +190,7 @@ export const MetricExploreComparison: FC<Props> = ({
                                                             metric,
                                                         ),
                                                         label: metric.label,
+                                                        group: metric.tableLabel,
                                                     }),
                                                 ) ?? []
                                             }

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -224,6 +224,7 @@ export const MetricExploreFilter: FC<Props> = ({
                             dimensions?.map((dimension) => ({
                                 value: getItemId(dimension),
                                 label: dimension.label,
+                                group: dimension.tableLabel,
                             })) ?? []
                         }
                         disabled={dimensions?.length === 0}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -25,7 +25,11 @@ import SelectItem from '../SelectItem';
 type Props = {
     query: MetricExplorerQuery;
     onSegmentDimensionChange: (value: string | null) => void;
-    segmentByData: Array<{ value: string; label: string }>;
+    segmentByData: Array<{
+        value: string;
+        label: string;
+        group: string;
+    }>;
     segmentDimensionsQuery: UseQueryResult;
     hasFilteredSeries: boolean;
 };

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionPicker.tsx
@@ -2,8 +2,8 @@ import {
     type ApiGetMetricPeek,
     type TimeDimensionConfig,
 } from '@lightdash/common';
-import { Box, Group, Select, Text } from '@mantine/core';
-import { IconChevronDown, IconTable } from '@tabler/icons-react';
+import { Box, Select, Text } from '@mantine/core';
+import { IconChevronDown } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useSelectStyles } from '../../styles/useSelectStyles';
@@ -19,22 +19,13 @@ const FieldItem = forwardRef<
     ComponentPropsWithoutRef<'div'> & {
         value: string;
         label: string;
-        tableLabel: string;
         selected: boolean;
     }
->(({ value, label, tableLabel, ...others }, ref) => (
+>(({ value, label, ...others }, ref) => (
     <Box ref={ref} {...others}>
-        <Group noWrap position="apart">
-            <Text fz="sm" c="dark.8" fw={500}>
-                {label}
-            </Text>
-            <Group spacing={4} noWrap>
-                <MantineIcon color="gray.6" size={12} icon={IconTable} />
-                <Text fz="xs" c="gray.6" span>
-                    {tableLabel}
-                </Text>
-            </Group>
-        </Group>
+        <Text fz="sm" c="dark.8" fw={500}>
+            {label}
+        </Text>
     </Box>
 ));
 
@@ -54,7 +45,7 @@ export const TimeDimensionPicker: FC<Props> = ({
             data={fields.map((f) => ({
                 value: f.name,
                 label: f.label,
-                tableLabel: f.tableLabel,
+                group: f.tableLabel,
             }))}
             value={dimension?.field}
             onChange={(value) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13149

### Description:

just adding "group" does it

<img width="455" alt="Screenshot 2025-01-13 at 12 41 18" src="https://github.com/user-attachments/assets/5018b033-e211-4b7a-b407-6a4155f9e897" />
<img width="348" alt="Screenshot 2025-01-13 at 12 41 26" src="https://github.com/user-attachments/assets/245b54d6-34ec-4aa5-b095-bd293e9157a9" />
<img width="324" alt="Screenshot 2025-01-13 at 12 41 22" src="https://github.com/user-attachments/assets/58dddcd3-10f0-4c70-8439-5237d4bccb30" />
<img width="345" alt="Screenshot 2025-01-13 at 12 41 30" src="https://github.com/user-attachments/assets/fbc5730b-54d8-44ae-9832-24bbe3aa651d" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
