### PR TITLE
feat: preserve YAML formatting and comments when running `lightdash generate` command

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -48,59 +48,6 @@ models:
               type: sum
 `;
 
-export const SCHEMA_JSON = {
-    version: 2,
-    models: [
-        {
-            name: 'table_a',
-            description: '# Description\nThis table has basic information\n',
-            columns: [
-                {
-                    name: 'dim_a',
-                    tests: ['unique', 'not_null'],
-                    meta: {
-                        metrics: {
-                            metric_a: {
-                                type: 'count_distinct',
-                            },
-                            metric_b: {
-                                type: 'sum',
-                            },
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            name: 'table_b',
-            description: '# Description This table has basic information',
-            columns: [
-                {
-                    name: 'dim_a',
-                    tests: ['unique', 'not_null'],
-                    meta: {
-                        metrics: {
-                            metric_a: {
-                                type: 'count_distinct',
-                            },
-                            metric_b: {
-                                type: 'sum',
-                            },
-                        },
-                    },
-                },
-            ],
-        },
-    ],
-};
-
-// invalid schema: models require a `name` field
-export const INVALID_SCHEMA_YML = `
-version: 2
-models:
- - label: table_a
-`;
-
 export const CUSTOM_METRIC: AdditionalMetric = {
     name: 'new_metric',
     description: 'description',

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,4 +1,3 @@
-import { ParseError } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { updateFile } from '../../clients/github/Github';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -13,10 +12,8 @@ import {
     EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
     EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
     GITHUB_APP_MODEL,
-    INVALID_SCHEMA_YML,
     PROJECT_MODEL,
     SAVED_CHART_MODEL,
-    SCHEMA_JSON,
     SCHEMA_YML,
     SPACE_MODEL,
 } from './GitIntegrationService.mock';
@@ -28,11 +25,6 @@ jest.mock('../../clients/github/Github.ts', () => ({
     })),
     updateFile: jest.fn().mockImplementation(() => undefined),
 }));
-
-// Mock the GitIntegrationService class and expose protected methods
-class TestGitIntegrationService extends GitIntegrationService {
-    static loadYamlSchema = GitIntegrationService.loadYamlSchema;
-}
 
 describe('GitIntegrationService', () => {
     const service = new GitIntegrationService({
@@ -49,6 +41,7 @@ describe('GitIntegrationService', () => {
         jest.clearAllMocks();
     });
 
+<<<<<<< HEAD
     describe('loadYamlSchema', () => {
         it('should load the yaml schema', async () => {
             const result = await TestGitIntegrationService.loadYamlSchema(

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -41,22 +41,6 @@ describe('GitIntegrationService', () => {
         jest.clearAllMocks();
     });
 
-<<<<<<< HEAD
-    describe('loadYamlSchema', () => {
-        it('should load the yaml schema', async () => {
-            const result = await TestGitIntegrationService.loadYamlSchema(
-                SCHEMA_YML,
-            );
-            expect(result.toJS()).toEqual(SCHEMA_JSON);
-        });
-
-        it('should throw error with invalid yaml schema', async () => {
-            await expect(
-                TestGitIntegrationService.loadYamlSchema(INVALID_SCHEMA_YML),
-            ).rejects.toThrowError(ParseError);
-        });
-    });
-
     describe('updateFile', () => {
         it('should update the file for custom metrics', async () => {
             await service.updateFile({

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -2,7 +2,6 @@
 import { subject } from '@casl/ability';
 import {
     AdditionalMetric,
-    AnyType,
     ApiGithubDbtWritePreview,
     CustomSqlDimension,
     DbtProjectType,
@@ -12,7 +11,6 @@ import {
     getErrorMessage,
     GitIntegrationConfiguration,
     isUserWithOrg,
-    lightdashDbtYamlSchema,
     ParameterError,
     ParseError,
     PullRequestCreated,
@@ -22,11 +20,8 @@ import {
     snakeCaseName,
     UnexpectedServerError,
     VizColumn,
-    YamlSchema,
 } from '@lightdash/common';
-import Ajv from 'ajv';
 import { nanoid } from 'nanoid';
-import { parse } from 'yaml';
 import {
     LightdashAnalytics,
     WriteBackEvent,
@@ -590,8 +585,10 @@ ${sql}
         const content = new DbtSchemaEditor(`version: 2`)
             .addModel({
                 name: snakeCaseName(name),
-                label: friendlyName(name),
                 description: `SQL model for ${friendlyName(name)}`,
+                meta: {
+                    label: friendlyName(name),
+                },
                 columns: columns.map((c) => ({
                     name: c.reference,
                     meta: {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -121,24 +121,6 @@ export class GitIntegrationService extends BaseService {
         };
     }
 
-    protected static async loadYamlSchema(
-        content: AnyType,
-    ): Promise<DbtSchemaEditor> {
-        const schemaFile = parse(content);
-        const ajvCompiler = new Ajv({ coerceTypes: true });
-
-        const validate = ajvCompiler.compile<YamlSchema>(
-            lightdashDbtYamlSchema,
-        );
-        if (schemaFile === undefined) {
-            return new DbtSchemaEditor(`version: 2`);
-        }
-        if (!validate(schemaFile)) {
-            throw new ParseError(`Not valid schema ${validate}`);
-        }
-        return new DbtSchemaEditor(content);
-    }
-
     static async createBranch({
         owner,
         repo,
@@ -263,9 +245,7 @@ Affected charts:
             token,
         });
 
-        const yamlSchema = await GitIntegrationService.loadYamlSchema(
-            fileContent,
-        );
+        const yamlSchema = new DbtSchemaEditor(fileContent);
 
         if (!yamlSchema.hasModels()) {
             throw new Error(`No models found in ${fileName}`);

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -80,23 +80,3 @@ export const searchForModel = async ({
     }
     return undefined;
 };
-
-export const getFileHeadComments = async (filePath: string) => {
-    let existingHeadComments: string | undefined;
-    try {
-        const raw = await fs.readFile(filePath, {
-            encoding: 'utf8',
-        });
-        const lines = raw.split('\n');
-        const nonCommentLineIndex = lines.findIndex(
-            (line) => line.length > 0 && line[0] !== '#',
-        );
-        if (nonCommentLineIndex >= 0) {
-            const commentLines = lines.slice(0, nonCommentLineIndex);
-            existingHeadComments = commentLines.join('\n');
-        }
-    } catch (e) {
-        // ignore
-    }
-    return existingHeadComments;
-};

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -1,12 +1,5 @@
-import {
-    DimensionType,
-    lightdashDbtYamlSchema,
-    ParseError,
-} from '@lightdash/common';
-import betterAjvErrors from 'better-ajv-errors';
+import { DbtSchemaEditor, DimensionType, ParseError } from '@lightdash/common';
 import { promises as fs } from 'fs';
-import * as yaml from 'js-yaml';
-import { ajv } from '../ajv';
 
 type YamlColumnMeta = {
     dimension?: {
@@ -31,26 +24,18 @@ export type YamlSchema = {
     models?: YamlModel[];
 };
 
-const loadYamlSchema = async (path: string): Promise<YamlSchema> => {
-    const schemaFile = yaml.load(await fs.readFile(path, 'utf8'));
-    const validate = ajv.compile<YamlSchema>(lightdashDbtYamlSchema);
-    if (schemaFile === undefined) {
-        return {
-            version: 2,
-        };
+const loadYamlSchema = async (path: string): Promise<DbtSchemaEditor> => {
+    try {
+        return new DbtSchemaEditor(await fs.readFile(path, 'utf8'));
+    } catch (e) {
+        if (e instanceof ParseError) {
+            // Prefix error message with file path
+            throw new ParseError(
+                `Couldn't parse existing yaml file at ${path}\n${e.message}`,
+            );
+        }
+        throw e;
     }
