### PR TITLE
fix: check if custom metric filter exists before validating

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -364,23 +364,21 @@ export class ValidationService extends BaseService {
                         [],
                     );
 
-                    const customMetricFilterErrors =
-                        customMetricsFilters.reduce<CreateChartValidation[]>(
-                            (acc, filter) => {
-                                const fieldId = convertFieldRefToFieldId(
-                                    filter.target.fieldRef,
-                                );
-                                return containsFieldId({
-                                    acc,
-                                    fieldIds: allItemIdsAvailableInChart,
-                                    fieldId,
-                                    error: `Custom metric filter error: the field '${fieldId}' no longer exists`,
-                                    errorType: ValidationErrorType.CustomMetric,
-                                    fieldName: fieldId,
-                                });
-                            },
-                            [],
-                        );
+                    const customMetricFilterErrors = customMetricsFilters
+                        .filter((f) => !!f?.target)
+                        .reduce<CreateChartValidation[]>((acc, filter) => {
+                            const fieldId = convertFieldRefToFieldId(
+                                filter.target.fieldRef,
+                            );
+                            return containsFieldId({
+                                acc,
+                                fieldIds: allItemIdsAvailableInChart,
+                                fieldId,
+                                error: `Custom metric filter error: the field '${fieldId}' no longer exists`,
+                                errorType: ValidationErrorType.CustomMetric,
+                                fieldName: fieldId,
+                            });
+                        }, []);
 
                     const sortErrors = sorts.reduce<CreateChartValidation[]>(
                         (acc, field) =>

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -365,7 +365,7 @@ export class ValidationService extends BaseService {
                     );
 
                     const customMetricFilterErrors = customMetricsFilters
-                        .filter((f) => !!f?.target)
+                        .filter((f) => !!f)
                         .reduce<CreateChartValidation[]>((acc, filter) => {
                             const fieldId = convertFieldRefToFieldId(
                                 filter.target.fieldRef,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13872

### Description:

custom metric filter could be `null`.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
