### PR TITLE
fix: allow devs to download

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -252,6 +252,9 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'SpotlightTableConfig', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'ContentAsCode', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     admin(member, { can }) {
         applyOrganizationMemberStaticAbilities.developer(member, { can });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -225,6 +225,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'SpotlightTableConfig', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'ContentAsCode', {
+            projectUuid: member.projectUuid,
+        });
     },
     admin(member, { can }) {
         projectMemberAbilities.developer(member, { can });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -50,6 +50,7 @@ type Subject =
     | 'PersonalAccessToken'
     | 'MetricsTree'
     | 'SpotlightTableConfig'
+    | 'ContentAsCode'
     | 'all';
 
 export type PossibleAbilities = [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13568


### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Admins can download /upload everything

![Screenshot from 2025-02-11 10-06-59](https://github.com/user-attachments/assets/ce1f31ea-f2a0-4b06-a84f-c430fe2f60e1)

Developers can only download stuff they have access


![Screenshot from 2025-02-11 10-16-17](https://github.com/user-attachments/assets/21ae72ee-40a6-43cc-895a-6eeaa7fabf86)

EVen if aprivate content is on Lightdash, a developer without access can't upload it (it will appear as skipped) 


![Screenshot from 2025-02-11 10-21-16](https://github.com/user-attachments/assets/7ad578f0-b15b-4ab3-835b-22438299adfe)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
