### PR TITLE
fix: Selecting dashboard filter label text results in dragging the filter rather than selecting text

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -226,7 +226,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                             <DraggableItem
                                 key={item.id}
                                 id={item.id}
-                                disabled={!isEditMode}
+                                disabled={!isEditMode || !!openPopoverId}
                             >
                                 {field ? (
                                     <Filter


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13760 
Closes: #13291

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR fixes an issue where attempting to interact with a filter popover (e.g., selecting text inside an input field) would unintentionally trigger the drag behavior.

#### Changes
- Updated the disabled condition in the `DraggableItem` component to include `!!openPopoverId`.
- Now, dragging is disabled when a filter popover is open, ensuring a smoother user experience.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
