### PR TITLE
fix: set left yaxis display if not set when theres 2

### DIFF
--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -175,7 +175,8 @@ export const cartesianChartConfigSlice = createSlice({
         ) => {
             if (!display) display = {};
 
-            display.yAxis = display.yAxis || [];
+            // Initialize yAxis array with empty objects to prevent null values in case one is not set
+            display.yAxis = display.yAxis || [{}, {}];
 
             const { index, label } = action.payload;
             if (display.yAxis[index] === undefined) {
@@ -323,10 +324,8 @@ export const cartesianChartConfigSlice = createSlice({
                 ? action.payload.format
                 : undefined;
 
-            display.yAxis = display.yAxis || [
-                { format: undefined },
-                { format: undefined },
-            ];
+            // Initialize with empty objects to prevent null values in case one is not set
+            display.yAxis = display.yAxis || [{}, {}];
 
             if (!display.yAxis[action.payload.index]) {
                 display.yAxis[action.payload.index] = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13260

### Description:

To replicate

- Create sql runner chart
- Select 2 y axis fields
- Go "Series" and set 2nd y axis as "right"  axis position
- go to "Display" and **only** update the right y axis - the left y axis should remain _untouched_
- hit save and see validation error

This is because the yAxis[0] is set to `null` - default to empty object so that the default are applied nicely


with this change the above error doesn't happen. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
