### PR TITLE
chore: store just the userUuid in catalog slice

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -319,7 +319,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                     'MetricsTree',
                 );
 
-                dispatch(setUser(user.data));
+                dispatch(setUser({ userUuid: user.data.userUuid }));
 
                 dispatch(
                     setAbility({

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -13,7 +13,7 @@ type MetricsCatalogState = {
             metric: Pick<CatalogField, 'name' | 'tableName'> | undefined;
         };
     };
-    user: UserWithAbility | undefined;
+    user: Pick<UserWithAbility, 'userUuid'> | undefined;
     abilities: {
         canManageTags: boolean;
         canRefreshCatalog: boolean;
@@ -105,7 +105,10 @@ export const metricsCatalogSlice = createSlice({
         setTableSorting: (state, action: PayloadAction<MRT_SortingState>) => {
             state.tableSorting = action.payload;
         },
-        setUser: (state, action: PayloadAction<UserWithAbility>) => {
+        setUser: (
+            state,
+            action: PayloadAction<Pick<UserWithAbility, 'userUuid'>>,
+        ) => {
             state.user = action.payload;
         },
         setAbility: (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

After this merge: #13275, the slice was storing unserializable data in redux
This only stores `userUuid` - if we need more info, we can get it from the endpoint response later.

events sent properly still: 
<img width="1869" alt="Screenshot 2025-01-16 at 16 39 05" src="https://github.com/user-attachments/assets/8a789379-5493-468b-8cda-bce6ce726c99" />




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
