### PR TITLE
fix: CLI commands fail when `version: 2` is missing in model YAML

### DIFF
--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -27,7 +27,7 @@ export type YamlModel = {
 };
 
 export type YamlSchema = {
-    version: 2;
+    version?: 2;
     models?: YamlModel[];
 };
 

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -746,5 +746,5 @@
         }
     },
     "additionalProperties": false,
-    "required": ["version"]
+    "required": []
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13770 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Allow YML models without `version: 2` field

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
