### PR TITLE
fix: error toast layout

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -17,9 +17,10 @@ const ApiErrorDisplay = ({ apiError }: { apiError: ApiErrorDetail }) => {
             <Text mb={0} weight="bold">
                 Contact support with the following information:
             </Text>
-            <Group spacing="xxs">
+            <Group spacing="xxs" align="flex-start">
                 <Text mb={0} weight="bold">
                     Error ID: {apiError.sentryEventId || 'n/a'}
+                    <br />
                     Trace ID: {apiError.sentryTraceId || 'n/a'}
                 </Text>
                 <CopyButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This error toast was a little bit broken. 

**Before**
<img width="457" alt="Screenshot 2025-02-12 at 12 44 13" src="https://github.com/user-attachments/assets/2b18c51a-8be2-4d4c-a9bc-015aceed45a5" />

**After**
<img width="449" alt="Screenshot 2025-02-12 at 12 57 16" src="https://github.com/user-attachments/assets/d584f5cb-fe77-444e-bf1c-95b177070716" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
