### PR TITLE
fix: resize edit tab to match Add New tab width

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/EditTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTabs/EditTabModal.tsx
@@ -42,7 +42,7 @@ export const TabEditModal: FC<AddProps> = ({
                 </Group>
             }
             {...modalProps}
-            size="xl"
+            size="sm"
             onClose={handleClose}
         >
             <form onSubmit={handleConfirm}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13250 

### Description:
This PR adjusts the width of the 'Edit Your Tab' modal to match the width of the 'Add New Tab' modal.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
