### PR TITLE
fix: get spotlight config and tags authorized in demo

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -796,11 +796,7 @@ export class ProjectController extends BaseController {
         };
     }
 
-    @Middlewares([
-        allowApiKeyAuthentication,
-        isAuthenticated,
-        unauthorisedInDemo,
-    ])
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('{projectUuid}/tags')
     @OperationId('getTags')

--- a/packages/backend/src/controllers/spotlightController.ts
+++ b/packages/backend/src/controllers/spotlightController.ts
@@ -55,11 +55,7 @@ export class SpotlightController extends BaseController {
         };
     }
 
-    @Middlewares([
-        allowApiKeyAuthentication,
-        isAuthenticated,
-        unauthorisedInDemo,
-    ])
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/table/config')
     @OperationId('getSpotlightTableConfig')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

GET for tags and config are unauthorized in demo
![image](https://github.com/user-attachments/assets/54752749-2f13-42ed-bac8-e5dc28e9e8e1)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
