### PR TITLE
chore: add metadata to scheduler job creation logs

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -458,7 +458,13 @@ export class SchedulerClient {
             );
 
             Logger.info(
-                `Creating ${promises.length} scheduled delivery jobs for scheduler ${scheduler.schedulerUuid}`,
+                `Creating ${
+                    promises.length
+                } scheduled delivery jobs for scheduler ${
+                    scheduler.schedulerUuid
+                }. Cron: ${scheduler.cron} Timezone: ${
+                    scheduler.timezone || defaultTimezone
+                } Since: ${startingDateTime} Job dates: ${dates}`,
             );
             const jobs = await Promise.all(promises);
             jobs.map(async ({ jobId, date }) => {

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -464,9 +464,16 @@ export class SchedulerClient {
                     scheduler.schedulerUuid
                 }. Cron: ${scheduler.cron} Timezone: ${
                     scheduler.timezone || defaultTimezone
-                } Since: ${startingDateTime} Job dates: ${dates}`,
+                } Since: ${startingDateTime || '(now)'}`,
             );
             const jobs = await Promise.all(promises);
+            Logger.info(
+                `Created ${
+                    promises.length
+                } scheduled delivery jobs for scheduler ${
+                    scheduler.schedulerUuid
+                }. Job IDs: ${jobs.map((j) => j.jobId)}`,
+            );
             jobs.map(async ({ jobId, date }) => {
                 await this.schedulerModel.logSchedulerJob({
                     task: 'handleScheduledDelivery',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add more information when we generate scheduler jobs to facilitate debugging. 

```
packages/backend dev: 2025-03-04 09:29:52 [Lightdash] info: Creating 15 scheduled delivery jobs for scheduler 2c3927be-6bcb-48d8-a509-bb7197747f2c. Cron: 30 * * * * Timezone: UTC Since: (now)
packages/backend dev: 2025-03-04 09:29:52 [Lightdash] info: Created 15 scheduled delivery jobs for scheduler 2c3927be-6bcb-48d8-a509-bb7197747f2c. Job IDs: 203,209,213,210,212,211,214,216,217,215,204,205,206,207,208
```
<img width="1408" alt="Screenshot 2025-03-04 at 09 32 12" src="https://github.com/user-attachments/assets/2d363cb1-1c98-4025-8332-d7c6d8752e09" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
