### PR TITLE
fix: use sessionStorage instead of localStorage for SDK routes

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -58,7 +58,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     headers,
     version = 'v1',
 }: LightdashApiProps): Promise<T> => {
-    const baseUrl = localStorage.getItem(
+    const baseUrl = sessionStorage.getItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
     );
     const apiPrefix = `${baseUrl ?? BASE_API_URL}api/${version}`;

--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -49,7 +49,7 @@ const persistInstanceUrl = (instanceUrl: string) => {
         instanceUrl = `${instanceUrl}/`;
     }
 
-    localStorage.setItem(
+    sessionStorage.setItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
         instanceUrl,
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Use sessionStorage for SDK instead of localStorage. Session storage will get set every time the SDK mounts, so it will work. But it won't be persisted in the domain when new tabs are opened. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
