### PR TITLE
fix: hide toasts in SDK

### DIFF
--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -13,6 +13,7 @@ type Props = {
     withCSSVariables?: boolean;
     theme?: MantineThemeOverride;
     themeOverride?: MantineThemeOverride;
+    notificationsLimit?: number;
 };
 
 const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
@@ -22,6 +23,7 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
     withCSSVariables = false,
     theme = getMantineThemeOverride(),
     themeOverride = {},
+    notificationsLimit,
 }) => {
     return (
         <MantineProviderBase
@@ -32,7 +34,7 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
         >
             {children}
 
-            <Notifications />
+            <Notifications limit={notificationsLimit} />
         </MantineProviderBase>
     );
 };

--- a/packages/sdk/src/Lightdash.tsx
+++ b/packages/sdk/src/Lightdash.tsx
@@ -70,6 +70,7 @@ const SdkProviders: FC<
                         chartFont: styles?.fontFamily,
                     },
                 }}
+                notificationsLimit={0}
             >
                 <AppProvider>
                     <FullscreenProvider enabled={false}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

The SDK was showing toasts overlaying the containing app like this:
<img width="1254" alt="Screenshot 2025-02-21 at 16 10 15" src="https://github.com/user-attachments/assets/a5c8b108-e899-494b-a50e-569f8a437788" />

This PR hides all toasts from the SDK. I don't imagine anyone will want these as toasts in their app, but we could make it an option in the future. Or find another place to put the information that's within the container. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
