### PR TITLE
fix: reload metrics catalog on index catalog complete

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -580,8 +580,7 @@ export class ProjectService extends BaseService {
         this.logger.info(
             `Saved ${cachedExploreUuids.length} explores to cache for project ${projectUuid}`,
         );
-
-        await this.schedulerClient.indexCatalog({
+        return this.schedulerClient.indexCatalog({
             projectUuid,
             userUuid,
             prevCatalogItemsWithTags,
@@ -3294,7 +3293,7 @@ export class ProjectService extends BaseService {
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.RUNNING,
                 });
-                await this.jobModel.tryJobStep(
+                const indexCatalogJobUuid = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
@@ -3327,7 +3326,7 @@ export class ProjectService extends BaseService {
                                 color: category.color ?? 'gray',
                             })),
                         );
-                        await this.saveExploresToCacheAndIndexCatalog(
+                        return this.saveExploresToCacheAndIndexCatalog(
                             user.userUuid,
                             projectUuid,
                             explores,
@@ -3337,6 +3336,9 @@ export class ProjectService extends BaseService {
 
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.DONE,
+                    jobResults: {
+                        indexCatalogJobUuid,
+                    },
                 });
             } catch (e) {
                 await this.jobModel.update(job.jobUuid, {

--- a/packages/common/src/types/job.ts
+++ b/packages/common/src/types/job.ts
@@ -53,7 +53,9 @@ export type BaseJob = {
 
 type CompileJob = BaseJob & {
     jobType: JobType.COMPILE_PROJECT;
-    jobResults?: undefined;
+    jobResults?: {
+        indexCatalogJobUuid: string;
+    };
 };
 
 type CreateProjectJob = BaseJob & {
@@ -64,6 +66,15 @@ type CreateProjectJob = BaseJob & {
 };
 
 export type Job = CompileJob | CreateProjectJob;
+
+export function isCompileJob(value: unknown): value is CompileJob {
+    return (
+        typeof value === 'object' &&
+        value != null &&
+        'jobType' in value &&
+        value.jobType === JobType.COMPILE_PROJECT
+    );
+}
 
 export type CreateJob = Pick<
     Job,

--- a/packages/common/src/types/job.ts
+++ b/packages/common/src/types/job.ts
@@ -76,6 +76,15 @@ export function isCompileJob(value: unknown): value is CompileJob {
     );
 }
 
+export function isCreateProjectJob(value: unknown): value is CreateProjectJob {
+    return (
+        typeof value === 'object' &&
+        value != null &&
+        'jobType' in value &&
+        value.jobType === JobType.CREATE_PROJECT
+    );
+}
+
 export type CreateJob = Pick<
     Job,
     'jobUuid' | 'projectUuid' | 'jobType' | 'jobStatus' | 'userUuid'

--- a/packages/frontend/src/components/ProjectConnection/index.tsx
+++ b/packages/frontend/src/components/ProjectConnection/index.tsx
@@ -3,6 +3,7 @@ import {
     DbtProjectType,
     ProjectType,
     friendlyName,
+    isCreateProjectJob,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
     type DbtVersionOption,
@@ -352,7 +353,8 @@ export const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         if (
             createProjectJobId &&
             createProjectJobId === activeJob?.jobUuid &&
-            activeJob?.jobResults?.projectUuid
+            isCreateProjectJob(activeJob) &&
+            activeJob.jobResults?.projectUuid
         ) {
             void navigate({
                 pathname: `/createProjectSettings/${activeJob?.jobResults?.projectUuid}`,

--- a/packages/frontend/src/features/catalog/hooks/useIndexCatalogJob.ts
+++ b/packages/frontend/src/features/catalog/hooks/useIndexCatalogJob.ts
@@ -1,0 +1,75 @@
+import {
+    SchedulerJobStatus,
+    type ApiError,
+    type ApiJobStatusResponse,
+} from '@lightdash/common';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { getSchedulerJobStatus } from '../../scheduler/hooks/useScheduler';
+
+// Recursively poll the job status until it is completed or errored
+const getIndexCatalogCompleteJob = async (
+    jobId: string,
+): Promise<ApiJobStatusResponse['results']> => {
+    const job = await getSchedulerJobStatus<ApiJobStatusResponse['results']>(
+        jobId,
+    );
+
+    if (job.status === SchedulerJobStatus.COMPLETED) {
+        return job;
+    }
+
+    if (job.status === SchedulerJobStatus.ERROR) {
+        throw <ApiError>{
+            status: SchedulerJobStatus.ERROR,
+            error: {
+                name: 'Error',
+                statusCode: 500,
+                message: job.details?.error,
+                data: job.details,
+            },
+        };
+    }
+
+    return new Promise((resolve) => {
+        setTimeout(async () => {
+            resolve(await getIndexCatalogCompleteJob(jobId));
+        }, 2000); // retry after 2 seconds
+    });
+};
+
+export const useIndexCatalogJob = (
+    jobId: string | undefined,
+    onSuccess: (job: ApiJobStatusResponse['results']) => void,
+) => {
+    const { showToastApiError, showToastError } = useToaster();
+    const queryClient = useQueryClient();
+
+    return useQuery<ApiJobStatusResponse['results'], ApiError>({
+        queryKey: ['index-catalog-job', jobId],
+        queryFn: () => getIndexCatalogCompleteJob(jobId || ''),
+        enabled: !!jobId,
+        staleTime: 0,
+        onSuccess: async (job) => {
+            if (job.status === SchedulerJobStatus.COMPLETED) {
+                await queryClient.resetQueries(['metrics-catalog'], {
+                    exact: false,
+                });
+                await queryClient.invalidateQueries(['catalog'], {
+                    exact: false,
+                });
+                onSuccess(job);
+            } else if (job.status === SchedulerJobStatus.ERROR) {
+                showToastError({
+                    title: 'Failed to refresh catalog',
+                });
+            }
+        },
+        onError: ({ error }: ApiError) => {
+            showToastApiError({
+                title: 'Failed to refresh catalog',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { isCompileJob } from '@lightdash/common';
 import {
     ActionIcon,
     Badge,
@@ -22,8 +23,10 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import useActiveJob from '../../../providers/ActiveJob/useActiveJob';
 import useApp from '../../../providers/App/useApp';
 import { LearnMoreContent } from '../../../svgs/metricsCatalog';
+import { useIndexCatalogJob } from '../../catalog/hooks/useIndexCatalogJob';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import {
     setAbility,
@@ -199,6 +202,17 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
     const { data: project } = useProject(projectUuid);
     const { user } = useApp();
 
+    // Track active compile job
+    const { activeJob } = useActiveJob();
+    // Track index catalog job
+    const { isFetching: isIndexingCatalog } = useIndexCatalogJob(
+        isCompileJob(activeJob)
+            ? activeJob.jobResults?.indexCatalogJobUuid
+            : undefined,
+        async () => {
+            setLastDbtRefreshAt(new Date());
+        },
+    );
     const isMetricUsageModalOpen = useAppSelector(
         (state) => state.metricsCatalog.modals.chartUsageModal.isOpen,
     );
@@ -363,10 +377,6 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         [tableName, metricName, dispatch],
     );
 
-    const handleRefreshDbt = () => {
-        setLastDbtRefreshAt(new Date());
-    };
-
     const headerButtonStyles: ButtonProps['sx'] = {
         borderRadius: theme.radius.md,
         backgroundColor: '#FAFAFA',
@@ -424,23 +434,40 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                     </Text>
                 </Box>
                 <Group spacing="xs">
-                    <RefreshDbtButton
-                        onClick={handleRefreshDbt}
-                        leftIcon={
-                            <MantineIcon
-                                size="sm"
-                                color="gray.7"
-                                icon={IconRefresh}
-                            />
-                        }
-                        buttonStyles={headerButtonStyles}
-                        defaultTextOverride={
-                            lastDbtRefreshAt
-                                ? `Last refreshed ${timeAgo}`
-                                : 'Refresh catalog'
-                        }
-                        refreshingTextOverride="Refreshing catalog"
-                    />
+                    {isIndexingCatalog ? (
+                        <Button
+                            size="xs"
+                            variant="default"
+                            leftIcon={
+                                <MantineIcon
+                                    size="sm"
+                                    color="gray.7"
+                                    icon={IconRefresh}
+                                />
+                            }
+                            loading={true}
+                            sx={headerButtonStyles}
+                        >
+                            Refreshing catalog
+                        </Button>
+                    ) : (
+                        <RefreshDbtButton
+                            leftIcon={
+                                <MantineIcon
+                                    size="sm"
+                                    color="gray.7"
+                                    icon={IconRefresh}
+                                />
+                            }
+                            buttonStyles={headerButtonStyles}
+                            defaultTextOverride={
+                                lastDbtRefreshAt
+                                    ? `Last refreshed ${timeAgo}`
+                                    : 'Refresh catalog'
+                            }
+                            refreshingTextOverride="Refreshing catalog"
+                        />
+                    )}
                     <LearnMorePopover buttonStyles={headerButtonStyles} />
                 </Group>
             </Group>

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -1,7 +1,6 @@
 import {
     JobStatusType,
     JobStepStatusType,
-    JobType,
     type ApiError,
     type ApiRefreshResults,
     type Job,
@@ -102,16 +101,6 @@ export const useJob = (
         onSuccess: async (job) => {
             if (job.jobStatus === JobStatusType.DONE) {
                 await queryClient.invalidateQueries(['tables']);
-                await queryClient.resetQueries(['metrics-catalog'], {
-                    exact: false,
-                });
-
-                if (job.jobType === JobType.COMPILE_PROJECT) {
-                    await queryClient.invalidateQueries([
-                        'catalog',
-                        job.projectUuid,
-                    ]);
-                }
             }
             onSuccess(job);
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13403](https://github.com/lightdash/lightdash/issues/13403)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- update compile project job to store index catalog job id
- FE checks index catalog job each 2 seconds
- show new loading button instead of refresh dbt button
- reload table once it is complete

Demo:


https://github.com/user-attachments/assets/ffdad5a3-af0b-48a8-8ba1-8a04541eedbd



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
