### PR TITLE
feat: allow slack channel cache reset and better messaging

### DIFF
--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -41,6 +41,8 @@ export class SlackController extends BaseController {
     async get(
         @Request() req: express.Request,
         @Query() search?: string,
+        @Query() excludeArchived?: boolean,
+        @Query() forceRefresh?: boolean,
     ): Promise<ApiSlackChannelsResponse> {
         this.setStatus(200);
         const organizationUuid = req.user?.organizationUuid;
@@ -49,7 +51,10 @@ export class SlackController extends BaseController {
             status: 'ok',
             results: await req.clients
                 .getSlackClient()
-                .getChannels(organizationUuid, search),
+                .getChannels(organizationUuid, search, {
+                    excludeArchived,
+                    forceRefresh,
+                }),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6764,6 +6764,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                tabName: { dataType: 'string' },
                 url: { dataType: 'string', required: true },
                 gdriveOrganizationName: { dataType: 'string', required: true },
                 gdriveName: { dataType: 'string', required: true },
@@ -18689,6 +18690,16 @@ export function RegisterRoutes(app: Router) {
     const argsSlackController_get: Record<string, TsoaRoute.ParameterSchema> = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
         search: { in: 'query', name: 'search', dataType: 'string' },
+        excludeArchived: {
+            in: 'query',
+            name: 'excludeArchived',
+            dataType: 'boolean',
+        },
+        forceRefresh: {
+            in: 'query',
+            name: 'forceRefresh',
+            dataType: 'boolean',
+        },
     };
     app.get(
         '/api/v1/slack/channels',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7467,6 +7467,9 @@
             },
             "SchedulerGsheetsOptions": {
                 "properties": {
+                    "tabName": {
+                        "type": "string"
+                    },
                     "url": {
                         "type": "string"
                     },
@@ -14580,7 +14583,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1465.0",
+        "version": "0.1469.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -16148,6 +16151,22 @@
                         "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "excludeArchived",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "forceRefresh",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.tsx
@@ -51,7 +51,7 @@ const Schedulers: FC<SchedulersProps> = ({
     const { data: slackInstallation } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
 
-    const { data: allSlackChannels } = useSlackChannels('', {
+    const { data: allSlackChannels } = useSlackChannels('', undefined, {
         enabled: organizationHasSlack,
     });
 

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -78,7 +78,7 @@ const SlackSettingsPanel: FC = () => {
     const debounceSetSearch = debounce((val) => setSearch(val), 1500);
 
     const { data: slackChannels, isInitialLoading: isLoadingSlackChannels } =
-        useSlackChannels(search, {
+        useSlackChannels(search, true, {
             enabled: organizationHasSlack,
         });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChannelProjectMappings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChannelProjectMappings.tsx
@@ -8,6 +8,7 @@ import {
     Radio,
     Select,
     Stack,
+    Text,
     Title,
     Tooltip,
 } from '@mantine/core';
@@ -18,11 +19,13 @@ import {
     IconHash,
     IconHelpCircle,
     IconPlus,
+    IconRefresh,
     IconX,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { TagInput } from '../../../../components/common/TagInput/TagInput';
+import { useSlackChannels } from '../../../../hooks/slack/useSlack';
 
 type Props = {
     channelOptions: { value: string; label: string }[];
@@ -153,20 +156,48 @@ const ChannelProjectMappings: FC<Props> = ({
         [form],
     );
 
+    const { refresh: refreshChannels, isLoading: isRefreshing } =
+        useSlackChannels('');
+
     return (
         <Stack spacing="sm" w="100%">
-            <Group spacing="two" mb="two">
-                <Title order={6} fw={500}>
-                    AI Bot channel mappings
-                </Title>
+            <Group position="apart" spacing="two" mb="two">
+                <Group spacing="two">
+                    <Title order={6} fw={500}>
+                        AI Bot channel mappings
+                    </Title>
+
+                    <Tooltip
+                        variant="xs"
+                        multiline
+                        maw={250}
+                        label="Map which project is associated with which Slack channel. When a user asks a question in a channel, Lightdash will look for the answer in the associated project."
+                    >
+                        <MantineIcon icon={IconHelpCircle} />
+                    </Tooltip>
+                </Group>
 
                 <Tooltip
                     variant="xs"
                     multiline
                     maw={250}
-                    label="Map which project is associated with which Slack channel. When a user asks a question in a channel, Lightdash will look for the answer in the associated project."
+                    label={
+                        <Text fw={500}>
+                            Refresh Slack channel list.
+                            <Text c="gray.4" fw={400}>
+                                To see private channels, ensure the bot has been
+                                invited to them. Archived channels are not
+                                included.
+                            </Text>
+                        </Text>
+                    }
                 >
-                    <MantineIcon icon={IconHelpCircle} />
+                    <ActionIcon
+                        loading={isRefreshing}
+                        onClick={() => refreshChannels()}
+                    >
+                        <MantineIcon icon={IconRefresh} />
+                    </ActionIcon>
                 </Tooltip>
             </Group>
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -410,7 +410,7 @@ const SchedulerForm: FC<Props> = ({
         return SlackStates.SUCCESS;
     }, [isInitialLoading, organizationHasSlack, slackInstallation]);
 
-    const slackChannelsQuery = useSlackChannels(search, {
+    const slackChannelsQuery = useSlackChannels(search, true, {
         enabled: organizationHasSlack,
     });
 

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -10,6 +10,7 @@ import {
     useQueryClient,
     type UseQueryOptions,
 } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 
@@ -54,22 +55,37 @@ export const useDeleteSlack = () => {
     });
 };
 
-const getSlackChannels = async (search: string) =>
+const getSlackChannels = async (
+    search: string,
+    excludeArchived: boolean = true,
+    forceRefresh: boolean = false,
+) =>
     lightdashApi<SlackChannel[] | undefined>({
-        url: `/slack/channels?search=${search}`,
+        url: `/slack/channels?search=${search}&excludeArchived=${excludeArchived}&forceRefresh=${forceRefresh}`,
         method: 'GET',
         body: undefined,
     });
 
 export const useSlackChannels = (
     search: string,
+    excludeArchived: boolean = true,
     useQueryOptions?: UseQueryOptions<SlackChannel[] | undefined, ApiError>,
-) =>
-    useQuery<SlackChannel[] | undefined, ApiError>({
-        queryKey: ['slack_channels', search],
-        queryFn: () => getSlackChannels(search),
+) => {
+    const queryClient = useQueryClient();
+
+    const query = useQuery<SlackChannel[] | undefined, ApiError>({
+        queryKey: ['slack_channels', search, excludeArchived],
+        queryFn: () => getSlackChannels(search, excludeArchived),
         ...useQueryOptions,
     });
+
+    const refresh = useCallback(async () => {
+        await getSlackChannels(search, excludeArchived, true);
+        await queryClient.invalidateQueries(['slack_channels']);
+    }, [search, excludeArchived, queryClient]);
+
+    return { ...query, refresh };
+};
 
 const updateSlackCustomSettings = async (opts: SlackAppCustomSettings) =>
     lightdashApi<null>({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- allow invalidating slack channels cache (move cache to inside the class and have it as a map)
- provide better messaging (on archived channels + on private)

<img width="513" alt="Screenshot 2025-01-28 at 16 35 55" src="https://github.com/user-attachments/assets/c7ba0bb9-14f8-4e70-9d98-56b117a54fc6" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
