### PR TITLE
feat: replace custom metric with matching metric during chart creatio…

### DIFF
--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -215,28 +215,34 @@ export function findReplaceableCustomMetrics({
     );
 }
 
+export function convertReplaceableFieldMatchMapToReplaceFieldsMap(
+    replaceableFieldMap: ReplaceableFieldMatchMap,
+): ReplaceCustomFields[string]['customMetrics'] {
+    return Object.entries(replaceableFieldMap).reduce<
+        ReplaceCustomFields[string]['customMetrics']
+    >((acc2, [customFieldId, customField]) => {
+        if (customField.match) {
+            return {
+                ...acc2,
+                [customFieldId]: {
+                    replaceWithFieldId: customField.match.fieldId,
+                },
+            };
+        }
+        return acc2;
+    }, {});
+}
+
+// todo: rename+breakdown this util and all the replace/replaceable types to be more descriptive
 export function convertReplaceableFieldMatchMapToReplaceCustomFields(
     replaceableCustomFields: ReplaceableCustomFields,
 ): ReplaceCustomFields {
     return Object.entries(replaceableCustomFields).reduce<ReplaceCustomFields>(
         (acc, [chartUuid, customFields]) => {
-            const customMetrics = Object.entries(
-                customFields.customMetrics,
-            ).reduce<ReplaceCustomFields[string]['customMetrics']>(
-                (acc2, [customFieldId, customField]) => {
-                    if (customField.match) {
-                        return {
-                            ...acc2,
-                            [customFieldId]: {
-                                replaceWithFieldId: customField.match.fieldId,
-                            },
-                        };
-                    }
-                    return acc2;
-                },
-                {},
-            );
-
+            const customMetrics =
+                convertReplaceableFieldMatchMapToReplaceFieldsMap(
+                    customFields.customMetrics,
+                );
             if (Object.keys(customMetrics).length > 0) {
                 acc[chartUuid] = {
                     customMetrics,

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -976,10 +976,6 @@ function reducer(
             };
         }
         case ActionType.REPLACE_FIELDS: {
-            console.log(
-                'action.payload.fieldsToReplace',
-                action.payload.fieldsToReplace,
-            );
             const { hasChanges, chartVersion } =
                 maybeReplaceFieldsInChartVersion({
                     fieldsToReplace: action.payload.fieldsToReplace,

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -6,6 +6,7 @@ import {
     getFieldRef,
     getItemId,
     lightdashVariablePattern,
+    maybeReplaceFieldsInChartVersion,
     removeEmptyProperties,
     removeFieldFromFilterGroup,
     toggleArrayValue,
@@ -17,6 +18,7 @@ import {
     type FieldId,
     type Metric,
     type MetricQuery,
+    type ReplaceCustomFields,
     type SavedChart,
     type SortField,
     type TableCalculation,
@@ -973,6 +975,24 @@ function reducer(
                 },
             };
         }
+        case ActionType.REPLACE_FIELDS: {
+            console.log(
+                'action.payload.fieldsToReplace',
+                action.payload.fieldsToReplace,
+            );
+            const { hasChanges, chartVersion } =
+                maybeReplaceFieldsInChartVersion({
+                    fieldsToReplace: action.payload.fieldsToReplace,
+                    chartVersion: state.unsavedChartVersion,
+                });
+            if (hasChanges) {
+                return {
+                    ...state,
+                    unsavedChartVersion: chartVersion,
+                };
+            }
+            return state;
+        }
         default: {
             return assertUnreachable(
                 action,
@@ -1397,6 +1417,18 @@ const ExplorerProvider: FC<
         [],
     );
 
+    const replaceFields = useCallback(
+        (fieldsToReplace: ReplaceCustomFields[string]) => {
+            dispatch({
+                type: ActionType.REPLACE_FIELDS,
+                payload: {
+                    fieldsToReplace,
+                },
+            });
+        },
+        [],
+    );
+
     const hasUnsavedChanges = useMemo<boolean>(() => {
         if (savedChart) {
             return !deepEqual(
@@ -1551,6 +1583,7 @@ const ExplorerProvider: FC<
             toggleCustomDimensionModal,
             toggleFormatModal,
             updateMetricFormat,
+            replaceFields,
         }),
         [
             clearExplore,
@@ -1586,6 +1619,7 @@ const ExplorerProvider: FC<
             toggleCustomDimensionModal,
             toggleFormatModal,
             updateMetricFormat,
+            replaceFields,
         ],
     );
 

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -15,6 +15,7 @@ import {
     type MetricQuery,
     type MetricType,
     type PieChartConfig,
+    type ReplaceCustomFields,
     type SavedChart,
     type SortField,
     type TableCalculation,
@@ -74,6 +75,7 @@ export enum ActionType {
     TOGGLE_CUSTOM_DIMENSION_MODAL,
     TOGGLE_FORMAT_MODAL,
     UPDATE_METRIC_FORMAT,
+    REPLACE_FIELDS,
 }
 
 export type ConfigCacheMap = {
@@ -215,6 +217,12 @@ export type Action =
     | {
           type: ActionType.UPDATE_METRIC_FORMAT;
           payload: { metric: Metric; formatOptions: CustomFormat | undefined };
+      }
+    | {
+          type: ActionType.REPLACE_FIELDS;
+          payload: {
+              fieldsToReplace: ReplaceCustomFields[string];
+          };
       };
 
 export interface ExplorerReduceState {
@@ -321,5 +329,6 @@ export interface ExplorerContextType {
             metric: Metric;
             formatOptions: CustomFormat | undefined;
         }) => void;
+        replaceFields: (fieldsToReplace: ReplaceCustomFields[string]) => void;
     };
 }


### PR DESCRIPTION
…n/update

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#13527](https://github.com/lightdash/lightdash/issues/13527)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
When creating/editing a chart, if the chat has a custom metric that is an exact match of a model metric, it will be replaced.
The following PR will add error messages when metric and custom metric have the same id but aren't an exact match.

https://github.com/user-attachments/assets/ad5980e1-a8c0-42e1-b8e3-09eb5327b7bb


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
