### PR TITLE
fix: disable emphasis on echarts mouseout

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -199,6 +199,10 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
                                     }
                                 },
                             },
+                            // Re-enable emphasis on mouse over
+                            emphasis: {
+                                disabled: false,
+                            },
                         },
                         false,
                         true, // lazy update
@@ -223,6 +227,10 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
             eCharts.setOption(
                 {
                     tooltip: eChartsOptions?.tooltip,
+                    // Disable emphasis on mouse out - this is helpful when moving outside the chart too quickly when immediately before  the mouse was over a highlighted series. This resets the emphasis state.
+                    emphasis: {
+                        disabled: true,
+                    },
                 },
                 false,
                 true, // lazy update


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

We have 2 tooltip trigger behaviours: on region of series and on a isolated series. 
When moving away from a chart too quickly, this can leave an undesired state: the series is emphasised and the rest isn't.

This PR toggles the emphasis state on mouse in and out (same way as with the tooltip). 
NOTE: I tried `dispatchAction` but nothing worked. Setting the spec like this did. 


before


https://github.com/user-attachments/assets/0d0fe079-060f-4511-8332-752d0b2b5df7




after

  

https://github.com/user-attachments/assets/9fed7574-f55a-458d-8b85-d454c95cf0be




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
