### PR TITLE
fix: exporting image for pie chart

### DIFF
--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useState } from 'react';
 
 import { copyImageToClipboard } from '../../../utils/copyImageToClipboard';
 import MantineIcon from '../MantineIcon';
+import { chartConfigs } from './chartConfigs';
 import {
     base64SvgToBase64Image,
     downloadImage,
@@ -22,7 +23,6 @@ import {
     downloadPdf,
     DownloadType,
 } from './chartDownloadUtils';
-
 type DownloadOptions = {
     getChartInstance: () => EChartsInstance | undefined;
     unavailableOptions?: DownloadType[];
@@ -45,10 +45,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
         }
 
         try {
-            const svgBase64 = chartInstance.getDataURL();
-            const width = chartInstance.getWidth();
-            const height = chartInstance.getHeight();
-
+            const { svgBase64, width, height } = chartConfigs(chartInstance);
             switch (type) {
                 case DownloadType.PDF:
                     downloadPdf(
@@ -99,8 +96,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
         }
 
         try {
-            const svgBase64 = chartInstance.getDataURL();
-            const width = chartInstance.getWidth();
+            const { svgBase64, width } = chartConfigs(chartInstance);
             const base64Image = await base64SvgToBase64Image(
                 svgBase64,
                 width,

--- a/packages/frontend/src/components/common/ChartDownload/chartConfigs.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartConfigs.ts
@@ -1,0 +1,53 @@
+export const chartConfigs = (chartInstance: any) => {
+    const isPieChat = chartInstance._chartsViews.some(
+        (view: { constructor: { name: string } }) =>
+            view.constructor.name === 'PieView2',
+    );
+    if (!isPieChat) {
+        const svgBase64 = chartInstance.getDataURL();
+        const width = chartInstance.getWidth();
+        const height = chartInstance.getHeight();
+        return { svgBase64, width, height };
+    } else {
+        const dataHeader = 'data:image/svg+xml;charset=utf-8';
+
+        const serializeAsXML = ($e: Node) =>
+            new XMLSerializer().serializeToString($e);
+
+        const encodeAsUTF8 = (s: string | number | boolean) =>
+            `${dataHeader},${encodeURIComponent(s)}`;
+
+        const $svg = chartInstance.getDom().querySelector('svg');
+
+        const svgData = encodeAsUTF8(serializeAsXML($svg));
+
+        const getSvgDimensions = (): { width: number; height: number } => {
+            const widthAttr = $svg.getAttribute('width');
+            const heightAttr = $svg.getAttribute('height');
+
+            if (widthAttr && heightAttr) {
+                const width = parseFloat(widthAttr);
+                const height = parseFloat(heightAttr);
+                if (!isNaN(width) && !isNaN(height)) {
+                    return { width, height };
+                }
+            }
+
+            const viewBox = $svg.getAttribute('viewBox');
+            if (viewBox) {
+                const parts = viewBox.split(/[\s,]+/).map(Number);
+                if (parts.length >= 4 && !parts.some(isNaN)) {
+                    return { width: parts[2], height: parts[3] };
+                }
+            }
+
+            return {
+                width: $svg.clientWidth,
+                height: $svg.clientHeight,
+            };
+        };
+        const svgBase64 = svgData;
+        const { width, height } = getSvgDimensions();
+        return { svgBase64, width, height };
+    }
+};

--- a/packages/frontend/src/components/common/ChartDownload/chartConfigs.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartConfigs.ts
@@ -1,4 +1,5 @@
-export const chartConfigs = (chartInstance: any) => {
+import { type EChartsInstance } from 'echarts-for-react';
+export const chartConfigs = (chartInstance: EChartsInstance) => {
     const isPieChat = chartInstance._chartsViews.some(
         (view: { constructor: { name: string } }) =>
             view.constructor.name === 'PieView2',


### PR DESCRIPTION
Closes: #12577

### Description:
This PR introduces changes to how the chart instance is handled for pie charts. Instead of directly extracting the URL (svgBase64) from  chart instance, the URL is now extracted from the DOM.
Works for both downloading (all format supported) and copying to clipboard.


https://github.com/user-attachments/assets/8126cb4b-3060-425e-978c-3809215535cd




### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
