### PR TITLE
fix: multiline descriptions

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -152,7 +152,11 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 ) : (
                     <Tooltip
                         disabled={!description || !!titleLeftIcon}
-                        label={description}
+                        label={
+                            <Text style={{ whiteSpace: 'pre-line' }}>
+                                {description}
+                            </Text>
+                        }
                         multiline
                         position="top-start"
                         withinPortal

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -244,7 +244,12 @@ const DashboardHeader = ({
                         <Popover.Dropdown maw={500}>
                             <Stack spacing="xs">
                                 {dashboard.description && (
-                                    <Text fz="xs" color="gray.7" fw={500}>
+                                    <Text
+                                        fz="xs"
+                                        color="gray.7"
+                                        fw={500}
+                                        style={{ whiteSpace: 'pre-line' }}
+                                    >
                                         {dashboard.description}
                                     </Text>
                                 )}

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -67,7 +67,9 @@ export const ResourceInfoPopup: FC<Props> = ({
                             <Text fz="xs" fw={600} color="gray.6">
                                 Description:{' '}
                             </Text>
-                            <Text fz="xs">{description}</Text>
+                            <Text fz="xs" style={{ whiteSpace: 'pre-line' }}>
+                                {description}
+                            </Text>
                         </Stack>
                     )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:   https://github.com/lightdash/lightdash/issues/13436

### Description:

I found this solution was the most consistent with our style style={{ whiteSpace: 'pre-line' }}

using "box" broke the font , and using component="pre" added some unexpected margins. 

Related: https://github.com/orgs/mantinedev/discussions/7127


Before

![Screenshot from 2025-02-11 11-57-34](https://github.com/user-attachments/assets/0a7a888c-02d4-44c1-8f60-314a6c8d8017)
![Screenshot from 2025-02-11 11-46-26](https://github.com/user-attachments/assets/aadd8afb-f34d-4d10-94ea-722c775da4f0)
![Screenshot from 2025-02-11 11-45-59](https://github.com/user-attachments/assets/252944fc-c16d-4ae5-bb0c-39bc6d8228b6)

After

![Screenshot from 2025-02-11 11-58-13](https://github.com/user-attachments/assets/a17a360e-6881-47ea-b45c-89a2e5e965a5)
![Screenshot from 2025-02-11 11-55-35](https://github.com/user-attachments/assets/f7d833a8-2f1d-4f1c-9047-50f598b6868f)

![Screenshot from 2025-02-11 11-56-56](https://github.com/user-attachments/assets/d5c24ce9-baa6-4817-bfd3-d9d672aa3216)

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
