### PR TITLE
chore: unused semantic viewer permission checks

### DIFF
--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -104,15 +104,6 @@ export const projectMemberAbilities: Record<
                 },
             },
         });
-        can('manage', 'SemanticViewer', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
         can('manage', 'Dashboard', {
             projectUuid: member.projectUuid,
             access: {
@@ -160,9 +151,6 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
         can('manage', 'DashboardComments', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'SemanticViewer', {
             projectUuid: member.projectUuid,
         });
         can('manage', 'Tags', {

--- a/packages/frontend/src/components/DashboardTiles/DashboardSemanticViewerChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSemanticViewerChartTile.tsx
@@ -151,15 +151,6 @@ const SemanticViewerChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             ? [chartQuery.data.space.userAccess]
             : [];
 
-    const canManageSemanticViewer = user.data?.ability?.can(
-        'manage',
-        subject('SemanticViewer', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-            access: savedChartSpaceUserAccess,
-        }),
-    );
-
     const canUpdateChart = user.data?.ability?.can(
         'update',
         subject('SavedChart', {
@@ -225,7 +216,6 @@ const SemanticViewerChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             {...rest}
             extraMenuItems={
                 projectUuid &&
-                canManageSemanticViewer &&
                 canUpdateChart && (
                     <ChartTileOptions
                         isEditMode={isEditMode}

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -93,7 +93,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             semanticLayerInfoQuery.isSuccess &&
                             semanticLayerInfoQuery.data !== null && (
                                 <Can
-                                    I="manage"
+                                    I="view"
                                     this={subject('SemanticViewer', {
                                         organizationUuid:
                                             user.data?.organizationUuid,

--- a/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Header/HeaderView.tsx
@@ -49,15 +49,6 @@ export const HeaderView: FC<Props> = ({
         ? [chart.space.userAccess]
         : [];
 
-    const canManageSemanticViewer = user.data?.ability?.can(
-        'manage',
-        subject('SemanticViewer', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-            access: savedChartSpaceUserAccess,
-        }),
-    );
-
     const canManageChart = user.data?.ability?.can(
         'manage',
         subject('SavedChart', {
@@ -103,7 +94,7 @@ export const HeaderView: FC<Props> = ({
                     </Stack>
 
                     <Group spacing="md">
-                        {canManageSemanticViewer && canManageChart && (
+                        {canManageChart && (
                             <Button
                                 size="xs"
                                 variant="default"
@@ -147,12 +138,7 @@ export const HeaderView: FC<Props> = ({
                                         />
                                     }
                                     color="red"
-                                    disabled={
-                                        !(
-                                            canManageSemanticViewer &&
-                                            canManageChart
-                                        )
-                                    }
+                                    disabled={!canManageChart}
                                     onClick={openDeleteModal}
                                 >
                                     Delete

--- a/packages/frontend/src/pages/SemanticViewerEdit.tsx
+++ b/packages/frontend/src/pages/SemanticViewerEdit.tsx
@@ -103,15 +103,6 @@ const SemanticViewerEditorPageWithStore = () => {
             ? [chartQuery.data.space.userAccess]
             : [];
 
-    const canManageSemanticViewer = user.data?.ability?.can(
-        'manage',
-        subject('SemanticViewer', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-            access: savedChartSpaceUserAccess,
-        }),
-    );
-
     const canSaveChart = user.data?.ability?.can(
         'create',
         subject('SavedChart', {
@@ -223,11 +214,7 @@ const SemanticViewerEditorPageWithStore = () => {
             noContentPadding
             withSidebarBorder
             noSidebarPadding
-            sidebar={
-                <SemanticViewer.Sidebar
-                    shouldShowSave={canManageSemanticViewer && canSaveChart}
-                />
-            }
+            sidebar={<SemanticViewer.Sidebar shouldShowSave={canSaveChart} />}
         >
             <SemanticViewer.Content />
         </Page>


### PR DESCRIPTION
`'manage', 'SemanticViewer'` permissions were not used for enforcing any permission checks

test-frontend test-backend