### PR TITLE
feat: override tiles' filters if dashboard ones target similar

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -745,6 +745,7 @@ export class EmbedService extends BaseService {
             ...addDashboardFiltersToMetricQuery(
                 chart.metricQuery,
                 appliedDashboardFilters,
+                explore,
             ),
         };
 

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -570,6 +570,7 @@ This method can be memory intensive
             ? addDashboardFiltersToMetricQuery(
                   metricQuery,
                   dashboardFiltersForTile,
+                  explore,
               )
             : metricQuery;
 
@@ -898,6 +899,7 @@ This method can be memory intensive
             ? addDashboardFiltersToMetricQuery(
                   metricQuery,
                   dashboardFiltersForTile,
+                  explore,
               )
             : metricQuery;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1605,106 +1605,7 @@ export class ProjectService extends BaseService {
             dimensions: getDashboardFilterRulesForTables(
                 tables,
                 dashboardFilters.dimensions,
-            ).map((filter) => {
-                const dimensionFiltersFromChart =
-                    savedChart.metricQuery.filters?.dimensions;
-
-                const baseDimension =
-                    explore.tables[filter.target.tableName].dimensions[
-                        filter.target.fieldId.replace(
-                            `${filter.target.tableName}_`,
-                            '',
-                        )
-                    ];
-                if (baseDimension.timeIntervalBaseDimensionName) {
-                    const fieldsToChange: string[] = [];
-
-                    const calculateFieldsToChange = (
-                        filterGroup: FilterGroup | undefined,
-                    ) => {
-                        if (!filterGroup) {
-                            return;
-                        }
-                        if (isAndFilterGroup(filterGroup)) {
-                            filterGroup.and.forEach((item) => {
-                                if (isFilterRule(item)) {
-                                    const baseDimensionOfFilterRule =
-                                        item.target.fieldId.replace(
-                                            `${filter.target.tableName}_`,
-                                            '',
-                                        ) in
-                                        explore.tables[filter.target.tableName]
-                                            .dimensions
-                                            ? explore.tables[
-                                                  filter.target.tableName
-                                              ].dimensions[
-                                                  item.target.fieldId.replace(
-                                                      `${filter.target.tableName}_`,
-                                                      '',
-                                                  )
-                                              ]
-                                            : undefined;
-
-                                    if (
-                                        baseDimensionOfFilterRule &&
-                                        baseDimension.timeIntervalBaseDimensionName ===
-                                            baseDimensionOfFilterRule.timeIntervalBaseDimensionName
-                                    ) {
-                                        fieldsToChange.push(
-                                            item.target.fieldId,
-                                        );
-                                    }
-                                }
-                            });
-                        }
-                        if (isOrFilterGroup(filterGroup)) {
-                            filterGroup.or.forEach((item) => {
-                                if (isFilterRule(item)) {
-                                    const baseDimensionOfFilterRule =
-                                        item.target.fieldId.replace(
-                                            `${filter.target.tableName}_`,
-                                            '',
-                                        ) in
-                                        explore.tables[filter.target.tableName]
-                                            .dimensions
-                                            ? explore.tables[
-                                                  filter.target.tableName
-                                              ].dimensions[
-                                                  item.target.fieldId.replace(
-                                                      `${filter.target.tableName}_`,
-                                                      '',
-                                                  )
-                                              ]
-                                            : undefined;
-
-                                    if (
-                                        baseDimensionOfFilterRule &&
-                                        baseDimension.timeIntervalBaseDimensionName ===
-                                            baseDimensionOfFilterRule.timeIntervalBaseDimensionName
-                                    ) {
-                                        fieldsToChange.push(
-                                            item.target.fieldId,
-                                        );
-                                    }
-                                }
-                            });
-                        }
-                    };
-
-                    calculateFieldsToChange(dimensionFiltersFromChart);
-
-                    return {
-                        ...filter,
-                        target: {
-                            ...filter.target,
-                            baseTimeDimensionName:
-                                baseDimension.timeIntervalBaseDimensionName,
-                            fieldsToChange,
-                        },
-                    };
-                }
-                return filter;
-            }),
+            ),
             metrics: getDashboardFilterRulesForTables(
                 tables,
                 dashboardFilters.metrics,
@@ -1719,6 +1620,7 @@ export class ProjectService extends BaseService {
             ...addDashboardFiltersToMetricQuery(
                 savedChart.metricQuery,
                 appliedDashboardFilters,
+                explore,
             ),
             sorts:
                 dashboardSorts && dashboardSorts.length > 0

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1703,7 +1703,7 @@ export class ProjectService extends BaseService {
                         },
                     };
                 }
