### PR TITLE
fix: interpolate string for page title

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -269,7 +269,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
 
     return (
         <>
-            {title ? <title>{title} - Lightdash</title> : null}
+            {title ? <title>{`${title} - Lightdash`}</title> : null}
 
             {header}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13141 

### Description:

Check https://github.com/lightdash/lightdash/issues/2395 for titles

**Before**
![image](https://github.com/user-attachments/assets/6d4ba8ea-a1e7-4570-933b-423ff6acfdd4)

**After**
![image](https://github.com/user-attachments/assets/1e60ead2-625e-4236-ad49-a794e6b470b4)

React docs: https://react.dev/reference/react-dom/components/title#use-variables-in-the-title

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
