### PR TITLE
fix: browse menu spaces list scroll

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -82,10 +82,10 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 ) : null}
 
                 <ScrollArea
-                    offsetScrollbars
                     variant="primary"
                     className="only-vertical"
-                    type="auto"
+                    scrollbarSize={6}
+                    type="hover"
                 >
                     <Box mah={300}>
                         {spaces


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

space list had weird bounds on its right and bottom designated for scrollbars, even though the scrollbars were not always visible.

before:

![CleanShot 2025-01-15 at 01 34 03@2x](https://github.com/user-attachments/assets/a80ca117-792e-4dae-8dc3-354a398f970e)

after:


https://github.com/user-attachments/assets/c8e1dd31-45e7-4089-b46a-3dffaaa9b568




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
