### PR TITLE
fix: hide page sidebar container's double scrollbar, defer to ScrollArea

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -98,6 +98,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                     flexGrow: 1,
                                     flexDirection: 'column',
                                     overflowY: 'auto',
+                                    scrollbarWidth: 'none',
                                 }}
                             >
                                 {children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13233 

### Description:

Likely caused by a slight dimension mismatch, the settings page sidebar has a double scrollbar (see issue above). This PR "fixes" it by hiding the scrollbar on the page sidebar, while maintaining its `overflowY: auto` property (and avoid hiding something unintentionally).

![Kapture 2025-01-14 at 16 51 30](https://github.com/user-attachments/assets/90c684ad-b8ef-4ff3-b19b-3e5fdb0831a8)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
