### PR TITLE
chore: track spotlight curation analytics events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1128,6 +1128,18 @@ type CreateTagEvent = BaseTrack & {
         name: string;
         projectId: string;
         organizationId: string;
+        context: 'yaml' | 'ui';
+    };
+};
+
+export type CategoriesAppliedEvent = BaseTrack & {
+    event: 'categories.applied';
+    userId: string;
+    properties: {
+        count: number;
+        projectId: string;
+        organizationId: string;
+        context: 'ui' | 'yaml';
     };
 };
 
@@ -1207,7 +1219,8 @@ type TypedEvent =
     | GithubInstallEvent
     | WriteBackEvent
     | SchedulerTimezoneUpdateEvent
-    | CreateTagEvent;
+    | CreateTagEvent
+    | CategoriesAppliedEvent;
 
 type WrapTypedEvent = SemanticLayerView;
 

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -40,11 +40,14 @@ export async function seed(knex: Knex): Promise<void> {
         seedEmail: Omit<DbEmailIn, 'user_id'>,
         seedPassword: { password: string },
     ) => {
-        const [{ organization_id: organizationId }] = await knex(
-            'organizations',
-        )
+        const [
+            {
+                organization_id: organizationId,
+                organization_uuid: organizationUuid,
+            },
+        ] = await knex('organizations')
             .insert(seedOrganization)
-            .returning('organization_id');
+            .returning(['organization_id', 'organization_uuid']);
         if (organizationId === undefined) {
             throw new Error('Organization was not created');
         }
@@ -76,10 +79,10 @@ export async function seed(knex: Knex): Promise<void> {
             shownSuccess_at: new Date(),
         });
 
-        return { organizationId, user };
+        return { organizationId, user, organizationUuid };
     };
 
