### PR TITLE
fix: editor project access

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -186,9 +186,6 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'PinnedItems', {
             organizationUuid: member.organizationUuid,
         });
-        can('update', 'Project', {
-            organizationUuid: member.organizationUuid,
-        });
         can('manage', 'ScheduledDeliveries', {
             organizationUuid: member.organizationUuid,
         });
@@ -244,7 +241,9 @@ const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
             type: ProjectType.PREVIEW,
         });
-
+        can('update', 'Project', {
+            organizationUuid: member.organizationUuid,
+        });
         can('delete', 'Project', {
             organizationUuid: member.organizationUuid,
             type: ProjectType.PREVIEW,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -156,9 +156,6 @@ export const projectMemberAbilities: Record<
         can('manage', 'PinnedItems', {
             projectUuid: member.projectUuid,
         });
-        can('update', 'Project', {
-            projectUuid: member.projectUuid,
-        });
         can('manage', 'ScheduledDeliveries', {
             projectUuid: member.projectUuid,
         });
@@ -221,6 +218,10 @@ export const projectMemberAbilities: Record<
         can('create', 'Project', {
             upstreamProjectUuid: member.projectUuid,
             type: ProjectType.PREVIEW,
+        });
+
+        can('update', 'Project', {
+            projectUuid: member.projectUuid,
         });
         can('manage', 'SpotlightTableConfig', {
             projectUuid: member.projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Editors should not be able to update project settings. There was a misinterpretation of the docs on "updating a project" and "updating content in a project" that originated this bug.
We have updated the [roles documentation](https://docs.lightdash.com/references/roles#organization-roles) to distinguish between those two

Demo editor user:

<img width="1505" alt="Screenshot 2025-02-20 at 15 38 07" src="https://github.com/user-attachments/assets/655d90f3-0029-4719-bcfc-c0389d6df6ee" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
