### PR TITLE
fix: can stack if grouped series ref has more than one

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -553,8 +553,8 @@ export class CartesianChartDataModel {
                     type: seriesType ?? defaultSeriesType,
                     stack:
                         shouldStack && seriesType === 'bar'
-                            ? 'stack-all-series'
-                            : undefined, // TODO: we should implement more sophisticated stacking logic once we have multi-pivoted charts
+                            ? `stack-${seriesColumn.referenceField}` // Use referenceField for stack ID
+                            : undefined,
                     name:
                         seriesLabel ||
                         capitalize(seriesColumnId.toLowerCase()).replaceAll(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12861

### Description:

Checks if groupedSeries' values (by reference) have more than one series so that we enable stacking.


https://github.com/user-attachments/assets/8e5e8f53-dbb5-4ec0-89ac-c38038a2eda5



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
