### PR TITLE
fix: clear dashboard storage after moving chart to space

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -209,7 +209,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
         return resultsData?.fields;
     }, [resultsData]);
 
-    const { clearIsEditingDashboardChart } = useDashboardStorage();
+    const { clearDashboardStorage } = useDashboardStorage();
     const [isRenamingChart, setIsRenamingChart] = useState(false);
     const [isMovingChart, setIsMovingChart] = useState(false);
     const [isQueryModalOpen, queryModalHandlers] = useDisclosure();
@@ -947,7 +947,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                         } else {
                             void navigate(`/`);
                         }
-                        clearIsEditingDashboardChart();
+                        clearDashboardStorage();
                         deleteModalHandlers.close();
                     }}
                 />
@@ -987,7 +987,7 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
                     opened={isMovingChart}
                     onClose={() => setIsMovingChart(false)}
                     onConfirm={() => {
-                        clearIsEditingDashboardChart();
+                        clearDashboardStorage();
                         void navigate(
                             `/projects/${projectUuid}/saved/${savedChart.uuid}/edit`,
                         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13223<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Change:
- clear the entire dashboard storage when a chart is moved to space.

Before:

https://github.com/user-attachments/assets/5a1f1980-d2c5-488a-80fe-241d0ee7c1c9

After:

https://github.com/user-attachments/assets/1147a764-9852-42e4-9418-d39d0895e224


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
