### PR TITLE
fix: use batch insert and don't pass full explores as index catalog job payload

### DIFF
--- a/packages/backend/src/ee/models/CommercialCatalogModel.ts
+++ b/packages/backend/src/ee/models/CommercialCatalogModel.ts
@@ -4,6 +4,7 @@ import {
     CatalogType,
     Explore,
     UnexpectedServerError,
+    type ExploreError,
     type TablesConfiguration,
     type UserAttributeValueMap,
 } from '@lightdash/common';
@@ -123,7 +124,7 @@ export class CommercialCatalogModel extends CatalogModel {
 
     async indexCatalog(
         projectUuid: string,
-        cachedExplores: (Explore & { cachedExploreUuid: string })[],
+        cachedExploreMap: { [exploreUuid: string]: Explore | ExploreError },
         projectYamlTags: DbTag[],
         userUuid: string | undefined,
     ): Promise<{
@@ -132,7 +133,7 @@ export class CommercialCatalogModel extends CatalogModel {
     }> {
         const { catalogInserts, catalogFieldMap } = await super.indexCatalog(
             projectUuid,
-            cachedExplores,
+            cachedExploreMap,
             projectYamlTags,
             userUuid,
         );

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1011,9 +1011,7 @@ export class ProjectModel {
                     .returning('cached_explore_uuid');
 
                 // cache explores together
-                const [cachedExplores] = await this.database(
-                    CachedExploresTableName,
-                )
+                await this.database(CachedExploresTableName)
                     .insert({
                         project_uuid: projectUuid,
                         explores: JSON.stringify(uniqueExplores),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -74,10 +74,10 @@ import {
     CachedExploresTableName,
     CachedExploreTableName,
     CachedWarehouseTableName,
-    DbCachedExplores,
     DbCachedWarehouse,
     DbProject,
     ProjectTableName,
+    type DbCachedExplore,
 } from '../../database/entities/projects';
 import {
     DbSavedChart,
@@ -865,6 +865,27 @@ export class ProjectModel {
         );
     }
 
+    async getAllExploresFromCache(
+        projectUuid: string,
+    ): Promise<{ [exploreUuid: string]: Explore | ExploreError }> {
+        const cachedExplores = await this.database(CachedExploreTableName)
+            .select<
+                {
+                    cached_explore_uuid: string;
+                    explore: Explore | ExploreError;
+                }[]
+            >(['explore', 'cached_explore_uuid'])
+            .where('project_uuid', projectUuid);
+
+        return cachedExplores.reduce<Record<string, Explore | ExploreError>>(
+            (acc, { cached_explore_uuid, explore }) => {
+                acc[cached_explore_uuid] = explore;
+                return acc;
+            },
+            {},
+        );
+    }
+
     async getExploreFromCache(
         projectUuid: string,
         exploreName: string,
@@ -947,40 +968,10 @@ export class ProjectModel {
         );
     }
 
-    static getExploresWithCacheUuids(
-        explores: (Explore | ExploreError)[],
-        cachedExplore: { name: string; cached_explore_uuid: string }[],
-    ) {
-        return explores.reduce<(Explore & { cachedExploreUuid: string })[]>(
-            (acc, explore) => {
-                if (isExploreError(explore)) return acc;
-                const cachedExploreUuid = cachedExplore.find(
-                    (cached) => cached.name === explore.name,
-                )?.cached_explore_uuid;
-                if (!cachedExploreUuid) {
-                    Logger.error(
-                        `Could not find cached explore uuid for explore ${explore.name}`,
-                    );
-                    return acc;
-                }
-                return [
-                    ...acc,
-                    {
-                        ...explore,
-                        cachedExploreUuid,
-                    },
-                ];
-            },
-            [],
-        );
-    }
-
     async saveExploresToCache(
         projectUuid: string,
         explores: (Explore | ExploreError)[],
-    ): Promise<{
-        cachedExplores: DbCachedExplores;
-    }> {
+    ) {
         return wrapSentryTransaction(
             'ProjectModel.saveExploresToCache',
             {},
@@ -1007,8 +998,9 @@ export class ProjectModel {
                 }
 
                 // cache explores individually
-                await this.database(CachedExploreTableName)
-                    .insert(
+                const individualCachedExplores = await this.database
+                    .batchInsert<DbCachedExplore>(
+                        CachedExploreTableName,
                         uniqueExplores.map((explore) => ({
                             project_uuid: projectUuid,
                             name: explore.name,
@@ -1016,9 +1008,7 @@ export class ProjectModel {
                             explore: JSON.stringify(explore),
                         })),
                     )
-                    .onConflict(['project_uuid', 'name'])
-                    .merge()
-                    .returning(['name', 'cached_explore_uuid']);
+                    .returning('cached_explore_uuid');
 
                 // cache explores together
                 const [cachedExplores] = await this.database(
@@ -1033,7 +1023,9 @@ export class ProjectModel {
                     .returning('*');
 
                 return {
-                    cachedExplores,
+                    cachedExploreUuids: individualCachedExplores.map(
+                        (explore) => explore.cached_explore_uuid,
+                    ),
                 };
             },
         );
@@ -2320,16 +2312,5 @@ export class ProjectModel {
             .returning('*');
 
         return updatedProject;
-    }
-
-    async getCachedExploresWithUuid(
-        projectUuid: string,
-        explores: (Explore | ExploreError)[],
-    ) {
-        const cachedExplores = await this.database(CachedExploreTableName)
-            .select('name', 'cached_explore_uuid')
-            .where('project_uuid', projectUuid);
-
-        return ProjectModel.getExploresWithCacheUuids(explores, cachedExplores);
     }
 }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -66,7 +66,6 @@ import {
     type RunQueryTags,
     type SchedulerIndexCatalogJobPayload,
 } from '@lightdash/common';
-import { instance } from 'apache-arrow/visitor/typecomparator';
 import fs from 'fs/promises';
 import { nanoid } from 'nanoid';
 import slackifyMarkdown from 'slackify-markdown';
@@ -2256,7 +2255,6 @@ export default class SchedulerTask {
                 const { catalogFieldMap } =
                     await this.catalogService.indexCatalog(
                         payload.projectUuid,
-                        payload.explores,
                         payload.userUuid,
                     );
 

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -315,22 +315,15 @@ export class CatalogService<
         return filteredExplores;
     }
 
-    async indexCatalog(
-        projectUuid: string,
-        explores: (Explore | ExploreError)[],
-        userUuid: string | undefined,
-    ) {
-        const exploresWithCachedExploreUuid =
-            await this.projectModel.getCachedExploresWithUuid(
-                projectUuid,
-                explores,
-            );
+    async indexCatalog(projectUuid: string, userUuid: string | undefined) {
+        const cachedExploresMap =
+            await this.projectModel.getAllExploresFromCache(projectUuid);
 
         const projectYamlTags = await this.tagsModel.getYamlTags(projectUuid);
 
         return this.catalogModel.indexCatalog(
             projectUuid,
-            exploresWithCachedExploreUuid,
+            cachedExploresMap,
             projectYamlTags,
             userUuid,
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -524,11 +524,15 @@ export class ProjectService extends BaseService {
         const prevMetricTreeEdges =
             await this.catalogModel.getAllMetricsTreeEdges(projectUuid);
 
-        await this.projectModel.saveExploresToCache(projectUuid, explores);
+        const { cachedExploreUuids } =
+            await this.projectModel.saveExploresToCache(projectUuid, explores);
+
+        this.logger.info(
+            `Saved ${cachedExploreUuids.length} explores to cache for project ${projectUuid}`,
+        );
 
         await this.schedulerClient.indexCatalog({
             projectUuid,
-            explores,
             userUuid,
             prevCatalogItemsWithTags,
             prevCatalogItemsWithIcons,

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -1,10 +1,5 @@
 import assertUnreachable from '../utils/assertUnreachable';
-import {
-    type CompiledExploreJoin,
-    type Explore,
-    type ExploreError,
-    type InlineError,
-} from './explore';
+import { type CompiledExploreJoin, type InlineError } from './explore';
 import {
     DimensionType,
     MetricType,
@@ -238,7 +233,6 @@ export type CatalogItemsWithIcons = CatalogItemSummary &
 
 export type SchedulerIndexCatalogJobPayload = {
     projectUuid: string;
-    explores: (Explore | ExploreError)[];
     userUuid: string;
     prevCatalogItemsWithTags: CatalogItemWithTagUuids[];
     prevCatalogItemsWithIcons: CatalogItemsWithIcons[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash-internal-work/issues/2777

### Description:

- Uses batch insert when inserting new cached explores instead single insert
- Logs amount of individual cached explores inserted
- Don't pass explores as an argument to `indexCatalog` since it is logged

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
