### PR TITLE
fix: sql runner error serialization error

### DIFF
--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -30,7 +30,7 @@ export const barChartConfigSlice = createSlice({
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
             state.chartData = undefined;
-            state.chartDataError = new Error(action.error.message);
+            state.chartDataError = action.error;
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
             if (action.payload.type !== ChartKind.VERTICAL_BAR) {

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -13,7 +13,7 @@ import {
     type VizCartesianChartOptions,
     type VizConfigErrors,
 } from '@lightdash/common';
-import type { PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { type prepareAndFetchChartData } from '../../../features/sqlRunner/store/thunks';
 
@@ -34,7 +34,7 @@ export type CartesianChartState = {
           >
         | undefined;
     chartDataLoading: boolean;
-    chartDataError: Error | null | undefined;
+    chartDataError: SerializedError | null | undefined;
     series?: PivotValuesColumn[];
 };
 

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -30,7 +30,7 @@ export const lineChartConfigSlice = createSlice({
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
             state.chartData = undefined;
-            state.chartDataError = new Error(action.error.message);
+            state.chartDataError = action.error;
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
             if (action.payload.type !== ChartKind.LINE) {

--- a/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/pieChartSlice.ts
@@ -9,7 +9,7 @@ import {
     type VizPieChartConfig,
     type VizPieChartOptions,
 } from '@lightdash/common';
-import type { PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { prepareAndFetchChartData } from '../../../features/sqlRunner/store/thunks';
 import {
@@ -29,7 +29,7 @@ export type PieChartState = {
     options: VizPieChartOptions;
     errors: VizConfigErrors | undefined;
     chartDataLoading: boolean;
-    chartDataError: Error | undefined;
+    chartDataError: SerializedError | null | undefined;
     chartData:
         | Awaited<
               ReturnType<
@@ -126,7 +126,7 @@ export const pieChartConfigSlice = createSlice({
         builder.addCase(prepareAndFetchChartData.rejected, (state, action) => {
             state.chartDataLoading = false;
             state.chartData = undefined;
-            state.chartDataError = new Error(action.error.message);
+            state.chartDataError = action.error;
         });
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
             if (action.payload.type !== ChartKind.PIE) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixes an error in the SQL runner where non-serializable objects (Error) were being stored. This makes it use the Serializable error type.

To test:
- Run a query like `SELECT * FROM "postgres"."jaffle"."orders" `
- Switch to chart tab
- Switch back to SQL tab
- Run a query on a different table, causing a chart error `SELECT * FROM "postgres"."jaffle"."events"`
- The console will show and error about the chart being invalid, but NOT the below serialization error. 

Error before:
<img width="716" alt="Screenshot 2025-01-29 at 15 24 58" src="https://github.com/user-attachments/assets/9d1c2987-340c-4012-b4ff-da251f33189d" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
