### PR TITLE
fix: check if scim flag is on via posthog or env

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -108,6 +108,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     groupsModel: models.getGroupsModel(),
                     scimOrganizationAccessTokenModel:
                         models.getScimOrganizationAccessTokenModel(),
+                    commercialFeatureFlagModel:
+                        models.getFeatureFlagModel() as CommercialFeatureFlagModel,
                 }),
             slackIntegrationService: ({ models, context }) =>
                 new CommercialSlackIntegrationService({

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -4,6 +4,7 @@ import { EmailModel } from '../../../models/EmailModel';
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OrganizationMemberProfileModel } from '../../../models/OrganizationMemberProfileModel';
 import { UserModel } from '../../../models/UserModel';
+import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ScimOrganizationAccessTokenModel } from '../../models/ScimOrganizationAccessTokenModel';
 import { ScimService } from './ScimService';
 
@@ -17,4 +18,5 @@ export const ScimServiceArgumentsMock: ConstructorParameters<
     analytics: {} as LightdashAnalytics,
     groupsModel: {} as GroupsModel,
     scimOrganizationAccessTokenModel: {} as ScimOrganizationAccessTokenModel,
+    commercialFeatureFlagModel: {} as CommercialFeatureFlagModel,
 };

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1,8 +1,8 @@
 import { subject } from '@casl/ability';
 import {
     AlreadyExistsError,
+    CommercialFeatureFlags,
     CreateScimOrganizationAccessToken,
-    FeatureFlags,
     ForbiddenError,
     getErrorMessage,
     GroupWithMembers,
@@ -40,12 +40,12 @@ import { EmailModel } from '../../../models/EmailModel';
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OrganizationMemberProfileModel } from '../../../models/OrganizationMemberProfileModel';
 import { UserModel } from '../../../models/UserModel';
-import { isFeatureFlagEnabled } from '../../../postHog';
 import { BaseService } from '../../../services/BaseService';
 import {
     ScimAccessTokenAuthenticationEvent,
     ScimAccessTokenEvent,
 } from '../../analytics';
+import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ScimOrganizationAccessTokenModel } from '../../models/ScimOrganizationAccessTokenModel';
 
 type ScimServiceArguments = {
@@ -56,6 +56,7 @@ type ScimServiceArguments = {
     analytics: LightdashAnalytics;
     groupsModel: GroupsModel;
     scimOrganizationAccessTokenModel: ScimOrganizationAccessTokenModel;
+    commercialFeatureFlagModel: CommercialFeatureFlagModel;
 };
 
 export class ScimService extends BaseService {
@@ -73,6 +74,8 @@ export class ScimService extends BaseService {
 
     private readonly scimOrganizationAccessTokenModel: ScimOrganizationAccessTokenModel;
 
+    private readonly commercialFeatureFlagModel: CommercialFeatureFlagModel;
+
     constructor({
         lightdashConfig,
         organizationMemberProfileModel,
@@ -81,6 +84,7 @@ export class ScimService extends BaseService {
         analytics,
         groupsModel,
         scimOrganizationAccessTokenModel,
+        commercialFeatureFlagModel,
     }: ScimServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -91,6 +95,7 @@ export class ScimService extends BaseService {
         this.groupsModel = groupsModel;
         this.scimOrganizationAccessTokenModel =
             scimOrganizationAccessTokenModel;
+        this.commercialFeatureFlagModel = commercialFeatureFlagModel;
     }
 
     private static throwForbiddenErrorOnNoPermission(user: SessionUser) {
@@ -106,16 +111,14 @@ export class ScimService extends BaseService {
         }
     }
 
-    private static async throwErrorOnFeatureDisabled(user: SessionUser) {
-        const isScimTokenManagementEnabled = await isFeatureFlagEnabled(
-            'scim-token-management' as FeatureFlags,
-            user,
-            {
-                throwOnTimeout: true,
-            },
-        );
+    private async throwErrorOnFeatureDisabled(user: SessionUser) {
+        const isScimTokenManagementEnabled =
+            await this.commercialFeatureFlagModel.get({
+                user,
+                featureFlagId: CommercialFeatureFlags.Scim,
+            });
 
-        if (!isScimTokenManagementEnabled) {
+        if (!isScimTokenManagementEnabled.enabled) {
             throw new Error('SCIM token management feature not enabled!');
         }
     }
@@ -1000,7 +1003,7 @@ export class ScimService extends BaseService {
         tokenDetails: CreateScimOrganizationAccessToken;
     }): Promise<ScimOrganizationAccessToken> {
         try {
-            await ScimService.throwErrorOnFeatureDisabled(user);
+            await this.throwErrorOnFeatureDisabled(user);
             ScimService.throwForbiddenErrorOnNoPermission(user);
             const token = await this.scimOrganizationAccessTokenModel.create({
                 user,
@@ -1034,7 +1037,7 @@ export class ScimService extends BaseService {
         tokenUuid: string;
     }): Promise<void> {
         try {
-            await ScimService.throwErrorOnFeatureDisabled(user);
+            await this.throwErrorOnFeatureDisabled(user);
             ScimService.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             // get by uuid to check if token exists
@@ -1081,7 +1084,7 @@ export class ScimService extends BaseService {
         tokenUuid: string;
         update: { expiresAt: Date };
     }): Promise<ScimOrganizationAccessTokenWithToken> {
-        await ScimService.throwErrorOnFeatureDisabled(user);
+        await this.throwErrorOnFeatureDisabled(user);
         ScimService.throwForbiddenErrorOnNoPermission(user);
 
         if (update.expiresAt.getTime() < Date.now()) {
@@ -1137,7 +1140,7 @@ export class ScimService extends BaseService {
         user: SessionUser;
         tokenUuid: string;
     }): Promise<ScimOrganizationAccessToken> {
-        await ScimService.throwErrorOnFeatureDisabled(user);
+        await this.throwErrorOnFeatureDisabled(user);
         ScimService.throwForbiddenErrorOnNoPermission(user);
 
         // get by uuid to check if token exists
@@ -1159,7 +1162,7 @@ export class ScimService extends BaseService {
         user: SessionUser,
     ): Promise<ScimOrganizationAccessToken[]> {
         try {
-            await ScimService.throwErrorOnFeatureDisabled(user);
+            await this.throwErrorOnFeatureDisabled(user);
             ScimService.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             const tokens =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

If posthog is not enabled, then also check if the SCIM feature flag is turned on via env var. This reuses the commercial feature flag model. 

To reproduce on `main`:

```
remove post hog api key env var, or taint it
turn on SCIM_ENABLED=true
```

To test on this branch:

```
remove post hog api key env var, or taint it
turn on SCIM_ENABLED=true
```

Go to the scim access tokens and see the list and you're able to generate
<img width="1866" alt="image" src="https://github.com/user-attachments/assets/af0d58d9-486d-473a-ac59-e46ae489c51e" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
