### PR TITLE
fix: only disable date range selection when fetching

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -141,7 +141,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
             <Popover.Target>
                 <Group position="apart" w="fill-available" noWrap>
                     <SegmentedControl
-                        disabled={!effectiveMatchingPresetLabel}
+                        disabled={isFetching}
                         size="xs"
                         h={32}
                         data={customWithPresets}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After selecting a custom date range the segmented control shouldn't be disabled. 

This fixes that

before


https://github.com/user-attachments/assets/6f59ff92-7e30-4a33-abfd-cb84cc71eb94



after


https://github.com/user-attachments/assets/a232eb45-4ee8-4484-875c-e53c6151c20b



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
