### PR TITLE
fix: add slash to lightdash URL when not present

### DIFF
--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -39,6 +39,10 @@ const decodeJWT = (token: string) => {
 };
 
 const persistInstanceUrl = (instanceUrl: string) => {
+    if (!instanceUrl.endsWith('/')) {
+        instanceUrl = `${instanceUrl}/`;
+    }
+
     localStorage.setItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
         instanceUrl,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds a slash to lightdash url when not present. Both of our initial uses had this problem.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
