### PR TITLE
feat(dashboard): load unaffected tiles when required filter is unset

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/components/DashboardTabs/GridTile.tsx
@@ -31,7 +31,16 @@ const GridTile: FC<
     if (props.locked) {
         return (
             <Box h="100%">
-                <TileBase isLoading={false} title={''} {...props} />
+                <TileBase
+                    isLoading={false}
+                    title={
+                        tile.properties.title ||
+                        ('chartName' in tile.properties
+                            ? tile.properties.chartName || ''
+                            : '')
+                    }
+                    {...props}
+                />
             </Box>
         );
     }

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -17,7 +17,6 @@ import '../../styles/droppable.css';
 import { SectionName } from '../../types/Events';
 import EmptyStateNoTiles from '../DashboardTiles/EmptyStateNoTiles';
 import MantineIcon from '../common/MantineIcon';
-import { LockedDashboardModal } from '../common/modal/LockedDashboardModal';
 import { TabAddModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
 import { TabEditModal } from './EditTabModal';
@@ -81,6 +80,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
 
     // tabs state
     const [isEditingTab, setEditingTab] = useState<boolean>(false);
@@ -100,6 +100,15 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             return a.y - b.y;
         }
     });
+
+    const tileUsesRequiredFilter = (tile: DashboardTile): boolean => {
+        return dashboardFilters?.dimensions.some(
+            (filter) =>
+                filter.required &&
+                (!filter.values || filter.values.length === 0) &&
+                filter.tileTargets?.[tile.uuid],
+        );
+    };
 
     const isActiveTile = (tile: DashboardTile) => {
         const tileBelongsToActiveTab = tile.tabUuid === activeTab?.uuid; // tiles belongs to current tab
@@ -193,7 +202,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             handleBatchDeleteTiles(tilesToDelete);
         }
     };
-
     return (
         <DragDropContext
             onDragEnd={(result) => {
@@ -359,9 +367,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                             }
                                                         >
                                                             <GridTile
-                                                                locked={
-                                                                    hasRequiredDashboardFiltersToSet
-                                                                }
+                                                                locked={tileUsesRequiredFilter(
+                                                                    tile,
+                                                                )}
                                                                 index={idx}
                                                                 isEditMode={
                                                                     isEditMode
@@ -387,12 +395,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                         })}
                                     </ResponsiveGridLayout>
                                 </Group>
-                                <LockedDashboardModal
-                                    opened={
-                                        hasRequiredDashboardFiltersToSet &&
-                                        !!hasDashboardTiles
-                                    }
-                                />
                                 {(!hasDashboardTiles ||
                                     !currentTabHasTiles) && (
                                     <EmptyStateNoTiles

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -21,6 +21,7 @@ import {
     IconArrowAutofitContent,
     IconDots,
     IconEdit,
+    IconLock,
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type ReactNode } from 'react';
@@ -57,6 +58,7 @@ type Props<T> = {
     minimal?: boolean;
     tabs?: DashboardTab[];
     lockHeaderVisibility?: boolean;
+    locked?: boolean;
 };
 
 const TileBase = <T extends Dashboard['tiles'][number]>({
@@ -76,6 +78,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     titleHref,
     minimal = false,
     tabs,
+    locked,
     lockHeaderVisibility = false,
 }: Props<T>) => {
     const [isEditingTileContent, setIsEditingTileContent] = useState(false);
@@ -322,7 +325,32 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             </HeaderContainer>
 
             <ChartContainer className="non-draggable sentry-block ph-no-capture">
-                {children}
+                {locked ? (
+                    <Card
+                        withBorder
+                        radius="sm"
+                        p="md"
+                        h="100%"
+                        style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '1em',
+                            width: '100%',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            textAlign: 'center',
+                            backgroundColor: '#f8f9fa',
+                            border: '1px dashed #ced4da',
+                        }}
+                    >
+                        <IconLock size={20} color="#adb5bd" />
+                        <Text size="sm" color="dimmed" fw={500}>
+                            Set required filters to unlock this tile.
+                        </Text>
+                    </Card>
+                ) : (
+                    children
+                )}
             </ChartContainer>
 
             {isEditingTileContent &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13791

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- Updated dashboard loading logic so that if a required filter is unset, **only the tiles that use that filter are blocked**.
- Tiles that do not depend on the required filter load immediately.
- Once the filter value is set, the additional tiles load.

![task_2](https://github.com/user-attachments/assets/116b28cc-5a1c-4706-bf1e-14e637bef942)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
