### PR TITLE
chore: share errors to ignore in sentry on BE and worker

### DIFF
--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -13,6 +13,7 @@ import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import PrometheusMetrics from './prometheus';
 import { SchedulerWorker } from './scheduler/SchedulerWorker';
+import { IGNORE_ERRORS } from './sentry';
 import {
     OperationContext,
     ServiceProviderMap,
@@ -170,7 +171,7 @@ export default class SchedulerApp {
                     ? 'development'
                     : this.lightdashConfig.mode,
             integrations: [],
-            ignoreErrors: ['WarehouseQueryError', 'FieldReferenceError'],
+            ignoreErrors: IGNORE_ERRORS,
         });
     }
 

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -12,6 +12,7 @@ export const IGNORE_ERRORS = [
     'NotFoundError',
     'ForbiddenError',
     'TokenError',
+    'AuthorizationError',
 ];
 
 Sentry.init({

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -3,6 +3,17 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { lightdashConfig } from './config/lightdashConfig';
 import { VERSION } from './version';
 
+export const IGNORE_ERRORS = [
+    'WarehouseQueryError',
+    'FieldReferenceError',
+    'NotEnoughResults',
+    'CompileError',
+    'NotExistsError',
+    'NotFoundError',
+    'ForbiddenError',
+    'TokenError',
+];
+
 Sentry.init({
     release: VERSION,
     dsn: lightdashConfig.sentry.backend.dsn,
@@ -24,16 +35,7 @@ Sentry.init({
               ]
             : []),
     ],
-    ignoreErrors: [
-        'WarehouseQueryError',
-        'FieldReferenceError',
-        'NotEnoughResults',
-        'CompileError',
-        'NotExistsError',
-        'NotFoundError',
-        'ForbiddenError',
-        'TokenError',
-    ],
+    ignoreErrors: IGNORE_ERRORS,
     tracesSampler: (context) => {
         if (
             context.request?.url?.endsWith('/status') ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Ignore more errors on Scheduler/Worker section. 
Now the errors-to-be-ignored are shared between backend apps.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
