### PR TITLE
fix: reset layout when initial edges or nodes change

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricTree/index.tsx
@@ -486,7 +486,7 @@ const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
         if (addNodeChanges.length > 0 || removeNodeChanges.length > 0) {
             onNodesChange([...addNodeChanges, ...removeNodeChanges]);
         }
-    }, [initialNodes, currentNodes, onNodesChange]);
+    }, [currentNodes, initialNodes, onNodesChange]);
 
     useEffect(() => {
         const addEdgeChanges: EdgeChange<Edge>[] = initialEdges
@@ -496,14 +496,12 @@ const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
                 type: 'add',
                 item: edge,
             }));
-
         const removeEdgeChanges: EdgeChange<Edge>[] = currentEdges
             .filter((edge) => !initialEdges.some((e) => e.id === edge.id))
             .map((edge) => ({
                 id: edge.id,
                 type: 'remove',
             }));
-
         if (addEdgeChanges.length > 0 || removeEdgeChanges.length > 0) {
             onEdgesChange([...addEdgeChanges, ...removeEdgeChanges]);
         }
@@ -516,6 +514,11 @@ const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
             applyLayout(true);
         }
     }, [applyLayout, nodesInitialized, isInitialLayoutReady]);
+
+    // Reset layout when initial edges or nodes change
+    useEffect(() => {
+        setIsInitialLayoutReady(false);
+    }, [initialNodes, initialEdges]);
 
     return (
         <Box h="100%">

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -210,7 +210,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                                 <Tooltip
                                                     withinPortal
                                                     variant="xs"
-                                                    label="Tree view"
+                                                    label="Canvas"
                                                 >
                                                     <Center>
                                                         <MantineIcon


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #12912 

### Description:

- Resets initial layout when reloading tree page

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
