### PR TITLE
fix: alignment of icons when title span across two lines

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -222,7 +222,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                     fw={500}
                                     disabled={value.disabled}
                                     label={
-                                        <Flex align="center" gap="xxs">
+                                        <Flex align="flex-start" gap="xxs">
                                             <MantineIcon
                                                 color="blue.8"
                                                 icon={getChartIcon(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13144 

### Description:
Fix alignment of icons in chart tile selection popup when title span across two lines

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
