### PR TITLE
feat: add a flag to disable telemetry

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -371,8 +371,8 @@ type PylonConfig = {
 };
 
 export type RudderConfig = {
-    writeKey: string;
-    dataPlaneUrl: string;
+    writeKey: string | undefined;
+    dataPlaneUrl: string | undefined;
 };
 
 export type PosthogConfig = {
@@ -589,12 +589,15 @@ export const parseConfig = (): LightdashConfig => {
             : undefined,
         rudder: {
             writeKey:
-                process.env.RUDDERSTACK_WRITE_KEY === undefined
-                    ? '1vqkSlWMVtYOl70rk3QSE0v1fqY'
-                    : process.env.RUDDERSTACK_WRITE_KEY,
+                process.env.RUDDERSTACK_ANALYTICS_DISABLED === 'true'
+                    ? undefined
+                    : process.env.RUDDERSTACK_WRITE_KEY ||
+                      '1vqkSlWMVtYOl70rk3QSE0v1fqY',
             dataPlaneUrl:
-                process.env.RUDDERSTACK_DATA_PLANE_URL ||
-                'https://analytics.lightdash.com',
+                process.env.RUDDERSTACK_ANALYTICS_DISABLED === 'true'
+                    ? undefined
+                    : process.env.RUDDERSTACK_DATA_PLANE_URL ||
+                      'https://analytics.lightdash.com',
         },
         sentry: {
             backend: {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -817,8 +817,8 @@ export type HealthState = {
         version?: string;
     };
     rudder: {
-        writeKey: string;
-        dataPlaneUrl: string;
+        writeKey: string | undefined;
+        dataPlaneUrl: string | undefined;
     };
     sentry: Pick<
         SentryConfig,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/13845

### Description:

We don't have an official way to disable rudderstack. When customers ask we have told them to use a space `' '`. This adds a flag to disable rudderstack. 

If this looks good I can add it to the docs. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
