### PR TITLE
feat: sort stacked bar charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2587,6 +2587,26 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    XAxisSortType: {
+        dataType: 'refEnum',
+        enums: ['default', 'bar_totals'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    XAxis: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Axis' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: { sortType: { ref: 'XAxisSortType' } },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Partial_CompleteEChartsConfig_: {
         dataType: 'refAlias',
         type: {
@@ -2621,7 +2641,7 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         {
                             dataType: 'array',
-                            array: { dataType: 'refAlias', ref: 'Axis' },
+                            array: { dataType: 'refAlias', ref: 'XAxis' },
                         },
                         { dataType: 'undefined' },
                     ],

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10086,7 +10086,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10096,7 +10096,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10106,7 +10106,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10119,7 +10119,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2857,6 +2857,25 @@
                 },
                 "type": "object"
             },
+            "XAxisSortType": {
+                "enum": ["default", "bar_totals"],
+                "type": "string"
+            },
+            "XAxis": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Axis"
+                    },
+                    {
+                        "properties": {
+                            "sortType": {
+                                "$ref": "#/components/schemas/XAxisSortType"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
             "Partial_CompleteEChartsConfig_": {
                 "properties": {
                     "legend": {
@@ -2873,7 +2892,7 @@
                     },
                     "xAxis": {
                         "items": {
-                            "$ref": "#/components/schemas/Axis"
+                            "$ref": "#/components/schemas/XAxis"
                         },
                         "type": "array"
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10908,22 +10908,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -14921,7 +14921,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1516.0",
+        "version": "0.1517.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -265,7 +265,7 @@ export type CompleteEChartsConfig = {
     legend?: EchartsLegend;
     grid?: EchartsGrid;
     series: Series[];
-    xAxis: Axis[];
+    xAxis: XAxis[];
     yAxis: Axis[];
 };
 
@@ -280,6 +280,37 @@ type Axis = {
     inverse?: boolean;
     rotate?: number;
 };
+
+export type XAxis = Axis & {
+    sortType?: XAxisSortType;
+};
+
+export enum XAxisSortType {
+    DEFAULT = 'default',
+    BAR_TOTALS = 'bar_totals',
+}
+
+export enum XAxisSort {
+    ASCENDING = 'ascending',
+    DESCENDING = 'descending',
+    BAR_TOTALS_ASCENDING = 'bar_totals_ascending',
+    BAR_TOTALS_DESCENDING = 'bar_totals_descending',
+}
+
+export function getXAxisSort(
+    xAxis: Pick<XAxis, 'sortType' | 'inverse'> | undefined,
+): XAxisSort {
+    if (!xAxis) return XAxisSort.ASCENDING;
+
+    switch (xAxis.sortType) {
+        case XAxisSortType.BAR_TOTALS:
+            return xAxis.inverse
+                ? XAxisSort.BAR_TOTALS_DESCENDING
+                : XAxisSort.BAR_TOTALS_ASCENDING;
+        default:
+            return xAxis.inverse ? XAxisSort.DESCENDING : XAxisSort.ASCENDING;
+    }
+}
 
 export type CompleteCartesianChartLayout = {
     xField: string;

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -25,6 +25,7 @@ import {
     IconStairsUp,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { getAxisTypeFromField } from '../../../../hooks/echarts/useEchartsCartesianConfig';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -38,7 +39,7 @@ type Props = {
 const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE = '5';
 
 export const Axes: FC<Props> = ({ itemsMap }) => {
-    const { visualizationConfig, pivotDimensions } = useVisualizationContext();
+    const { visualizationConfig } = useVisualizationContext();
 
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
 
@@ -89,7 +90,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
     );
 
     const canSortByBarTotals =
-        dirtyChartType === CartesianSeriesType.BAR && pivotDimensions?.length;
+        dirtyChartType === CartesianSeriesType.BAR &&
+        getAxisTypeFromField(xAxisField) === 'category';
 
     return (
         <Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -1,4 +1,5 @@
 import {
+    CartesianSeriesType,
     getAxisName,
     getDateGroupLabel,
     getItemLabelWithoutTableName,
@@ -11,19 +12,19 @@ import {
     Checkbox,
     Group,
     NumberInput,
-    Select,
+    SegmentedControl,
     Stack,
     Switch,
-    Text,
     TextInput,
+    Tooltip,
 } from '@mantine/core';
 import {
-    IconChartBar,
     IconSortAscending,
     IconSortDescending,
-    type Icon,
+    IconStairsDown,
+    IconStairsUp,
 } from '@tabler/icons-react';
-import { forwardRef, type FC } from 'react';
+import { type FC } from 'react';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -35,16 +36,6 @@ type Props = {
 };
 
 const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE = '5';
-
-const XAxisSortSelectItem = forwardRef<
-    HTMLDivElement,
-    { icon: Icon; label: string }
->(({ icon, label, ...others }: { icon: Icon; label: string }, ref) => (
-    <Group ref={ref} spacing="xs" {...others} noWrap>
-        <MantineIcon icon={icon} />
-        <Text fz="xs">{label}</Text>
-    </Group>
-));
 
 export const Axes: FC<Props> = ({ itemsMap }) => {
     const { visualizationConfig, pivotDimensions } = useVisualizationContext();
@@ -66,6 +57,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setShowGridY,
         setXAxisSort,
         setXAxisLabelRotation,
+        dirtyChartType,
     } = visualizationConfig.chartConfig;
 
     const xAxisField =
@@ -95,6 +87,9 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         },
         [false, false],
     );
+
+    const canSortByBarTotals =
+        dirtyChartType === CartesianSeriesType.BAR && pivotDimensions?.length;
 
     return (
         <Stack>
@@ -157,34 +152,69 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     <Group spacing="xs">
                         <Group spacing="xs">
                             <Config.Label>Sort</Config.Label>
-                            <Select
+                            <SegmentedControl
                                 value={getXAxisSort(
                                     dirtyEchartsConfig?.xAxis?.[0],
                                 )}
                                 onChange={setXAxisSort}
-                                itemComponent={XAxisSortSelectItem}
                                 data={[
                                     {
                                         value: XAxisSort.ASCENDING,
-                                        label: 'Ascending',
-                                        icon: IconSortAscending,
+                                        label: (
+                                            <Tooltip
+                                                label="Sort ascending"
+                                                variant="xs"
+                                                withinPortal
+                                            >
+                                                <MantineIcon
+                                                    icon={IconSortAscending}
+                                                />
+                                            </Tooltip>
+                                        ),
                                     },
                                     {
                                         value: XAxisSort.DESCENDING,
-                                        label: 'Descending',
-                                        icon: IconSortDescending,
+                                        label: (
+                                            <Tooltip
+                                                label="Sort descending"
+                                                variant="xs"
+                                                withinPortal
+                                            >
+                                                <MantineIcon
+                                                    icon={IconSortDescending}
+                                                />
+                                            </Tooltip>
+                                        ),
                                     },
                                     {
                                         value: XAxisSort.BAR_TOTALS_ASCENDING,
-                                        label: 'Bar Totals Ascending',
-                                        disabled: !pivotDimensions?.length,
-                                        icon: IconChartBar,
+                                        label: (
+                                            <Tooltip
+                                                label="Sort by bar totals ascending"
+                                                variant="xs"
+                                                withinPortal
+                                            >
+                                                <MantineIcon
+                                                    icon={IconStairsUp}
+                                                />
+                                            </Tooltip>
+                                        ),
+                                        disabled: !canSortByBarTotals,
                                     },
                                     {
                                         value: XAxisSort.BAR_TOTALS_DESCENDING,
-                                        label: 'Bar Totals Descending',
-                                        disabled: !pivotDimensions?.length,
-                                        icon: IconChartBar,
+                                        label: (
+                                            <Tooltip
+                                                label="Sort by bar totals descending"
+                                                variant="xs"
+                                                withinPortal
+                                            >
+                                                <MantineIcon
+                                                    icon={IconStairsDown}
+                                                />
+                                            </Tooltip>
+                                        ),
+                                        disabled: !canSortByBarTotals,
                                     },
                                 ]}
                             />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -12,25 +12,38 @@ import {
     Checkbox,
     Group,
     NumberInput,
-    SegmentedControl,
+    Select,
     Stack,
     Switch,
+    Text,
     TextInput,
-    Tooltip,
 } from '@mantine/core';
 import {
+    IconChartBar,
     IconSortAscending,
     IconSortDescending,
-    IconStairsDown,
-    IconStairsUp,
+    type Icon,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { forwardRef, type FC } from 'react';
 import { getAxisTypeFromField } from '../../../../hooks/echarts/useEchartsCartesianConfig';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
 import { AxisMinMax } from './AxisMinMax';
+
+const XAxisSortSelectItem = forwardRef<
+    HTMLDivElement,
+    { icon: Icon; label: string; mirrorIcon: boolean }
+>(({ icon, label, mirrorIcon, ...others }, ref) => (
+    <Group ref={ref} spacing="xs" {...others} noWrap>
+        <MantineIcon
+            style={mirrorIcon ? { transform: 'rotateY(180deg)' } : undefined}
+            icon={icon}
+        />
+        <Text fz="xs">{label}</Text>
+    </Group>
+));
 
 type Props = {
     itemsMap: ItemsMap | undefined;
@@ -154,68 +167,34 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     <Group spacing="xs">
                         <Group spacing="xs">
                             <Config.Label>Sort</Config.Label>
-                            <SegmentedControl
+                            <Select
                                 value={getXAxisSort(
                                     dirtyEchartsConfig?.xAxis?.[0],
                                 )}
                                 onChange={setXAxisSort}
+                                itemComponent={XAxisSortSelectItem}
                                 data={[
                                     {
                                         value: XAxisSort.ASCENDING,
-                                        label: (
-                                            <Tooltip
-                                                label="Sort ascending"
-                                                variant="xs"
-                                                withinPortal
-                                            >
-                                                <MantineIcon
-                                                    icon={IconSortAscending}
-                                                />
-                                            </Tooltip>
-                                        ),
+                                        label: 'Ascending',
+                                        icon: IconSortAscending,
                                     },
                                     {
                                         value: XAxisSort.DESCENDING,
-                                        label: (
-                                            <Tooltip
-                                                label="Sort descending"
-                                                variant="xs"
-                                                withinPortal
-                                            >
-                                                <MantineIcon
-                                                    icon={IconSortDescending}
-                                                />
-                                            </Tooltip>
-                                        ),
+                                        label: 'Descending',
+                                        icon: IconSortDescending,
                                     },
                                     {
                                         value: XAxisSort.BAR_TOTALS_ASCENDING,
-                                        label: (
-                                            <Tooltip
-                                                label="Sort by bar totals ascending"
-                                                variant="xs"
-                                                withinPortal
-                                            >
-                                                <MantineIcon
-                                                    icon={IconStairsUp}
-                                                />
-                                            </Tooltip>
-                                        ),
+                                        label: 'Bars ascending',
+                                        icon: IconChartBar,
                                         disabled: !canSortByBarTotals,
                                     },
                                     {
                                         value: XAxisSort.BAR_TOTALS_DESCENDING,
-                                        label: (
-                                            <Tooltip
-                                                label="Sort by bar totals descending"
-                                                variant="xs"
-                                                withinPortal
-                                            >
-                                                <MantineIcon
-                                                    icon={IconStairsDown}
-                                                />
-                                            </Tooltip>
-                                        ),
+                                        label: 'Bars descending',
+                                        icon: IconChartBar,
+                                        mirrorIcon: true,
                                         disabled: !canSortByBarTotals,
                                     },
                                 ]}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -2,20 +2,28 @@ import {
     getAxisName,
     getDateGroupLabel,
     getItemLabelWithoutTableName,
+    getXAxisSort,
     isNumericItem,
+    XAxisSort,
     type ItemsMap,
 } from '@lightdash/common';
 import {
     Checkbox,
     Group,
     NumberInput,
-    SegmentedControl,
+    Select,
     Stack,
     Switch,
+    Text,
     TextInput,
 } from '@mantine/core';
-import { IconSortAscending, IconSortDescending } from '@tabler/icons-react';
-import { type FC } from 'react';
+import {
+    IconChartBar,
+    IconSortAscending,
+    IconSortDescending,
+    type Icon,
+} from '@tabler/icons-react';
+import { forwardRef, type FC } from 'react';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -28,8 +36,18 @@ type Props = {
 
 const DEFAULT_OFFSET_VALUE_FOR_MANUAL_RANGE_PERCENTAGE = '5';
 
+const XAxisSortSelectItem = forwardRef<
+    HTMLDivElement,
+    { icon: Icon; label: string }
+>(({ icon, label, ...others }: { icon: Icon; label: string }, ref) => (
+    <Group ref={ref} spacing="xs" {...others} noWrap>
+        <MantineIcon icon={icon} />
+        <Text fz="xs">{label}</Text>
+    </Group>
+));
+
 export const Axes: FC<Props> = ({ itemsMap }) => {
-    const { visualizationConfig } = useVisualizationContext();
+    const { visualizationConfig, pivotDimensions } = useVisualizationContext();
 
     if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
 
@@ -46,7 +64,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setXMaxOffsetValue,
         setShowGridX,
         setShowGridY,
-        setInverseX,
+        setXAxisSort,
         setXAxisLabelRotation,
     } = visualizationConfig.chartConfig;
 
@@ -139,33 +157,36 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     <Group spacing="xs">
                         <Group spacing="xs">
                             <Config.Label>Sort</Config.Label>
-                            <SegmentedControl
-                                defaultValue={
-                                    dirtyEchartsConfig?.xAxis?.[0]?.inverse
-                                        ? 'descending'
-                                        : 'ascending'
-                                }
+                            <Select
+                                value={getXAxisSort(
+                                    dirtyEchartsConfig?.xAxis?.[0],
+                                )}
+                                onChange={setXAxisSort}
+                                itemComponent={XAxisSortSelectItem}
                                 data={[
                                     {
-                                        value: 'ascending',
-                                        label: (
-                                            <MantineIcon
-                                                icon={IconSortAscending}
-                                            />
-                                        ),
+                                        value: XAxisSort.ASCENDING,
+                                        label: 'Ascending',
+                                        icon: IconSortAscending,
                                     },
                                     {
-                                        value: 'descending',
-                                        label: (
-                                            <MantineIcon
-                                                icon={IconSortDescending}
-                                            />
-                                        ),
+                                        value: XAxisSort.DESCENDING,
+                                        label: 'Descending',
+                                        icon: IconSortDescending,
+                                    },
+                                    {
+                                        value: XAxisSort.BAR_TOTALS_ASCENDING,
+                                        label: 'Bar Totals Ascending',
+                                        disabled: !pivotDimensions?.length,
+                                        icon: IconChartBar,
+                                    },
+                                    {
+                                        value: XAxisSort.BAR_TOTALS_DESCENDING,
+                                        label: 'Bar Totals Descending',
+                                        disabled: !pivotDimensions?.length,
+                                        icon: IconChartBar,
                                     },
                                 ]}
-                                onChange={(value) => {
-                                    setInverseX(value === 'descending');
-                                }}
                             />
                         </Group>
                         {!dirtyLayout?.flipAxes && (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -5,7 +5,6 @@ import {
     isDimension,
     isNumericItem,
     replaceStringInArray,
-    XAxisSort,
     type CustomDimension,
     type Field,
     type TableCalculation,
@@ -156,7 +155,6 @@ export const Layout: FC<Props> = ({ items }) => {
         updateYField,
         removeSingleSeries,
         addSingleSeries,
-        setXAxisSort,
     } = visualizationConfig.chartConfig;
 
     return (
@@ -331,24 +329,13 @@ export const Layout: FC<Props> = ({ items }) => {
                                                 groupSelectedField && (
                                                     <CloseButton
                                                         onClick={() => {
-                                                            const newPivotDimensions =
+                                                            setPivotDimensions(
                                                                 pivotDimensions.filter(
                                                                     (key) =>
                                                                         key !==
                                                                         pivotKey,
-                                                                );
-
-                                                            setPivotDimensions(
-                                                                newPivotDimensions,
+                                                                ),
                                                             );
-
-                                                            if (
-                                                                !newPivotDimensions.length
-                                                            ) {
-                                                                setXAxisSort(
-                                                                    XAxisSort.ASCENDING,
-                                                                );
-                                                            }
                                                         }}
                                                     />
                                                 )

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -5,6 +5,7 @@ import {
     isDimension,
     isNumericItem,
     replaceStringInArray,
+    XAxisSort,
     type CustomDimension,
     type Field,
     type TableCalculation,
@@ -155,6 +156,7 @@ export const Layout: FC<Props> = ({ items }) => {
         updateYField,
         removeSingleSeries,
         addSingleSeries,
+        setXAxisSort,
     } = visualizationConfig.chartConfig;
 
     return (
@@ -329,13 +331,24 @@ export const Layout: FC<Props> = ({ items }) => {
                                                 groupSelectedField && (
                                                     <CloseButton
                                                         onClick={() => {
-                                                            setPivotDimensions(
+                                                            const newPivotDimensions =
                                                                 pivotDimensions.filter(
                                                                     (key) =>
                                                                         key !==
                                                                         pivotKey,
-                                                                ),
+                                                                );
+
+                                                            setPivotDimensions(
+                                                                newPivotDimensions,
                                                             );
+
+                                                            if (
+                                                                !newPivotDimensions.length
+                                                            ) {
+                                                                setXAxisSort(
+                                                                    XAxisSort.ASCENDING,
+                                                                );
+                                                            }
                                                         }}
                                                     />
                                                 )

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1,9 +1,12 @@
 import {
+    assertUnreachable,
     CartesianSeriesType,
     getSeriesId,
     isCompleteEchartsConfig,
     isCompleteLayout,
     isNumericItem,
+    XAxisSort,
+    XAxisSortType,
     type ApiQueryResults,
     type CartesianChart,
     type CompleteCartesianChartLayout,
@@ -14,6 +17,7 @@ import {
     type Series,
     type SeriesMetadata,
     type TableCalculationMetadata,
+    type XAxis,
 } from '@lightdash/common';
 import { produce } from 'immer';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -107,6 +111,33 @@ const applyReferenceLines = (
         };
     });
 };
+
+function getXAxisSort(sort: XAxisSort): Pick<XAxis, 'inverse' | 'sortType'> {
+    switch (sort) {
+        case XAxisSort.ASCENDING:
+            return {
+                inverse: false,
+                sortType: XAxisSortType.DEFAULT,
+            };
+        case XAxisSort.DESCENDING:
+            return {
+                inverse: true,
+                sortType: XAxisSortType.DEFAULT,
+            };
+        case XAxisSort.BAR_TOTALS_ASCENDING:
+            return {
+                inverse: false,
+                sortType: XAxisSortType.BAR_TOTALS,
+            };
+        case XAxisSort.BAR_TOTALS_DESCENDING:
+            return {
+                inverse: true,
+                sortType: XAxisSortType.BAR_TOTALS,
+            };
+        default:
+            return assertUnreachable(sort, `Invalid sort ${sort}`);
+    }
+}
 
 export const EMPTY_CARTESIAN_CHART_CONFIG: CartesianChart = {
     layout: {},
@@ -313,14 +344,14 @@ const useCartesianChartConfig = ({
             showGridY: show,
         }));
     }, []);
-    const setInverseX = useCallback((inverse: boolean) => {
+    const setXAxisSort = useCallback((sort: XAxisSort) => {
         setDirtyEchartsConfig((prevState) => {
             const [firstAxis, ...axes] = prevState?.xAxis || [];
-            const x = {
+            const { inverse, sortType } = getXAxisSort(sort);
+            return {
                 ...prevState,
-                xAxis: [{ ...firstAxis, inverse }, ...axes],
+                xAxis: [{ ...firstAxis, inverse, sortType }, ...axes],
             };
-            return x;
         });
     }, []);
     const setXAxisLabelRotation = useCallback((rotation: number) => {
@@ -926,7 +957,7 @@ const useCartesianChartConfig = ({
         setGrid,
         setShowGridX,
         setShowGridY,
-        setInverseX,
+        setXAxisSort,
         setXAxisLabelRotation,
         updateSeries,
         referenceLines,

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -426,6 +426,15 @@ const useCartesianChartConfig = ({
                             type,
                             areaStyle: hasAreaStyle ? {} : undefined,
                         })),
+                        xAxis: prevState?.xAxis?.map((axis) => ({
+                            ...axis,
+                            // If the chart is not a bar chart, and the xAxis is sorted by bar totals, set the sort type to default ( bar totals are not applied to non-bar charts )
+                            sortType:
+                                type !== CartesianSeriesType.BAR &&
+                                axis.sortType === XAxisSortType.BAR_TOTALS
+                                    ? XAxisSortType.DEFAULT
+                                    : axis.sortType,
+                        })),
                     },
             );
         },

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -112,7 +112,9 @@ const applyReferenceLines = (
     });
 };
 
-function getXAxisSort(sort: XAxisSort): Pick<XAxis, 'inverse' | 'sortType'> {
+function getXAxisSortConfig(
+    sort: XAxisSort,
+): Pick<XAxis, 'inverse' | 'sortType'> {
     switch (sort) {
         case XAxisSort.ASCENDING:
             return {
@@ -347,7 +349,7 @@ const useCartesianChartConfig = ({
     const setXAxisSort = useCallback((sort: XAxisSort) => {
         setDirtyEchartsConfig((prevState) => {
             const [firstAxis, ...axes] = prevState?.xAxis || [];
-            const { inverse, sortType } = getXAxisSort(sort);
+            const { inverse, sortType } = getXAxisSortConfig(sort);
             return {
                 ...prevState,
                 xAxis: [{ ...firstAxis, inverse, sortType }, ...axes],

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2005,8 +2005,6 @@ const useEchartsCartesianConfig = (
         ],
     );
 
-    console.log(eChartsOptions);
-
     if (
         !itemsMap ||
         rows.length <= 0 ||

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1923,7 +1923,7 @@ const useEchartsCartesianConfig = (
             // Also grouping by here since when there are no groups in the config we need to calculate the totals for bar
             const stackTotalEntries: [unknown, number][] = Object.entries(
                 groupBy(stackTotals, (total) => total[stackTotalValueIndex]),
-            ).reduce<[string, number][]>((acc, [key, totals]) => {
+            ).reduce<[unknown, number][]>((acc, [key, totals]) => {
                 acc.push([
                     key,
                     totals.reduce((sum, total) => sum + total[2], 0),
@@ -2004,6 +2004,8 @@ const useEchartsCartesianConfig = (
             theme?.other.chartFont,
         ],
     );
+
+    console.log(eChartsOptions);
 
     if (
         !itemsMap ||

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2001,7 +2001,7 @@ const useEchartsCartesianConfig = (
             series,
             sortedResultsByTotals,
             tooltip,
-            theme?.other.chartFont,
+            theme?.other?.chartFont,
         ],
     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1892,6 +1892,35 @@ const useEchartsCartesianConfig = (
         [itemsMap, validCartesianConfig?.layout.flipAxes],
     );
 
+    const sortedResultsByTotals = useMemo(() => {
+        if (!stackedSeriesWithColorAssignments?.length) return sortedResults;
+
+        const stackTotals = getStackTotalRows(
+            rows,
+            stackedSeriesWithColorAssignments,
+            validCartesianConfig?.layout.flipAxes,
+            validCartesianConfigLegend,
+        );
+
+        const xField = validCartesianConfig?.layout.xField;
+
+        if (!xField) return sortedResults;
+
+        return sortedResults.sort((a, b) => {
+            const totalA = stackTotals.find((total) => total[0] === a[xField]);
+            const totalB = stackTotals.find((total) => total[0] === b[xField]);
+
+            return (totalA?.[2] ?? 0) - (totalB?.[2] ?? 0);
+        });
+    }, [
+        rows,
+        sortedResults,
+        stackedSeriesWithColorAssignments,
+        validCartesianConfig?.layout.flipAxes,
+        validCartesianConfig?.layout.xField,
+        validCartesianConfigLegend,
+    ]);
+
     const eChartsOptions = useMemo(
         () => ({
             xAxis: axes.xAxis,
@@ -1906,7 +1935,7 @@ const useEchartsCartesianConfig = (
             ),
             dataset: {
                 id: 'lightdashResults',
-                source: sortedResults,
+                source: sortedResultsByTotals,
             },
             tooltip,
             grid: {
@@ -1931,9 +1960,9 @@ const useEchartsCartesianConfig = (
             validCartesianConfig?.eChartsConfig.grid,
             validCartesianConfigLegend,
             series,
-            sortedResults,
+            sortedResultsByTotals,
             tooltip,
-            theme?.other?.chartFont,
+            theme?.other.chartFont,
         ],
     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1903,22 +1903,45 @@ const useEchartsCartesianConfig = (
         );
 
         const xField = validCartesianConfig?.layout.xField;
+        const firstYField = validCartesianConfig?.layout.yField?.[0];
 
-        if (!xField) return sortedResults;
+        if (!xField || !firstYField) return sortedResults;
 
-        return sortedResults.sort((a, b) => {
-            const totalA = stackTotals.find((total) => total[0] === a[xField]);
-            const totalB = stackTotals.find((total) => total[0] === b[xField]);
+        const metricQueryFirstYFieldSort = resultsData?.metricQuery.sorts.find(
+            (sort) => sort.fieldId === firstYField,
+        );
 
-            return (totalA?.[2] ?? 0) - (totalB?.[2] ?? 0);
-        });
+        const xAxis = axes.xAxis[0];
+
+        if (
+            xAxis?.type === 'category' &&
+            metricQueryFirstYFieldSort &&
+            pivotedKeys?.includes(firstYField)
+        ) {
+            return sortedResults.sort((a, b) => {
+                const totalA =
+                    stackTotals.find((total) => total[0] === a[xField])?.[2] ??
+                    0;
+                const totalB =
+                    stackTotals.find((total) => total[0] === b[xField])?.[2] ??
+                    0;
+
+                return metricQueryFirstYFieldSort.descending
+                    ? totalB - totalA
+                    : totalA - totalB;
+            });
+        }
+
+        return sortedResults;
     }, [
-        rows,
-        sortedResults,
         stackedSeriesWithColorAssignments,
-        validCartesianConfig?.layout.flipAxes,
-        validCartesianConfig?.layout.xField,
+        sortedResults,
+        rows,
+        validCartesianConfig,
         validCartesianConfigLegend,
+        resultsData?.metricQuery,
+        axes.xAxis,
+        pivotedKeys,
     ]);
 
     const eChartsOptions = useMemo(

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1896,15 +1896,16 @@ const useEchartsCartesianConfig = (
     const sortedResultsByTotals = useMemo(() => {
         if (!stackedSeriesWithColorAssignments?.length) return sortedResults;
 
-        const xField = validCartesianConfig?.layout.xField;
+        const axis = validCartesianConfig?.layout.flipAxes
+            ? axes.yAxis[0]
+            : axes.xAxis[0];
 
-        if (!xField) return sortedResults;
-
-        const xAxis = axes.xAxis[0];
+        const xFieldId = validCartesianConfig?.layout?.xField;
         const xAxisConfig = validCartesianConfig?.eChartsConfig.xAxis?.[0];
 
         if (
-            xAxis?.type === 'category' &&
+            xFieldId &&
+            axis?.type === 'category' &&
             xAxisConfig?.sortType === XAxisSortType.BAR_TOTALS &&
             (pivotDimensions?.length ?? 0) >= 1
         ) {
@@ -1915,13 +1916,20 @@ const useEchartsCartesianConfig = (
                 validCartesianConfigLegend,
             );
 
+            const stackTotalValueIndex = validCartesianConfig?.layout.flipAxes
+                ? 1
+                : 0;
+
             return sortedResults.sort((a, b) => {
                 const totalA =
-                    stackTotals.find((total) => total[0] === a[xField])?.[2] ??
-                    0;
+                    stackTotals.find(
+                        (total) => total[stackTotalValueIndex] === a[xFieldId],
+                    )?.[2] ?? 0;
+
                 const totalB =
-                    stackTotals.find((total) => total[0] === b[xField])?.[2] ??
-                    0;
+                    stackTotals.find(
+                        (total) => total[stackTotalValueIndex] === b[xFieldId],
+                    )?.[2] ?? 0;
 
                 return totalA - totalB; // Asc/Desc will be taken care of by inverse config
             });
@@ -1931,9 +1939,10 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         sortedResults,
-        validCartesianConfig?.layout.xField,
         validCartesianConfig?.layout.flipAxes,
+        validCartesianConfig?.layout?.xField,
         validCartesianConfig?.eChartsConfig.xAxis,
+        axes.yAxis,
         axes.xAxis,
         pivotDimensions?.length,
         rows,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#5564](https://github.com/lightdash/lightdash/issues/5564)

## Summary
- Added ability to sort bar charts by total bar values
- Implemented two new sorting options: Bars Ascending, Bars Descending
- Added UI controls in chart configuration panel

## Test Steps
1. Create a bar chart (with or without grouping)
2. Open chart configuration and check Sort dropdown in Axes section
3. Test each sorting option:
   - Default: Maintains original results order
   - Inverted: Reverses original results order
   - Bars Ascending: Sorts by total bar values (smallest to largest)
   - Bars Descending: Sorts by total bar values (largest to smallest)

## Known Limitations
- Bar total sorting only works with categorical x-axis

**AC:**
- Works for horizontal/vertical bar charts, for other cartesian chart types it shows as disabled
- Backwards compatible with prev configs

https://github.com/user-attachments/assets/2d9bb9c2-4250-4606-95a6-8315721ff6d8

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
