### PR TITLE
feat: support Postgres client and root certificates

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8507,6 +8507,27 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    sslcertFileName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    sslkeyFileName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    sslrootcertFileName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     searchPath: {
                         dataType: 'union',
                         subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9432,6 +9432,15 @@
                         "type": "number",
                         "format": "double"
                     },
+                    "sslcertFileName": {
+                        "type": "string"
+                    },
+                    "sslkeyFileName": {
+                        "type": "string"
+                    },
+                    "sslrootcertFileName": {
+                        "type": "string"
+                    },
                     "searchPath": {
                         "type": "string"
                     }
@@ -14813,7 +14822,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1509.1",
+        "version": "0.1512.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -2,6 +2,7 @@ import {
     AnyType,
     ConditionalOperator,
     CreateBigqueryCredentials,
+    CreatePostgresCredentials,
     DbtCloudIDEProjectConfig,
     DbtProjectType,
     DefaultSupportedDbtVersion,
@@ -400,3 +401,23 @@ export const exploresWithSameName: Explore[] = [
         targetDatabase: SupportedDbtAdapter.POSTGRES,
     },
 ];
+
+export const IncompletePostgresCredentialsWithoutSecrets: Omit<
+    CreatePostgresCredentials,
+    'user' | 'password'
+> = {
+    type: WarehouseTypes.POSTGRES,
+    host: 'localhost',
+    port: 5432,
+    dbname: 'dbname',
+    schema: 'schema',
+};
+export const CompletePostgresCredentials: CreatePostgresCredentials = {
+    type: WarehouseTypes.POSTGRES,
+    host: 'localhost',
+    user: 'saved_user',
+    password: 'saved_password',
+    port: 5432,
+    dbname: 'dbname',
+    schema: 'schema',
+};

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -62,6 +62,9 @@ export const sensitiveCredentialsFieldNames = [
     'privateKey',
     'privateKeyPass',
     'sshTunnelPrivateKey',
+    'sslcert',
+    'sslkey',
+    'sslrootcert',
 ] as const;
 export type SensitiveCredentialsFieldNames =
     typeof sensitiveCredentialsFieldNames[number];
@@ -88,23 +91,34 @@ export type DatabricksCredentials = Omit<
     CreateDatabricksCredentials,
     SensitiveCredentialsFieldNames
 >;
-export type CreatePostgresCredentials = SshTunnelConfiguration & {
-    type: WarehouseTypes.POSTGRES;
-    host: string;
-    user: string;
-    password: string;
-    requireUserCredentials?: boolean;
-    port: number;
-    dbname: string;
-    schema: string;
-    threads?: number;
-    keepalivesIdle?: number;
-    searchPath?: string;
-    role?: string;
+
+export type SslConfiguration = {
     sslmode?: string;
-    startOfWeek?: WeekDay | null;
-    timeoutSeconds?: number;
+    sslcertFileName?: string;
+    sslcert?: string | null; // file content
+    sslkeyFileName?: string;
+    sslkey?: string | null; // file content
+    sslrootcertFileName?: string;
+    sslrootcert?: string | null; // file content
 };
+
+export type CreatePostgresCredentials = SshTunnelConfiguration &
+    SslConfiguration & {
+        type: WarehouseTypes.POSTGRES;
+        host: string;
+        user: string;
+        password: string;
+        requireUserCredentials?: boolean;
+        port: number;
+        dbname: string;
+        schema: string;
+        threads?: number;
+        keepalivesIdle?: number;
+        searchPath?: string;
+        role?: string;
+        startOfWeek?: WeekDay | null;
+        timeoutSeconds?: number;
+    };
 export type PostgresCredentials = Omit<
     CreatePostgresCredentials,
     SensitiveCredentialsFieldNames


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#1816](https://github.com/lightdash/lightdash/issues/1816)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Allow to upload client certificate, private key, root certificate for Postgres connections in the UI.
CLI support will be done under: https://github.com/lightdash/lightdash/issues/7939 

#### How to reproduce
https://www.notion.so/lightdash/How-to-develop-debug-Postgres-with-certificates-1a1a63207a7a8052b644e589a13c6e58

#### Demo error & uploading certificates:

https://github.com/user-attachments/assets/c4e8ff21-0957-4143-b95e-a13e3980ebe0


#### Demo update connection without uploading files again & removing secrets:

https://github.com/user-attachments/assets/025594aa-dce9-45e4-80ce-eb5a5b09e47e



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
