### PR TITLE
fix: make row-limit forms consistent

### DIFF
--- a/packages/frontend/src/components/LimitButton/LimitForm.tsx
+++ b/packages/frontend/src/components/LimitButton/LimitForm.tsx
@@ -39,7 +39,8 @@ const LimitForm = forwardRef<HTMLFormElement, LimitFormProps>(
                         step={100}
                         min={1}
                         required
-                        label="Total rows:"
+                        size="xs"
+                        label="Row limit:"
                         {...form.getInputProps('limit')}
                     />
 

--- a/packages/frontend/src/features/semanticViewer/components/ContentResults.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/ContentResults.tsx
@@ -156,7 +156,7 @@ const ContentResults: FC<ContentResultsProps> = ({
                     </Tabs.Tab>
 
                     <Text ml="auto" mr="lg" fz="sm">
-                        Total rows:{' '}
+                        Row limit:{' '}
                         <Text span fw={500}>
                             {results.length}
                         </Text>

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
@@ -50,7 +50,7 @@ export const ResultsDownloadFromUrl: FC<Props> = ({
                     <NumberInput
                         size="xs"
                         type="number"
-                        label="Row limit"
+                        label="Row limit:"
                         step={100}
                         min={1}
                         autoFocus

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
@@ -50,14 +50,17 @@ export const ResultsDownloadFromUrl: FC<Props> = ({
                     <NumberInput
                         size="xs"
                         type="number"
-                        label="Limit"
+                        label="Row limit"
+                        step={100}
+                        min={1}
+                        autoFocus
+                        required
                         defaultValue={DEFAULT_SQL_LIMIT}
                         onChange={(value: number) => setCustomLimit(value)}
                     />
                     <Button
                         size="xs"
                         ml="auto"
-                        leftIcon={<MantineIcon icon={IconDownload} />}
                         onClick={handleDownload}
                         loading={isLoading}
                     >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Makes the row limit forms more consistent. Explore, SQL Runner, and the sql runner results downloads forms now have more consistent styling:
- Label is now "Row limit"
- Inputs are the same size
- 'required' asterisk is there

**SQL Runner**
<img width="304" alt="Screenshot 2025-01-16 at 12 11 57" src="https://github.com/user-attachments/assets/081a97fa-1ed5-4519-878a-b2a9a91d684d" />

**Explorer**
<img width="336" alt="Screenshot 2025-01-16 at 12 18 59" src="https://github.com/user-attachments/assets/24ce5d9a-2cb3-458c-80e6-b9fd6df03e2e" />

**Results download**
<img width="225" alt="Screenshot 2025-01-16 at 13 20 26" src="https://github.com/user-attachments/assets/fb520b97-4f69-4229-b361-77ea141294f4" />


Note the that SQL runner table doesn't respect the limit correctly, there is a ticket: #13310

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
