### PR TITLE
feat: allow tab and enter to navigate/apply categories

### DIFF
--- a/packages/frontend/src/components/common/TagInput/TagInput.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInput.tsx
@@ -461,7 +461,6 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
                 // @ts-ignore
                 autoComplete="off"
                 data-1p-ignore
-                data-autofocus
                 {...rest}
             />
         );

--- a/packages/frontend/src/components/common/TagInput/TagInput.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInput.tsx
@@ -461,6 +461,7 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
                 // @ts-ignore
                 autoComplete="off"
                 data-1p-ignore
+                data-autofocus
                 {...rest}
             />
         );

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -23,12 +23,6 @@ export const CatalogCategory: FC<Props> = ({
 }) => {
     const { classes } = useCategoryStyles(category.color);
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-        if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
-            onRemove();
-        }
-    };
-
     return (
         <Badge
             key={category.name}
@@ -66,8 +60,6 @@ export const CatalogCategory: FC<Props> = ({
                     paddingRight: onRemove ? 2 : 8,
                 },
             })}
-            onKeyDown={handleKeyDown}
-            tabIndex={onRemove ? 0 : -1}
         >
             <Group spacing={1}>
                 {category.name}
@@ -77,7 +69,15 @@ export const CatalogCategory: FC<Props> = ({
                         color="gray"
                         size={14}
                         onClick={onRemove}
-                        tabIndex={-1}
+                        sx={(theme) => ({
+                            '&:focus': {
+                                backgroundColor: theme.fn.rgba(
+                                    theme.colors.gray[5],
+                                    0.35,
+                                ),
+                                outline: 'none',
+                            },
+                        })}
                     >
                         <MantineIcon
                             className={classes.removeIcon}

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -23,6 +23,12 @@ export const CatalogCategory: FC<Props> = ({
 }) => {
     const { classes } = useCategoryStyles(category.color);
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if ((event.key === 'Backspace' || event.key === 'Delete') && onRemove) {
+            onRemove();
+        }
+    };
+
     return (
         <Badge
             key={category.name}
@@ -60,6 +66,8 @@ export const CatalogCategory: FC<Props> = ({
                     paddingRight: onRemove ? 2 : 8,
                 },
             })}
+            onKeyDown={handleKeyDown}
+            tabIndex={onRemove ? 0 : -1}
         >
             <Group spacing={1}>
                 {category.name}
@@ -69,6 +77,7 @@ export const CatalogCategory: FC<Props> = ({
                         color="gray"
                         size={14}
                         onClick={onRemove}
+                        tabIndex={-1}
                     >
                         <MantineIcon
                             className={classes.removeIcon}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -181,7 +181,6 @@ const EditPopover: FC<EditPopoverProps> = ({
 type Props = {
     category: CatalogItem['categories'][number];
     onClick?: () => void;
-    onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
     onSubPopoverChange?: (isOpen: boolean) => void;
     canEdit: boolean;
 };
@@ -189,7 +188,6 @@ type Props = {
 export const MetricCatalogCategoryFormItem: FC<Props> = ({
     category,
     onClick,
-    onFocus,
     onSubPopoverChange,
     canEdit,
 }) => {
@@ -215,8 +213,6 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
             tabIndex={0}
             role="button"
             onKeyDown={handleKeyDown}
-            onFocus={onFocus}
-            data-metrics-catalog-category-item
             sx={(theme) => ({
                 borderRadius: theme.radius.md,
                 outline: 'none',

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -81,7 +81,7 @@ const EditPopover: FC<EditPopoverProps> = ({
             closeOnClickOutside
             width={200}
             onClose={handleClose}
-            trapFocus
+            trapFocus={opened}
         >
             <Popover.Target>
                 <ActionIcon
@@ -98,6 +98,7 @@ const EditPopover: FC<EditPopoverProps> = ({
                         open();
                         onOpenChange?.(true);
                     }}
+                    tabIndex={-1}
                 >
                     <MantineIcon icon={IconDots} color="gray.6" size={14} />
                 </ActionIcon>
@@ -180,6 +181,7 @@ const EditPopover: FC<EditPopoverProps> = ({
 type Props = {
     category: CatalogItem['categories'][number];
     onClick?: () => void;
+    onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
     onSubPopoverChange?: (isOpen: boolean) => void;
     canEdit: boolean;
 };
@@ -187,10 +189,21 @@ type Props = {
 export const MetricCatalogCategoryFormItem: FC<Props> = ({
     category,
     onClick,
+    onFocus,
     onSubPopoverChange,
     canEdit,
 }) => {
     const { ref: hoverRef, hovered } = useHover<HTMLDivElement>();
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                onClick?.();
+            }
+        },
+        [onClick],
+    );
 
     return (
         <Group
@@ -199,15 +212,27 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
             py={3}
             pos="relative"
             position="apart"
+            tabIndex={0}
+            role="button"
+            onKeyDown={handleKeyDown}
+            onFocus={onFocus}
+            data-metrics-catalog-category-item
             sx={(theme) => ({
                 borderRadius: theme.radius.md,
-                '&:hover': {
+                outline: 'none',
+                '&:focus, &:hover': {
                     backgroundColor: '#F8F9FA',
                     transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
                 },
             })}
         >
-            <UnstyledButton onClick={onClick} h="100%" w="90%" pos="absolute" />
+            <UnstyledButton
+                onClick={onClick}
+                h="100%"
+                w="90%"
+                pos="absolute"
+                tabIndex={-1}
+            />
             <CatalogCategory category={category} onClick={onClick} />
 
             {canEdit && (

--- a/packages/frontend/src/features/metricsCatalog/styles/useCategoryStyles.ts
+++ b/packages/frontend/src/features/metricsCatalog/styles/useCategoryStyles.ts
@@ -20,6 +20,9 @@ export const useCategoryStyles = createStyles(
         const removeIconColor = isMantineColorKey
             ? theme.fn.darken(theme.colors[color][6], 0.4)
             : theme.fn.darken(color, 0.4);
+        const focusOutlineColor = isMantineColorKey
+            ? theme.colors[color][5]
+            : theme.fn.darken(color, 0.3);
 
         return {
             base: {
@@ -28,6 +31,13 @@ export const useCategoryStyles = createStyles(
                 color: textColor,
                 cursor: 'pointer',
                 boxShadow: '0px -1px 0px 0px rgba(4, 4, 4, 0.04) inset',
+                outline: 'none',
+                '&:focus': {
+                    outline: `2px solid ${focusOutlineColor}`,
+                    outlineOffset: '2px',
+                    backgroundColor: hoverBackgroundColor,
+                    transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                },
             },
             removeIcon: {
                 color: removeIconColor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13350 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This pull request introduces several enhancements across multiple components in the `metricsCatalog` feature. The changes focus on improving keyboard accessibility, error handling, and user experience with the metrics catalog form.

### Accessibility Improvements:
* [`packages/frontend/src/components/common/TagInput/TagInput.tsx`](diffhunk://#diff-7c7e43cee6b2ff2e9542c03f7cce078a542599fa8cde01af373dfc044e7c01d6R464): Added `data-autofocus` attribute to ensure the input is still focused when the Popover's dropdown is initially rendered. This complements the removal of `useFocusTrap` and `inputFocusTrapRef` from `packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryForm.tsx`.
* [`packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx`](diffhunk://#diff-5fb364cbdafe5de0780cac06c86e2beedb694cfb5d18870667b4c1db15a1b575R26-R31): Added `handleKeyDown` function to handle 'Backspace' and 'Delete' keys for item removal, and updated `onKeyDown` and `tabIndex` properties to improve keyboard navigation. [[1]](diffhunk://#diff-5fb364cbdafe5de0780cac06c86e2beedb694cfb5d18870667b4c1db15a1b575R26-R31) [[2]](diffhunk://#diff-5fb364cbdafe5de0780cac06c86e2beedb694cfb5d18870667b4c1db15a1b575R69-R70) [[3]](diffhunk://#diff-5fb364cbdafe5de0780cac06c86e2beedb694cfb5d18870667b4c1db15a1b575R80)
* [`packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx`](diffhunk://#diff-3f1f5d872d8b64f8ea141191cbf7d52edbc83b6f4c7a844d21cb65f5e3083c05L84-R84): Added `handleKeyDown` for 'Enter' key to trigger clicks, and updated `tabIndex`, `role`, and `onFocus` properties for better focus management. [[1]](diffhunk://#diff-3f1f5d872d8b64f8ea141191cbf7d52edbc83b6f4c7a844d21cb65f5e3083c05L84-R84) [[2]](diffhunk://#diff-3f1f5d872d8b64f8ea141191cbf7d52edbc83b6f4c7a844d21cb65f5e3083c05R101) [[3]](diffhunk://#diff-3f1f5d872d8b64f8ea141191cbf7d52edbc83b6f4c7a844d21cb65f5e3083c05R184-R235)
* [`packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx`](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R89-R99): Implemented focus management and keyboard navigation for category items using `useEffect`, `handleKeyDownInCategoriesStack`, and `handleCategoryItemFocus`. [[1]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R89-R99) [[2]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R232-R281) [[3]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649L308-R398) [[4]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R413) [[5]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R423)

### Error Handling:
* [`packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx`](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649L129-R150): Added `showToastError` and `captureException` for better error reporting when adding or removing tags. [[1]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649L129-R150) [[2]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R181-R198)

### Code Cleanup and Refactoring:
* [`packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx`](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R64-L70): Removed `useFocusTrap` import and related code, and replaced it with custom focus management logic. [[1]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649R64-L70) [[2]](diffhunk://#diff-a44287556ddbda69764bc45d34993beae18d2273b5393b1408bff546b1864649L266)
* [`packages/frontend/src/features/metricsCatalog/styles/useCategoryStyles.ts`](diffhunk://#diff-c2b65ffea410a488cbf0976502b7f3553435c959c1fe972555acd32f80867c1bR23-R25): Enhanced focus styles for better visual feedback when navigating with the keyboard. [[1]](diffhunk://#diff-c2b65ffea410a488cbf0976502b7f3553435c959c1fe972555acd32f80867c1bR23-R25) [[2]](diffhunk://#diff-c2b65ffea410a488cbf0976502b7f3553435c959c1fe972555acd32f80867c1bR34-R40)

<!-- Even better add a screenshot / gif / loom -->
### Demo Flow (With On-Screen Keyboard):
1. Tab navigation
2. Arrow keys navigation
3. Tab + arrow keys navigation
4. Add new tags (First using Tab + Enter, then using Arrow keys + Enter)
5. Delete new tags (First with del, then with Backspace)
6. Add a new tag by manually clicking (just for testing sake xD)

[lightdash-metrics-catalog-form-keybaord-navigation-and-selection.webm](https://github.com/user-attachments/assets/111691a1-c092-48c5-b84d-31c4ddcb0b7a)

### Key Behavior Notes  
- The inner `input` of the `TagInput` is initially focused.  
  - Pressing **Tab** moves focus forward to the first item in the categories list.  
  - Pressing **Shift + Tab** moves focus backward to the selected categories.  
- **Arrow key navigation** is only active when a category list item is focused.  
  - The **Tab** key is used to move focus from `TagInput` to the categories list.  
  - Arrow keys **do not** move focus from `TagInput` to avoid disrupting users when editing text.  

### Focus Wrapping  
- **Tab** at the end of the category list wraps focus to the first selected tag in `TagInput`.  
- **Shift + Tab** when the first selected tag is focused moves focus to the last category item in the list.  
- **Arrow Down** on the last category item moves focus back to the first category item.  
- **Arrow Up** on the first category item moves focus to the last category item.  

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
