### PR TITLE
chore: revert back to original metric explore date ranges

### DIFF
--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -398,8 +398,8 @@ export const getMetricExplorerDataPointsWithCompare = (
 
 /**
  * Get the date range for a given time interval, based on the current date and the time interval
- * Time grain Year: -> this year (i.e. start of this year until now)
- * Time grain Month -> past 3 months (i.e. 3 completed months + this uncompleted month)
+ * Time grain Year: -> past 5 years (i.e. 5 completed years + this uncompleted year)
+ * Time grain Month -> past 12 months (i.e. 12 completed months + this uncompleted month)
  * Time grain Week -> past 12 weeks (i.e. 12 completed weeks + this uncompleted week)
  * Time grain Day -> past 30 days (i.e. 30 completed days + this uncompleted day)
  * @param timeInterval - The time interval
@@ -423,11 +423,14 @@ export const getDefaultDateRangeFromInterval = (
             ];
         case TimeFrames.MONTH:
             return [
-                now.subtract(3, 'month').startOf('month').toDate(),
+                now.subtract(12, 'month').startOf('month').toDate(),
                 now.toDate(),
             ];
         case TimeFrames.YEAR:
-            return [now.startOf('year').toDate(), now.toDate()];
+            return [
+                now.subtract(5, 'year').startOf('year').toDate(),
+                now.toDate(),
+            ];
         default:
             return assertUnimplementedTimeframe(timeInterval);
     }

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -398,7 +398,7 @@ export const getMetricExplorerDataPointsWithCompare = (
 
 /**
  * Get the date range for a given time interval, based on the current date and the time interval
- * Time grain Year: -> past 5 years (i.e. 5 completed years + this uncompleted year)
+ * Time grain Year: -> past 3 years (i.e. 3 completed years + this uncompleted year)
  * Time grain Month -> past 12 months (i.e. 12 completed months + this uncompleted month)
  * Time grain Week -> past 12 weeks (i.e. 12 completed weeks + this uncompleted week)
  * Time grain Day -> past 30 days (i.e. 30 completed days + this uncompleted day)
@@ -428,7 +428,7 @@ export const getDefaultDateRangeFromInterval = (
             ];
         case TimeFrames.YEAR:
             return [
-                now.subtract(5, 'year').startOf('year').toDate(),
+                now.subtract(3, 'year').startOf('year').toDate(),
                 now.toDate(),
             ];
         default:

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
@@ -218,10 +218,18 @@ export const getDateRangePresets = (
                     ],
                 },
                 {
-                    label: 'Past 5 years',
-                    controlLabel: '5Y',
+                    label: 'Past 3 years',
+                    controlLabel: '3Y',
                     getValue: () =>
                         getDefaultDateRangeFromInterval(timeInterval),
+                },
+                {
+                    label: 'Past 5 years',
+                    controlLabel: '5Y',
+                    getValue: () => [
+                        today.subtract(5, 'year').startOf('year').toDate(),
+                        now.toDate(),
+                    ],
                 },
             ];
 

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreDate.tsx
@@ -164,8 +164,10 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 3 months',
                     controlLabel: '3M',
-                    getValue: () =>
-                        getDefaultDateRangeFromInterval(timeInterval),
+                    getValue: () => [
+                        today.subtract(3, 'month').startOf('month').toDate(),
+                        now.toDate(),
+                    ],
                 },
                 {
                     label: 'Past 6 months',
@@ -178,10 +180,8 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 12 months',
                     controlLabel: '12M',
-                    getValue: () => [
-                        today.subtract(12, 'month').startOf('month').toDate(),
-                        now.toDate(),
-                    ],
+                    getValue: () =>
+                        getDefaultDateRangeFromInterval(timeInterval),
                 },
                 {
                     label: 'Past 5 years',
@@ -204,8 +204,10 @@ export const getDateRangePresets = (
                 {
                     label: 'This year',
                     controlLabel: 'This year',
-                    getValue: () =>
-                        getDefaultDateRangeFromInterval(timeInterval),
+                    getValue: () => [
+                        today.startOf('year').toDate(),
+                        now.toDate(),
+                    ],
                 },
                 {
                     label: 'Past 1 year',
@@ -218,10 +220,8 @@ export const getDateRangePresets = (
                 {
                     label: 'Past 5 years',
                     controlLabel: '5Y',
-                    getValue: () => [
-                        today.subtract(5, 'year').startOf('year').toDate(),
-                        now.toDate(),
-                    ],
+                    getValue: () =>
+                        getDefaultDateRangeFromInterval(timeInterval),
                 },
             ];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13193

### Description:

reverts: https://github.com/lightdash/lightdash/pull/12944/files

demo
<img width="1777" alt="Screenshot 2025-01-14 at 14 19 24" src="https://github.com/user-attachments/assets/896f6279-df08-4e06-a2e9-ab309e533d06" />
<img width="1778" alt="Screenshot 2025-01-14 at 14 19 30" src="https://github.com/user-attachments/assets/a54d4256-12b7-4bd1-9019-13b11e0b0e68" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
