### PR TITLE
style: apply misc style tweaks to metric explorer

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
@@ -600,7 +600,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
 
                     <Divider orientation="vertical" color="gray.2" />
 
-                    <Box w="100%" py="xl" px="xxl">
+                    <Box w="100%" px={40} py="lg">
                         <MetricsVisualization
                             query={query}
                             dateRange={dateRange ?? undefined}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -124,8 +124,7 @@ export const MetricExploreComparison: FC<Props> = ({
                         withinPortal
                     >
                         <Paper
-                            px="md"
-                            py="sm"
+                            p="sm"
                             sx={(theme) => ({
                                 cursor: 'pointer',
                                 transition: `all ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13209

### Description:

boxes

<img width="331" alt="Screenshot 2025-01-14 at 15 24 18" src="https://github.com/user-attachments/assets/abcdbff6-7d8f-47e2-806a-84c2f9f78c05" />

chart area x padding is larger

<img width="1400" alt="Screenshot 2025-01-14 at 15 27 04" src="https://github.com/user-attachments/assets/3283b3c7-b572-468f-b5b7-f3a131be035e" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
