### PR TITLE
chore: rename metric tree to canvas

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -371,13 +371,13 @@ const METRICS_ROUTES: RouteObject[] = [
         ),
     },
     {
-        path: '/projects/:projectUuid/metrics/tree',
+        path: '/projects/:projectUuid/metrics/canvas',
         element: (
             <>
                 <NavBar />
                 <TrackPage name={PageName.METRICS_CATALOG}>
                     <MetricsCatalog
-                        metricCatalogView={MetricCatalogView.TREE}
+                        metricCatalogView={MetricCatalogView.CANVAS}
                     />
                 </TrackPage>
             </>

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
@@ -2,7 +2,7 @@ import { useMantineTheme } from '@mantine/core';
 import { BaseEdge, getSimpleBezierPath, type EdgeProps } from '@xyflow/react';
 import type { FC } from 'react';
 
-const MetricTreeDefaultEdge: FC<EdgeProps> = ({
+const DefaultEdge: FC<EdgeProps> = ({
     sourceX,
     sourceY,
     targetX,
@@ -29,4 +29,4 @@ const MetricTreeDefaultEdge: FC<EdgeProps> = ({
     );
 };
 
-export default MetricTreeDefaultEdge;
+export default DefaultEdge;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/CollapsedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/CollapsedNode.tsx
@@ -3,16 +3,17 @@ import { Group, Paper, Text, Tooltip } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { type Node, type NodeProps } from '@xyflow/react';
 import React, { useMemo } from 'react';
-import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
 
-export type MetricTreeCollapsedNodeData = Node<{
+export type CollapsedNodeData = Node<{
     label: string;
     tableName?: string;
 }>;
 
-const MetricTreeCollapsedNode: React.FC<
-    NodeProps<MetricTreeCollapsedNodeData>
-> = ({ data, selected }) => {
+const CollapsedNode: React.FC<NodeProps<CollapsedNodeData>> = ({
+    data,
+    selected,
+}) => {
     //TODO: fetch real data for these
     const title = useMemo(() => friendlyName(data.label), [data.label]);
 
@@ -58,4 +59,4 @@ const MetricTreeCollapsedNode: React.FC<
     );
 };
 
-export default MetricTreeCollapsedNode;
+export default CollapsedNode;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -21,11 +21,11 @@ import {
 import { IconInfoCircle } from '@tabler/icons-react';
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import React, { useMemo, type FC } from 'react';
-import MantineIcon from '../../../../components/common/MantineIcon';
-import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
-import { useAppSelector } from '../../../sqlRunner/store/hooks';
-import { useRunMetricTotal } from '../../hooks/useRunMetricExplorerQuery';
-import { useChangeIndicatorStyles } from '../../styles/useChangeIndicatorStyles';
+import { useChangeIndicatorStyles } from '../../../../styles/useChangeIndicatorStyles';
+import { useAppSelector } from '../../../../../sqlRunner/store/hooks';
+import { useRunMetricTotal } from '../../../../hooks/useRunMetricExplorerQuery';
+import { calculateComparisonValue } from '../../../../../../hooks/useBigNumberConfig';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
 
 const ChangeIndicator: FC<{ change: number; formattedChange: string }> = ({
     change,
@@ -56,7 +56,7 @@ const ChangeIndicator: FC<{ change: number; formattedChange: string }> = ({
     );
 };
 
-export type MetricTreeExpandedNodeData = Node<{
+export type ExpandedNodeData = Node<{
     label: string;
     tableName: string;
     metricName: string;
@@ -65,9 +65,11 @@ export type MetricTreeExpandedNodeData = Node<{
     timeFrame: TimeFrames;
 }>;
 
-const MetricTreeExpandedNode: React.FC<
-    NodeProps<MetricTreeExpandedNodeData>
-> = ({ data, isConnectable, selected }) => {
+const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
+    data,
+    isConnectable,
+    selected,
+}) => {
     const title = useMemo(() => friendlyName(data.label), [data.label]);
 
     const projectUuid = useAppSelector(
@@ -196,4 +198,4 @@ const MetricTreeExpandedNode: React.FC<
     );
 };
 
-export default MetricTreeExpandedNode;
+export default ExpandedNode;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/FreeGroupNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/FreeGroupNode.tsx
@@ -2,12 +2,9 @@ import { Paper, Text } from '@mantine/core';
 import type { Node, NodeProps } from '@xyflow/react';
 import { useRef, type FC } from 'react';
 
-export type MetricTreeFreeGroupNodeData = Node;
+export type FreeGroupNodeData = Node;
 
-const MetricTreeFreeGroupNode: FC<NodeProps<MetricTreeFreeGroupNodeData>> = ({
-    height,
-    width,
-}) => {
+const FreeGroupNode: FC<NodeProps<FreeGroupNodeData>> = ({ height, width }) => {
     const ref = useRef<HTMLDivElement>(null);
 
     return (
@@ -21,4 +18,4 @@ const MetricTreeFreeGroupNode: FC<NodeProps<MetricTreeFreeGroupNodeData>> = ({
     );
 };
 
-export default MetricTreeFreeGroupNode;
+export default FreeGroupNode;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -43,23 +43,23 @@ import {
     useDeleteMetricsTreeEdge,
 } from '../../hooks/useMetricsTree';
 import { useTreeNodePosition } from '../../hooks/useTreeNodePosition';
-import MetricTreeCollapsedNode, {
-    type MetricTreeCollapsedNodeData,
-} from './MetricTreeCollapsedNode';
-import MetricTreeDefaultEdge from './MetricTreeDefaultEdge';
-import MetricTreeExpandedNode, {
-    type MetricTreeExpandedNodeData,
-} from './MetricTreeExpandedNode';
-import MetricTreeFreeGroupNode, {
-    type MetricTreeFreeGroupNodeData,
-} from './MetricTreeFreeGroupNode';
+import CollapsedNode, {
+    type CollapsedNodeData,
+} from './TreeComponents/nodes/CollapsedNode';
+import DefaultEdge from './TreeComponents/edges/DefaultEdge';
+import ExpandedNode, {
+    type ExpandedNodeData,
+} from './TreeComponents/nodes/ExpandedNode';
+import FreeGroupNode, {
+    type FreeGroupNodeData,
+} from './TreeComponents/nodes/FreeGroupNode';
 
 enum MetricTreeEdgeType {
     DEFAULT = 'default',
 }
 
 const metricTreeEdgeTypes: EdgeTypes = {
-    [MetricTreeEdgeType.DEFAULT]: MetricTreeDefaultEdge,
+    [MetricTreeEdgeType.DEFAULT]: DefaultEdge,
 };
 
 enum MetricTreeNodeType {
@@ -69,9 +69,9 @@ enum MetricTreeNodeType {
 }
 
 const metricTreeNodeTypes: NodeTypes = {
-    [MetricTreeNodeType.EXPANDED]: MetricTreeExpandedNode,
-    [MetricTreeNodeType.COLLAPSED]: MetricTreeCollapsedNode,
-    [MetricTreeNodeType.FREE_GROUP]: MetricTreeFreeGroupNode,
+    [MetricTreeNodeType.EXPANDED]: ExpandedNode,
+    [MetricTreeNodeType.COLLAPSED]: CollapsedNode,
+    [MetricTreeNodeType.FREE_GROUP]: FreeGroupNode,
 };
 
 type Props = {
@@ -86,10 +86,7 @@ enum STATIC_NODE_TYPES {
 
 const DEFAULT_TIME_FRAME = DEFAULT_METRICS_EXPLORER_TIME_INTERVAL; // TODO: this should be dynamic
 
-type MetricTreeNode =
-    | MetricTreeExpandedNodeData
-    | MetricTreeCollapsedNodeData
-    | MetricTreeFreeGroupNodeData;
+type MetricTreeNode = ExpandedNodeData | CollapsedNodeData | FreeGroupNodeData;
 
 function getEdgeId(edge: Pick<CatalogMetricsTreeEdge, 'source' | 'target'>) {
     return `${edge.source.catalogSearchUuid}_${edge.target.catalogSearchUuid}`;
@@ -103,13 +100,12 @@ const getNodeGroups = (nodes: MetricTreeNode[], edges: Edge[]) => {
         connectedNodeIds.add(edge.target);
     });
 
-    const connectedNodes = nodes.filter(
-        (node): node is MetricTreeExpandedNodeData =>
-            connectedNodeIds.has(node.id),
+    const connectedNodes = nodes.filter((node): node is ExpandedNodeData =>
+        connectedNodeIds.has(node.id),
     );
 
     const freeNodes = nodes.filter(
-        (node): node is MetricTreeCollapsedNodeData =>
+        (node): node is CollapsedNodeData =>
             !connectedNodeIds.has(node.id) &&
             node.id !== STATIC_NODE_TYPES.UNCONNECTED,
     );
@@ -139,7 +135,7 @@ const getNodeLayout = (
 
     // Organize nodes into a 2D grid array first
     const GRID_COLUMNS = 2;
-    const freeNodesGridArray: MetricTreeCollapsedNodeData[][] = [];
+    const freeNodesGridArray: CollapsedNodeData[][] = [];
 
     freeNodes.forEach((node, index) => {
         const row = Math.floor(index / GRID_COLUMNS);
@@ -151,7 +147,7 @@ const getNodeLayout = (
 
     // Draw the unconnected grid
     const free = freeNodesGridArray.flatMap((row, rowIndex) =>
-        row.map<MetricTreeCollapsedNodeData>((node, colIndex) => {
+        row.map<CollapsedNodeData>((node, colIndex) => {
             // Calculate x position based on widths of nodes in same row
             const allPrevNodesInRowWidths = row
                 .slice(0, colIndex)
@@ -176,11 +172,11 @@ const getNodeLayout = (
                 ...node,
                 type: MetricTreeNodeType.COLLAPSED,
                 position: { x, y },
-            } satisfies MetricTreeCollapsedNodeData;
+            } satisfies CollapsedNodeData;
         }),
     );
 
-    let unconnectedGroup: MetricTreeFreeGroupNodeData | undefined;
+    let unconnectedGroup: FreeGroupNodeData | undefined;
     let unconnectedGroupWidth = 0;
     let unconnectedGroupHeight = 0;
 
@@ -215,7 +211,7 @@ const getNodeLayout = (
                   },
                   type: MetricTreeNodeType.FREE_GROUP,
                   selectable: false,
-              } satisfies MetricTreeFreeGroupNodeData)
+              } satisfies FreeGroupNodeData)
             : undefined;
     }
 
@@ -259,7 +255,7 @@ const getNodeLayout = (
     };
 };
 
-const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
+const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
     const { track } = useTracking();
     const theme = useMantineTheme();
     const userUuid = useAppSelector(
@@ -609,4 +605,4 @@ const MetricTree: FC<Props> = ({ metrics, edges, viewOnly }) => {
     );
 };
 
-export default MetricTree;
+export default Canvas;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -59,7 +59,7 @@ import { MetricCatalogView } from '../types';
 import { MetricExploreModal } from './MetricExploreModal';
 import { MetricsCatalogColumns } from './MetricsCatalogColumns';
 import { MetricsTableTopToolbar } from './MetricsTableTopToolbar';
-import MetricTree from './MetricTree';
+import Canvas from './Canvas';
 
 type MetricsTableProps = {
     metricCatalogView: MetricCatalogView;
@@ -581,7 +581,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
             if (
                 data &&
                 metricCatalogView === MetricCatalogView.LIST &&
-                prevView.current === MetricCatalogView.TREE
+                prevView.current === MetricCatalogView.CANVAS
             ) {
                 table.setRowSelection({}); // Force a re-render of the table
             }
@@ -605,7 +605,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                     )}
                 </>
             );
-        case MetricCatalogView.TREE:
+        case MetricCatalogView.CANVAS:
             return (
                 <Paper {...mantinePaperProps}>
                     <Box>
@@ -630,7 +630,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                     <Box w="100%" h="calc(100dvh - 350px)" mih={600}>
                         <ReactFlowProvider>
                             {isValidMetricsTree ? (
-                                <MetricTree
+                                <Canvas
                                     metrics={flatData}
                                     edges={metricsTree?.edges ?? []}
                                     viewOnly={!canManageMetricsTree}
@@ -650,7 +650,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                                                 void navigate({
                                                     pathname:
                                                         location.pathname.replace(
-                                                            /\/tree/,
+                                                            /\/canvas/,
                                                             '',
                                                         ),
                                                 });

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -233,7 +233,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                         </Center>
                                     </SegmentedControlHoverCard>
                                 ),
-                                value: MetricCatalogView.TREE,
+                                value: MetricCatalogView.CANVAS,
                             },
                         ]}
                         onChange={(value) => {
@@ -247,13 +247,13 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                 case MetricCatalogView.LIST:
                                     void navigate({
                                         pathname: location.pathname.replace(
-                                            /\/tree/,
+                                            /\/canvas/,
                                             '',
                                         ),
                                         search: location.search,
                                     });
                                     break;
-                                case MetricCatalogView.TREE:
+                                case MetricCatalogView.CANVAS:
                                     track({
                                         name: EventName.METRICS_CATALOG_TREES_CANVAS_MODE_CLICKED,
                                         properties: {
@@ -263,7 +263,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                         },
                                     });
                                     void navigate({
-                                        pathname: `${location.pathname}/tree`,
+                                        pathname: `${location.pathname}/canvas`,
                                         search: location.search,
                                     });
                                     break;

--- a/packages/frontend/src/features/metricsCatalog/types.ts
+++ b/packages/frontend/src/features/metricsCatalog/types.ts
@@ -1,4 +1,4 @@
 export enum MetricCatalogView {
     LIST = 'list',
-    TREE = 'tree',
+    CANVAS = 'canvas',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Renames `MetricTree` component to `Canvas`
- Replaces `/tree` route to `/canvas`

This is so we follow new naming.
Canvas will still render metric trees (it only renders that for now) so the backend endpoints to fetch the tree remains the same, but new naming makes it more generic and future proof as the canvas might be able to render other things.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
