### PR TITLE
fix: use base query explore name when running comparison

### DIFF
--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -138,6 +138,7 @@ export class MetricsExplorerService<
     private async runCompareDifferentMetricQuery(
         user: SessionUser,
         projectUuid: string,
+        baseMetricQuery: MetricQuery,
         query: MetricExplorerQuery,
         dateRange: MetricExplorerDateRange,
         timeDimensionOverride: TimeDimensionConfig | undefined,
@@ -185,9 +186,8 @@ export class MetricsExplorerService<
         });
 
         const metricQuery: MetricQuery = {
-            exploreName: query.metric.table,
+            ...baseMetricQuery,
             metrics: [getItemId(metric)],
-            dimensions: [dimensionFieldId],
             filters: {
                 dimensions: {
                     id: uuidv4(),
@@ -204,16 +204,13 @@ export class MetricsExplorerService<
                     ],
                 },
             },
-            sorts: [{ fieldId: dimensionFieldId, descending: false }],
-            tableCalculations: [],
-            limit: this.maxQueryLimit,
         };
 
         const { rows, fields } =
             await this.projectService.runMetricExplorerQuery(
                 user,
                 projectUuid,
-                query.metric.table,
+                baseMetricQuery.exploreName,
                 metricQuery,
             );
 
@@ -460,6 +457,7 @@ export class MetricsExplorerService<
                 } = await this.runCompareDifferentMetricQuery(
                     user,
                     projectUuid,
+                    baseQuery,
                     query,
                     dateRange,
                     timeDimensionOverride,

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -138,7 +138,7 @@ export class MetricsExplorerService<
     private async runCompareDifferentMetricQuery(
         user: SessionUser,
         projectUuid: string,
-        baseMetricQuery: MetricQuery,
+        sourceMetricExploreName: string,
         query: MetricExplorerQuery,
         dateRange: MetricExplorerDateRange,
         timeDimensionOverride: TimeDimensionConfig | undefined,
@@ -186,8 +186,9 @@ export class MetricsExplorerService<
         });
 
         const metricQuery: MetricQuery = {
-            ...baseMetricQuery,
+            exploreName: sourceMetricExploreName, // Query must be run on the source metric explore, this is because of filters and references to source metric explore fields
             metrics: [getItemId(metric)],
+            dimensions: [dimensionFieldId],
             filters: {
                 dimensions: {
                     id: uuidv4(),
@@ -204,13 +205,16 @@ export class MetricsExplorerService<
                     ],
                 },
             },
+            sorts: [{ fieldId: dimensionFieldId, descending: false }],
+            tableCalculations: [],
+            limit: this.maxQueryLimit,
         };
 
         const { rows, fields } =
             await this.projectService.runMetricExplorerQuery(
                 user,
                 projectUuid,
-                baseMetricQuery.exploreName,
+                sourceMetricExploreName,
                 metricQuery,
             );
 
@@ -457,7 +461,7 @@ export class MetricsExplorerService<
                 } = await this.runCompareDifferentMetricQuery(
                     user,
                     projectUuid,
-                    baseQuery,
+                    exploreName,
                     query,
                     dateRange,
                     timeDimensionOverride,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13237 

### Description:

- Sets the explore of the compare metric query to the same as the base query so it finds the filter field

**Steps to reproduce**
- Select a metric
- Filter on a field from that explore
- Compare to a metric on a separate explore


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
