### PR TITLE
fix: use current_database instead of matviewowner

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -354,7 +354,7 @@ export class PostgresClient<
 
             UNION ALL
 
-            SELECT mv.matviewowner AS table_catalog,
+            SELECT current_database() AS table_catalog,
                 n.nspname AS table_schema,
                 c.relname AS table_name,
                 a.attname AS column_name,
@@ -364,7 +364,7 @@ export class PostgresClient<
             JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
             JOIN pg_catalog.pg_matviews mv ON n.nspname = mv.schemaname AND c.relname = mv.matviewname
             WHERE c.relkind = 'm'
-            AND mv.matviewowner IN (${Array.from(databases)})
+            AND current_database() IN (${Array.from(databases)})
             AND n.nspname IN (${Array.from(schemas)})
             AND c.relname IN (${Array.from(tables)})
             AND a.attnum > 0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #11855

### Description:

- Check current database against list of databases instead of `matviewowner`

Previously we had a where clause when listing models materialized as `materialized_view` that checked if `database` matched `matviewowner` - this is the user that materialized the model and not the database where the materialized view exists. Therefore if `user` was different from `database` name, it would fail finding the mat views.

To reproduce:
1. Change db that has contains jaffle schema to something other than `postgres` so that it is different from the user
2. in `dbt_project.yml` change `staging` to materialize as `materialized_view`
3. run `lightdash dbt run`
4. run `lightdash generate`

**Before**

![image](https://github.com/user-attachments/assets/226aed65-affa-452c-b79b-6e1066bd63a7)


**After**
![image](https://github.com/user-attachments/assets/1f2d875d-8e97-4d7a-9762-c68967250d10)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
