### PR TITLE
fix: email with pdf attachments

### DIFF
--- a/packages/backend/src/clients/Aws/s3.ts
+++ b/packages/backend/src/clients/Aws/s3.ts
@@ -97,6 +97,10 @@ export class S3Client {
         }
     }
 
+    async uploadPdf(pdf: Buffer, id: string): Promise<string> {
+        return this.uploadFile(`${id}.pdf`, pdf, 'application/pdf');
+    }
+
     async uploadImage(image: Buffer, imageId: string): Promise<string> {
         return this.uploadFile(`${imageId}.png`, image, 'image/png');
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#2723](https://github.com/lightdash/lightdash-internal-work/issues/2723)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Problem: There was a change where generated pdf files were not available in the machine that was sending the email.
Solution: Save generated pdfs in S3 and use S3 URL for the email attachment. 

Before: 
Email with pdf attachment could fail because pdf could not be found.
```
Failed task 927252 (sendEmailNotification) with error Failed to send email. Error: ENOENT: no such file or directory, open '/tmp/slack-image-notification-1234_abcd.pdf' (281.63ms):
  SmptError: Failed to send email. Error: ENOENT: no such file or directory, open '/tmp/slack-image-notification-1234_abcd.pdf'
      at EmailClient.sendEmail (/usr/app/packages/backend/dist/clients/EmailClient/EmailClient.js:66:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async CommercialSchedulerWorker.sendEmailNotification (/usr/app/packages/backend/dist/scheduler/SchedulerTask.js:821:17)
      at async /usr/app/packages/backend/dist/scheduler/SchedulerWorker.js:168:21
      at async /usr/app/packages/backend/dist/scheduler/SchedulerClient.js:67:29
      at async /usr/app/packages/backend/dist/scheduler/SchedulerClient.js:52:21
      at async /usr/app/packages/backend/dist/scheduler/SchedulerClient.js:49:17
```

After:

email test
<img width="383" alt="Screenshot 2025-01-17 at 16 08 11" src="https://github.com/user-attachments/assets/5ea22945-8ef6-4ae3-bb9a-6fd6b0d28f96" />
email raw content
<img width="492" alt="Screenshot 2025-01-17 at 16 08 37" src="https://github.com/user-attachments/assets/c4658ba4-2454-496f-8c5b-f413ba2617f7" />
logs
<img width="1330" alt="Screenshot 2025-01-17 at 16 06 57" src="https://github.com/user-attachments/assets/e8cb70e8-e33d-4f02-b494-6cf84c8fbc99" />




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
