### PR TITLE
fix: always force slug when creating chart or dashboard

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -529,11 +529,10 @@ export class PromoteService extends BaseService {
                                   slug: changeChart.slug,
                               };
                     return this.savedChartModel
-                        .create(
-                            changeChart.projectUuid,
-                            user.userUuid,
-                            chartData,
-                        )
+                        .create(changeChart.projectUuid, user.userUuid, {
+                            ...chartData,
+                            forceSlug: true,
+                        })
                         .then((chart) => ({
                             ...chart,
                             oldUuid: changeChart.oldUuid,
@@ -747,7 +746,10 @@ export class PromoteService extends BaseService {
         // Update dashboard with new space if it was created
         const newDashboard = await this.dashboardModel.create(
             promotedDashboard.spaceUuid,
-            promotedDashboard,
+            {
+                ...promotedDashboard,
+                forceSlug: true,
+            },
             user,
             promotedDashboard.projectUuid,
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13705 

### Description:

- Always force slugs when creating charts and dashboard while promoting like we do for space upsert.

To test:
1. Create project (not preview)
2. Set new project as upstream of existing project
3. Promote dashboard/chart
4. Make changes to dashboard/chart
5. Promote again
6. Make sure dashboard/chart is updated and a new one is not created

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
