### PR TITLE
fix: EE migration rollbacks + add embed management API tests

### DIFF
--- a/packages/backend/src/ee/database/migrations/20240522101742_add_embedding_vector_to_catalog.ts
+++ b/packages/backend/src/ee/database/migrations/20240522101742_add_embedding_vector_to_catalog.ts
@@ -15,5 +15,9 @@ export async function down(knex: Knex): Promise<void> {
         `ALTER TABLE ${CatalogTableName} DROP COLUMN IF EXISTS embedding_vector`,
     );
 
-    await knex.raw('DROP EXTENSION IF EXISTS vector');
+    await knex.raw('DROP EXTENSION IF EXISTS vector').catch(() => {
+        console.warn(
+            "Failed to drop vector extension. This is expected if the user doesn't have permission to drop access methods.",
+        );
+    });
 }

--- a/packages/backend/src/ee/database/migrations/20240617193700_changes_to_project_to_slack_channel_mapping.ts
+++ b/packages/backend/src/ee/database/migrations/20240617193700_changes_to_project_to_slack_channel_mapping.ts
@@ -22,7 +22,7 @@ export async function down(knex: Knex): Promise<void> {
         SlackChannelProjectMappingsTable,
         (tableBuilder) => {
             tableBuilder.dropUnique(['slack_channel_id', 'organization_uuid']);
-            tableBuilder.dropPrimary('slack_channel_project_mapping_uuid');
+            tableBuilder.dropPrimary();
             tableBuilder.primary(['project_uuid', 'organization_uuid']);
         },
     );

--- a/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
@@ -1,0 +1,109 @@
+import { CreateEmbedJwt, DecodedEmbed, SEED_PROJECT } from '@lightdash/common';
+
+const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
+
+const getEmbedConfig = () =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config`,
+        method: 'GET',
+    });
+const replaceEmbedConfig = (dashboardUuids: string[]) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'POST',
+        body: {
+            dashboardUuids,
+        },
+    });
+const updateEmbedConfigDashboards = (dashboardUuids: string[]) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config/dashboards`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'PATCH',
+        body: {
+            dashboardUuids,
+        },
+    });
+const getEmbedUrl = (body: CreateEmbedJwt) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/get-embed-url`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'POST',
+        body,
+    });
+
+describe('Embed Management API', () => {
+    let embedConfig: DecodedEmbed;
+
+    before(() => {
+        cy.login();
+        // Get initial data
+        getEmbedConfig().then((resp) => {
+            expect(resp.status).to.eq(200);
+            embedConfig = resp.body.results;
+        });
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('should get project embed configuration', () => {
+        expect(embedConfig).to.not.eq(null);
+        expect(embedConfig.projectUuid).to.eq(SEED_PROJECT.project_uuid);
+        expect(embedConfig.dashboardUuids).to.have.length.greaterThan(0);
+        expect(embedConfig.createdAt).to.not.eq(null);
+        expect(embedConfig.user).to.not.eq(null);
+        expect(embedConfig.secret).to.not.eq(null);
+        expect(embedConfig.encodedSecret).to.eq(undefined);
+    });
+
+    it('should replace project embed configuration', () => {
+        replaceEmbedConfig(embedConfig.dashboardUuids).then((updateResp) => {
+            expect(updateResp.status).to.eq(201);
+            // should have new secret
+            expect(updateResp.body.results.secret).to.not.eq(
+                embedConfig.secret,
+            );
+            expect(updateResp.body.results.dashboardUuids).to.have.members(
+                embedConfig.dashboardUuids,
+            );
+        });
+    });
+
+    it('should update project embed allowed dashboards', () => {
+        cy.request(`/api/v2/content?pageSize=999&contentTypes=dashboard`).then(
+            (resp) => {
+                expect(resp.status).to.eq(200);
+                const dashboardsUuids = resp.body.results.data.map(
+                    (d: { uuid: string }) => d.uuid,
+                );
+                expect(dashboardsUuids).to.have.length.greaterThan(1);
+                updateEmbedConfigDashboards(dashboardsUuids).then(
+                    (updateResp) => {
+                        expect(updateResp.status).to.eq(200);
+                        getEmbedConfig().then((newConfigResp) => {
+                            expect(newConfigResp.status).to.eq(200);
+                            expect(
+                                newConfigResp.body.results.dashboardUuids,
+                            ).to.have.members(dashboardsUuids);
+                        });
+                    },
+                );
+            },
+        );
+    });
+
+    it('should create embed url', () => {
+        getEmbedUrl({
+            content: {
+                type: 'dashboard',
+                dashboardUuid: embedConfig.dashboardUuids[0],
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results.url).to.not.eq(null);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#2622](https://github.com/lightdash/lightdash-internal-work/issues/2622)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- amend 2 EE migration rollbacks
- add API tests for embed management features: manage embed token/config, create embed url.
- add license to staging env ( will make it available in all render PRS after merge )

Next PR:
- add e2e test for embed page

test-frontend
test-cli
test-backend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
