### PR TITLE
fix: aggregate tabs into one view when sending now/scheduling

### DIFF
--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -80,6 +80,16 @@ const MinimalDashboard: FC = () => {
         return undefined;
     }, [schedulerTabs]);
 
+    useEffect(() => {
+        if (selectedTabs) {
+            setActiveTab(
+                dashboard?.tabs.find((tab) =>
+                    selectedTabs.includes(tab.uuid),
+                ) ?? null,
+            );
+        }
+    }, [selectedTabs, dashboard?.tabs]);
+
     const generateTabUrl = useCallback(
         (tabId: string) =>
             `/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tabId}`,

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -73,22 +73,12 @@ const MinimalDashboard: FC = () => {
         return undefined;
     }, [scheduler, schedulerUuid, sendNowSchedulerFilters]);
 
-    const selectedTabs = useMemo(() => {
+    const schedulerTabsSelected = useMemo(() => {
         if (schedulerTabs) {
             return JSON.parse(schedulerTabs);
         }
         return undefined;
     }, [schedulerTabs]);
-
-    useEffect(() => {
-        if (selectedTabs) {
-            setActiveTab(
-                dashboard?.tabs.find((tab) =>
-                    selectedTabs.includes(tab.uuid),
-                ) ?? null,
-            );
-        }
-    }, [selectedTabs, dashboard?.tabs]);
 
     const generateTabUrl = useCallback(
         (tabId: string) =>
@@ -115,6 +105,34 @@ const MinimalDashboard: FC = () => {
         });
     }, [sortedTabs, generateTabUrl]);
 
+    const layouts = useMemo(() => {
+        return {
+            lg:
+                dashboard?.tiles
+                    .filter((tile) =>
+                        // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
+                        schedulerTabsSelected
+                            ? schedulerTabsSelected.includes(tile.tabUuid)
+                            : // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.
+                              !activeTab || activeTab.uuid === tile.tabUuid,
+                    )
+                    .map<Layout>((tile) => getReactGridLayoutConfig(tile)) ??
+                [],
+        };
+    }, [dashboard?.tiles, schedulerTabsSelected, activeTab]);
+
+    const filteredDashboardTiles = useMemo(() => {
+        return (
+            dashboard?.tiles.filter((tile) =>
+                // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
+                schedulerTabsSelected
+                    ? schedulerTabsSelected.includes(tile.tabUuid)
+                    : // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.
+                      !activeTab || activeTab.uuid === tile.tabUuid,
+            ) ?? []
+        );
+    }, [dashboard?.tiles, schedulerTabsSelected, activeTab]);
+
     if (isDashboardError || isSchedulerError) {
         if (dashboardError) return <>{dashboardError.error.message}</>;
         if (schedulerError) return <>{schedulerError.error.message}</>;
@@ -132,26 +150,20 @@ const MinimalDashboard: FC = () => {
         return <>No tiles</>;
     }
 
-    const layouts = {
-        lg: dashboard.tiles
-            .filter(
-                (tile) =>
-                    (!selectedTabs || selectedTabs.includes(tile.tabUuid)) &&
-                    (!activeTab || activeTab.uuid === tile.tabUuid),
-            )
-            .map<Layout>((tile) => getReactGridLayoutConfig(tile)),
-    };
-
     const isTabEmpty =
         activeTab &&
         !dashboard.tiles.find((tile) => tile.tabUuid === activeTab.uuid);
+
+    const canNavigateBetweenTabs =
+        !schedulerTabsSelected && tabsWithUrls.length > 0;
 
     return (
         <DashboardProvider
             schedulerFilters={schedulerFilters}
             dateZoom={dateZoom}
         >
-            {tabsWithUrls.length > 0 && (
+            {/* This is when viewing a dashboard with tabs in mobile mode - you can navigate between tabs. */}
+            {canNavigateBetweenTabs && (
                 <MinimalDashboardTabs
                     tabs={tabsWithUrls}
                     activeTabId={activeTab?.uuid || null}
@@ -171,68 +183,58 @@ const MinimalDashboard: FC = () => {
                     })}
                     layouts={layouts}
                 >
-                    {dashboard.tiles
-                        .filter(
-                            (tile) =>
-                                (!selectedTabs ||
-                                    selectedTabs.includes(tile.tabUuid)) &&
-                                (!activeTab || activeTab.uuid === tile.tabUuid),
-                        )
-                        .map((tile) => (
-                            <div key={tile.uuid}>
-                                {tile.type ===
-                                DashboardTileTypes.SAVED_CHART ? (
-                                    <ChartTile
-                                        key={tile.uuid}
-                                        minimal
-                                        tile={tile}
-                                        isEditMode={false}
-                                        onDelete={() => {}}
-                                        onEdit={() => {}}
-                                    />
-                                ) : tile.type ===
-                                  DashboardTileTypes.MARKDOWN ? (
-                                    <MarkdownTile
-                                        key={tile.uuid}
-                                        tile={tile}
-                                        isEditMode={false}
-                                        onDelete={() => {}}
-                                        onEdit={() => {}}
-                                    />
-                                ) : tile.type === DashboardTileTypes.LOOM ? (
-                                    <LoomTile
-                                        key={tile.uuid}
-                                        tile={tile}
-                                        isEditMode={false}
-                                        onDelete={() => {}}
-                                        onEdit={() => {}}
-                                    />
-                                ) : tile.type ===
-                                  DashboardTileTypes.SQL_CHART ? (
-                                    <SqlChartTile
-                                        key={tile.uuid}
-                                        tile={tile}
-                                        isEditMode={false}
-                                        onDelete={() => {}}
-                                        onEdit={() => {}}
-                                    />
-                                ) : tile.type ===
-                                  DashboardTileTypes.SEMANTIC_VIEWER_CHART ? (
-                                    <SemanticViewerChartTile
-                                        key={tile.uuid}
-                                        tile={tile}
-                                        isEditMode={false}
-                                        onDelete={() => {}}
-                                        onEdit={() => {}}
-                                    />
-                                ) : (
-                                    assertUnreachable(
-                                        tile,
-                                        `Dashboard tile type is not recognised`,
-                                    )
-                                )}
-                            </div>
-                        ))}
+                    {filteredDashboardTiles.map((tile) => (
+                        <div key={tile.uuid}>
+                            {tile.type === DashboardTileTypes.SAVED_CHART ? (
+                                <ChartTile
+                                    key={tile.uuid}
+                                    minimal
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.MARKDOWN ? (
+                                <MarkdownTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.LOOM ? (
+                                <LoomTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.SQL_CHART ? (
+                                <SqlChartTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type ===
+                              DashboardTileTypes.SEMANTIC_VIEWER_CHART ? (
+                                <SemanticViewerChartTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : (
+                                assertUnreachable(
+                                    tile,
+                                    `Dashboard tile type is not recognised`,
+                                )
+                            )}
+                        </div>
+                    ))}
                 </ResponsiveGridLayout>
             )}
         </DashboardProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13650


### Description:

To test on main
- create dashboard with 2 tabs
- select "send now" or scheduled delivery for tab 2 (just has to be other than the first)
- see error
This fixes: 
- when `schedulerTabs` is set in the search params, then aggregate all tabs in one view.
- if viewing in mobile mode, allow navigation between tabs.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
