### PR TITLE
fix: do not filter explores early on for chart results

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -46,7 +46,7 @@ import {
 import { isArray } from 'lodash';
 import { hasUserAttribute } from './services/UserAttributesService/UserAttributeUtils';
 
-const getDimensionFromId = (
+export const getDimensionFromId = (
     dimId: FieldId,
     explore: Explore,
     adapterType: SupportedDbtAdapter,
@@ -79,8 +79,10 @@ const getDimensionFromId = (
                 };
         }
 
+        console.trace();
         throw new FieldReferenceError(
             `Tried to reference dimension with unknown field id: ${dimId}`,
+            { dimId },
         );
     }
     return dimension;

--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -79,7 +79,6 @@ export const getDimensionFromId = (
                 };
         }
 
-        console.trace();
         throw new FieldReferenceError(
             `Tried to reference dimension with unknown field id: ${dimId}`,
             { dimId },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #13323

Alternative solution 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Before:

![Screenshot from 2025-01-21 09-16-14](https://github.com/user-attachments/assets/d3f3bc08-0350-4644-b571-363afeb7d84a)

After

![Screenshot from 2025-01-21 10-30-50](https://github.com/user-attachments/assets/3373316e-18f6-4b8b-acd2-146b0fc17342)


unfilterdTables is not exposed on the explore api

![Screenshot from 2025-01-21 10-36-00](https://github.com/user-attachments/assets/35cd895f-9af5-4107-b310-c581fdad559b)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