-    if (!validate(schemaFile)) {
-        const errors = betterAjvErrors(
-            lightdashDbtYamlSchema,
-            schemaFile,
-            validate.errors || [],
-            { indent: 2 },
-        );
-        throw new ParseError(
-            `Couldn't parse existing yaml file at ${path}\n${errors}`,
-        );
-    }
-    return schemaFile;
 };
 
 type FindModelInYamlArgs = {
@@ -62,19 +47,12 @@ const findModelInYaml = async ({
     modelName,
 }: FindModelInYamlArgs) => {
     try {
-        const existingYaml = await loadYamlSchema(filename);
-        const models = existingYaml.models || [];
-        const modelIndex = models.findIndex(
-            (model) => model.name === modelName,
-        );
-        if (modelIndex < 0) {
-            return undefined;
+        const schemaEditor = await loadYamlSchema(filename);
+
+        if (schemaEditor.findModelByName(modelName)) {
+            return schemaEditor;
         }
-        return {
-            doc: existingYaml as YamlSchema &
-                Required<Pick<YamlSchema, 'models'>>,
-            modelIndex,
-        };
+        return undefined;
     } catch (e: unknown) {
         if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
             return undefined;
@@ -92,10 +70,10 @@ export const searchForModel = async ({
     filenames,
 }: SearchForModelArgs) => {
     for await (const filename of filenames) {
-        const results = await findModelInYaml({ filename, modelName });
-        if (results) {
+        const schemaEditor = await findModelInYaml({ filename, modelName });
+        if (schemaEditor) {
             return {
-                ...results,
+                schemaEditor,
                 filename,
             };
         }

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import inquirer from 'inquirer';
-import * as yaml from 'js-yaml';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
@@ -16,7 +15,6 @@ import {
     getCompiledModels,
     getWarehouseTableForModel,
 } from '../dbt/models';
-import { getFileHeadComments } from '../dbt/schema';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { CompileHandlerOptions } from './compile';
@@ -138,13 +136,6 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     }
                 }
 
-                const existingHeadComments = await getFileHeadComments(
-                    outputFilePath,
-                );
-                const ymlString = yaml.dump(updatedYml, {
-                    quotingType: '"',
-                });
-
                 const outputDirPath = path.dirname(outputFilePath);
                 // Create a directory if it doesn't exist
                 try {
@@ -155,9 +146,9 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
 
                 await fs.writeFile(
                     outputFilePath,
-                    existingHeadComments
-                        ? `${existingHeadComments}\n${ymlString}`
-                        : ymlString,
+                    updatedYml.toString({
+                        quoteChar: '"',
+                    }),
                 );
             } catch (e) {
                 const msg = getErrorMessage(e);

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -80,6 +80,13 @@ export const SCHEMA_JSON = {
     ],
 };
 
+// invalid schema: models require a `name` field
+export const INVALID_SCHEMA_YML = `
+version: 2
+models:
+ - label: table_a
+`;
+
 export const CUSTOM_METRIC: AdditionalMetric = {
     name: 'new_metric',
     description: 'description',

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -135,8 +135,10 @@ models:
 
 export const NEW_MODEL = {
     name: 'new_model',
-    label: 'New model',
     description: `SQL model for testing`,
+    meta: {
+        label: 'New model',
+    },
     columns: [
         {
             name: 'new_column',
@@ -155,8 +157,9 @@ export const EXPECTED_SCHEMA_JSON_WITH_NEW_MODEL = {
 
 export const EXPECTED_SCHEMA_YML_WITH_NEW_MODEL = `models:
   - name: new_model
-    label: New model
     description: SQL model for testing
+    meta:
+      label: New model
     columns:
       - name: new_column
         meta:

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -1,9 +1,11 @@
+import { ParseError } from '../../types/errors';
 import DbtSchemaEditor from './DbtSchemaEditor';
 import {
     CUSTOM_METRIC,
     EXPECTED_SCHEMA_JSON_WITH_NEW_MODEL,
     EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
     EXPECTED_SCHEMA_YML_WITH_NEW_MODEL,
+    INVALID_SCHEMA_YML,
     NEW_MODEL,
     SCHEMA_JSON,
     SCHEMA_YML,
@@ -16,6 +18,12 @@ describe('DbtSchemaEditor', () => {
         expect(editor.toJS()).toEqual(SCHEMA_JSON);
         // can convert back to string
         expect(editor.toString()).toEqual(SCHEMA_YML);
+    });
+
+    it('should throw error with invalid yaml schema', () => {
+        expect(() => new DbtSchemaEditor(INVALID_SCHEMA_YML)).toThrowError(
+            ParseError,
+        );
     });
 
     it('should update the file for custom metrics', () => {

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -1,6 +1,13 @@
 import Ajv from 'ajv';
 import betterAjvErrors from 'better-ajv-errors';
-import { isMap, isSeq, parseDocument, type Document, type YAMLMap } from 'yaml';
+import {
+    isMap,
+    isSeq,
+    parseDocument,
+    YAMLSeq,
+    type Document,
+    type YAMLMap,
+} from 'yaml';
 import { parseAllReferences } from '../../compiler/exploreCompiler';
 import lightdashDbtYamlSchema from '../../schemas/json/lightdash-dbt-2.0.json';
 import { type DeepPartialNullable } from '../../types/deepPartial';
@@ -145,7 +152,15 @@ export default class DbtSchemaEditor {
                 `Column ${column.name} already exists in model ${modelName}`,
             );
         }
-        model.setIn(['columns'], column);
+
+        // If columns doesn't exist, create a new YAMLSeq
+        if (!isSeq(model.get('columns'))) {
+            model.set('columns', new YAMLSeq());
+        }
+
+        // Add the new column
+        model.addIn(['columns'], column);
+
         return this;
     }
 

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -312,15 +312,6 @@ export default class DbtSchemaEditor {
         );
     }
 
-    updateColumnDimensionType(
-        modelName: string,
-        columnName: string,
-        type: string,
-    ) {
-        const column = this.getColumnByName(modelName, columnName);
-        column.setIn(['meta', 'dimension', 'type'], type);
-    }
-
     // Returns the updated schema as a string(YAML)
     toString(options?: { quoteChar?: `'` | `"` }): string {
         return this.doc.toString({

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -127,7 +127,6 @@ export default class DbtSchemaEditor {
             .map<YamlColumn>((column) => column.toJSON());
     }
 
-    // TODO: the class should be the one converting the model to YamlModel
     addModel(model: YamlModel): DbtSchemaEditor {
         const models = this.doc.get('models');
         if (!isSeq(models)) {
@@ -140,7 +139,6 @@ export default class DbtSchemaEditor {
         return this;
     }
 
-    // Todo: the class should be the one converting the column to YamlColumn
     addColumn(modelName: string, column: YamlColumn): DbtSchemaEditor {
         const model = this.findModelByName(modelName);
         if (!model) {

--- a/packages/common/src/types/deepPartial.ts
+++ b/packages/common/src/types/deepPartial.ts
@@ -1,0 +1,13 @@
+/**
+ * DeepPartial
+ * Here's a utility type that makes all nested objects and arrays within a type partial as well. Usage:
+ * type PartialYamlModel = DeepPartial<YamlModel>;
+ */
+
+export type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[]
+        ? DeepPartial<U>[] // Handle arrays
+        : T[P] extends object
+        ? DeepPartial<T[P]> // Handle nested objects
+        : T[P]; // Handle primitive types
+};

--- a/packages/common/src/types/deepPartial.ts
+++ b/packages/common/src/types/deepPartial.ts
@@ -11,3 +11,16 @@ export type DeepPartial<T> = {
         ? DeepPartial<T[P]> // Handle nested objects
         : T[P]; // Handle primitive types
 };
+
+/**
+ * DeepPartialAndNullable
+ * Here's a utility type that makes all nested objects and arrays within a type partial as well, and allows null values. Usage:
+ * type PartialNullableYamlModel = DeepPartialNullable<YamlModel>;
+ */
+export type DeepPartialNullable<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[]
+        ? DeepPartial<U>[] | null // Handle arrays and allow null
+        : T[P] extends object
+        ? DeepPartial<T[P]> | null // Handle nested objects and allow null
+        : T[P] | null; // Handle primitive types and allow null
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5422 <!-- reference the related issue e.g. #150 -->
Closes: [#13896](https://github.com/lightdash/lightdash/issues/13896)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Changes:
- move schema validation to class constructor (+ test)
- refactor `lightdash generate` command to use the new class. Preserves YAML formatting and comments.

Update meta:

https://github.com/user-attachments/assets/fb53d90d-092d-4b25-ae87-0b296df6b4d5

Generate columns:

https://github.com/user-attachments/assets/635209e9-5e7d-430b-a490-3550dd8d26ac


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
