### PR TITLE
fix: batch insert catalog search entries

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -117,14 +117,17 @@ export class CatalogModel {
                                     .where('project_uuid', projectUuid)
                                     .delete();
 
-                                const results = await trx(CatalogTableName)
-                                    .insert(
+                                const BATCH_SIZE = 3000;
+                                const results = await trx
+                                    .batchInsert<DbCatalog>(
+                                        CatalogTableName,
                                         catalogInserts.map(
                                             ({
                                                 assigned_yaml_tags,
                                                 ...catalogInsert
                                             }) => catalogInsert,
                                         ),
+                                        BATCH_SIZE,
                                     )
                                     .returning('*')
                                     .transacting(trx);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13407

### Description:

When indexing the catalog with a large number of items, we hit PostgreSQL's parameter limit (65,535) due to bulk inserting all records at once. Each catalog record has 11 columns, so inserting more than ~5,957 records at once would exceed this limit.

Use Knex's batchInsert utility to automatically split the inserts into smaller batches. We've set the batch size to 3,000 records, which means each batch will use at most 33,000 parameters (3,000 records × 11 columns), staying under PostgreSQL's limit while maintaining good performance.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
