### PR TITLE
fix: new line processing in results

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -63,7 +63,7 @@ export const formatCellContent = (
     const { value } = data;
 
     if (typeof value?.formatted === 'string') {
-        const lines = value?.formatted.split('\\n') ?? [];
+        const lines = value?.formatted.split('\n') ?? [];
         return lines.length > 1
             ? lines.map((line, index, array) => (
                   <Fragment key={index}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13491

# Fix newline handling in table visualization

This PR fixes an issue with how newlines are displayed in table visualizations when using PostgreSQL as the database backend.

## Background

Different warehouses handle string escaping differently, e.g.
- **Snowflake** interprets `\n` directly as a newline character
- **PostgreSQL** treats `\n` as literal characters (backslash + n) unless using the `E` prefix for C-style escapes - https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE

When data containing newlines is returned from PostgreSQL to the frontend, the newlines appear as literal `\n` strings rather than actual newline characters. Our previous fix in PR #13703 incorrectly attempted to split on `\\n` instead of the correct `\n` pattern.

## Changes

- Updated the string splitting logic in `formatCellContent` to correctly handle the escaped newlines from PostgreSQL
- Changed from splitting on `\\n` to splitting on `\n` which matches the actual format of the data returned from PostgreSQL

## Steps to Test

1. Change your project `events.sql` to
```sql
with events as (
    select * from {{ ref('raw_events') }}
),

events_agg as (
    select 
        date,
        string_agg(event_id || ' on ' || date || ': "' || event || E'" \n\n', '' order by event_id) as events_list
    from events
    group by date
)

select 
    e.*,
    ea.events_list
from events e
left join events_agg ea on e.date = ea.date
```

**Notice the 'E' string before \n\n**

2. Change your events model to add a new string dimension for `events_list`
3. Run `dbt run`
4. Open explore and create a table viz that uses `events_list`
5. events_list column should display the values with new lines

![image](https://github.com/user-attachments/assets/ba1663ed-b7cc-440c-8771-2971f8449dd0)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
