### PR TITLE
fix: get formatted value when tooltip in isolation

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -11,6 +11,7 @@ import {
     type FC,
 } from 'react';
 import useEchartsCartesianConfig, {
+    getFormattedValue,
     isLineSeriesOption,
 } from '../../hooks/echarts/useEchartsCartesianConfig';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -91,7 +92,7 @@ type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
 };
 
 const SimpleChart: FC<SimpleChartProps> = memo((props) => {
-    const { chartRef, isLoading, onSeriesContextMenu } =
+    const { chartRef, isLoading, onSeriesContextMenu, itemsMap } =
         useVisualizationContext();
 
     const [selectedLegends, setSelectedLegends] = useState({});
@@ -187,13 +188,22 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
                                                 : '';
 
                                         const axisValue = param.value[dim];
+                                        const formattedValue = itemsMap
+                                            ? getFormattedValue(
+                                                  axisValue,
+                                                  dim,
+                                                  itemsMap,
+                                                  true,
+                                              )
+                                            : axisValue;
+
                                         return (
                                             eChartsOptions.tooltip
                                                 .formatter as any
                                         )([
                                             {
                                                 ...param,
-                                                axisValueLabel: axisValue,
+                                                axisValueLabel: formattedValue,
                                             },
                                         ]);
                                     }
@@ -217,7 +227,7 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
                 }, 100);
             }
         },
-        [chartRef, eChartsOptions?.tooltip.formatter],
+        [chartRef, eChartsOptions?.tooltip.formatter, itemsMap],
     );
 
     const handleOnMouseOut = useCallback(() => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -300,7 +300,7 @@ export type EChartSeries = {
     symbolSize?: number;
 };
 
-const getFormattedValue = (
+export const getFormattedValue = (
     value: any,
     key: string,
     itemsMap: ItemsMap,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13613

### Description:	

before  (see ticket)

after:

<img width="449" alt="Screenshot 2025-02-11 at 10 28 44" src="https://github.com/user-attachments/assets/51b39d15-2f75-4f43-95e6-01dfdd9fd224" />
<img width="472" alt="Screenshot 2025-02-11 at 10 28 38" src="https://github.com/user-attachments/assets/0f2ecd59-ec06-4870-803c-e6e436fe390d" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
