### PR TITLE
fix: compare filter unit of time

### DIFF
--- a/packages/common/src/utils/fields.mock.ts
+++ b/packages/common/src/utils/fields.mock.ts
@@ -7,6 +7,7 @@ import {
     MetricType,
     SupportedDbtAdapter,
     type AdditionalMetric,
+    type DateFilterSettings,
     type Explore,
     type Metric,
     type MetricFilterRule,
@@ -165,11 +166,13 @@ export const metricFilterRule = (args?: {
     fieldRef?: string;
     values?: unknown[];
     operator?: FilterOperator;
+    settings?: DateFilterSettings;
 }): MetricFilterRule => ({
     id: 'uuid',
     operator: args?.operator || FilterOperator.GREATER_THAN_OR_EQUAL,
     target: {
         fieldRef: args?.fieldRef || 'a_dim1',
     },
+    settings: args?.settings || undefined,
     values: args?.values || [14],
 });

--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -9,6 +9,7 @@ import {
     type Metric,
     type TableCalculation,
 } from '../types/field';
+import { isDateFilterRule, type DateFilterSettings } from '../types/filter';
 import { type AdditionalMetric, type MetricQuery } from '../types/metricQuery';
 import {
     type ReplaceCustomFields,
@@ -145,7 +146,24 @@ export function compareMetricAndCustomMetric({
                             customFilter.values?.every((value) =>
                                 filter.values?.includes(value),
                             );
-                        return fieldRefMatch && operatorMatch && valuesMatch;
+                        let settingsMatch =
+                            isDateFilterRule(customFilter) ===
+                            isDateFilterRule(filter);
+                        if (isDateFilterRule(customFilter)) {
+                            const metricSettings =
+                                filter.settings as DateFilterSettings;
+                            const customMetricSettings =
+                                customFilter.settings as DateFilterSettings;
+                            settingsMatch =
+                                metricSettings.unitOfTime ===
+                                customMetricSettings.unitOfTime;
+                        }
+                        return (
+                            fieldRefMatch &&
+                            operatorMatch &&
+                            valuesMatch &&
+                            settingsMatch
+                        );
                     }),
                 ),
             requiredForSuggestion: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13560](https://github.com/lightdash/lightdash/issues/13560)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Compare filter unit of time when matching custom metrics with metrics.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
