### PR TITLE
fix: don't use theme fonts in lightdash charts

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1915,7 +1915,7 @@ const useEchartsCartesianConfig = (
                 ),
             },
             textStyle: {
-                fontFamily: theme?.fontFamily as string | undefined,
+                fontFamily: theme?.other.chartFont as string | undefined,
             },
             // We assign colors per series, so we specify an empty list here.
             color: [],
@@ -1932,7 +1932,7 @@ const useEchartsCartesianConfig = (
             series,
             sortedResults,
             tooltip,
-            theme.fontFamily,
+            theme?.other?.chartFont,
         ],
     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -157,7 +157,7 @@ const useEchartsFunnelConfig = (isInDashboard: boolean) => {
 
         return {
             textStyle: {
-                fontFamily: theme?.fontFamily as string | undefined,
+                fontFamily: theme?.other.chartFont as string | undefined,
             },
             tooltip: {
                 trigger: 'item',
@@ -186,7 +186,7 @@ const useEchartsFunnelConfig = (isInDashboard: boolean) => {
         funnelSeriesOptions,
         seriesData,
         isInDashboard,
-        theme?.fontFamily,
+        theme?.other?.chartFont,
     ]);
 
     if (!itemsMap) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -164,7 +164,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
 
         return {
             textStyle: {
-                fontFamily: theme?.fontFamily as string | undefined,
+                fontFamily: theme?.other?.chartFont as string | undefined,
             },
             legend: {
                 show: showLegend,
@@ -208,7 +208,7 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         isInDashboard,
         minimal,
         pieSeriesOption,
-        theme?.fontFamily,
+        theme?.other?.chartFont,
     ]);
 
     if (!itemsMap) return;

--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -63,7 +63,10 @@ const SdkProviders: FC<
             <MantineProvider
                 themeOverride={{
                     fontFamily: styles?.fontFamily,
-                    other: { tableFont: styles?.fontFamily },
+                    other: {
+                        tableFont: styles?.fontFamily,
+                        chartFont: styles?.fontFamily,
+                    },
                 }}
             >
                 <AppProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Don't use theme-based fonts in internal Lightdash charts. Charts will pick up the styles only when passed to the SDK. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
