### PR TITLE
feat: handle yml-vs-ui catagories on spotlight

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -1,17 +1,26 @@
 import type { CatalogItem } from '@lightdash/common';
-import { ActionIcon, Badge, Group } from '@mantine/core';
-import { IconX } from '@tabler/icons-react';
+import { ActionIcon, Badge, Group, Tooltip } from '@mantine/core';
+import { IconCode, IconX } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCategoryStyles } from '../styles/useCategoryStyles';
 
 type Props = {
-    category: Pick<CatalogItem['categories'][number], 'name' | 'color'>;
+    category: Pick<
+        CatalogItem['categories'][number],
+        'name' | 'color' | 'yamlReference'
+    >;
     onClick?: React.MouseEventHandler<HTMLDivElement> | undefined;
     onRemove?: () => void;
+    showYamlIcon?: boolean;
 };
 
-export const CatalogCategory: FC<Props> = ({ category, onClick, onRemove }) => {
+export const CatalogCategory: FC<Props> = ({
+    category,
+    onClick,
+    onRemove,
+    showYamlIcon = false,
+}) => {
     const { classes } = useCategoryStyles(category.color);
 
     return (
@@ -24,6 +33,24 @@ export const CatalogCategory: FC<Props> = ({ category, onClick, onRemove }) => {
             onClick={onClick}
             py={10}
             h={24}
+            rightSection={
+                showYamlIcon && (
+                    <Tooltip
+                        variant="xs"
+                        maw={200}
+                        position="top"
+                        withinPortal
+                        label="This category cannot be removed from this metric because it was defined in the .yml file."
+                    >
+                        <MantineIcon
+                            icon={IconCode}
+                            size={12}
+                            strokeWidth={2.5}
+                            opacity={0.5}
+                        />
+                    </Tooltip>
+                )
+            }
             className={classes.base}
             styles={() => ({
                 root: {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -1,6 +1,7 @@
 import { getErrorMessage, type CatalogItem } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     Button,
     Divider,
     Group,
@@ -13,7 +14,7 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
-import { IconDots, IconTrash } from '@tabler/icons-react';
+import { IconCode, IconDots, IconTrash } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
@@ -180,12 +181,14 @@ type Props = {
     category: CatalogItem['categories'][number];
     onClick?: () => void;
     onSubPopoverChange?: (isOpen: boolean) => void;
+    canEdit: boolean;
 };
 
 export const MetricCatalogCategoryFormItem: FC<Props> = ({
     category,
     onClick,
     onSubPopoverChange,
+    canEdit,
 }) => {
     const { ref: hoverRef, hovered } = useHover<HTMLDivElement>();
 
@@ -206,11 +209,33 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
         >
             <UnstyledButton onClick={onClick} h="100%" w="90%" pos="absolute" />
             <CatalogCategory category={category} onClick={onClick} />
-            <EditPopover
-                hovered={hovered}
-                category={category}
-                onOpenChange={onSubPopoverChange}
-            />
+
+            {canEdit && (
+                <EditPopover
+                    hovered={hovered}
+                    category={category}
+                    onOpenChange={onSubPopoverChange}
+                />
+            )}
+
+            {!canEdit && (
+                <Tooltip
+                    variant="xs"
+                    maw={200}
+                    position="top"
+                    withinPortal
+                    label="This category was created in the .yml config and its properties cannot be edited"
+                >
+                    <Box
+                        p="xxs"
+                        sx={{
+                            visibility: hovered ? 'visible' : 'hidden',
+                        }}
+                    >
+                        <MantineIcon icon={IconCode} color="gray.6" size={14} />
+                    </Box>
+                </Tooltip>
+            )}
         </Group>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13394

### Description:

See AC. Visually approved by @PriPatel 

only show code icon on TagInput, dont show on dropdown
can't use yml-categories to categorise other metrics - this makes things more complex and could be very confusing to users! They will probably only define categories on the yml or on the ui, not both. Let's see!

<img width="372" alt="image" src="https://github.com/user-attachments/assets/24e2093e-95ef-4004-9867-1def8b33d0dc" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
