### PR TITLE
fix: whitespace handling

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -4,6 +4,7 @@ import uniq from 'lodash/uniq';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../MantineIcon';
 import MultiValuePastePopover from './MultiValuePastePopover';
+import { formatDisplayValue } from './utils';
 
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     values: string[];
@@ -71,7 +72,7 @@ const FilterMultiStringInput: FC<Props> = ({
         // also we are merging status indicator as a first item
         return uniq([...results, ...values]).map((value) => ({
             value,
-            label: value,
+            label: formatDisplayValue(value),
         }));
     }, [results, values]);
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -28,6 +28,7 @@ import {
 import MantineIcon from '../../MantineIcon';
 import useFiltersContext from '../useFiltersContext';
 import MultiValuePastePopover from './MultiValuePastePopover';
+import { formatDisplayValue } from './utils';
 
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     filterId: string;
@@ -150,7 +151,7 @@ const FilterStringAutoComplete: FC<Props> = ({
         // also we are merging status indicator as a first item
         return uniq([...results, ...values]).map((value) => ({
             value,
-            label: value,
+            label: formatDisplayValue(value),
         }));
     }, [results, values]);
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -231,6 +231,6 @@ export const getFilterRuleTables = (
 
 export const formatDisplayValue = (value: string): string => {
     return value
-        .replace(/^\s+|\s+$/g, (match) => '·'.repeat(match.length))
+        .replace(/^\s+|\s+$/g, (match) => '␣'.repeat(match.length))
         .replace(/\n/g, '↵');
 };

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -228,3 +228,9 @@ export const getFilterRuleTables = (
         return [field.tableLabel];
     }
 };
+
+export const formatDisplayValue = (value: string): string => {
+    return value
+        .replace(/^\s+|\s+$/g, (match) => '·'.repeat(match.length))
+        .replace(/\n/g, '↵');
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8341 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Replaces whitespace with '·' and new line '↵'

<!-- Even better add a screenshot / gif / loom -->
A few more solutions are proposed in the comments for issue: #8341 
![image](https://github.com/user-attachments/assets/2836fc00-1177-4f25-82fa-28c89f863ef1)

Final solution with a few edge cases:
![image](https://github.com/user-attachments/assets/f7df12ee-78d4-43eb-9268-30b197e2aeab)
![image](https://github.com/user-attachments/assets/bfabcb9e-9153-4ba3-83c3-c3844f021beb)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