-    const { organizationId, user } = await addUser(
+    const { organizationId, organizationUuid, user } = await addUser(
         SEED_ORG_1,
         SEED_ORG_1_ADMIN,
         SEED_ORG_1_ADMIN_EMAIL,
@@ -109,7 +112,9 @@ export async function seed(knex: Knex): Promise<void> {
         JSON.stringify(projectSettings),
     );
 
-    const [{ project_id: projectId }] = await knex('projects')
+    const [{ project_id: projectId, project_uuid: projectUuid }] = await knex(
+        'projects',
+    )
         .insert({
             ...SEED_PROJECT,
             organization_id: organizationId,
@@ -118,7 +123,7 @@ export async function seed(knex: Knex): Promise<void> {
             semantic_layer_connection: null,
             created_by_user_uuid: user.user_uuid,
         })
-        .returning('project_id');
+        .returning(['project_id', 'project_uuid']);
 
     if (projectId === undefined) {
         throw new Error('Project was not created');
@@ -185,7 +190,11 @@ export async function seed(knex: Knex): Promise<void> {
             },
             SupportedDbtVersions.V1_4,
         );
-        const explores = await adapter.compileAllExplores();
+        const explores = await adapter.compileAllExplores({
+            userUuid: user.user_uuid,
+            organizationUuid,
+            projectUuid,
+        });
         await new ProjectModel({
             database: knex,
             lightdashConfig,

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -37,9 +37,12 @@ export const convertExploresToCatalog = (
 ): {
     catalogInserts: CatalogInsertWithYamlTags[];
     catalogFieldMap: CatalogFieldMap;
+    numberOfCategoriesApplied: number;
 } => {
     // Track fields' ids and names to calculate their chart usage
     const catalogFieldMap: CatalogFieldMap = {};
+
+    let numberOfCategoriesApplied = 0;
 
     const catalogInserts = cachedExplores.reduce<CatalogInsertWithYamlTags[]>(
         (acc, explore) => {
@@ -83,6 +86,10 @@ export const convertExploresToCatalog = (
                           )
                         : [];
 
+                    if (assignedYamlTags.length > 0) {
+                        numberOfCategoriesApplied += assignedYamlTags.length;
+                    }
+
                     return {
                         project_uuid: projectUuid,
                         cached_explore_uuid: explore.cachedExploreUuid,
@@ -115,6 +122,7 @@ export const convertExploresToCatalog = (
     return {
         catalogInserts,
         catalogFieldMap,
+        numberOfCategoriesApplied,
     };
 };
 

--- a/packages/backend/src/models/TagsModel.ts
+++ b/packages/backend/src/models/TagsModel.ts
@@ -68,7 +68,14 @@ export class TagsModel {
         return tags;
     }
 
-    async replaceYamlTags(projectUuid: string, yamlTags: DbTagIn[]) {
+    async replaceYamlTags(
+        projectUuid: string,
+        yamlTags: DbTagIn[],
+    ): Promise<{ yamlTagsToCreateOrUpdate: string[] }> {
+        const result: {
+            yamlTagsToCreateOrUpdate: string[];
+        } = { yamlTagsToCreateOrUpdate: [] };
+
         await this.database.transaction(async (trx) => {
             // get all yaml tags in the project
             const projectYamlTags = await trx(TagsTableName)
@@ -83,6 +90,10 @@ export class TagsModel {
                             projectYamlTag.yaml_reference ===
                             yamlTag.yaml_reference,
                     ),
+            );
+
+            result.yamlTagsToCreateOrUpdate = yamlTagsToCreate.map(
+                (tag) => tag.name,
             );
 
             // get all updates for the existing project yaml tags
@@ -109,6 +120,11 @@ export class TagsModel {
                 },
                 {},
             );
+
+            result.yamlTagsToCreateOrUpdate = [
+                ...result.yamlTagsToCreateOrUpdate,
+                ...Object.values(yamlTagUpdates).map((tag) => tag.name ?? ''),
+            ];
 
             // delete all yaml tags that are in the project but are not in the yamlTags array
             await trx(TagsTableName)
@@ -137,5 +153,7 @@ export class TagsModel {
                 await Promise.all(updatePromises);
             }
         });
+
+        return result;
     }
 }

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
@@ -4,6 +4,7 @@ import {
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
@@ -22,10 +23,12 @@ type Args = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
     constructor({
+        analytics,
         warehouseClient,
         personalAccessToken,
         organization,
@@ -43,6 +46,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
     }: Args) {
         const remoteRepositoryUrl = `https://${personalAccessToken}@dev.azure.com/${organization}/${project}/_git/${repository}`;
         super({
+            analytics,
             warehouseClient,
             gitBranch: branch,
             remoteRepositoryUrl,

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
@@ -5,6 +5,7 @@ import {
     type WarehouseClient,
 } from '@lightdash/common';
 import fs from 'fs/promises';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import type { CachedWarehouse, DbtClient } from '../types';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -84,7 +84,15 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         return undefined;
     }
 
-    public async getLightdashProjectConfig(): Promise<LightdashProjectConfig> {
+    public async getLightdashProjectConfig({
+        projectUuid,
+        organizationUuid,
+        userUuid,
+    }: {
+        userUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<LightdashProjectConfig> {
         if (!this.dbtProjectDir) {
             return {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
@@ -104,9 +112,9 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     void this.analytics?.track({
                         event: 'lightdashconfig.loaded',
                         properties: {
-                            // projectId: projectUuid,
-                            // userId: userUuid,
-                            // organizationId: organizationUuid,
+                            projectId: projectUuid,
+                            userId: userUuid,
+                            organizationId: organizationUuid,
                             categories_count: Number(
                                 Object.keys(
                                     lightdashConfig.spotlight.categories ?? {},
@@ -133,6 +141,15 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     }
 
     public async compileAllExplores(
+        {
+            userUuid,
+            organizationUuid,
+            projectUuid,
+        }: {
+            userUuid: string;
+            organizationUuid: string;
+            projectUuid: string;
+        },
         loadSources: boolean = false,
     ): Promise<(Explore | ExploreError)[]> {
         Logger.debug('Install dependencies');
@@ -205,7 +222,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 : Object.values(manifest.metrics),
         );
 
-        const lightdashProjectConfig = await this.getLightdashProjectConfig();
+        const lightdashProjectConfig = await this.getLightdashProjectConfig({
+            userUuid,
+            organizationUuid,
+            projectUuid,
+        });
 
         // Be lazy and try to attach types to the remaining models without refreshing the catalog
         try {

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -4,6 +4,7 @@ import {
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
@@ -24,10 +25,12 @@ type Args = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
     constructor({
+        analytics,
         warehouseClient,
         username,
         branch,
@@ -47,6 +50,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
             hostDomain || DEFAULT_HOST_DOMAIN
         }/${repository}.git`;
         super({
+            analytics,
             warehouseClient,
             gitBranch: branch,
             remoteRepositoryUrl,

--- a/packages/backend/src/projectAdapters/dbtCloudIdeProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtCloudIdeProjectAdapter.ts
@@ -1,5 +1,6 @@
 import { SupportedDbtVersions } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { DbtMetadataApiClient } from '../dbt/DbtMetadataApiClient';
 import { CachedWarehouse, ProjectAdapter } from '../types';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
@@ -12,6 +13,7 @@ type DbtCloudideProjectAdapterArgs = {
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     tags: string[] | undefined;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtCloudIdeProjectAdapter
@@ -26,6 +28,7 @@ export class DbtCloudIdeProjectAdapter
         dbtVersion,
         discoveryApiEndpoint,
         tags,
+        analytics,
     }: DbtCloudideProjectAdapterArgs) {
         const dbtClient = new DbtMetadataApiClient({
             environmentId,
@@ -33,6 +36,13 @@ export class DbtCloudIdeProjectAdapter
             discoveryApiEndpoint,
             tags,
         });
-        super(dbtClient, warehouseClient, cachedWarehouse, dbtVersion);
+        super(
+            dbtClient,
+            warehouseClient,
+            cachedWarehouse,
+            dbtVersion,
+            undefined,
+            analytics,
+        );
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -213,9 +213,21 @@ export class DbtGitProjectAdapter extends DbtLocalCredentialsProjectAdapter {
         }
     }
 
-    public async compileAllExplores() {
+    public async compileAllExplores({
+        userUuid,
+        organizationUuid,
+        projectUuid,
+    }: {
+        userUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }) {
         await this._refreshRepo();
-        return super.compileAllExplores();
+        return super.compileAllExplores({
+            userUuid,
+            organizationUuid,
+            projectUuid,
+        });
     }
 
     public async test() {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -17,6 +17,7 @@ import simpleGit, {
     SimpleGit,
     SimpleGitProgressEvent,
 } from 'simple-git';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
 import { CachedWarehouse } from '../types';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
@@ -34,6 +35,7 @@ export type DbtGitProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 const stripTokensFromUrls = (raw: string) => {
@@ -96,6 +98,7 @@ export class DbtGitProjectAdapter extends DbtLocalCredentialsProjectAdapter {
         dbtVersion,
         useDbtLs,
         selector,
+        analytics,
     }: DbtGitProjectAdapterArgs) {
         const localRepositoryDir = fs.mkdtempSync('/tmp/git_');
         const projectDir = path.join(
@@ -112,6 +115,7 @@ export class DbtGitProjectAdapter extends DbtLocalCredentialsProjectAdapter {
             dbtVersion,
             useDbtLs,
             selector,
+            analytics,
         });
         this.projectDirectorySubPath = projectDirectorySubPath;
         this.localRepositoryDir = localRepositoryDir;

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -5,6 +5,7 @@ import {
     validateGithubToken,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
@@ -24,6 +25,7 @@ type DbtGithubProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
@@ -41,6 +43,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         useDbtLs,
         selector,
+        analytics,
     }: DbtGithubProjectAdapterArgs) {
         const [isValid, error] = validateGithubToken(githubPersonalAccessToken);
         if (!isValid) {
@@ -62,6 +65,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             useDbtLs,
             selector,
+            analytics,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -4,6 +4,7 @@ import {
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 
@@ -23,6 +24,7 @@ type DbtGitlabProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
@@ -40,6 +42,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         useDbtLs,
         selector,
+        analytics,
     }: DbtGitlabProjectAdapterArgs) {
         const remoteRepositoryUrl = `https://lightdash:${gitlabPersonalAccessToken}@${
             hostDomain || DEFAULT_GITLAB_HOST_DOMAIN
@@ -57,6 +60,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             useDbtLs,
             selector,
+            analytics,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -7,6 +7,7 @@ import { WarehouseClient } from '@lightdash/warehouses';
 import fs, { writeFileSync } from 'fs';
 import * as fspromises from 'fs/promises';
 import * as path from 'path';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import {
     LIGHTDASH_PROFILE_NAME,
     LIGHTDASH_TARGET_NAME,
@@ -26,6 +27,7 @@ type DbtLocalCredentialsProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
@@ -41,6 +43,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
         dbtVersion,
         useDbtLs,
         selector,
+        analytics,
     }: DbtLocalCredentialsProjectAdapterArgs) {
         const profilesDir = fs.mkdtempSync('/tmp/local_');
         const profilesFilename = path.join(profilesDir, 'profiles.yml');
@@ -82,6 +85,7 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             dbtVersion,
             useDbtLs,
             selector,
+            analytics,
         });
         this.profilesDir = profilesDir;
     }

--- a/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalProjectAdapter.ts
@@ -1,5 +1,6 @@
 import { SupportedDbtVersions } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { DbtCliClient } from '../dbt/dbtCliClient';
 import { CachedWarehouse } from '../types';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
@@ -15,10 +16,12 @@ type DbtLocalProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     useDbtLs: boolean;
     selector?: string;
+    analytics?: LightdashAnalytics;
 };
 
 export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
     constructor({
+        analytics,
         warehouseClient,
         projectDir,
         profilesDir,
@@ -46,6 +49,7 @@ export class DbtLocalProjectAdapter extends DbtBaseProjectAdapter {
             cachedWarehouse,
             dbtVersion,
             projectDir,
+            analytics,
         );
     }
 }

--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
@@ -32,9 +32,11 @@ export class DbtNoneCredentialsProjectAdapter implements ProjectAdapter {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public async compileAllExplores(
-        loadSources: boolean = false,
-    ): Promise<(Explore | ExploreError)[]> {
+    public async compileAllExplores(_args: {
+        userUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<(Explore | ExploreError)[]> {
         throw new Error('Cannot compile explores with CLI-created projects');
     }
 

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -8,6 +8,7 @@ import {
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
 import { CachedWarehouse, ProjectAdapter } from '../types';
 import { DbtAzureDevOpsProjectAdapter } from './dbtAzureDevOpsProjectAdapter';
@@ -24,6 +25,7 @@ export const projectAdapterFromConfig = async (
     cachedWarehouse: CachedWarehouse,
     dbtVersionOption: DbtVersionOption,
     useDbtLs: boolean = true,
+    analytics?: LightdashAnalytics,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -41,6 +43,7 @@ export const projectAdapterFromConfig = async (
     switch (config.type) {
         case DbtProjectType.DBT:
             return new DbtLocalCredentialsProjectAdapter({
+                analytics,
                 warehouseClient,
                 projectDir: config.project_dir || '/usr/app/dbt',
                 warehouseCredentials,
@@ -58,6 +61,7 @@ export const projectAdapterFromConfig = async (
 
         case DbtProjectType.DBT_CLOUD_IDE:
             return new DbtCloudIdeProjectAdapter({
+                analytics,
                 warehouseClient,
                 environmentId: `${config.environment_id}`,
                 discoveryApiEndpoint: config.discovery_api_endpoint,
@@ -69,6 +73,7 @@ export const projectAdapterFromConfig = async (
             });
         case DbtProjectType.GITHUB:
             return new DbtGithubProjectAdapter({
+                analytics,
                 warehouseClient,
                 githubPersonalAccessToken: config.personal_access_token,
                 githubRepository: config.repository,
@@ -85,6 +90,7 @@ export const projectAdapterFromConfig = async (
             });
         case DbtProjectType.GITLAB:
             return new DbtGitlabProjectAdapter({
+                analytics,
                 warehouseClient,
                 gitlabPersonalAccessToken: config.personal_access_token,
                 gitlabRepository: config.repository,
@@ -101,6 +107,7 @@ export const projectAdapterFromConfig = async (
             });
         case DbtProjectType.BITBUCKET:
             return new DbtBitBucketProjectAdapter({
+                analytics,
                 warehouseClient,
                 username: config.username,
                 personalAccessToken: config.personal_access_token,
@@ -118,6 +125,7 @@ export const projectAdapterFromConfig = async (
             });
         case DbtProjectType.AZURE_DEVOPS:
             return new DbtAzureDevOpsProjectAdapter({
+                analytics,
                 warehouseClient,
                 personalAccessToken: config.personal_access_token,
                 organization: config.organization,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -707,7 +707,10 @@ export class ProjectService extends BaseService {
                 JobStepType.COMPILING,
                 async () => {
                     try {
-                        return await adapter.compileAllExplores();
+                        return await adapter.compileAllExplores({
+                            userUuid: user.userUuid,
+                            organizationUuid: user.organizationUuid,
+                        });
                     } finally {
                         await adapter.destroy();
                         await sshTunnel.disconnect();
@@ -734,7 +737,11 @@ export class ProjectService extends BaseService {
                     }
 
                     const lightdashProjectConfig =
-                        await adapter.getLightdashProjectConfig();
+                        await adapter.getLightdashProjectConfig({
+                            projectUuid: newProjectUuid,
+                            organizationUuid: user.organizationUuid,
+                            userUuid: user.userUuid,
+                        });
 
                     await this.replaceYamlTags(
                         user,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -8,7 +8,15 @@ import {
 import { WarehouseCatalog } from '@lightdash/warehouses';
 
 export interface ProjectAdapter {
-    compileAllExplores(): Promise<(Explore | ExploreError)[]>;
+    compileAllExplores({
+        userUuid,
+        organizationUuid,
+        projectUuid,
+    }: {
+        userUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<(Explore | ExploreError)[]>;
 
     getDbtPackages(): Promise<DbtPackages | undefined>;
 
@@ -16,7 +24,15 @@ export interface ProjectAdapter {
 
     destroy(): Promise<void>;
 
-    getLightdashProjectConfig(): Promise<LightdashProjectConfig>;
+    getLightdashProjectConfig({
+        projectUuid,
+        organizationUuid,
+        userUuid,
+    }: {
+        userUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<LightdashProjectConfig>;
 }
 
 export interface DbtClient {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -8,15 +8,20 @@ import {
 import { WarehouseCatalog } from '@lightdash/warehouses';
 
 export interface ProjectAdapter {
-    compileAllExplores({
-        userUuid,
-        organizationUuid,
-        projectUuid,
-    }: {
-        userUuid: string;
-        organizationUuid: string;
-        projectUuid: string;
-    }): Promise<(Explore | ExploreError)[]>;
+    /**
+     * Compile all explores
+     * @param trackingParams - Optional tracking parameters to track the compilation and lightdash project config (lightdash.config.yml) overrides
+     * @returns A promise that resolves to an array of explores or explore errors
+     */
+    compileAllExplores(
+        trackingParams:
+            | {
+                  userUuid: string;
+                  organizationUuid: string;
+                  projectUuid: string;
+              }
+            | undefined,
+    ): Promise<(Explore | ExploreError)[]>;
 
     getDbtPackages(): Promise<DbtPackages | undefined>;
 
@@ -24,14 +29,10 @@ export interface ProjectAdapter {
 
     destroy(): Promise<void>;
 
-    getLightdashProjectConfig({
-        projectUuid,
-        organizationUuid,
-        userUuid,
-    }: {
-        userUuid: string;
-        organizationUuid: string;
+    getLightdashProjectConfig(trackingParams: {
         projectUuid: string;
+        organizationUuid: string;
+        userUuid: string;
     }): Promise<LightdashProjectConfig>;
 }
 

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -275,6 +275,17 @@ type CliContentAsCode = BaseTrack &
           }
     );
 
+type CliLightdashConfigLoaded = BaseTrack & {
+    event: 'lightdashconfig.loaded';
+    properties: {
+        userId?: string;
+        organizationId?: string;
+        projectId: string;
+        categories_count?: number;
+        default_visibility?: 'show' | 'hide';
+    };
+};
+
 type Track =
     | CliGenerateStarted
     | CliGenerateCompleted
@@ -301,7 +312,8 @@ type Track =
     | CliGenerateExposuresCompleted
     | CliGenerateExposuresError
     | CliLogin
-    | CliContentAsCode;
+    | CliContentAsCode
+    | CliLightdashConfigLoaded;
 
 export class LightdashAnalytics {
     static async track(payload: Track): Promise<void> {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -90,6 +90,7 @@ export const deploy = async (
 
     const lightdashProjectConfig = await readAndLoadLightdashProjectConfig(
         path.resolve(options.projectDir),
+        options.projectUuid,
     );
 
     await replaceProjectYamlTags(options.projectUuid, lightdashProjectConfig);

--- a/packages/cli/src/lightdash-config/index.ts
+++ b/packages/cli/src/lightdash-config/index.ts
@@ -4,13 +4,38 @@ import {
 } from '@lightdash/common';
 import fs from 'fs/promises';
 import path from 'path';
+import { LightdashAnalytics } from '../analytics/analytics';
+import { getConfig } from '../config';
 import GlobalState from '../globalState';
 
-export const readAndLoadLightdashProjectConfig = async (projectDir: string) => {
+export const readAndLoadLightdashProjectConfig = async (
+    projectDir: string,
+    projectUuid?: string,
+) => {
+    const { user, context } = await getConfig();
     const configPath = path.join(projectDir, 'lightdash.config.yml');
     try {
         const fileContents = await fs.readFile(configPath, 'utf8');
-        const config = await loadLightdashProjectConfig(fileContents);
+        const config = await loadLightdashProjectConfig(
+            fileContents,
+            async (lightdashConfig) => {
+                void LightdashAnalytics.track({
+                    event: 'lightdashconfig.loaded',
+                    properties: {
+                        projectId: projectUuid ?? context?.project ?? '',
+                        userId: user?.userUuid,
+                        organizationId: user?.organizationUuid,
+                        categories_count: Number(
+                            Object.keys(
+                                lightdashConfig.spotlight.categories ?? {},
+                            ).length,
+                        ),
+                        default_visibility:
+                            lightdashConfig.spotlight.default_visibility,
+                    },
+                });
+            },
+        );
         return config;
     } catch (e) {
         GlobalState.debug(`No lightdash.config.yml found in ${configPath}`);

--- a/packages/cli/src/lightdash-config/lightdash-config.test.ts
+++ b/packages/cli/src/lightdash-config/lightdash-config.test.ts
@@ -38,7 +38,10 @@ describe('Existing lightdash.config.yml file', () => {
     describe('when valid', () => {
         it('should load the config file', async () => {
             readFileSpy.mockResolvedValueOnce(VALID_CONFIG_CONTENTS);
-            const config = await readAndLoadLightdashProjectConfig('');
+            const config = await readAndLoadLightdashProjectConfig(
+                '',
+                'projectUuid',
+            );
             expect(config).toEqual(VALID_CONFIG);
         });
     });
@@ -46,9 +49,9 @@ describe('Existing lightdash.config.yml file', () => {
     describe('when invalid', () => {
         it('should throw an error', async () => {
             readFileSpy.mockResolvedValueOnce(INVALID_CONFIG_CONTENTS);
-            await expect(readAndLoadLightdashProjectConfig('')).rejects.toThrow(
-                /Invalid lightdash.config.yml with errors/,
-            );
+            await expect(
+                readAndLoadLightdashProjectConfig('', 'projectUuid'),
+            ).rejects.toThrow(/Invalid lightdash.config.yml with errors/);
         });
     });
 });
@@ -71,6 +74,7 @@ describe('Missing lightdash.config.yml file', () => {
         );
         const config = await readAndLoadLightdashProjectConfig(
             './some/path/to/nonexisting/file',
+            'projectUuid',
         );
 
         expect(config).toEqual({

--- a/packages/cli/src/lightdash-config/lightdash-config.test.ts
+++ b/packages/cli/src/lightdash-config/lightdash-config.test.ts
@@ -34,14 +34,16 @@ const INVALID_CONFIG_CONTENTS = 'I am invalid';
 
 const readFileSpy = jest.spyOn(fs, 'readFile');
 
+// Mock getConfig
+jest.mock('../config', () => ({
+    getConfig: jest.fn().mockResolvedValue({ user: null, context: null }),
+}));
+
 describe('Existing lightdash.config.yml file', () => {
     describe('when valid', () => {
         it('should load the config file', async () => {
             readFileSpy.mockResolvedValueOnce(VALID_CONFIG_CONTENTS);
-            const config = await readAndLoadLightdashProjectConfig(
-                '',
-                'projectUuid',
-            );
+            const config = await readAndLoadLightdashProjectConfig('');
             expect(config).toEqual(VALID_CONFIG);
         });
     });
@@ -49,9 +51,9 @@ describe('Existing lightdash.config.yml file', () => {
     describe('when invalid', () => {
         it('should throw an error', async () => {
             readFileSpy.mockResolvedValueOnce(INVALID_CONFIG_CONTENTS);
-            await expect(
-                readAndLoadLightdashProjectConfig('', 'projectUuid'),
-            ).rejects.toThrow(/Invalid lightdash.config.yml with errors/);
+            await expect(readAndLoadLightdashProjectConfig('')).rejects.toThrow(
+                /Invalid lightdash.config.yml with errors/,
+            );
         });
     });
 });
@@ -74,7 +76,6 @@ describe('Missing lightdash.config.yml file', () => {
         );
         const config = await readAndLoadLightdashProjectConfig(
             './some/path/to/nonexisting/file',
-            'projectUuid',
         );
 
         expect(config).toEqual({

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -10,6 +10,7 @@ import {
 
 export const loadLightdashProjectConfig = async (
     yamlFileContents: string,
+    onLoaded?: (config: LightdashProjectConfig) => Promise<void>,
 ): Promise<LightdashProjectConfig> => {
     if (yamlFileContents.trim() === '') {
         return {
@@ -32,6 +33,10 @@ export const loadLightdashProjectConfig = async (
         throw new ParseError(
             `Invalid lightdash.config.yml with errors:\n${errors}`,
         );
+    }
+
+    if (onLoaded) {
+        await onLoaded(configFile);
     }
 
     return configFile;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13309](https://github.com/lightdash/lightdash/issues/13309)

### Description:

> [!IMPORTANT]
> Didn't add code to track "default_time_dimension" as there is no context of tracking when converting Explores (see translator.ts and dbt.ts)

lightdash config loaded

<img width="1860" alt="Screenshot 2025-01-29 at 10 17 03" src="https://github.com/user-attachments/assets/0c64b5a3-db64-491b-9431-f49583b79740" />

⚠️ if no yml file, this event won't be sent


category applied (yml)

<img width="1886" alt="Screenshot 2025-01-29 at 10 18 35" src="https://github.com/user-attachments/assets/439687b7-08b1-462f-a7f0-53e898c02396" />


category applied (ui) - always 1 (for now, bc there is no way to do a batch assign on the ui)

<img width="1820" alt="Screenshot 2025-01-29 at 10 19 09" src="https://github.com/user-attachments/assets/395c06c5-dc35-4cfa-a23d-84d6d7713b63" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
