### PR TITLE
feat: put formatting rules delete button in a menu

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -4,12 +4,12 @@ import {
     Box,
     Flex,
     Group,
+    Menu,
     Text,
     Tooltip,
     type AccordionControlProps as MantineAccordionControlProps,
 } from '@mantine/core';
-import { useHover } from '@mantine/hooks';
-import { IconTrash } from '@tabler/icons-react';
+import { IconDots, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
@@ -28,11 +28,8 @@ export const AccordionControl: FC<Props> = ({
     extraControlElements,
     ...props
 }) => {
-    const { ref, hovered } = useHover<HTMLDivElement>();
-
     return (
         <Flex
-            ref={ref}
             px="xs"
             pos="relative"
             align="center"
@@ -69,14 +66,24 @@ export const AccordionControl: FC<Props> = ({
                     position="right"
                     withinPortal
                 >
-                    <ActionIcon
-                        onClick={onRemove}
-                        sx={{
-                            visibility: hovered ? 'visible' : 'hidden',
-                        }}
-                    >
-                        <MantineIcon icon={IconTrash} />
-                    </ActionIcon>
+                    <Menu withArrow offset={-2}>
+                        <Menu.Target>
+                            <ActionIcon variant="transparent">
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                icon={<MantineIcon icon={IconTrash} />}
+                                color="red"
+                                onClick={onRemove}
+                            >
+                                <Text fz="xs" fw={500}>
+                                    Delete
+                                </Text>
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
                 </Tooltip>
                 <Accordion.Control
                     w="sm"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13859 

### Description:

Customers were having an issue with accidentally deleting conditional formatting rules since the delete button is right next to collapse. Priyanka suggested we fix this for now by making it a 1-item menu with delete

<img width="398" alt="Screenshot 2025-02-28 at 15 21 07" src="https://github.com/user-attachments/assets/4834c9fb-742e-412e-beb1-fe137f0cc702" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
