### PR TITLE
chore: trigger GCP workflow on chore(release) commit

### DIFF
--- a/.github/workflows/gcp-build-and-push.yml
+++ b/.github/workflows/gcp-build-and-push.yml
@@ -1,13 +1,17 @@
-name: GCP build and push
+name: Build and push image to GCP
 on:
-  workflow_dispatch
+  push:
+    branches:
+      - main
 
 jobs:
   release:
+    if: >
+      startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: lightdash-large-runner
     concurrency: ${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -70,14 +70,3 @@ jobs:
                   /repos/lightdash/lightdash/actions/workflows/create-sentry-release.yml/dispatches \
                   -f "ref=main" \
                   -f "inputs[version]=${{ steps.semantic.outputs.new_release_version }}"
-            - name: Trigger GCP build and push
-              if: steps.semantic.outputs.new_release_published == 'true' &&
-                steps.semantic.outputs.new_release_channel == null
-              env:
-                GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-              run: |
-                gh api --method POST \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  /repos/lightdash/lightdash/actions/workflows/gcp-build-and-push.yml/dispatches \
-                  -f "ref=main"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Change how we trigger the GCP workflow so we can see its state in the commit status.

<img width="616" alt="Screenshot 2025-01-28 at 14 22 57" src="https://github.com/user-attachments/assets/bbe1c41a-c6f7-4253-b0e3-fa5848bbd16b" />

At the moment, even if you open to see all the checks, GCP workflow is not part of it.

<img width="654" alt="Screenshot 2025-01-28 at 14 23 17" src="https://github.com/user-attachments/assets/fe70f934-4a4c-44eb-9ff1-dd558ad37ec4" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
