### PR TITLE
feat: allow accessing Lightdash from an iframe

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -300,7 +300,9 @@ export default class App {
                 cors({
                     methods: 'OPTIONS, GET, HEAD, PUT, PATCH, POST, DELETE',
                     allowedHeaders: '*',
-                    credentials: false,
+                    credentials:
+                        this.lightdashConfig.security
+                            .crossOriginResourceSharingPolicy.allowCredentials,
                     origin: allowedOrigins,
                 }),
             );
@@ -384,7 +386,11 @@ export default class App {
                         ],
                         'img-src': ["'self'", 'data:', 'https://*'],
                         'frame-src': ["'self'", 'https://*'],
-                        'frame-ancestors': ["'self'", 'https://*'],
+                        'frame-ancestors': [
+                            "'self'",
+                            ...this.lightdashConfig.security
+                                .contentSecurityPolicy.frameAncestors,
+                        ],
                         'worker-src': [
                             "'self'",
                             'blob:',
@@ -455,7 +461,7 @@ export default class App {
                         1000, // in ms
                     secure: this.lightdashConfig.secureCookies,
                     httpOnly: true,
-                    sameSite: 'lax',
+                    sameSite: this.lightdashConfig.cookieSameSite,
                 },
                 resave: false,
                 saveUninitialized: false,

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -300,9 +300,7 @@ export default class App {
                 cors({
                     methods: 'OPTIONS, GET, HEAD, PUT, PATCH, POST, DELETE',
                     allowedHeaders: '*',
-                    credentials:
-                        this.lightdashConfig.security
-                            .crossOriginResourceSharingPolicy.allowCredentials,
+                    credentials: false,
                     origin: allowedOrigins,
                 }),
             );

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -168,6 +168,7 @@ export const lightdashConfigMock: LightdashConfig = {
         contentSecurityPolicy: {
             reportOnly: false,
             allowedDomains: [],
+            frameAncestors: [],
         },
         crossOriginResourceSharingPolicy: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -528,7 +528,7 @@ export const parseConfig = (): LightdashConfig => {
         'LIGHTDASH_CORS_ALLOWED_DOMAINS,',
     );
     const iframeEmbeddingEnabled = iframeAllowedDomains.length > 0;
-    const corsEnabled = corsAllowedDomains.length > 0;
+    const corsEnabled = process.env.LIGHTDASH_CORS_ENABLED === 'true';
     const secureCookies = process.env.SECURE_COOKIES === 'true';
 
     if (iframeEmbeddingEnabled && !secureCookies) {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -231,7 +231,6 @@ export type LightdashConfig = {
         crossOriginResourceSharingPolicy: {
             enabled: boolean;
             allowedDomains: string[];
-            allowCredentials: boolean;
         };
     };
     cookiesMaxAgeHours?: number;
@@ -557,7 +556,6 @@ export const parseConfig = (): LightdashConfig => {
             crossOriginResourceSharingPolicy: {
                 enabled: corsEnabled,
                 allowedDomains: corsEnabled ? corsAllowedDomains : [],
-                allowCredentials: iframeEmbeddingEnabled,
             },
         },
         smtp: process.env.EMAIL_SMTP_HOST

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -549,7 +549,9 @@ export const parseConfig = (): LightdashConfig => {
                 allowedDomains: getArrayFromCommaSeparatedList(
                     'LIGHTDASH_CSP_ALLOWED_DOMAINS',
                 ),
-                frameAncestors: iframeAllowedDomains,
+                frameAncestors: iframeEmbeddingEnabled
+                    ? iframeAllowedDomains
+                    : ['https://*'],
                 reportUri: process.env.LIGHTDASH_CSP_REPORT_URI,
             },
             crossOriginResourceSharingPolicy: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -4,6 +4,7 @@ import {
     isOrganizationMemberRole,
     LightdashMode,
     OrganizationMemberRole,
+    ParameterError,
     ParseError,
     SentryConfig,
 } from '@lightdash/common';
@@ -76,6 +77,18 @@ export const getObjectFromEnvironmentVariable = (
             )}`,
         );
     }
+};
+
+const getArrayFromCommaSeparatedList = (envVar: string) => {
+    const raw = process.env[envVar];
+    if (!raw) {
+        return [];
+    }
+
+    return raw
+        .split(',')
+        .map((domain) => domain.trim())
+        .filter((domain) => domain.length > 0);
 };
 
 /**
@@ -207,15 +220,18 @@ export type LoggingConfig = {
 export type LightdashConfig = {
     lightdashSecret: string;
     secureCookies: boolean;
+    cookieSameSite?: 'lax' | 'none';
     security: {
         contentSecurityPolicy: {
             reportOnly: boolean;
             allowedDomains: string[];
             reportUri?: string;
+            frameAncestors: string[];
         };
         crossOriginResourceSharingPolicy: {
             enabled: boolean;
             allowedDomains: string[];
+            allowCredentials: boolean;
         };
     };
     cookiesMaxAgeHours?: number;
@@ -505,28 +521,41 @@ export const parseConfig = (): LightdashConfig => {
         );
     }
 
+    const iframeAllowedDomains = getArrayFromCommaSeparatedList(
+        'LIGHTDASH_IFRAME_EMBEDDING_DOMAINS',
+    );
+    const corsAllowedDomains = getArrayFromCommaSeparatedList(
+        'LIGHTDASH_CORS_ALLOWED_DOMAINS,',
+    );
+    const iframeEmbeddingEnabled = iframeAllowedDomains.length > 0;
+    const corsEnabled = corsAllowedDomains.length > 0;
+    const secureCookies = process.env.SECURE_COOKIES === 'true';
+
+    if (iframeEmbeddingEnabled && !secureCookies) {
+        throw new ParameterError(
+            'To enable iframe embedding, SECURE_COOKIES must be set to true',
+        );
+    }
+
     return {
         mode,
+        cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {
             licenseKey: process.env.LIGHTDASH_LICENSE_KEY || null,
         },
         security: {
             contentSecurityPolicy: {
                 reportOnly: process.env.LIGHTDASH_CSP_REPORT_ONLY !== 'false', // defaults to true
-                allowedDomains: (
-                    process.env.LIGHTDASH_CSP_ALLOWED_DOMAINS || ''
-                )
-                    .split(',')
-                    .map((domain) => domain.trim()),
+                allowedDomains: getArrayFromCommaSeparatedList(
+                    'LIGHTDASH_CSP_ALLOWED_DOMAINS',
+                ),
+                frameAncestors: iframeAllowedDomains,
                 reportUri: process.env.LIGHTDASH_CSP_REPORT_URI,
             },
             crossOriginResourceSharingPolicy: {
-                enabled: process.env.LIGHTDASH_CORS_ENABLED === 'true',
-                allowedDomains: (
-                    process.env.LIGHTDASH_CORS_ALLOWED_DOMAINS || ''
-                )
-                    .split(',')
-                    .map((domain) => domain.trim()),
+                enabled: corsEnabled,
+                allowedDomains: corsEnabled ? corsAllowedDomains : [],
+                allowCredentials: iframeEmbeddingEnabled,
             },
         },
         smtp: process.env.EMAIL_SMTP_HOST
@@ -595,7 +624,7 @@ export const parseConfig = (): LightdashConfig => {
             },
         },
         lightdashSecret,
-        secureCookies: process.env.SECURE_COOKIES === 'true',
+        secureCookies,
         cookiesMaxAgeHours: getIntegerFromEnvironmentVariable(
             'COOKIES_MAX_AGE_HOURS',
         ),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -524,7 +524,7 @@ export const parseConfig = (): LightdashConfig => {
         'LIGHTDASH_IFRAME_EMBEDDING_DOMAINS',
     );
     const corsAllowedDomains = getArrayFromCommaSeparatedList(
-        'LIGHTDASH_CORS_ALLOWED_DOMAINS,',
+        'LIGHTDASH_CORS_ALLOWED_DOMAINS',
     );
     const iframeEmbeddingEnabled = iframeAllowedDomains.length > 0;
     const corsEnabled = process.env.LIGHTDASH_CORS_ENABLED === 'true';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13821 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR adds support for securely embedding the Lightdash application within iframes on third-party websites

Required env vars:
```
LIGHTDASH_IFRAME_EMBEDDING_DOMAINS=https://example.com,https://www.example.com
SECURE_COOKIES=true
```

Optional relevant env vars:
```
TRUST_PROXY=true #in cases where server might be behind a proxy (e.g. locally)
```

<!-- Even better add a screenshot / gif / loom -->
How to run locally:

- Tunnel locally running app so that it's accessible with https
  - e.g. `claudflared --tunnel  http://localhost:3000`
- Setup all of the above env variables
- Embed into iframe:
  ```tsx
  <iframe
          width="1280px"
          height="720px"
          src="<YOUR_TUNNELED_URL>"
          allow="fullscreen"
          title="Lightdash Dashboard"
        />
  ```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
