### PR TITLE
fix: prevent canvas infinite loop when calling setLayout on useEffect

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -356,6 +356,7 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
 
             setCurrentNodes(layout.nodes);
             setCurrentEdges(layout.edges);
+            setIsLayoutReady(true); // Prevent layout from being applied again - relevant to be set before renderTwice because of setTimeout otherwise it goes into an infinite loop
 
             if (renderTwice) {
                 setTimeout(() => {
@@ -368,8 +369,6 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
             window.requestAnimationFrame(() => {
                 void fitView({ maxZoom: 1.2 });
             });
-
-            setIsLayoutReady(true);
         },
         [currentNodes, currentEdges, setCurrentNodes, setCurrentEdges, fitView],
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

**Before**
![image](https://github.com/user-attachments/assets/910d301a-dc98-47d8-85dd-215905ca8241)

**After**
![image](https://github.com/user-attachments/assets/8770c7ab-d94c-4ee9-88e9-e6aecda7a609)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
