### PR TITLE
feat: sql runner consistent style for series config form

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -191,9 +191,21 @@ export const CartesianChartSeries = ({
             {isGrouped
                 ? Object.entries(groupedSeries).map(
                       ([referenceField, seriesArray]) => (
-                          <Accordion key={referenceField} variant="contained">
+                          <Accordion
+                              key={referenceField}
+                              variant="contained"
+                              sx={(theme) => ({
+                                  root: {
+                                      border: `1px solid ${theme.colors.gray[2]}`,
+                                  },
+                              })}
+                          >
                               <Accordion.Item value={referenceField} m={0}>
-                                  <Accordion.Control>
+                                  <Accordion.Control
+                                      sx={{
+                                          backgroundColor: 'white',
+                                      }}
+                                  >
                                       <Config.Subheading>
                                           {friendlyName(referenceField)}
                                       </Config.Subheading>
@@ -201,6 +213,9 @@ export const CartesianChartSeries = ({
                                   {seriesArray.map((s, index) => (
                                       <Accordion.Panel
                                           key={`${s.reference}-${index}`}
+                                          sx={{
+                                              backgroundColor: 'white',
+                                          }}
                                       >
                                           <SingleSeriesConfiguration
                                               key={`${s.reference}-${index}`}

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -210,13 +210,13 @@ export const CartesianChartSeries = ({
                                           {friendlyName(referenceField)}
                                       </Config.Subheading>
                                   </Accordion.Control>
-                                  {seriesArray.map((s, index) => (
-                                      <Accordion.Panel
-                                          key={`${s.reference}-${index}`}
-                                          sx={{
-                                              backgroundColor: 'white',
-                                          }}
-                                      >
+                                  <Accordion.Panel
+                                      sx={(theme) => ({
+                                          backgroundColor: 'white',
+                                          borderRadius: theme.radius.sm,
+                                      })}
+                                  >
+                                      {seriesArray.map((s, index) => (
                                           <SingleSeriesConfiguration
                                               key={`${s.reference}-${index}`}
                                               reference={s.reference}
@@ -239,8 +239,8 @@ export const CartesianChartSeries = ({
                                                   handleValueLabelPositionChange
                                               }
                                           />
-                                      </Accordion.Panel>
-                                  ))}
+                                      ))}
+                                  </Accordion.Panel>
                               </Accordion.Item>
                           </Accordion>
                       ),

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -70,7 +70,6 @@ export const CartesianChartTypeConfig: FC<Props> = ({ onChangeType, type }) => {
             ) => value && onChangeType(value)}
             styles={(theme) => ({
                 input: {
-                    width: '150px',
                     fontWeight: 500,
                 },
                 item: {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -22,7 +22,7 @@ const ChartTypeIcon: FC<{ type: CartesianSeriesType }> = ({ type }) => {
             ? ChartKind.VERTICAL_BAR
             : ChartKind.LINE;
 
-    return <MantineIcon icon={getChartIcon(chartKind)} color="indigo.4" />;
+    return <MantineIcon icon={getChartIcon(chartKind)} color="dark.0" />;
 };
 
 const ChartTypeItem = forwardRef<
@@ -69,8 +69,12 @@ export const CartesianChartTypeConfig: FC<Props> = ({ onChangeType, type }) => {
                 >,
             ) => value && onChangeType(value)}
             styles={(theme) => ({
+                root: {
+                    flex: 1,
+                },
                 input: {
                     fontWeight: 500,
+                    border: `1px solid ${theme.colors.gray[2]}`,
                 },
                 item: {
                     '&[data-selected="true"]': {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -83,7 +83,6 @@ export const CartesianChartValueLabelConfig: FC<Props> = ({
             }
             styles={(theme) => ({
                 input: {
-                    width: '110px',
                     fontWeight: 500,
                 },
                 item: {

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -40,7 +40,7 @@ const ValueLabelIcon: FC<{
             icon = IconClearAll;
     }
 
-    return <MantineIcon color={position ? 'indigo.4' : 'gray.4'} icon={icon} />;
+    return <MantineIcon color={position ? 'dark.0' : 'gray.4'} icon={icon} />;
 };
 
 type Props = {
@@ -82,8 +82,12 @@ export const CartesianChartValueLabelConfig: FC<Props> = ({
                 onChangeValueLabelPosition(value as ValueLabelPositionOptions)
             }
             styles={(theme) => ({
+                root: {
+                    flex: 1,
+                },
                 input: {
                     fontWeight: 500,
+                    borderColor: theme.colors.gray[2],
                 },
                 item: {
                     '&[data-selected="true"]': {

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import {
     Box,
+    Flex,
     Group,
     SegmentedControl,
     Stack,
@@ -19,6 +20,8 @@ import ColorSelector from '../../VisualizationConfigs/ColorSelector';
 import { Config } from '../../VisualizationConfigs/common/Config';
 import { CartesianChartTypeConfig } from './CartesianChartTypeConfig';
 import { CartesianChartValueLabelConfig } from './CartesianChartValueLabelConfig';
+
+const LABEL_WIDTH = 120;
 
 type SingleSeriesConfigurationProps = {
     reference: string;
@@ -63,37 +66,58 @@ export const SingleSeriesConfiguration = ({
                 pl="sm"
                 spacing="xs"
                 sx={(theme) => ({
-                    borderLeft: `1px solid ${theme.colors.gray[2]}`,
-                    backgroundColor: theme.colors.gray[1],
+                    backgroundColor: theme.colors.gray[0],
                     borderRadius: theme.radius.md,
                     padding: theme.spacing.xs,
                 })}
             >
                 <Config.Subheading>{reference}</Config.Subheading>
-                <Config.Group grow spacing={0}>
-                    <Config.Label>Label</Config.Label>
-                    <Group spacing="xs" noWrap grow position="left">
-                        <Box w="20px">
-                            <ColorSelector
-                                color={color}
-                                onColorChange={(c) =>
-                                    onColorChange(reference, c)
+                <Flex justify="flex-start" align="center" wrap="nowrap">
+                    <Config.Label w={LABEL_WIDTH}>Label</Config.Label>
+                    <Group
+                        spacing="xs"
+                        position="left"
+                        noWrap
+                        grow
+                        style={{ flex: 3 }}
+                    >
+                        <Box
+                            sx={{
+                                flex: 1,
+                                display: 'flex',
+                                flexDirection: 'row',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Box w="20px">
+                                <ColorSelector
+                                    color={color}
+                                    onColorChange={(c) =>
+                                        onColorChange(reference, c)
+                                    }
+                                    swatches={colors}
+                                />
+                            </Box>
+                            <TextInput
+                                maw="100%"
+                                radius="md"
+                                value={label}
+                                onChange={(e) =>
+                                    onLabelChange(reference, e.target.value)
                                 }
-                                swatches={colors}
+                                sx={(theme) => ({
+                                    input: {
+                                        border: `1px solid ${theme.colors.gray[2]}`,
+                                    },
+                                    flex: 1,
+                                    marginLeft: theme.spacing.xs,
+                                })}
                             />
                         </Box>
-                        <TextInput
-                            maw="100%"
-                            radius="md"
-                            value={label}
-                            onChange={(e) =>
-                                onLabelChange(reference, e.target.value)
-                            }
-                        />
                     </Group>
-                </Config.Group>
-                <Config.Group grow spacing={0} noWrap>
-                    <Config.Label>Chart Type</Config.Label>
+                </Flex>
+                <Flex justify="flex-start" align="center" wrap="nowrap">
+                    <Config.Label w={LABEL_WIDTH}>Chart Type</Config.Label>
                     <CartesianChartTypeConfig
                         canSelectDifferentTypeFromBaseChart={true}
                         type={
@@ -102,18 +126,21 @@ export const SingleSeriesConfiguration = ({
                         }
                         onChangeType={(value) => onTypeChange(reference, value)}
                     />
-                </Config.Group>
-                <Config.Group grow spacing={0} noWrap>
-                    <Config.Label>Y Axis</Config.Label>
+                </Flex>
+                <Flex justify="flex-start" align="center" wrap="nowrap">
+                    <Config.Label w={LABEL_WIDTH}>Y Axis</Config.Label>
                     <SegmentedControl
-                        sx={{ minWidth: '130px' }}
+                        sx={{ minWidth: '130px', flex: 1 }}
                         radius="md"
                         data={[
                             {
                                 value: 'left',
                                 label: (
                                     <Group spacing="xs" noWrap>
-                                        <MantineIcon icon={IconAlignLeft} />
+                                        <MantineIcon
+                                            icon={IconAlignLeft}
+                                            color="dark.0"
+                                        />
                                         <Text>Left</Text>
                                     </Group>
                                 ),
@@ -123,7 +150,10 @@ export const SingleSeriesConfiguration = ({
                                 label: (
                                     <Group spacing="xs" noWrap position="right">
                                         <Text>Right</Text>
-                                        <MantineIcon icon={IconAlignRight} />
+                                        <MantineIcon
+                                            icon={IconAlignRight}
+                                            color="dark.0"
+                                        />
                                     </Group>
                                 ),
                             },
@@ -138,9 +168,9 @@ export const SingleSeriesConfiguration = ({
                             )
                         }
                     />
-                </Config.Group>
-                <Config.Group grow spacing={0} noWrap>
-                    <Config.Label>Value labels</Config.Label>
+                </Flex>
+                <Flex justify="flex-start" align="center" wrap="nowrap">
+                    <Config.Label w={LABEL_WIDTH}>Value labels</Config.Label>
                     <CartesianChartValueLabelConfig
                         valueLabelPosition={
                             valueLabelPosition ??
@@ -150,7 +180,7 @@ export const SingleSeriesConfiguration = ({
                             onValueLabelPositionChange(reference, position)
                         }
                     />
-                </Config.Group>
+                </Flex>
             </Stack>
         </Stack>
     );

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -5,7 +5,14 @@ import {
     type CartesianChartDisplay,
     type ChartKind,
 } from '@lightdash/common';
-import { Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
+import {
+    Box,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';
@@ -63,15 +70,20 @@ export const SingleSeriesConfiguration = ({
                 })}
             >
                 <Config.Subheading>{reference}</Config.Subheading>
-                <Config.Group>
+                <Config.Group grow spacing={0}>
                     <Config.Label>Label</Config.Label>
-                    <Group spacing="xs" noWrap>
-                        <ColorSelector
-                            color={color}
-                            onColorChange={(c) => onColorChange(reference, c)}
-                            swatches={colors}
-                        />
+                    <Group spacing="xs" noWrap grow position="left">
+                        <Box w="20px">
+                            <ColorSelector
+                                color={color}
+                                onColorChange={(c) =>
+                                    onColorChange(reference, c)
+                                }
+                                swatches={colors}
+                            />
+                        </Box>
                         <TextInput
+                            maw="100%"
                             radius="md"
                             value={label}
                             onChange={(e) =>
@@ -80,7 +92,7 @@ export const SingleSeriesConfiguration = ({
                         />
                     </Group>
                 </Config.Group>
-                <Config.Group>
+                <Config.Group grow spacing={0} noWrap>
                     <Config.Label>Chart Type</Config.Label>
                     <CartesianChartTypeConfig
                         canSelectDifferentTypeFromBaseChart={true}
@@ -91,10 +103,10 @@ export const SingleSeriesConfiguration = ({
                         onChangeType={(value) => onTypeChange(reference, value)}
                     />
                 </Config.Group>
-                <Config.Group>
+                <Config.Group grow spacing={0} noWrap>
                     <Config.Label>Y Axis</Config.Label>
                     <SegmentedControl
-                        sx={{ alignSelf: 'center' }}
+                        sx={{ minWidth: '130px' }}
                         radius="md"
                         data={[
                             {
@@ -109,7 +121,7 @@ export const SingleSeriesConfiguration = ({
                             {
                                 value: 'right',
                                 label: (
-                                    <Group spacing="xs" noWrap>
+                                    <Group spacing="xs" noWrap position="right">
                                         <Text>Right</Text>
                                         <MantineIcon icon={IconAlignRight} />
                                     </Group>
@@ -127,7 +139,7 @@ export const SingleSeriesConfiguration = ({
                         }
                     />
                 </Config.Group>
-                <Config.Group>
+                <Config.Group grow spacing={0} noWrap>
                     <Config.Label>Value labels</Config.Label>
                     <CartesianChartValueLabelConfig
                         valueLabelPosition={

--- a/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
@@ -4,6 +4,7 @@ import {
     Stack,
     Text,
     type GroupProps,
+    type TextProps,
 } from '@mantine/core';
 import { type FC, type PropsWithChildren } from 'react';
 
@@ -12,7 +13,7 @@ interface ConfigComponent extends FC<PropsWithChildren> {
     Heading: FC<PropsWithChildren>;
     Subheading: FC<PropsWithChildren>;
     Group: FC<PropsWithChildren & GroupProps>;
-    Label: FC<PropsWithChildren>;
+    Label: FC<PropsWithChildren & TextProps>;
 }
 
 export const Config: ConfigComponent = ({ children }) => <Box>{children}</Box>;
@@ -33,8 +34,8 @@ const Subheading: FC<PropsWithChildren> = ({ children }) => (
     </Text>
 );
 
-const Label: FC<PropsWithChildren> = ({ children }) => (
-    <Text fw={500} size="xs" color="gray.6">
+const Label: FC<PropsWithChildren & TextProps> = ({ children, ...props }) => (
+    <Text fw={500} size="xs" color="gray.6" {...props}>
         {children}
     </Text>
 );

--- a/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
@@ -1,11 +1,17 @@
-import { Box, Group as MantineGroup, Stack, Text } from '@mantine/core';
+import {
+    Box,
+    Group as MantineGroup,
+    Stack,
+    Text,
+    type GroupProps,
+} from '@mantine/core';
 import { type FC, type PropsWithChildren } from 'react';
 
 interface ConfigComponent extends FC<PropsWithChildren> {
     Section: FC<PropsWithChildren>;
     Heading: FC<PropsWithChildren>;
     Subheading: FC<PropsWithChildren>;
-    Group: FC<PropsWithChildren>;
+    Group: FC<PropsWithChildren & GroupProps>;
     Label: FC<PropsWithChildren>;
 }
 
@@ -33,8 +39,10 @@ const Label: FC<PropsWithChildren> = ({ children }) => (
     </Text>
 );
 
-const Group: FC<PropsWithChildren> = ({ children }) => (
-    <MantineGroup position="apart">{children}</MantineGroup>
+const Group: FC<PropsWithChildren & GroupProps> = ({ children, ...props }) => (
+    <MantineGroup position="apart" {...props}>
+        {children}
+    </MantineGroup>
 );
 
 Config.Section = Section;


### PR DESCRIPTION
### Description:

Make the sql runner series config form have uniform inputs. 

**With this change**
<img width="394" alt="Screenshot 2025-01-23 at 13 45 25" src="https://github.com/user-attachments/assets/a871873f-4d7f-40a0-a625-45c9be1f1f77" />

**Before**
<img width="393" alt="Screenshot 2025-01-23 at 13 45 41" src="https://github.com/user-attachments/assets/41068213-2db0-4138-b87c-a163feb59972" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
