### PR TITLE
chore: format date when in_between and type date

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -124,6 +124,20 @@ const getValueAsString = (
                         rule.settings?.completed ? 'completed ' : ''
                     }${rule.settings?.unitOfTime}`;
                 case FilterOperator.IN_BETWEEN:
+                    if (
+                        isDimension(field) &&
+                        isMomentInput(firstValue) &&
+                        isMomentInput(secondValue) &&
+                        field.type === DimensionType.DATE
+                    ) {
+                        return `${formatDate(
+                            firstValue as MomentInput,
+                            field.timeInterval,
+                        )} and ${formatDate(
+                            secondValue as MomentInput,
+                            field.timeInterval,
+                        )}`;
+                    }
                     return `${getLocalTimeDisplay(
                         firstValue as MomentInput,
                         false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13697

### Description:

before (see how timezone-based **but** date fields had the hh:mm when doing "in between") 

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/3be8788f-cdd5-4a55-a9d0-d7a0ae49ebfb" />

after (fixed for in between operator, the other operators had already the correct formatting)

<img width="1318" alt="Screenshot 2025-02-14 at 14 17 25" src="https://github.com/user-attachments/assets/6e1df477-ceed-44bf-805e-577641e99d00" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
