### PR TITLE
fix:  disable calculate series color

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -42,6 +42,13 @@ export enum FeatureFlags {
      * Enable scheduler task that replaces custom metrics after project compile
      */
     ReplaceCustomMetricsOnCompile = 'replace-custom-metrics-on-compile',
+
+    /**
+     * Enable the dynamic calculation of series color, when not manually set on the chart config.
+     * This aims to make the colors more consistent, depending on the groups, but this could cause the opposite effect.
+     * For more details, see https://github.com/lightdash/lightdash/issues/13831
+     */
+    CalculateSeriesColor = 'calculate-series-color',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    FeatureFlags,
     assertUnreachable,
     isDimension,
     type ApiQueryResults,
@@ -27,6 +28,7 @@ import {
     calculateSeriesLikeIdentifier,
     isGroupedSeries,
 } from '../../hooks/useChartColorConfig/utils';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { type EchartSeriesClickEvent } from '../SimpleChart';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
@@ -192,12 +194,18 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
         [calculateKeyColorAssignment, itemsMap],
     );
 
+    const isCalculateSeriesColorEnabled = useFeatureFlagEnabled(
+        FeatureFlags.CalculateSeriesColor,
+    );
+
     /**
      * Gets a shared color for a given series.
      */
     const getSeriesColor = useCallback(
         (seriesLike: SeriesLike) => {
-            if (seriesLike.color) return seriesLike.color;
+            if (seriesLike.color && !isGroupedSeries(seriesLike)) {
+                return seriesLike.color;
+            }
 
             // Check if color is stored in metadata
             const serieId = calculateSeriesLikeIdentifier(seriesLike).join('.');
@@ -205,8 +213,9 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
                 chartConfig.type === ChartType.CARTESIAN
                     ? chartConfig.config?.metadata
                     : undefined;
-            if (metadata && metadata?.[serieId]?.color)
+            if (metadata && metadata?.[serieId]?.color) {
                 return metadata?.[serieId].color;
+            }
 
             /** Check if color is set in the dimension metadata */
 
@@ -235,14 +244,21 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
              * If this series is grouped, figure out a shared color assignment from the series;
              * otherwise, pick a series color from the palette based on its order.
              */
-            return isGroupedSeries(seriesLike)
+            return isGroupedSeries(seriesLike) && isCalculateSeriesColorEnabled
                 ? calculateSeriesColorAssignment(seriesLike)
                 : fallbackColors[
                       // Note: we don't use getSeriesId since we may not be dealing with a Series type here
                       calculateSeriesLikeIdentifier(seriesLike).join('|')
                   ];
         },
-        [calculateSeriesColorAssignment, fallbackColors, chartConfig, itemsMap],
+
+        [
+            calculateSeriesColorAssignment,
+            fallbackColors,
+            chartConfig,
+            itemsMap,
+            isCalculateSeriesColorEnabled,
+        ],
     );
 
     const value: Omit<

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -204,6 +204,9 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
     const getSeriesColor = useCallback(
         (seriesLike: SeriesLike) => {
             if (seriesLike.color && !isGroupedSeries(seriesLike)) {
+                // It doesn't make sense to use the color if it's a grouped series
+                // Grouped series colors should be in metadata
+                // this is likely to be a an leftover from a non-grouped chart
                 return seriesLike.color;
             }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/13831
Closes: https://github.com/lightdash/lightdash/issues/13464

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
I was able to replicate by removing the color on the groups (after looking at the chartconfig form the customer) . I even copied their org palette

THe colors were a bit random, when `calculateSeriesColorAssignment` was enabled. 

The good colors: 

![image](https://github.com/user-attachments/assets/3ad78249-5bd3-4699-9e47-4bde83b855d5)

Random colors: 

![Screenshot from 2025-03-04 16-27-43](https://github.com/user-attachments/assets/2a57015d-7e8b-4f2f-9f10-8b0221af036d)

Sometimes even the color in series were reversed: 

![Screenshot from 2025-03-04 16-38-45](https://github.com/user-attachments/assets/fed02612-9d50-4b0a-a405-948c278228be)



<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
