### PR TITLE
style: correctly load svg background image

### DIFF
--- a/packages/frontend/src/components/common/BackgroundSvg.tsx
+++ b/packages/frontend/src/components/common/BackgroundSvg.tsx
@@ -1,0 +1,28 @@
+import { Box, type BoxProps } from '@mantine/core';
+import { type ComponentType, type FC, type SVGProps } from 'react';
+
+type Props = BoxProps & {
+    SvgComponent: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+export const BackgroundSvg: FC<Props> = ({
+    SvgComponent,
+    children,
+    ...props
+}) => (
+    <Box pos="relative" {...props}>
+        <Box
+            sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                zIndex: 0,
+            }}
+        >
+            <SvgComponent width="100%" height="100%" />
+        </Box>
+        <Box sx={{ position: 'relative', zIndex: 1 }}>{children}</Box>
+    </Box>
+);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsVisualizationEmptyState.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsVisualizationEmptyState.tsx
@@ -1,41 +1,50 @@
 import { Center, Paper, Stack, Text } from '@mantine/core';
 import { IconClockCancel } from '@tabler/icons-react';
+import { BackgroundSvg } from '../../../components/common/BackgroundSvg';
 import MantineIcon from '../../../components/common/MantineIcon';
-import MetricsVisualizationEmptyStateImage from '../../../svgs/metricsCatalog/metrics-visualization-empty-state.svg';
+import MetricsVisualizationEmptyStateImage from '../../../svgs/metricsCatalog/metrics-visualization-empty-state.svg?react';
 
 export const MetricsVisualizationEmptyState = () => {
     return (
         <Paper
-            p="xl"
             h="100%"
+            w="100%"
             sx={{
-                width: 'fill-available',
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundImage: `url(${MetricsVisualizationEmptyStateImage})`,
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
             }}
         >
-            <Center>
-                <Stack spacing="sm" align="center">
-                    <Paper p="xs">
-                        <MantineIcon icon={IconClockCancel} />
-                    </Paper>
-                    <Stack spacing={0} align="center" maw={360}>
-                        <Text fw={600} fz="md" c="dark.7" ta="center">
-                            Data unavailable for selected range
-                        </Text>
-                        <Text fz="sm" c="gray.6" ta="center">
-                            We'd love to show you more, but the data isn't
-                            available for this range. Try selecting a different
-                            range to continue exploring!
-                        </Text>
+            <BackgroundSvg
+                SvgComponent={MetricsVisualizationEmptyStateImage}
+                sx={{
+                    width: '100%',
+                    height: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                <Center>
+                    <Stack spacing="sm" align="center">
+                        <Paper p="xs">
+                            <MantineIcon icon={IconClockCancel} />
+                        </Paper>
+                        <Stack spacing={0} align="center" maw={360}>
+                            <Text fw={600} fz="md" c="dark.7" ta="center">
+                                Data unavailable for selected range
+                            </Text>
+                            <Text fz="sm" c="gray.6" ta="center">
+                                We'd love to show you more, but the data isn't
+                                available for this range. Try selecting a
+                                different range to continue exploring!
+                            </Text>
+                        </Stack>
                     </Stack>
-                </Stack>
-            </Center>
+                </Center>
+            </BackgroundSvg>
         </Paper>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13156

### Description:

Creates common component `BackgroundSvg` - mantine's one (BackgroundImage) doesn't work with svgs

demo:

<img width="1514" alt="Screenshot 2025-01-14 at 15 11 48" src="https://github.com/user-attachments/assets/d6ac5d6d-c40e-44ba-b236-a06d5fea07a8" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
