### PR TITLE
feat: calculate subtotals in the backend

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -254,6 +254,18 @@ type QueryExecutionEvent = BaseTrack & {
     );
 };
 
+type SubtotalQueryEvent = BaseTrack & {
+    event: 'query.subtotal';
+    properties: {
+        context: QueryExecutionContext.CALCULATE_SUBTOTAL;
+        organizationId: string;
+        projectId: string;
+        exploreName: string;
+        subtotalDimensionGroups: string[];
+        subtotalQueryCount: number;
+    };
+};
+
 type CreateOrganizationEvent = BaseTrack & {
     event: 'organization.created';
     properties: {
@@ -1248,7 +1260,8 @@ type TypedEvent =
     | SchedulerTimezoneUpdateEvent
     | CreateTagEvent
     | CategoriesAppliedEvent
-    | CustomFieldsReplaced;
+    | CustomFieldsReplaced
+    | SubtotalQueryEvent;
 
 type WrapTypedEvent = SemanticLayerView;
 

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -27,10 +27,12 @@ import {
     UpdateProjectMember,
     UserWarehouseCredentials,
     isDuplicateDashboardParams,
+    type ApiCalculateSubtotalsResponse,
     type ApiCreateDashboardResponse,
     type ApiGetDashboardsResponse,
     type ApiGetTagsResponse,
     type ApiUpdateDashboardsResponse,
+    type CalculateSubtotalsFromQuery,
     type CreateDashboard,
     type DuplicateDashboardParams,
     type SemanticLayerConnectionUpdate,
@@ -370,6 +372,25 @@ export class ProjectController extends BaseController {
         return {
             status: 'ok',
             results: totalResult,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/calculate-subtotals')
+    @OperationId('CalculateSubtotalsFromQuery')
+    async CalculateSubtotalsFromQuery(
+        @Path() projectUuid: string,
+        @Body() body: CalculateSubtotalsFromQuery,
+        @Request() req: express.Request,
+    ): Promise<ApiCalculateSubtotalsResponse> {
+        this.setStatus(200);
+        const subtotalsResult = await this.services
+            .getProjectService()
+            .calculateSubtotalsFromQuery(req.user!, projectUuid, body);
+        return {
+            status: 'ok',
+            results: subtotalsResult,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9227,6 +9227,46 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCalculateSubtotalsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'Record_string.number_',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CalculateSubtotalsFromQuery: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CalculateTotalFromQuery' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        groupedDimensions: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DbtExposureType: {
         dataType: 'refEnum',
         enums: ['dashboard', 'notebook', 'analysis', 'ml', 'application'],
@@ -21728,6 +21768,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'CalculateTotalFromQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_CalculateSubtotalsFromQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CalculateSubtotalsFromQuery',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/calculate-subtotals',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.CalculateSubtotalsFromQuery,
+        ),
+
+        async function ProjectController_CalculateSubtotalsFromQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_CalculateSubtotalsFromQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ProjectController>(
+                    ProjectController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'CalculateSubtotalsFromQuery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9260,6 +9260,10 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        pivotDimensions: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                        },
                         columnOrder: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -10147,7 +10151,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10157,7 +10161,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10167,7 +10171,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10180,7 +10184,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9253,7 +9253,23 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CalculateSubtotalsFromQuery: {
         dataType: 'refAlias',
-        type: { ref: 'CalculateTotalFromQuery', validators: {} },
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CalculateTotalFromQuery' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        columnOrder: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DbtExposureType: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10151,7 +10151,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10161,7 +10161,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10171,7 +10171,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10184,7 +10184,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9233,10 +9233,15 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'Record_string.number_',
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {},
+                    additionalProperties: {
+                        dataType: 'array',
+                        array: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {},
+                            additionalProperties: { dataType: 'double' },
+                        },
                     },
                     required: true,
                 },
@@ -9248,23 +9253,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CalculateSubtotalsFromQuery: {
         dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'CalculateTotalFromQuery' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        groupedDimensions: {
-                            dataType: 'array',
-                            array: { dataType: 'string' },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
+        type: { ref: 'CalculateTotalFromQuery', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DbtExposureType: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10146,6 +10146,12 @@
                     },
                     {
                         "properties": {
+                            "pivotDimensions": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
                             "columnOrder": {
                                 "items": {
                                     "type": "string"
@@ -10965,22 +10971,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10116,10 +10116,19 @@
             "ApiCalculateSubtotalsResponse": {
                 "properties": {
                     "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/Record_string.number_"
+                        "properties": {},
+                        "additionalProperties": {
+                            "items": {
+                                "properties": {},
+                                "additionalProperties": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
                         },
-                        "type": "array"
+                        "type": "object"
                     },
                     "status": {
                         "type": "string",
@@ -10131,23 +10140,7 @@
                 "type": "object"
             },
             "CalculateSubtotalsFromQuery": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/CalculateTotalFromQuery"
-                    },
-                    {
-                        "properties": {
-                            "groupedDimensions": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["groupedDimensions"],
-                        "type": "object"
-                    }
-                ]
+                "$ref": "#/components/schemas/CalculateTotalFromQuery"
             },
             "DbtExposureType": {
                 "enum": [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10140,7 +10140,23 @@
                 "type": "object"
             },
             "CalculateSubtotalsFromQuery": {
-                "$ref": "#/components/schemas/CalculateTotalFromQuery"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CalculateTotalFromQuery"
+                    },
+                    {
+                        "properties": {
+                            "columnOrder": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["columnOrder"],
+                        "type": "object"
+                    }
+                ]
             },
             "DbtExposureType": {
                 "enum": [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10971,22 +10971,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15129,7 +15129,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1522.4",
+        "version": "0.1525.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10113,6 +10113,42 @@
                 "required": ["explore", "metricQuery"],
                 "type": "object"
             },
+            "ApiCalculateSubtotalsResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Record_string.number_"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "CalculateSubtotalsFromQuery": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CalculateTotalFromQuery"
+                    },
+                    {
+                        "properties": {
+                            "groupedDimensions": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["groupedDimensions"],
+                        "type": "object"
+                    }
+                ]
+            },
             "DbtExposureType": {
                 "enum": [
                     "dashboard",
@@ -18494,6 +18530,55 @@
                             "schema": {
                                 "$ref": "#/components/schemas/CalculateTotalFromQuery",
                                 "description": "The metric query to calculate totals for"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/calculate-subtotals": {
+            "post": {
+                "operationId": "CalculateSubtotalsFromQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCalculateSubtotalsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CalculateSubtotalsFromQuery"
                             }
                         }
                     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -110,6 +110,7 @@ import {
     getIntrinsicUserAttributes,
     getItemId,
     getMetrics,
+    getSubtotalKey,
     getTimezoneLabel,
     hasIntersection,
     isAndFilterGroup,
@@ -4986,11 +4987,11 @@ export class ProjectService extends BaseService {
         };
 
         const subtotalsPromises = dimensionGroupsToSubtotal.map(
-            async (dimensions) => [
-                dimensions.join(':'), // TODO subtotals - this should be in common
+            async (subtotalDimensions) => [
+                getSubtotalKey(subtotalDimensions),
                 await runQueryAndFormatRaw({
                     ...metricQuery,
-                    dimensions,
+                    dimensions: subtotalDimensions,
                 }),
             ],
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4984,6 +4984,21 @@ export class ProjectService extends BaseService {
             },
         );
 
+        this.analytics.track({
+            userId: user.userUuid,
+            event: 'query.subtotal',
+            properties: {
+                context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                exploreName,
+                subtotalDimensionGroups: dimensionGroupsToSubtotal.map(
+                    (group) => group.join(','),
+                ),
+                subtotalQueryCount: dimensionGroupsToSubtotal.length,
+            },
+        });
+
         const queryTags: RunQueryTags = {
             organization_uuid: user.organizationUuid,
             project_uuid: projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4960,7 +4960,10 @@ export class ProjectService extends BaseService {
             return aIndex - bIndex;
         });
 
+        // Remove the last dimension since it will not be used for subtotals, would produce the most detailed row
         const dimensionsToSubtotal = orderedDimensions.slice(0, -1);
+
+        // Create a list of all the dimension groups to subtotal, starting with the first dimension, then the first two dimensions, then the first three dimensions, etc.
         const dimensionGroupsToSubtotal = dimensionsToSubtotal.map(
             (dimension, index) => {
                 if (index === 0) {
@@ -4979,6 +4982,7 @@ export class ProjectService extends BaseService {
             query_context: QueryExecutionContext.CALCULATE_SUBTOTAL,
         };
 
+        // Run the query for each dimension group and format the raw rows, this is needed because we apply raw formatting to date dimensions, and we need to compare values in the same format in the frontend
         const runQueryAndFormatRaw = async (
             subtotalMetricQuery: MetricQuery,
         ) => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2038,6 +2038,7 @@ export class ProjectService extends BaseService {
                                     ),
                                 'runWarehouseQuery',
                                 this.logger,
+                                context,
                             );
                         } catch (e) {
                             this.logger.warn(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5007,6 +5007,7 @@ export class ProjectService extends BaseService {
                 await runQueryAndFormatRaw({
                     ...metricQuery,
                     dimensions: subtotalDimensions,
+                    sorts: [],
                 }),
             ],
         );

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -273,6 +273,7 @@ export * from './utils/sanitizeHtml';
 export * from './utils/scheduler';
 export * from './utils/semanticLayer';
 export * from './utils/slugs';
+export * from './utils/subtotals';
 export * from './utils/time';
 export * from './utils/timeFrames';
 export * from './utils/virtualView';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1145,7 +1145,7 @@ export function itemsInMetricQuery(
           ];
 }
 
-export function formatRawValue(
+function formatRawValue(
     field: Field | Metric | TableCalculation | CustomDimension | undefined,
     value: AnyType,
 ) {

--- a/packages/common/src/pivotTable/pivotQueryResults.test.ts
+++ b/packages/common/src/pivotTable/pivotQueryResults.test.ts
@@ -586,6 +586,7 @@ describe('Should pivot data', () => {
             rowTotals: true,
         };
         const expected = {
+            groupedSubtotals: undefined,
             headerValueTypes: [{ type: 'dimension', fieldId: 'site' }],
             headerValues: [
                 [

--- a/packages/common/src/pivotTable/pivotQueryResults.ts
+++ b/packages/common/src/pivotTable/pivotQueryResults.ts
@@ -29,6 +29,7 @@ type PivotQueryResultsArgs = {
         | 'customDimensions'
     >;
     rows: ResultRow[];
+    groupedSubtotals?: Record<string, Record<string, number>[]>;
     options: {
         maxColumns: number;
     };
@@ -375,6 +376,7 @@ export const pivotQueryResults = ({
     options,
     getField,
     getFieldLabel,
+    groupedSubtotals,
 }: PivotQueryResultsArgs): PivotData => {
     if (rows.length === 0) {
         throw new Error('Cannot pivot results with no rows');
@@ -782,6 +784,7 @@ export const pivotQueryResults = ({
             allCombinedData: [],
             pivotColumnInfo: [],
         },
+        groupedSubtotals,
     };
     return combinedRetrofit(pivotData, getField, getFieldLabel);
 };

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -57,6 +57,7 @@ export enum QueryExecutionContext {
     SCHEDULED_CHART = 'scheduledChart',
     SCHEDULED_DASHBOARD = 'scheduledDashboard',
     CALCULATE_TOTAL = 'calculateTotal',
+    CALCULATE_SUBTOTAL = 'calculateSubtotal',
     EMBED = 'embed',
     AI = 'ai',
     API = 'api',

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -69,6 +69,7 @@ export type PivotData = {
         allCombinedData: ResultRow[];
         pivotColumnInfo: PivotColumn[];
     };
+    groupedSubtotals?: Record<string, Record<string, number>[]>;
 };
 
 export const getPivotConfig = (

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -725,7 +725,9 @@ export type ApiCalculateTotalResponse = {
     results: Record<string, number>;
 };
 
-export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery;
+export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery & {
+    columnOrder: string[];
+};
 
 export type ApiCalculateSubtotalsResponse = {
     status: 'ok';

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -725,13 +725,15 @@ export type ApiCalculateTotalResponse = {
     results: Record<string, number>;
 };
 
-export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery & {
-    groupedDimensions: string[];
-};
+export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery;
 
 export type ApiCalculateSubtotalsResponse = {
     status: 'ok';
-    results: Record<string, number>[];
+    results: {
+        [subtotalDimensions: string]: {
+            [key: string]: number;
+        }[];
+    };
 };
 
 export type ReplaceableFieldMatchMap = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -725,6 +725,15 @@ export type ApiCalculateTotalResponse = {
     results: Record<string, number>;
 };
 
+export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery & {
+    groupedDimensions: string[];
+};
+
+export type ApiCalculateSubtotalsResponse = {
+    status: 'ok';
+    results: Record<string, number>[];
+};
+
 export type ReplaceableFieldMatchMap = {
     [fieldId: string]: {
         fieldId: string;

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -727,6 +727,7 @@ export type ApiCalculateTotalResponse = {
 
 export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery & {
     columnOrder: string[];
+    pivotDimensions?: string[];
 };
 
 export type ApiCalculateSubtotalsResponse = {

--- a/packages/common/src/utils/subtotals.ts
+++ b/packages/common/src/utils/subtotals.ts
@@ -1,0 +1,3 @@
+export function getSubtotalKey(dimensions: string[]) {
+    return dimensions.join(':');
+}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -167,9 +167,6 @@ const PivotTable: FC<PivotTableProps> = ({
                         aggregatedCell: (info) => {
                             if (info.row.getIsGrouped()) {
                                 // TODO: Deduplicate this with the getDataAndColumns code
-                                console.log({
-                                    data,
-                                });
                                 const groupedDimensions = info.row.id
                                     .split('>')
                                     .map(
@@ -204,15 +201,25 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const subtotalsGroup = data.groupedSubtotals?.[
                                     subtotalGroupKey
                                 ]?.find((subtotal) => {
-                                    return Object.keys(groupingValues).every(
-                                        (key) => {
-                                            return (
-                                                groupingValues[key]?.value
-                                                    .raw === subtotal[key] ||
-                                                pivotedHeaderValues[key]
-                                                    ?.raw === subtotal[key]
-                                            );
-                                        },
+                                    return (
+                                        // All grouping values in the row must match the subtotal values
+                                        Object.keys(groupingValues).every(
+                                            (key) => {
+                                                return (
+                                                    groupingValues[key]?.value
+                                                        .raw === subtotal[key]
+                                                );
+                                            },
+                                        ) &&
+                                        // All pivoted header values in the row must match the subtotal values
+                                        Object.keys(pivotedHeaderValues).every(
+                                            (key) => {
+                                                return (
+                                                    pivotedHeaderValues[key]
+                                                        ?.raw === subtotal[key]
+                                                );
+                                            },
+                                        )
                                     );
                                 });
 
@@ -552,7 +559,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 if (item && isDimension(item)) {
                                     const underlyingId = data.indexValues[
                                         rowIndex
-                                    ].find(
+                                    ]?.find(
                                         (indexValue) =>
                                             indexValue.type === 'label',
                                     )?.fieldId;

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -361,6 +361,7 @@ const PivotTable: FC<PivotTableProps> = ({
             const groupedColumns = data.indexValueTypes.map(
                 (valueType) => valueType.fieldId,
             );
+
             const sortedColumns = table
                 .getState()
                 .columnOrder.reduce<string[]>((acc, sortedId) => {

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -314,9 +314,14 @@ const PivotTable: FC<PivotTableProps> = ({
             visibleCells.forEach((cell, cellIndex) => {
                 if (cell.column.columnDef.meta?.type === 'indexValue') {
                     if (cell.column.columnDef.id) {
-                        const fullValue = cell.getValue() as ResultRow[0];
-                        underlyingValues[cell.column.columnDef.id] =
-                            fullValue.value;
+                        const fullValue = cell.getValue() as
+                            | ResultRow[0]
+                            | undefined;
+
+                        if (fullValue) {
+                            underlyingValues[cell.column.columnDef.id] =
+                                fullValue.value;
+                        }
                     }
                 } else if (cell.column.columnDef.meta?.type === 'label') {
                     const info = data.indexValues[rowIndex].find(

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -240,6 +240,12 @@ const PivotTable: FC<PivotTableProps> = ({
         hideRowNumbers,
     ]);
 
+    const groupedRowModel = getGroupedRowModelLightdash();
+
+    console.log({
+        groupedRowModel,
+    });
+
     const table = useReactTable({
         data: data.retrofitData.allCombinedData,
         columns: columns,
@@ -252,7 +258,7 @@ const PivotTable: FC<PivotTableProps> = ({
         },
         onGroupingChange: setGrouping,
         getExpandedRowModel: getExpandedRowModel(),
-        getGroupedRowModel: getGroupedRowModelLightdash(),
+        getGroupedRowModel: groupedRowModel,
         getCoreRowModel: getCoreRowModel(),
     });
 

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -167,21 +167,17 @@ const PivotTable: FC<PivotTableProps> = ({
                         aggregatedCell: (info) => {
                             if (info.row.getIsGrouped()) {
                                 // TODO: Deduplicate this with the getDataAndColumns code
-                                const groupedDimensions = info.row.id
-                                    .split('>')
-                                    .map(
-                                        (rowIdParts) =>
-                                            rowIdParts.split(':')[0],
-                                    )
-                                    .filter((d) => d !== undefined);
+                                const groupingDimensions = info.table
+                                    .getState()
+                                    .grouping.slice(0, info.row.depth + 1);
 
-                                if (!groupedDimensions.length) {
+                                if (!groupingDimensions.length) {
                                     return null;
                                 }
 
                                 // Get the grouping values for each of the dimensions in the row
                                 const groupingValues = Object.fromEntries(
-                                    groupedDimensions.map((d) => [
+                                    groupingDimensions.map((d) => [
                                         d,
                                         info.row.getGroupingValue(d) as
                                             | ResultRow[number]
@@ -195,7 +191,7 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 // Calculate the subtotal key for the row, this is used to find the subtotal in the groupedSubtotals object
                                 const subtotalGroupKey =
-                                    getSubtotalKey(groupedDimensions);
+                                    getSubtotalKey(groupingDimensions);
 
                                 // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
                                 const subtotal = data.groupedSubtotals?.[

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -240,12 +240,6 @@ const PivotTable: FC<PivotTableProps> = ({
         hideRowNumbers,
     ]);
 
-    const groupedRowModel = getGroupedRowModelLightdash();
-
-    console.log({
-        groupedRowModel,
-    });
-
     const table = useReactTable({
         data: data.retrofitData.allCombinedData,
         columns: columns,
@@ -258,7 +252,7 @@ const PivotTable: FC<PivotTableProps> = ({
         },
         onGroupingChange: setGrouping,
         getExpandedRowModel: getExpandedRowModel(),
-        getGroupedRowModel: groupedRowModel,
+        getGroupedRowModel: getGroupedRowModelLightdash(),
         getCoreRowModel: getCoreRowModel(),
     });
 

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -198,16 +198,16 @@ const PivotTable: FC<PivotTableProps> = ({
                                     getSubtotalKey(groupedDimensions);
 
                                 // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                                const subtotalsGroup = data.groupedSubtotals?.[
+                                const subtotal = data.groupedSubtotals?.[
                                     subtotalGroupKey
-                                ]?.find((subtotal) => {
+                                ]?.find((sub) => {
                                     return (
                                         // All grouping values in the row must match the subtotal values
                                         Object.keys(groupingValues).every(
                                             (key) => {
                                                 return (
                                                     groupingValues[key]?.value
-                                                        .raw === subtotal[key]
+                                                        .raw === sub[key]
                                                 );
                                             },
                                         ) &&
@@ -216,7 +216,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                             (key) => {
                                                 return (
                                                     pivotedHeaderValues[key]
-                                                        ?.raw === subtotal[key]
+                                                        ?.raw === sub[key]
                                                 );
                                             },
                                         )
@@ -224,7 +224,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 });
 
                                 const subtotalColumnIds = Object.keys(
-                                    subtotalsGroup ?? {},
+                                    subtotal ?? {},
                                 );
 
                                 // If the subtotal column is not in the subtotalsGroup, return null
@@ -239,7 +239,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 }
 
                                 const subtotalValue =
-                                    subtotalsGroup?.[col.baseId ?? col.fieldId];
+                                    subtotal?.[col.baseId ?? col.fieldId];
 
                                 return (
                                     <Text span fw={600}>

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { Draggable } from '@hello-pangea/dnd';
-import { FieldType, isField } from '@lightdash/common';
+import { isCustomDimension, isDimension, isField } from '@lightdash/common';
 import { Tooltip } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import isEqual from 'lodash/isEqual';
@@ -32,9 +32,9 @@ const TableHeader: FC<TableHeaderProps> = ({
             const groupedColumns = columns
                 .filter((col) => {
                     const item = col.meta?.item;
-                    return item && isField(item)
-                        ? item.fieldType === FieldType.DIMENSION
-                        : false;
+                    return (
+                        item && (isDimension(item) || isCustomDimension(item))
+                    );
                 })
                 .map((col) => col.id);
 

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -33,15 +33,6 @@ type Args = {
     groupedSubtotals?: Record<string, Record<string, number>[]>;
 };
 
-// Adapted from https://stackoverflow.com/a/45337588
-const decimalLength = (numStr: number) => {
-    const pieces = numStr.toString().split('.');
-    if (!pieces[1]) return 0;
-    return pieces[1].length;
-};
-export const getDecimalPrecision = (addend1: number, addend2: number) =>
-    Math.pow(10, Math.max(decimalLength(addend1), decimalLength(addend2)));
-
 const getDataAndColumns = ({
     itemsMap,
     selectedItemIds,
@@ -123,6 +114,7 @@ const getDataAndColumns = ({
                     // aggregationFn: 'sum', // Not working.
                     // aggregationFn: 'max', // At least results in a cell value, although it's incorrect.
                     aggregatedCell: (info) => {
+                        // TODO: Deduplicate this with the pivotTable code
                         if (info.row.getIsGrouped()) {
                             const groupedDimensions = info.row.id
                                 .split('>')

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -145,7 +145,7 @@ const getDataAndColumns = ({
                                         rowAggregatedColumnValues,
                                     ).every(
                                         (dimension) =>
-                                            subtotal[dimension] ===
+                                            subtotal[dimension]?.toString() ===
                                             rowAggregatedColumnValues[
                                                 dimension
                                             ],

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -7,6 +7,7 @@ import {
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
+import { getSubtotalKey } from '@lightdash/common/src/utils/subtotals';
 import { Text } from '@mantine/core';
 import {
     TableHeaderBoldLabel,
@@ -155,7 +156,7 @@ const getDataAndColumns = ({
                             );
 
                             const subtotalGroupKey =
-                                groupedDimensions.join(':');
+                                getSubtotalKey(groupedDimensions);
 
                             const foundSubtotal = groupedSubtotals?.[
                                 subtotalGroupKey

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -116,18 +116,17 @@ const getDataAndColumns = ({
                     aggregatedCell: (info) => {
                         // TODO: Deduplicate this with the pivotTable code
                         if (info.row.getIsGrouped()) {
-                            const groupedDimensions = info.row.id
-                                .split('>')
-                                .map((rowIdParts) => rowIdParts.split(':')[0])
-                                .filter((d) => d !== undefined);
+                            const groupingDimensions = info.table
+                                .getState()
+                                .grouping.slice(0, info.row.depth + 1);
 
-                            if (!groupedDimensions.length) {
+                            if (!groupingDimensions.length) {
                                 return null;
                             }
 
                             // Get the grouping values for each of the dimensions in the row
                             const groupingValues = Object.fromEntries(
-                                groupedDimensions.map((d) => [
+                                groupingDimensions.map((d) => [
                                     d,
                                     info.row.getGroupingValue(d) as
                                         | ResultRow[number]
@@ -137,7 +136,7 @@ const getDataAndColumns = ({
 
                             // Calculate the subtotal key for the row, this is used to find the subtotal in the groupedSubtotals object
                             const subtotalGroupKey =
-                                getSubtotalKey(groupedDimensions);
+                                getSubtotalKey(groupingDimensions);
 
                             // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
                             const subtotal = groupedSubtotals?.[

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -140,21 +140,21 @@ const getDataAndColumns = ({
                                 getSubtotalKey(groupedDimensions);
 
                             // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                            const subtotalsGroup = groupedSubtotals?.[
+                            const subtotal = groupedSubtotals?.[
                                 subtotalGroupKey
-                            ]?.find((subtotal) => {
+                            ]?.find((sub) => {
                                 return Object.keys(groupingValues).every(
                                     (key) => {
                                         return (
                                             groupingValues[key]?.value.raw ===
-                                            subtotal[key]
+                                            sub[key]
                                         );
                                     },
                                 );
                             });
 
                             const subtotalColumnIds = Object.keys(
-                                subtotalsGroup ?? {},
+                                subtotal ?? {},
                             );
 
                             // If the subtotal column is not in the subtotalsGroup, return null
@@ -164,8 +164,7 @@ const getDataAndColumns = ({
                                 return null;
                             }
 
-                            const subtotalValue =
-                                subtotalsGroup?.[info.column.id];
+                            const subtotalValue = subtotal?.[info.column.id];
 
                             return (
                                 <Text span fw={600}>

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -148,7 +148,7 @@ const getDataAndColumns = ({
                                 getSubtotalKey(groupedDimensions);
 
                             // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                            const foundSubtotal = groupedSubtotals?.[
+                            const subtotalsGroup = groupedSubtotals?.[
                                 subtotalGroupKey
                             ]?.find((subtotal) => {
                                 return Object.keys(groupingValues).every(
@@ -161,12 +161,19 @@ const getDataAndColumns = ({
                                 );
                             });
 
-                            const subtotalValue =
-                                foundSubtotal?.[info.column.id];
+                            const subtotalColumnIds = Object.keys(
+                                subtotalsGroup ?? {},
+                            );
 
-                            if (!subtotalValue) {
+                            // If the subtotal column is not in the subtotalsGroup, return null
+                            // This is needed to prevent showing '-' when processing a value for the last grouped dimension column which is not taken into account for subtotals
+                            // This column only exists when we're expanding the last grouped dimension
+                            if (!subtotalColumnIds.includes(info.column.id)) {
                                 return null;
                             }
+
+                            const subtotalValue =
+                                subtotalsGroup?.[info.column.id];
 
                             return (
                                 <Text span fw={600}>

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -122,10 +122,6 @@ const getDataAndColumns = ({
                     // aggregationFn: 'sum', // Not working.
                     // aggregationFn: 'max', // At least results in a cell value, although it's incorrect.
                     aggregatedCell: (info) => {
-                        console.log({
-                            som: info.row.getAllCells(),
-                        });
-
                         if (info.row.getIsGrouped()) {
                             const rowAggregatedColumnValues =
                                 Object.fromEntries(

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -219,11 +219,12 @@ const useTableConfig = (
               },
     );
 
-    const { data: subtotalsCalculations } = useCalculateSubtotals({
+    const { data: groupedSubtotals } = useCalculateSubtotals({
         metricQuery: resultsData?.metricQuery,
         explore: resultsData?.metricQuery.exploreName,
         showSubtotals,
         columnOrder,
+        pivotDimensions,
     });
 
     const { rows, columns, error } = useMemo<{
@@ -255,7 +256,7 @@ const useTableConfig = (
             isColumnFrozen,
             columnOrder,
             totals: totalCalculations,
-            groupedSubtotals: subtotalsCalculations,
+            groupedSubtotals,
         });
     }, [
         columnOrder,
@@ -268,7 +269,7 @@ const useTableConfig = (
         isColumnFrozen,
         getFieldLabelOverride,
         totalCalculations,
-        subtotalsCalculations,
+        groupedSubtotals,
     ]);
     const worker = useWorker(createWorker);
     const [pivotTableData, setPivotTableData] = useState<{
@@ -343,6 +344,7 @@ const useTableConfig = (
                 },
                 metricQuery: resultsData.metricQuery,
                 rows: resultsData.rows,
+                groupedSubtotals,
                 options: {
                     maxColumns: pivotTableMaxColumnLimit,
                 },
@@ -376,6 +378,7 @@ const useTableConfig = (
         tableChartConfig?.showRowCalculation,
         worker,
         pivotTableMaxColumnLimit,
+        groupedSubtotals,
     ]);
 
     // Remove columnProperties from map if the column has been removed from results
@@ -526,7 +529,7 @@ const useTableConfig = (
         setMetricsAsRows,
         isPivotTableEnabled,
         canUseSubtotals,
-        subtotalsCalculations,
+        groupedSubtotals,
     };
 };
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -27,6 +27,7 @@ import {
     type TableColumn,
     type TableHeader,
 } from '../../components/common/Table/types';
+import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
 import getDataAndColumns from './getDataAndColumns';
 
@@ -219,6 +220,16 @@ const useTableConfig = (
                       tableChartConfig?.showColumnCalculation,
               },
     );
+
+    const { data: subtotalsCalculations } = useCalculateSubtotals({
+        metricQuery: resultsData?.metricQuery,
+        explore: resultsData?.metricQuery.exploreName,
+        fieldIds: selectedItemIds,
+        itemsMap,
+        showSubtotals,
+        groupedDimensions: dimensions.slice(0, -1),
+    });
+
     const { rows, columns, error } = useMemo<{
         rows: ResultRow[];
         columns: Array<TableColumn | TableHeader>;
@@ -248,6 +259,7 @@ const useTableConfig = (
             isColumnFrozen,
             columnOrder,
             totals: totalCalculations,
+            subtotals: subtotalsCalculations,
         });
     }, [
         columnOrder,
@@ -260,6 +272,7 @@ const useTableConfig = (
         isColumnFrozen,
         getFieldLabelOverride,
         totalCalculations,
+        subtotalsCalculations,
     ]);
     const worker = useWorker(createWorker);
     const [pivotTableData, setPivotTableData] = useState<{
@@ -517,6 +530,7 @@ const useTableConfig = (
         setMetricsAsRows,
         isPivotTableEnabled,
         canUseSubtotals,
+        subtotalsCalculations,
     };
 };
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -225,6 +225,7 @@ const useTableConfig = (
         metricQuery: resultsData?.metricQuery,
         explore: resultsData?.metricQuery.exploreName,
         showSubtotals,
+        columnOrder,
     });
 
     const { rows, columns, error } = useMemo<{

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -227,7 +227,7 @@ const useTableConfig = (
         fieldIds: selectedItemIds,
         itemsMap,
         showSubtotals,
-        groupedDimensions: dimensions.slice(0, -1),
+        groupedDimensions: dimensions.slice(0, -1), // TODO: this should change with the grouped dimensions in each specific row
     });
 
     const { rows, columns, error } = useMemo<{

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -224,8 +224,6 @@ const useTableConfig = (
     const { data: subtotalsCalculations } = useCalculateSubtotals({
         metricQuery: resultsData?.metricQuery,
         explore: resultsData?.metricQuery.exploreName,
-        fieldIds: selectedItemIds,
-        itemsMap,
         showSubtotals,
         groupedDimensions: dimensions.slice(0, -1), // TODO: this should change with the grouped dimensions in each specific row
     });

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -1,7 +1,7 @@
 import {
-    FieldType,
     convertFormattedValue,
     getItemLabel,
+    isCustomDimension,
     isDimension,
     isField,
     isFilterableItem,
@@ -180,9 +180,7 @@ const useTableConfig = (
 
         return columnOrder.filter((fieldId) => {
             const item = itemsMap[fieldId];
-            return item && isField(item)
-                ? item.fieldType === FieldType.DIMENSION
-                : false;
+            return item && (isDimension(item) || isCustomDimension(item));
         });
     }, [columnOrder, itemsMap]);
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -225,7 +225,6 @@ const useTableConfig = (
         metricQuery: resultsData?.metricQuery,
         explore: resultsData?.metricQuery.exploreName,
         showSubtotals,
-        groupedDimensions: dimensions.slice(0, -1), // TODO: this should change with the grouped dimensions in each specific row
     });
 
     const { rows, columns, error } = useMemo<{
@@ -257,7 +256,7 @@ const useTableConfig = (
             isColumnFrozen,
             columnOrder,
             totals: totalCalculations,
-            subtotals: subtotalsCalculations,
+            groupedSubtotals: subtotalsCalculations,
         });
     }, [
         columnOrder,

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -63,6 +63,7 @@ export const useCalculateSubtotals = ({
                 : Promise.reject(),
         retry: false,
         enabled:
+            !window.location.pathname.startsWith('/embed/') &&
             showSubtotals === true &&
             metricQuery !== undefined &&
             metricQuery.metrics.length > 0 &&

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -1,0 +1,118 @@
+import {
+    getItemId,
+    isField,
+    isMetric,
+    type ApiCalculateSubtotalsResponse,
+    type ApiError,
+    type CalculateSubtotalsFromQuery,
+    type ItemsMap,
+    type MetricQuery,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useParams } from 'react-router';
+import { lightdashApi } from '../api';
+import { convertDateFilters } from '../utils/dateFilter';
+
+const calculateSubtotalsFromQuery = async (
+    projectUuid: string,
+    metricQuery?: MetricQuery,
+    explore?: string,
+    groupedDimensions?: string[],
+): Promise<ApiCalculateSubtotalsResponse['results']> => {
+    if (!metricQuery || !explore || !groupedDimensions) {
+        throw new Error(
+            'missing metricQuery, explore, or groupedDimensions on calculateSubtotalsFromQuery',
+        );
+    }
+
+    const timezoneFixPayload: CalculateSubtotalsFromQuery = {
+        explore: explore,
+        metricQuery: {
+            ...metricQuery,
+            filters: convertDateFilters(metricQuery.filters),
+        },
+        groupedDimensions,
+    };
+    return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
+        url: `/projects/${projectUuid}/calculate-subtotals`,
+        method: 'POST',
+        body: JSON.stringify(timezoneFixPayload),
+    });
+};
+
+const getCalculationColumnFields = (
+    selectedItemIds: string[],
+    itemsMap: ItemsMap,
+) => {
+    // This method will return the metric ids that need to be calculated in the backend
+    const items = selectedItemIds
+        ?.map((item) => {
+            return itemsMap[item];
+        })
+        .filter((item) => isField(item) && isMetric(item));
+
+    return items?.reduce<string[]>((acc, item) => {
+        if (isField(item)) return [...acc, getItemId(item)];
+        return acc;
+    }, []);
+};
+
+export const useCalculateSubtotals = ({
+    metricQuery,
+    explore,
+    fieldIds,
+    itemsMap,
+    showSubtotals,
+    groupedDimensions,
+}: {
+    metricQuery?: MetricQuery;
+    explore?: string;
+    fieldIds?: string[];
+    itemsMap: ItemsMap | undefined;
+    showSubtotals?: boolean;
+    groupedDimensions?: string[];
+}) => {
+    const metricsWithSubtotals = useMemo(() => {
+        if (!fieldIds || !itemsMap) return [];
+        if (showSubtotals === false) return [];
+        return getCalculationColumnFields(fieldIds, itemsMap);
+    }, [fieldIds, itemsMap, showSubtotals]);
+
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    // only add relevant fields to the key (filters, metrics, groupedDimensions)
+    const queryKey = {
+        filters: metricQuery?.filters,
+        metrics: metricQuery?.metrics,
+        additionalMetrics: metricQuery?.additionalMetrics,
+        groupedDimensions,
+    };
+
+    return useQuery<ApiCalculateSubtotalsResponse['results'], ApiError>({
+        queryKey: ['calculate_subtotals', projectUuid, queryKey],
+        queryFn: () =>
+            projectUuid
+                ? calculateSubtotalsFromQuery(
+                      projectUuid,
+                      metricQuery,
+                      explore,
+                      groupedDimensions,
+                  )
+                : Promise.reject(),
+        retry: false,
+        enabled:
+            !window.location.pathname.startsWith('/embed/') &&
+            metricsWithSubtotals.length > 0 &&
+            showSubtotals === true &&
+            metricQuery !== undefined &&
+            groupedDimensions !== undefined &&
+            groupedDimensions.length > 0,
+        onError: (result) =>
+            console.error(
+                `Unable to calculate subtotals from query: ${
+                    result?.error?.message || result
+                }`,
+            ),
+    });
+};

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -14,6 +14,7 @@ const calculateSubtotalsFromQuery = async (
     explore: string,
     metricQuery: MetricQuery,
     columnOrder: string[],
+    pivotDimensions?: string[],
 ): Promise<ApiCalculateSubtotalsResponse['results']> => {
     const timezoneFixPayload: CalculateSubtotalsFromQuery = {
         explore: explore,
@@ -22,6 +23,7 @@ const calculateSubtotalsFromQuery = async (
             filters: convertDateFilters(metricQuery.filters),
         },
         columnOrder,
+        pivotDimensions,
     };
     return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
         url: `/projects/${projectUuid}/calculate-subtotals`,
@@ -35,11 +37,13 @@ export const useCalculateSubtotals = ({
     explore,
     showSubtotals,
     columnOrder,
+    pivotDimensions,
 }: {
     metricQuery?: MetricQuery;
     explore?: string;
     showSubtotals?: boolean;
     columnOrder?: string[];
+    pivotDimensions?: string[];
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
@@ -51,6 +55,7 @@ export const useCalculateSubtotals = ({
             explore,
             columnOrder,
             showSubtotals,
+            pivotDimensions,
         ],
         queryFn: () =>
             projectUuid && metricQuery && explore && columnOrder
@@ -59,6 +64,7 @@ export const useCalculateSubtotals = ({
                       explore,
                       metricQuery,
                       columnOrder,
+                      pivotDimensions,
                   )
                 : Promise.reject(),
         retry: false,

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -193,6 +193,10 @@ function reducer(
                 unsavedChartVersion: {
                     ...state.unsavedChartVersion,
                     tableName: action.payload,
+                    metricQuery: {
+                        ...state.unsavedChartVersion.metricQuery,
+                        exploreName: action.payload,
+                    },
                 },
             };
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#11348](https://github.com/lightdash/lightdash/issues/11348)

# Calculate Subtotals in the Backend

## Overview
This PR moves the subtotal calculation logic from the frontend to the backend so that they are calculated by a warehouse query and thus supporting all metric types

## Key Changes
- Added new `/calculate-subtotals` endpoint in the backend to handle subtotal computations
    - This endpoint returns the calculations for all subtotal groupings
- Updated frontend table visualization to use the new backend endpoint
- Can now calculate subtotals when having custom dimensions (bin/sql) in the subtotal dimension groups

## Known limitations
- Disabled for embedding scenarios like `/calculate-totals` hook
- The way the subtotals are being calculated is by running a metric query with a subgroup of dimensions, e.g.
    - my query has `status`, `date_month`, `date_week`, we will calculate subtotals for `status` and then for `status, date_month`. Notice that `date_week` is not included since it is part of the full detailed results query.

This means that if I have a table calculation that references `date_week` the query for the subtotals will fail because it is stripped out of the subtotals metric query

![image](https://github.com/user-attachments/assets/801c67d9-c67a-497b-a73d-76397a75caf4)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
