### PR TITLE
fix: add trace id to api response

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -556,7 +556,13 @@ export default class App {
                         name: errorResponse.name,
                         message: errorResponse.message,
                         data: errorResponse.data,
-                        id:
+                        sentryTraceId:
+                            // Only return the Sentry trace ID for unexpected server errors
+                            errorResponse.statusCode === 500
+                                ? Sentry.getActiveSpan()?.spanContext().traceId
+                                : undefined,
+                        sentryEventId:
+                            // Only return the Sentry event ID for unexpected server errors
                             errorResponse.statusCode === 500
                                 ? Sentry.lastEventId()
                                 : undefined,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -750,7 +750,8 @@ export type ApiErrorDetail = {
     statusCode: number;
     message: string;
     data: { [key: string]: string };
-    id?: string;
+    sentryTraceId?: string;
+    sentryEventId?: string;
 };
 export type ApiError = {
     status: 'error';

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,5 +1,6 @@
 import { type ApiErrorDetail } from '@lightdash/common';
 import { Text } from '@mantine/core';
+import { Prism } from '@mantine/prism';
 import { IconAlertCircle, IconLock } from '@tabler/icons-react';
 import React, { useMemo, type ComponentProps, type FC } from 'react';
 import SuboptimalState from '../SuboptimalState/SuboptimalState';
@@ -22,11 +23,17 @@ const ErrorState: FC<{
             const description = (
                 <>
                     <Text maw={400}>{error.message}</Text>
-                    {error.id && (
-                        <Text maw={400} weight="bold">
-                            You can contact support with the following error ID{' '}
-                            {error.id}
-                        </Text>
+                    {(error.sentryEventId || error.sentryTraceId) && (
+                        <>
+                            <Text maw={400} weight="bold">
+                                Contact support with the following information:
+                            </Text>
+                            <Prism ta="left" language="yaml" pr="lg">
+                                {`\nError ID: ${
+                                    error.sentryEventId || 'n/a'
+                                }\nTrace ID: ${error.sentryTraceId || 'n/a'}`}
+                            </Prism>
+                        </>
                     )}
                 </>
             );

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -11,17 +11,22 @@ import { IconCheck, IconCopy } from '@tabler/icons-react';
 import MantineIcon from '../../components/common/MantineIcon';
 
 const ApiErrorDisplay = ({ apiError }: { apiError: ApiErrorDetail }) => {
-    return apiError.id ? (
+    return apiError.sentryEventId || apiError.sentryTraceId ? (
         <Stack spacing="xxs">
             <Text mb={0}>{apiError.message}</Text>
             <Text mb={0} weight="bold">
-                You can contact support with this error ID
+                Contact support with the following information:
             </Text>
             <Group spacing="xxs">
                 <Text mb={0} weight="bold">
-                    {apiError.id}
+                    Error ID: {apiError.sentryEventId || 'n/a'}
+                    Trace ID: {apiError.sentryTraceId || 'n/a'}
                 </Text>
-                <CopyButton value={apiError.id}>
+                <CopyButton
+                    value={`Error ID: ${
+                        apiError.sentryEventId || 'n/a'
+                    } Trace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                >
                     {({ copied, copy }) => (
                         <Tooltip
                             label={copied ? 'Copied' : 'Copy error ID'}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#2801](https://github.com/lightdash/lightdash-internal-work/issues/2801)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- add trace ID to error metadata
- adjust UI to show both ids and easy copy

Replicate:
- add `SENTRY_DSN` env var
- throw a 500 error in a service (example: list projects)
- see error in UI (example project home page)

<img width="494" alt="Screenshot 2025-01-30 at 17 09 45" src="https://github.com/user-attachments/assets/4b039a6d-876b-4d94-a04d-79fd080793bd" />

<img width="491" alt="Screenshot 2025-01-30 at 17 04 52" src="https://github.com/user-attachments/assets/ca882ee1-ddea-4508-9039-3f7fdb62c4fa" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
