### PR TITLE
feat: redirect legacy SQL Runner URLs to new page

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -19,6 +19,7 @@ import Explorer from './pages/Explorer';
 import Home from './pages/Home';
 import Invite from './pages/Invite';
 import JoinOrganization from './pages/JoinOrganization';
+import LegacySqlRunner from './pages/LegacySqlRunner';
 import Login from './pages/Login';
 import MetricsCatalog from './pages/MetricsCatalog';
 import MinimalDashboard from './pages/MinimalDashboard';
@@ -214,6 +215,11 @@ const DASHBOARD_ROUTES: RouteObject[] = [
 ];
 
 const SQL_RUNNER_ROUTES: RouteObject[] = [
+    {
+        path: '/projects/:projectUuid/sqlRunner',
+        // Support old share links. Redirects to new route.
+        element: <LegacySqlRunner />,
+    },
     {
         path: '/projects/:projectUuid/sql-runner',
         element: (

--- a/packages/frontend/src/pages/LegacySqlRunner.tsx
+++ b/packages/frontend/src/pages/LegacySqlRunner.tsx
@@ -19,7 +19,6 @@ const RedirectToSqlRunner: FC = () => {
         // Note: In development, the SqlRunner state is reset so it doesn't work. If you want to debug this, disable React.StrictMode in packages/frontend/src/index.tsx
         dispatch(setSql(legacySqlState.sql));
     }
-    console.log('here');
 
     return <Navigate to={`/projects/${projectUuid}/sql-runner`} replace />;
 };

--- a/packages/frontend/src/pages/LegacySqlRunner.tsx
+++ b/packages/frontend/src/pages/LegacySqlRunner.tsx
@@ -1,0 +1,35 @@
+import type { FC } from 'react';
+import { Provider } from 'react-redux';
+import { Navigate, useLocation, useParams } from 'react-router';
+import { store } from '../features/sqlRunner/store';
+import { useAppDispatch } from '../features/sqlRunner/store/hooks';
+import { setSql } from '../features/sqlRunner/store/sqlRunnerSlice';
+
+const RedirectToSqlRunner: FC = () => {
+    const dispatch = useAppDispatch();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { search } = useLocation();
+    const searchParams = new URLSearchParams(search);
+    const sqlRunnerSearchParam = searchParams.get('sql_runner');
+    const legacySqlState = sqlRunnerSearchParam
+        ? JSON.parse(sqlRunnerSearchParam)
+        : undefined;
+
+    if (projectUuid && legacySqlState) {
+        // Note: In development, the SqlRunner state is reset so it doesn't work. If you want to debug this, disable React.StrictMode in packages/frontend/src/index.tsx
+        dispatch(setSql(legacySqlState.sql));
+    }
+    console.log('here');
+
+    return <Navigate to={`/projects/${projectUuid}/sql-runner`} replace />;
+};
+
+const LegacySqlRunner: FC = () => {
+    return (
+        <Provider store={store}>
+            <RedirectToSqlRunner />
+        </Provider>
+    );
+};
+
+export default LegacySqlRunner;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#2918](https://github.com/lightdash/lightdash-internal-work/issues/2918) <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Redirect legacy SQL Runner URLs to new page.
Copies over the SQL but no chart config.


![redirect](https://github.com/user-attachments/assets/4cdc6536-cca1-40e2-a396-942b7623ba23)

Reproduce locally by inserting the following data in `postgres.public.share` and disable `React.StrictMode` in `packages/frontend/src/index.tsx`

```
{
    "share_id": 1,
    "nanoid": "GZ-OqNIzkTWFlHkHzJqoh",
    "path": "/projects/3675b69e-8324-4110-bdca-059031aa8da3/sqlRunner",
    "params": "?create_saved_chart_version=%7B%22tableName%22%3A%22sql_runner%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22sql_runner%22%2C%22dimensions%22%3A%5B%22sql_runner_order_date%22%2C%22sql_runner_status%22%2C%22sql_runner_is_completed%22%5D%2C%22metrics%22%3A%5B%22sql_runner_order_id%22%2C%22sql_runner_customer_id%22%2C%22sql_runner_credit_card_amount%22%2C%22sql_runner_coupon_amount%22%2C%22sql_runner_bank_transfer_amount%22%2C%22sql_runner_gift_card_amount%22%2C%22sql_runner_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%5D%2C%22limit%22%3A0%2C%22tableCalculations%22%3A%5B%5D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22sql_runner_status%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22sql_runner_order_date%22%2C%22yField%22%3A%5B%22sql_runner_order_id%22%2C%22sql_runner_customer_id%22%2C%22sql_runner_credit_card_amount%22%2C%22sql_runner_coupon_amount%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_order_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22returned%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_customer_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22returned%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_credit_card_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22returned%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_coupon_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22returned%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_order_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22completed%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_customer_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22completed%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_credit_card_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22completed%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_coupon_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22completed%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_order_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22return_pending%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_customer_id%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22return_pending%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_credit_card_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22return_pending%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22sql_runner_order_date%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22sql_runner_coupon_amount%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22sql_runner_status%22%2C%22value%22%3A%22return_pending%22%7D%5D%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22sql_runner_order_date%22%2C%22sql_runner_status%22%2C%22sql_runner_is_completed%22%2C%22sql_runner_order_id%22%2C%22sql_runner_customer_id%22%2C%22sql_runner_credit_card_amount%22%2C%22sql_runner_coupon_amount%22%2C%22sql_runner_bank_transfer_amount%22%2C%22sql_runner_gift_card_amount%22%2C%22sql_runner_amount%22%5D%7D%7D&sql_runner=%7B%22sql%22%3A%22SELECT+*%5Cn+++++FROM+%5C%22postgres%5C%22.%5C%22jaffle%5C%22.%5C%22orders%5C%22+LIMIT+25%22%7D",
    "created_by_user_id": 1,
    "organization_id": 1,
    "created_at": "2025-02-21 15:51:44.840387"
  }
```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
