### PR TITLE
chore: reuse autocomplete metric query

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2738,7 +2738,7 @@ export class ProjectService extends BaseService {
         }
     }
 
-    // reused on `projectService.searchFieldUniqueValues` and `embedService.searchFilterValues`
+    // Note: can't be private method as it is used in EE
     async _getFieldValuesMetricQuery({
         projectUuid,
         table,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#2720](https://github.com/lightdash/lightdash-internal-work/issues/2720)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Reuse autocomplete metric query in OSS/EE endpoints.

OSS

<img width="1342" alt="Screenshot 2025-02-17 at 10 46 33" src="https://github.com/user-attachments/assets/ccf40d54-6f07-417d-a5b0-f81ab985e34b" />

EE

<img width="905" alt="Screenshot 2025-02-17 at 11 08 18" src="https://github.com/user-attachments/assets/95b10f43-abbe-4ce3-a88c-892bca95d543" />


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
