### PR TITLE
chore: remove unused promote permissions

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -21,6 +21,18 @@ module.exports = {
         'no-template-curly-in-string': 'off',
         'no-restricted-syntax': 'off',
         eqeqeq: 'error',
+        // '@typescript-eslint/no-floating-promises': [
+        //     'error',
+        //     {
+        //         allowForKnownSafePromises: [
+        //             {
+        //                 from: 'package',
+        //                 name: 'QueryBuilder',
+        //                 package: 'knex',
+        //             }
+        //         ]
+        //     }
+        // ]
     },
     overrides: [
         

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -175,25 +175,6 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
 
-        can('promote', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
-        can('promote', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
-
         can('manage', 'CompileProject', {
             projectUuid: member.projectUuid,
         });


### PR DESCRIPTION
Promote permissions are already enforced because editors have the ability to `'manage', '...'` and manage allows all actions (including promote). 

This removes the permissions, which doesn't change app behaviour. However we could rewrite the permissions for editors so it doesn't include promoting (not use 'manage')