### PR TITLE
fix: bad double scroll in sdk dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -27,7 +27,9 @@ import { convertSdkFilterToDashboardFilter } from '../utils';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
-const EmbedDashboard: FC = () => {
+const EmbedDashboard: FC<{
+    containerStyles?: React.CSSProperties;
+}> = ({ containerStyles }) => {
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
@@ -164,7 +166,7 @@ const EmbedDashboard: FC = () => {
         ),
     };
     return (
-        <div style={{ height: '100vh', overflowY: 'auto' }}>
+        <div style={containerStyles ?? { height: '100vh', overflowY: 'auto' }}>
             <EmbedDashboardHeader
                 dashboard={dashboard}
                 projectUuid={projectUuid}

--- a/packages/frontend/src/ee/pages/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/pages/EmbedDashboard.tsx
@@ -6,7 +6,9 @@ import DashboardProvider from '../../providers/Dashboard/DashboardProvider';
 import EmbedDashboard from '../features/embed/EmbedDashboard/components/EmbedDashboard';
 import useEmbed from '../providers/Embed/useEmbed';
 
-const EmbedDashboardPage: FC = () => {
+const EmbedDashboardPage: FC<{
+    containerStyles?: React.CSSProperties;
+}> = ({ containerStyles }) => {
     const { projectUuid: projectUuidFromParams } = useParams<{
         projectUuid?: string;
     }>();
@@ -28,7 +30,7 @@ const EmbedDashboardPage: FC = () => {
 
     return (
         <DashboardProvider embedToken={embedToken} projectUuid={projectUuid}>
-            <EmbedDashboard />
+            <EmbedDashboard containerStyles={containerStyles} />
         </DashboardProvider>
     );
 };

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -70,9 +70,9 @@ function App() {
         maxWidth: '600px',
         height: '400px',
         border: '2px dashed #ccc',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
+        // display: 'flex',
+        // justifyContent: 'center',
+        // alignItems: 'center',
         backgroundColor: 'aliceblue',
     };
 

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -79,9 +79,9 @@ function App() {
         maxWidth: '600px',
         height: '400px',
         border: '2px dashed #ccc',
-        // display: 'flex',
-        // justifyContent: 'center',
-        // alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
         backgroundColor: 'aliceblue',
     };
 

--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -145,17 +145,15 @@ const Dashboard: FC<Props> = ({
                 projectUuid={projectUuid}
                 filters={filters}
             >
-                <div
-                    style={{
+                <EmbedDashboard
+                    containerStyles={{
                         width: '100%',
                         height: '100%',
                         position: 'relative',
-                        // overflow: 'auto',
+                        overflow: 'auto',
                         backgroundColor: styles?.backgroundColor,
                     }}
-                >
-                    <EmbedDashboard />
-                </div>
+                />
             </EmbedProvider>
         </SdkProviders>
     );

--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -150,7 +150,7 @@ const Dashboard: FC<Props> = ({
                         width: '100%',
                         height: '100%',
                         position: 'relative',
-                        overflow: 'auto',
+                        // overflow: 'auto',
                         backgroundColor: styles?.backgroundColor,
                     }}
                 >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13666 

### Description:

Fix a double scroll in embedding. We had two nested containers handling sizing differently. Now we have one container with different styles. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
