### PR TITLE
fix: use getCatalog to get columns information when all arguments of get fields are available

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -521,6 +521,11 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         database?: string,
         tags?: Record<string, string>,
     ): Promise<WarehouseCatalog> {
+        if (tableName && database && schema) {
+            // When having all three we can use the catalog to get the fields using the correct connection args and table names
+            return this.getCatalog([{ database, schema, table: tableName }]);
+        }
+
         const query = `
             SELECT TABLE_CATALOG as "table_catalog",
                    TABLE_SCHEMA  as "table_schema",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13615 

### Description:

- When `database`, `schema` and `table` exist, we can use `getCatalog` to get the table fields using a fully qualified name that will not fail because of casing - query with where clauses fails because of that.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
