### PR TITLE
fix: sql runner table borders

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -643,7 +643,7 @@ export const ContentPanel: FC = () => {
                         sx={(theme) => ({
                             transition: 'background-color 0.2s ease-in-out',
                             cursor: 'row-resize',
-                            display: 'flex',
+                            display: hideResultsPanel ? 'none' : 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
                             '&:hover': {
@@ -652,6 +652,7 @@ export const ContentPanel: FC = () => {
                             '&[data-resize-handle-state="drag"]': {
                                 backgroundColor: theme.colors.gray[3],
                             },
+                            borderLeft: `1px solid ${theme.colors.gray[3]}`,
                             gap: 5,
                         })}
                     >
@@ -690,12 +691,9 @@ export const ContentPanel: FC = () => {
                         <Box
                             h="100%"
                             pos="relative"
-                            sx={(theme) => ({
+                            sx={{
                                 overflow: 'auto',
-                                borderWidth: '0 0 1px 1px',
-                                borderStyle: 'solid',
-                                borderColor: theme.colors.gray[3],
-                            })}
+                            }}
                         >
                             <LoadingOverlay
                                 pos="absolute"


### PR DESCRIPTION
### Description:

Fixes a couple issues with SQL runner table styles.

1. Cleans up result table and drag handle borders. The drag handle had no left border and the table had double borders. To repro: run a query and look at the results table and drag handle at the bottom of the page.
**Before**
<img width="212" alt="Screenshot 2025-01-17 at 16 51 37" src="https://github.com/user-attachments/assets/25c7765b-8f72-4b19-8379-e72276d0973d" />

**Now**
<img width="344" alt="Screenshot 2025-01-17 at 16 51 01" src="https://github.com/user-attachments/assets/0630f5df-f581-4f02-810a-3d7fc2ed2999" />


2. Remove the resize handle when only the table is showing. To repro: run a query, switch to the chart tab, select table viz. Before, there was a resize handle that didn't do anything, now it is hidden. 
**Before**
<img width="765" alt="Screenshot 2025-01-17 at 16 51 29" src="https://github.com/user-attachments/assets/322a6159-5b9b-4eaf-b739-0ec2f64d4e83" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
