### PR TITLE
fix: get inherited roles if org roles exist

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -131,7 +131,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
 
     const inheritedRoles = useMemo(() => {
         // Organization users and org roles are not always available, and we don't want to show the user access page if they are not available
-        if (!organizationUsers || !orgRoles) return {};
+        if (!organizationUsers || !orgRoles) return undefined;
         return organizationUsers.reduce<Record<string, InheritedRoles>>(
             (acc, orgUser) => {
                 return {
@@ -159,7 +159,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
     }, [organizationUsers, orgRoles, groupRoles, projectRoles]);
 
     const usersWithProjectRole = useMemo(() => {
-        if (!organizationUsers) return [];
+        if (!organizationUsers || !inheritedRoles) return [];
 
         return organizationUsers.map((orgUser) => {
             const highestRole = getHighestProjectRole(
@@ -241,7 +241,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                                 canManageProjectAccess={canManageProjectAccess}
                                 user={orgUser}
                                 inheritedRoles={
-                                    inheritedRoles[orgUser.userUuid]
+                                    inheritedRoles?.[orgUser.userUuid]
                                 }
                             />
                         ))}

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -177,6 +177,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                               ProjectMemberRole.VIEWER,
                       )
                     : inheritedRole,
+                inheritedRole: inheritedRoles?.[orgUser.userUuid],
             };
         });
     }, [organizationUsers, projectRoles, inheritedRoles]);
@@ -189,10 +190,13 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                 threshold: 0.3,
             })
                 .search(search)
-                .map((result) => result.item);
+                .map((result) => ({
+                    ...result.item,
+                    inheritedRole: inheritedRoles?.[result.item.userUuid],
+                }));
         }
         return usersWithProjectRole;
-    }, [usersWithProjectRole, search]);
+    }, [usersWithProjectRole, search, inheritedRoles]);
 
     if (isProjectAccessLoading || isOrganizationUsersLoading) {
         return <LoadingState title="Loading user access" />;
@@ -239,9 +243,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                                 projectUuid={projectUuid}
                                 canManageProjectAccess={canManageProjectAccess}
                                 user={orgUser}
-                                inheritedRoles={
-                                    inheritedRoles?.[orgUser.userUuid]
-                                }
+                                inheritedRoles={orgUser.inheritedRole}
                             />
                         ))}
                     </tbody>

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -9,7 +9,7 @@ import {
     type InheritedRoles,
 } from '@lightdash/common';
 import { ActionIcon, Paper, Table, TextInput } from '@mantine/core';
-import { IconX } from '@tabler/icons-react';
+import { IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
 import { useProjectGroupAccessList } from '../../features/projectGroupAccess/hooks/useProjectGroupAccess';
@@ -56,8 +56,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
     const { data: projectGroupAccess } = useProjectGroupAccessList(projectUuid);
 
     const orgRoles = useMemo(() => {
-        if (!organizationUsers) return {};
-        if (!projectAccess) return {};
+        if (!organizationUsers || !projectAccess) return undefined;
 
         return organizationUsers.reduce<Record<string, OrganizationMemberRole>>(
             (acc, orgUser) => {
@@ -131,7 +130,8 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
     );
 
     const inheritedRoles = useMemo(() => {
-        if (!organizationUsers) return {};
+        // Organization users and org roles are not always available, and we don't want to show the user access page if they are not available
+        if (!organizationUsers || !orgRoles) return {};
         return organizationUsers.reduce<Record<string, InheritedRoles>>(
             (acc, orgUser) => {
                 return {
@@ -182,6 +182,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
             };
         });
     }, [organizationUsers, projectRoles, inheritedRoles]);
+
     const filteredUsers = useMemo(() => {
         if (search && usersWithProjectRole) {
             return new Fuse(usersWithProjectRole, {
@@ -209,6 +210,12 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                         onChange={(e) => setSearch(e.target.value)}
                         value={search}
                         w={320}
+                        icon={<MantineIcon icon={IconSearch} />}
+                        sx={(theme) => ({
+                            input: {
+                                boxShadow: theme.shadows.subtle,
+                            },
+                        })}
                         rightSection={
                             search.length > 0 && (
                                 <ActionIcon onClick={() => setSearch('')}>

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -140,8 +140,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
                         {
                             type: 'organization',
                             role: convertOrganizationRoleToProjectRole(
-                                orgRoles[orgUser.userUuid] ||
-                                    OrganizationMemberRole.MEMBER,
+                                orgRoles[orgUser.userUuid],
                             ),
                         },
                         {

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -1,12 +1,12 @@
 import { subject } from '@casl/ability';
 import {
-    OrganizationMemberRole,
     ProjectMemberRole,
     convertOrganizationRoleToProjectRole,
     convertProjectRoleToOrganizationRole,
     getHighestProjectRole,
     isGroupWithMembers,
     type InheritedRoles,
+    type OrganizationMemberRole,
 } from '@lightdash/common';
 import { ActionIcon, Paper, Table, TextInput } from '@mantine/core';
 import { IconSearch, IconX } from '@tabler/icons-react';
@@ -163,8 +163,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
 
         return organizationUsers.map((orgUser) => {
             const highestRole = getHighestProjectRole(
-                inheritedRoles[orgUser.userUuid] ||
-                    OrganizationMemberRole.MEMBER,
+                inheritedRoles[orgUser.userUuid],
             );
             const hasProjectRole = !!projectRoles[orgUser.userUuid];
             const inheritedRole = highestRole?.role

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessRow.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessRow.tsx
@@ -30,7 +30,7 @@ type Props = {
     projectUuid: string;
     canManageProjectAccess: boolean;
     user: OrganizationMemberProfile;
-    inheritedRoles: InheritedRoles;
+    inheritedRoles: InheritedRoles | undefined;
 };
 
 const ProjectAccessRow: FC<Props> = ({
@@ -82,10 +82,12 @@ const ProjectAccessRow: FC<Props> = ({
     }, [canManageProjectAccess, revokeAccess, user.userUuid]);
 
     const highestRole = useMemo(() => {
+        if (!inheritedRoles) return undefined;
         return getHighestProjectRole(inheritedRoles);
     }, [inheritedRoles]);
 
     const projectRole = useMemo(() => {
+        if (!inheritedRoles) return undefined;
         return inheritedRoles.find(
             (role): role is ProjectRole => role.type === 'project',
         );

--- a/packages/frontend/src/hooks/useProjectAccess.tsx
+++ b/packages/frontend/src/hooks/useProjectAccess.tsx
@@ -22,6 +22,7 @@ export const useProjectAccess = (projectUuid: string) => {
         queryKey: ['project_access_users', projectUuid],
         queryFn: () => getProjectAccessQuery(projectUuid),
         onError: (result) => setErrorResponse(result),
+        enabled: !!projectUuid,
     });
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13551

### Description:

- Go to /projectAccess
- The util convertOrganizationRoleToProjectRole was expecting the role from orgRoles to always be defined. this is now addressed

(made small style improvements)

<img width="1659" alt="image" src="https://github.com/user-attachments/assets/42ea74bc-87a7-49ae-bbc5-cd91cbbc2940" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
