### PR TITLE
fix: disable custom metric write back if not github

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -322,19 +322,20 @@ const TableTreeSections: FC<Props> = ({
                             }}
                         />
                     </Group>
-
-                    <Tooltip label="Write back custom metrics">
-                        <ActionIcon
-                            onClick={() => {
-                                toggleAdditionalMetricWriteBackModal({
-                                    items: allAdditionalMetrics || [],
-                                    multiple: true,
-                                });
-                            }}
-                        >
-                            <MantineIcon icon={IconCode} />
-                        </ActionIcon>
-                    </Tooltip>
+                    {isGithubProject && isCustomSqlEnabled && (
+                        <Tooltip label="Write back custom metrics">
+                            <ActionIcon
+                                onClick={() => {
+                                    toggleAdditionalMetricWriteBackModal({
+                                        items: allAdditionalMetrics || [],
+                                        multiple: true,
+                                    });
+                                }}
+                            >
+                                <MantineIcon icon={IconCode} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
                 </Group>
             ) : null}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Until we add this modal for not github projects, keep it consistent, disable the mulitple modal , like we do already for single custom metrics 

![image](https://github.com/user-attachments/assets/d1f47028-57e3-427e-a9fe-b2b00719452d)


<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
