### PR TITLE
feat: add --assume-no option

### DIFF
--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -1,5 +1,5 @@
 import { getErrorMessage, ParseError } from '@lightdash/common';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import execa from 'execa';
 import { LightdashAnalytics } from '../../analytics/analytics';
 import GlobalState from '../../globalState';
@@ -23,6 +23,12 @@ export const dbtRunHandler = async (
 
     if (!command.parent) {
         throw new Error('Parent command not found');
+    }
+
+    if (options.assumeYes && options.assumeNo) {
+        throw new InvalidArgumentError(
+            'Cannot use both --assume-yes and --assume-no flags',
+        );
     }
 
     await LightdashAnalytics.track({

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -12,6 +12,7 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
     excludeMeta: boolean;
     verbose: boolean;
     assumeYes: boolean;
+    assumeNo: boolean;
 };
 
 export const dbtRunHandler = async (
@@ -32,7 +33,12 @@ export const dbtRunHandler = async (
     });
 
     const commands = command.parent.args.reduce<string[]>((acc, arg) => {
-        if (arg === '--verbose' || arg === '--assume-yes') return acc;
+        if (
+            arg === '--verbose' ||
+            arg === '--assume-yes' ||
+            arg === '--assume-no'
+        )
+            return acc;
         return [...acc, arg];
     }, []);
 
@@ -54,8 +60,11 @@ export const dbtRunHandler = async (
         });
         throw new ParseError(`Failed to run dbt:\n  ${msg}`);
     }
-    await generateHandler({
-        ...options,
-        excludeMeta: options.excludeMeta,
-    });
+
+    if (!options.assumeNo) {
+        await generateHandler({
+            ...options,
+            excludeMeta: options.excludeMeta,
+        });
+    }
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -264,6 +264,7 @@ ${styles.bold('Examples:')}
     )
     .option('--verbose', undefined, false)
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('-no, --assume-no', 'assume no to prompts', false)
     .action(dbtRunHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #13542

### Description:

- Adds `--assume-no` option to `dbt run` to skip all prompts to update yaml files

AC:
- `--assume-yes` should still work as is (write all files without prompting)
- default should still ask for files
- `--assume-no` should not prompt and not write files

Related docs PR: https://github.com/lightdash/lightdash-docs/pull/40

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
