### PR TITLE
chore(backend): Fix logger config for tests

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -94,7 +94,7 @@ export const lightdashConfigMock: LightdashConfig = {
     logging: {
         level: 'debug',
         format: 'pretty',
-        outputs: [],
+        outputs: ['console'],
         consoleFormat: undefined,
         consoleLevel: undefined,
         fileFormat: undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
When running tests, winston was throwing this error because no transports were initialized:

```sh
  console.error
    [winston] Attempt to write logs with no transports, which can increase memory usage: {"serviceName":"ValidationService","message":"Generating validation of every target for project projectUuid with explores from cache","level":"debug"}

      541 |             : 'every target';
      542 |
    > 543 |         this.logger.debug(
          |                     ^
      544 |             `Generating validation of ${targetsString} for project ${projectUuid} with explores ${
      545 |                 compiledExplores ? 'from CLI' : 'from cache'
      546 |             }`,

      at DerivedLogger._transform (../../node_modules/.pnpm/winston@3.13.0/node_modules/winston/lib/winston/logger.js:302:15)
      at DerivedLogger.Object.<anonymous>.Transform._read (../../node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:166:10)
      at DerivedLogger.Object.<anonymous>.Transform._write (../../node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:155:83)
      at doWrite (../../node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:390:139)
      at writeOrBuffer (../../node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:381:5)
      at DerivedLogger.Object.<anonymous>.Writable.write (../../node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:302:11)
      at DerivedLogger.value (../../node_modules/.pnpm/winston@3.13.0/node_modules/winston/lib/winston/logger.js:67:18)
      at DerivedLogger.<computed> [as debug] (../../node_modules/.pnpm/winston@3.13.0/node_modules/winston/lib/winston/create-logger.js:81:14)
      at ValidationService.generateValidation (src/services/ValidationService/ValidationService.ts:543:21)
      at Object.<anonymous> (src/services/ValidationService/ValidationService.test.ts:60:37)
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