-                return null;
+                return filter;
             }),
             metrics: getDashboardFilterRulesForTables(
                 tables,
@@ -1714,15 +1714,6 @@ export class ProjectService extends BaseService {
                 dashboardFilters.tableCalculations,
             ),
         };
-
-        console.log('appliedDashboardFilters', {
-            appliedDashboardFilters: JSON.stringify(
-                appliedDashboardFilters,
-                null,
-                2,
-            ),
-            savedChart: JSON.stringify(savedChart, null, 2),
-        });
 
         const metricQueryWithDashboardOverrides: MetricQuery = {
             ...addDashboardFiltersToMetricQuery(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -33,7 +33,6 @@ import {
     Explore,
     ExploreError,
     ExploreType,
-    FilterGroup,
     FilterGroupItem,
     FilterOperator,
     FilterableDimension,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1590,11 +1590,6 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
-        // TODO: get explore dimension base dimension for time dimensions
-        // Check agains the same
-        // Figure out how to override.
-        // Figure out if all should be replaced! There is a consideration for partial overrides. - chat to Katie about this.
-
         await this.analyticsModel.addChartViewEvent(
             savedChart.uuid,
             user.userUuid,

--- a/packages/common/src/types/filter.test.ts
+++ b/packages/common/src/types/filter.test.ts
@@ -1,13 +1,13 @@
 import { cloneDeep } from 'lodash';
 import { ConditionalOperator } from './conditionalRule';
 import {
+    type AndFilterGroup,
     compressDashboardFiltersToParam,
     convertDashboardFiltersParamToDashboardFilters,
-    isFilterRuleDefinedForFieldId,
-    removeFieldFromFilterGroup,
-    type AndFilterGroup,
     type DashboardTileTarget,
     type FilterGroup,
+    isFilterRuleDefinedForFieldId,
+    removeFieldFromFilterGroup,
 } from './filter';
 
 describe('compress and uncompress dashboard filters', () => {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -78,6 +78,8 @@ export interface MetricFilterRule
 export type DashboardFieldTarget = {
     fieldId: string;
     tableName: string;
+    baseTimeDimensionName?: string;
+    fieldsToChange?: string[];
 };
 
 export type DashboardTileTarget = DashboardFieldTarget | false;

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -78,8 +78,6 @@ export interface MetricFilterRule
 export type DashboardFieldTarget = {
     fieldId: string;
     tableName: string;
-    baseTimeDimensionName?: string;
-    fieldsToChange?: string[];
 };
 
 export type DashboardTileTarget = DashboardFieldTarget | false;
@@ -466,5 +464,17 @@ export const isFilterRuleDefinedForFieldId = (
     // If the filter rule was not found in the filter group, return false
     return filterGroupItems.some(isFilterRulePresent);
 };
+
+/**
+ * Type tracking time-based filter overrides using an external map instead of modifying filter rules
+ * Maps dashboard filter rule IDs to their override configurations
+ */
+export type TimeBasedOverrideMap = Record<
+    string,
+    {
+        baseTimeDimensionName: string;
+        fieldsToChange: string[];
+    }
+>;
 
 export { ConditionalOperator as FilterOperator };

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,10 +1,15 @@
 import { ConditionalOperator } from '../types/conditionalRule';
-import { type Table } from '../types/explore';
+import { SupportedDbtAdapter } from '../types/dbt';
+import { type Explore, type Table } from '../types/explore';
+import { DimensionType, FieldType } from '../types/field';
 import {
+    type AndFilterGroup,
+    type DashboardFilterRule,
     type FilterGroup,
     type FilterRule,
     type Filters,
     type MetricFilterRule,
+    type OrFilterGroup,
 } from '../types/filter';
 import {
     addDashboardFiltersToMetricQuery,
@@ -14,6 +19,7 @@ import {
     overrideChartFilter,
     reduceRequiredDimensionFiltersToFilterRules,
     resetRequiredFilterRules,
+    trackWhichTimeBasedMetricFiltersToOverride,
 } from './filters';
 import {
     baseTable,
@@ -232,5 +238,239 @@ describe('resetRequiredFilterRules', () => {
             'someOther',
         ]);
         expect(newFilterRules).toEqual(expectedRequiredResetResult);
+    });
+});
+
+describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
+    const mockExplore: Explore = {
+        name: 'test',
+        label: 'Test',
+        tags: [],
+        baseTable: 'orders',
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
+        joinedTables: [],
+        tables: {
+            orders: {
+                name: 'orders',
+                label: 'Orders',
+                database: 'test',
+                schema: 'public',
+                sqlTable: 'orders',
+                metrics: {},
+                lineageGraph: {},
+                dimensions: {
+                    order_date_year: {
+                        name: 'order_date_year',
+                        label: 'Order Date Year',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        compiledSql: 'order_date_year',
+                        tablesReferences: [],
+                        sql: 'order_date_year',
+                        hidden: false,
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.DATE,
+                        timeIntervalBaseDimensionName: 'order_date',
+                    },
+                    order_date_month: {
+                        name: 'order_date_month',
+                        label: 'Order Date Month',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        compiledSql: 'order_date_month',
+                        tablesReferences: [],
+                        sql: 'order_date_month',
+                        hidden: false,
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.DATE,
+                        timeIntervalBaseDimensionName: 'order_date',
+                    },
+                    order_date_week: {
+                        name: 'order_date_week',
+                        label: 'Order Date Week',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        compiledSql: 'order_date_week',
+                        sql: 'order_date_week',
+                        hidden: false,
+                        tablesReferences: [],
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.DATE,
+                        timeIntervalBaseDimensionName: 'order_date',
+                    },
+                    status: {
+                        name: 'status',
+                        label: 'Status',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        compiledSql: 'status',
+                        sql: 'status',
+                        hidden: false,
+                        tablesReferences: [],
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.BOOLEAN,
+                    },
+                },
+            },
+        },
+    };
+
+    test('should track fields to change when dashboard filter targets base time dimension', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'month-filter',
+                    target: { fieldId: 'order_date_month' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['2024-03'],
+                },
+                {
+                    id: 'week-filter',
+                    target: { fieldId: 'order_date_week' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['2024-03-25'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'year-filter',
+            label: 'Year Filter',
+            target: {
+                fieldId: 'order_date_year',
+                tableName: 'orders',
+                fieldsToChange: [],
+            },
+            operator: ConditionalOperator.EQUALS,
+            values: ['2024'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.target.fieldsToChange).toEqual(
+            expect.arrayContaining(['order_date_month', 'order_date_week']),
+        );
+    });
+
+    test('should not track fields when dashboard filter targets non-base dimension', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'status-filter',
+                    target: { fieldId: 'status' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'status-filter',
+            label: 'Status Filter',
+            target: {
+                fieldId: 'status',
+                tableName: 'orders',
+            },
+            operator: ConditionalOperator.EQUALS,
+            values: ['shipped'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.target.fieldsToChange).toBeUndefined();
+    });
+
+    test('should handle multiple time intervals in metric query', () => {
+        const metricQueryDimensionFilters: OrFilterGroup = {
+            id: 'dim-filter-group',
+            or: [
+                {
+                    id: 'month-filter',
+                    target: { fieldId: 'order_date_month' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['2024-03'],
+                },
+                {
+                    id: 'week-filter',
+                    target: { fieldId: 'order_date_week' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['2024-03-25'],
+                },
+                {
+                    id: 'year-filter',
+                    target: { fieldId: 'order_date_year' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['2024'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'base-filter',
+            label: 'Base Filter',
+            target: {
+                fieldId: 'order_date_year',
+                tableName: 'orders',
+            },
+            operator: ConditionalOperator.EQUALS,
+            values: ['2024'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.target.fieldsToChange).toEqual(
+            expect.arrayContaining([
+                'order_date_month',
+                'order_date_week',
+                'order_date_year',
+            ]),
+        );
+    });
+
+    test('should return original filter when no matching time intervals', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'status-filter',
+                    target: { fieldId: 'status' },
+                    operator: ConditionalOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'year-filter',
+            label: 'Year Filter',
+            target: {
+                fieldId: 'order_date_year',
+                tableName: 'orders',
+            },
+            operator: ConditionalOperator.EQUALS,
+            values: ['2024'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.target.fieldsToChange).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -66,6 +66,7 @@ describe('overrideChartFilter', () => {
         const result = overrideChartFilter(
             chartAndFilterGroup,
             dashboardFilterWithSameTargetAndOperator,
+            {},
         );
         expect(result).toEqual({
             id: 'fillter-group-1',
@@ -92,6 +93,7 @@ describe('overrideChartFilter', () => {
         const result = overrideChartFilter(
             chartOrFilterGroup,
             dashboardFilterWithSameTargetAndOperator,
+            {},
         );
         expect(result).toEqual({
             id: 'fillter-group-1',
@@ -118,6 +120,7 @@ describe('overrideChartFilter', () => {
         const result = overrideChartFilter(
             chartAndFilterGroup,
             dashboardFilterWithSameTargetButDifferentOperator,
+            {},
         );
         expect(result).toEqual({
             id: 'fillter-group-1',
@@ -340,7 +343,6 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
             target: {
                 fieldId: 'order_date_year',
                 tableName: 'orders',
-                fieldsToChange: [],
             },
             operator: ConditionalOperator.EQUALS,
             values: ['2024'],
@@ -352,7 +354,7 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
             mockExplore,
         );
 
-        expect(result.target.fieldsToChange).toEqual(
+        expect(result.overrideData?.fieldsToChange).toEqual(
             expect.arrayContaining(['order_date_month', 'order_date_week']),
         );
     });
@@ -387,7 +389,7 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
             mockExplore,
         );
 
-        expect(result.target.fieldsToChange).toBeUndefined();
+        expect(result.overrideData?.fieldsToChange).toBeUndefined();
     });
 
     test('should handle multiple time intervals in metric query', () => {
@@ -432,7 +434,7 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
             mockExplore,
         );
 
-        expect(result.target.fieldsToChange).toEqual(
+        expect(result.overrideData?.fieldsToChange).toEqual(
             expect.arrayContaining([
                 'order_date_month',
                 'order_date_week',
@@ -471,6 +473,6 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
             mockExplore,
         );
 
-        expect(result.target.fieldsToChange).toBeUndefined();
+        expect(result.overrideData?.fieldsToChange).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -748,15 +748,15 @@ const findAndOverrideChartFilter = (
         ? filterRulesList.find((dashboardFilter) => {
               const dashboardTarget =
                   dashboardFilter.target as DashboardFieldTarget;
+
               return (
                   // @ts-expect-error
-                  dashboardTarget.fieldsToChange?.includes(item.target.fieldId)
+                  dashboardTarget.fieldsToChange?.includes(
+                      item.target.fieldId,
+                  ) || dashboardTarget.fieldId === item.target.fieldId
               );
           })
         : undefined;
-
-    // @ts-expect-error
-    console.log({ identicalDashboardFilter, item: item.target.fieldId });
 
     return identicalDashboardFilter
         ? {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -782,7 +782,9 @@ const findAndOverrideChartFilter = (
               id: identicalDashboardFilter.id,
               values: identicalDashboardFilter.values,
 
-              settings: identicalDashboardFilter.settings ?? {},
+              ...(identicalDashboardFilter.settings && {
+                  settings: identicalDashboardFilter.settings,
+              }),
 
               operator: identicalDashboardFilter.operator,
           }

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -745,18 +745,30 @@ const findAndOverrideChartFilter = (
     filterRulesList: FilterRule[],
 ): FilterGroupItem => {
     const identicalDashboardFilter = isFilterRule(item)
-        ? filterRulesList.find((x) => x.target.fieldId === item.target.fieldId)
+        ? filterRulesList.find((dashboardFilter) => {
+              const dashboardTarget =
+                  dashboardFilter.target as DashboardFieldTarget;
+              return (
+                  // @ts-expect-error
+                  dashboardTarget.fieldsToChange?.includes(item.target.fieldId)
+              );
+          })
         : undefined;
+
+    // @ts-expect-error
+    console.log({ identicalDashboardFilter, item: item.target.fieldId });
+
     return identicalDashboardFilter
         ? {
               ...item,
+              target: {
+                  fieldId: identicalDashboardFilter.target.fieldId,
+              },
               id: identicalDashboardFilter.id,
               values: identicalDashboardFilter.values,
-              ...(identicalDashboardFilter.settings
-                  ? {
-                        settings: identicalDashboardFilter.settings,
-                    }
-                  : {}),
+
+              settings: identicalDashboardFilter.settings ?? {},
+
               operator: identicalDashboardFilter.operator,
           }
         : item;
@@ -827,6 +839,7 @@ const convertDashboardFilterRuleToFilterRule = (
 ): FilterRule => ({
     id: dashboardFilterRule.id,
     target: {
+        ...dashboardFilterRule.target,
         fieldId: dashboardFilterRule.target.fieldId,
     },
     operator: dashboardFilterRule.operator,

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -91,6 +91,7 @@ const FiltersCard: FC = memo(() => {
                     dimensions: overrideFilterGroupWithFilterRules(
                         unsavedQueryFilters.dimensions,
                         reducedRules,
+                        undefined,
                     ),
                 };
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13576

### Description:


Automatically override chart filters when dashboard filters use:
- Same dimension (e.g., dashboard filter on status overrides chart's status filter)
- Different granularity of same time dimension (e.g., dashboard order_date_year overrides chart's order_date_month)
- Add tracking of overridden filters using new fieldsToChange property
- Maintain existing AND/OR logic for unrelated filters

New filter resolution logic in filters.ts:
- trackWhichTimeBasedMetricFiltersToOverride identifies override candidates
- Enhanced findAndOverrideChartFilter handles granularity overrides

#### How to test

Time based dimension:
- Create dashboard 
- Create chart (with filter `order_date_month` = march 2018)
- Add dashboard filter `order_date_day` = 2018-03-24
- Explore from here on chart with dashboard filter applied - it will override `order_date_month` with `order_date_day` = 2018-03-24

Other type of filter (like `status`)
- Create dashboard 
- Create chart (with filter `completed` = 'false')
- Add dashboard filter `status` = 'true'
- Explore from here on chart with dashboard filter applied - it will override `status` with `status` = 'true'


> [!NOTE]
> if there is more than one time-based dimension on the chart that is overriden by one dashboard filter, then we replace all, but not clean duplicates. This is fine for now after chatting with @TuringLovesDeathMetal 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

test-cli
test-backend
test-frontend
