### PR TITLE
Chore: Update setup steps for Docker-less setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -309,13 +309,15 @@ nvm install v20.8.0
 nvm alias default v20.8.0
 
 # 4 Install postgres (https://wiki.postgresql.org/wiki/Homebrew) and pgvector
-
-# pgvector is an extension for postgres we use in Lightdash, it needs to be installed separately 
-# More info about this extension and a detailed installation guide available here: https://github.com/pgvector/pgvector
-# on Linux, you can install `postgresql-14-pgvector`, available on apt
-git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && sudo make install && cd .. 
 brew install postgresql@14
 brew services start postgresql@14
+
+# pgvector is an extension for postgres we use in Lightdash, it needs to be installed separately
+# More info about this extension and a detailed installation guide available here: https://github.com/pgvector/pgvector
+# on Linux, you can install `postgresql-14-pgvector`, available on apt
+# You might need to point pgvector to a correct postgres instance if you have multiple versions installed
+# export PG_CONFIG=/opt/homebrew/opt/postgresql@14/bin/pg_config
+git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && sudo make install && cd ..
 
 # 5 Install dbt (https://docs.getdbt.com/dbt-cli/install/homebrew)
 brew tap dbt-labs/dbt

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -319,9 +319,15 @@ brew services start postgresql@14
 # export PG_CONFIG=/opt/homebrew/opt/postgresql@14/bin/pg_config
 git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git && cd pgvector && make && sudo make install && cd ..
 
-# 5 Install dbt (https://docs.getdbt.com/dbt-cli/install/homebrew)
-brew tap dbt-labs/dbt
-brew install dbt-postgres@1.5.4
+# 5 Install dbt using pip
+# Detailed installation guide available here: https://docs.getdbt.com/docs/core/pip-install
+# Create python virtual env
+python3 -m venv env-lightdash # or your preferred env name
+# Activate the env
+# You can deactivate python virtual env by running `deactivate` later
+source env-lightdash/bin/activate
+
+python -m pip install dbt-postgres==1.4.9
 
 # 6 Clone the repo and open it in your IDE
 git clone https://github.com/lightdash/lightdash.git


### PR DESCRIPTION
### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR addresses some issues I experienced while setting up lightdash on MacOS without Docker



- DBT no longer supports homebrew as a installation method

    ```sh
    brew install dbt-postgres@1.5.4                                                                                         

    ==> Downloading https://formulae.brew.sh/api/formula.jws.json
    ==> Downloading https://formulae.brew.sh/api/cask.jws.json
    Error: dbt-labs/dbt/dbt-postgres@1.5.4 has been disabled because it is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options! It was disabled on 2024-04-27.
    ```


- DBT 1.5 failing to install dependencies

    When I ran `pnpm load:env ./scripts/seed-lightdash.sh` it failed with the following error message

    ```sh
    RecursionError: maximum recursion depth exceeded while calling a Python object
    2025-02-12 11:21:35 [Lightdash] error: Error running dbt command with version v1.4: Command failed with exit code 1: dbt --no-use-colors --log-format json deps --profiles-dir /tmp/local_vlhF02 --project-dir /develop/lightdash/examples/full-jaffle-shop-demo/dbt --target prod --profile lightdash_profile

    2025-02-12 11:21:35 [Lightdash] warn: Error parsing dbt json log Unexpected end of JSON input
    DbtError: Failed to run "dbt deps" with dbt version "v1.4"
        at DbtCliClient._runDbtCommand (/develop/lightdash/packages/backend/src/dbt/dbtCliClient.ts:226:23)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async /develop/lightdash/packages/backend/src/dbt/dbtCliClient.ts:244:17
        at async DbtLocalCredentialsProjectAdapter.compileAllExplores (/develop/lightdash/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts:155:13)
        at async Object.seed (/develop/lightdash/packages/backend/src/database/seeds/development/01_initial_user.ts:193:26)
        at async Seeder._waterfallBatch (/develop/lightdash/node_modules/.pnpm/knex@2.5.1_pg@8.13.1/node_modules/knex/lib/migrations/seed/Seeder.js:115:9) {
    statusCode: 400,
    data: {},
    logs: []
    }
    Error while executing "/develop/lightdash/packages/backend/src/database/seeds/development/01_initial_user.ts" seed: Failed to run "dbt deps" with dbt version "v1.4"
    Error: Error while executing "/develop/lightdash/packages/backend/src/database/seeds/development/01_initial_user.ts" seed: Failed to run "dbt deps" with dbt version "v1.4"
        at Seeder._waterfallBatch (/develop/lightdash/node_modules/.pnpm/knex@2.5.1_pg@8.13.1/node_modules/knex/lib/migrations/seed/Seeder.js:118:23)
    DbtError: Failed to run "dbt deps" with dbt version "v1.4"
        at DbtCliClient._runDbtCommand (/develop/lightdash/packages/backend/src/dbt/dbtCliClient.ts:226:23)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async /develop/lightdash/packages/backend/src/dbt/dbtCliClient.ts:244:17
        at async DbtLocalCredentialsProjectAdapter.compileAllExplores (/develop/lightdash/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts:155:13)
        at async Object.seed (/develop/lightdash/packages/backend/src/database/seeds/development/01_initial_user.ts:193:26)
        at async Seeder._waterfallBatch (/develop/lightdash/node_modules/.pnpm/knex@2.5.1_pg@8.13.1/node_modules/knex/lib/migrations/seed/Seeder.js:115:9)
    /develop/lightdash/packages/backend:
     ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  backend@0.1484.10 seed: `knex seed:run --knexfile src/knexfile.ts`
    Exit status 1
     ELIFECYCLE  Command failed with exit code 1.
    ```

    I replaced dbt@1.5.4 with dbt@1.4.9 (version that Docker image uses) and it worked


- pg-vector installation might fail if multiple postgres instances are present

    In my case I had both `postgresql@14` and `postgresql@16` installed and `pgvector` defaulted to 16.


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
