### PR TITLE
feat: feature flag write back for bin dimensions

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -49,6 +49,11 @@ export enum FeatureFlags {
      * For more details, see https://github.com/lightdash/lightdash/issues/13831
      */
     CalculateSeriesColor = 'calculate-series-color',
+
+    /**
+     * Enable the ability to write back custom bin dimensions to dbt.
+     */
+    WriteBackCustomBinDimensions = 'write-back-custom-bin-dimensions',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -7,6 +7,7 @@ import {
     type CompiledTable,
     type CustomDimension,
 } from '@lightdash/common';
+import { isCustomSqlDimension } from '@lightdash/common/dist';
 import {
     ActionIcon,
     Button,
@@ -134,6 +135,14 @@ const TableTreeSections: FC<Props> = ({
     const isCustomSqlEnabled = useFeatureFlagEnabled(
         FeatureFlags.CustomSQLEnabled,
     );
+    const isWriteBackCustomBinDimensionsEnabled = useFeatureFlagEnabled(
+        FeatureFlags.WriteBackCustomBinDimensions,
+    );
+    const customDimensionsToWriteBack = isWriteBackCustomBinDimensionsEnabled
+        ? allCustomDimensions
+        : allCustomDimensions?.filter(isCustomSqlDimension);
+    const hasCustomDimensionsToWriteBack =
+        customDimensionsToWriteBack && customDimensionsToWriteBack.length > 0;
 
     const customMetricsIssues: {
         [id: string]: {
@@ -411,7 +420,7 @@ const TableTreeSections: FC<Props> = ({
                             }}
                         />
                     </Group>
-                    {isCustomSqlEnabled && hasCustomDimensions && (
+                    {isCustomSqlEnabled && hasCustomDimensionsToWriteBack && (
                         <Tooltip label="Write back custom dimensions">
                             <ActionIcon
                                 onClick={() => {
@@ -428,13 +437,14 @@ const TableTreeSections: FC<Props> = ({
                                                     user.data.organizationUuid,
                                                 customMetricsCount: 0,
                                                 customDimensionsCount:
-                                                    allCustomDimensions?.length ||
+                                                    customDimensionsToWriteBack?.length ||
                                                     0,
                                             },
                                         });
                                     }
                                     toggleWriteBackModal({
-                                        items: allCustomDimensions || [],
+                                        items:
+                                            customDimensionsToWriteBack || [],
                                     });
                                 }}
                             >

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -122,6 +122,10 @@ const TreeSingleNodeActions: FC<Props> = ({
         FeatureFlags.CustomSQLEnabled,
     );
 
+    const isWriteBackCustomBinDimensionsEnabled = useFeatureFlagEnabled(
+        FeatureFlags.WriteBackCustomBinDimensions,
+    );
+
     const duplicateCustomMetric = (customMetric: AdditionalMetric) => {
         const newDeepCopyItem = JSON.parse(JSON.stringify(customMetric));
         let newId = uuidv4();
@@ -325,38 +329,41 @@ const TreeSingleNodeActions: FC<Props> = ({
                         >
                             Duplicate custom dimension
                         </Menu.Item>
-                        {isCustomSqlEnabled && (
-                            <Menu.Item
-                                component="button"
-                                icon={<MantineIcon icon={IconCode} />}
-                                onClick={(
-                                    e: React.MouseEvent<HTMLButtonElement>,
-                                ) => {
-                                    e.stopPropagation();
-                                    if (
-                                        projectUuid &&
-                                        user.data?.organizationUuid
-                                    ) {
-                                        track({
-                                            name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
-                                            properties: {
-                                                userId: user.data.userUuid,
-                                                projectId: projectUuid,
-                                                organizationId:
-                                                    user.data.organizationUuid,
-                                                customDimensionsCount: 1,
-                                            },
-                                        });
-                                    }
+                        {isCustomSqlEnabled &&
+                            (isCustomSqlDimension(item) ||
+                                isWriteBackCustomBinDimensionsEnabled) && (
+                                <Menu.Item
+                                    component="button"
+                                    icon={<MantineIcon icon={IconCode} />}
+                                    onClick={(
+                                        e: React.MouseEvent<HTMLButtonElement>,
+                                    ) => {
+                                        e.stopPropagation();
+                                        if (
+                                            projectUuid &&
+                                            user.data?.organizationUuid
+                                        ) {
+                                            track({
+                                                name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
+                                                properties: {
+                                                    userId: user.data.userUuid,
+                                                    projectId: projectUuid,
+                                                    organizationId:
+                                                        user.data
+                                                            .organizationUuid,
+                                                    customDimensionsCount: 1,
+                                                },
+                                            });
+                                        }
 
-                                    toggleWriteBackModal({
-                                        items: [item],
-                                    });
-                                }}
-                            >
-                                Write back to dbt
-                            </Menu.Item>
-                        )}
+                                        toggleWriteBackModal({
+                                            items: [item],
+                                        });
+                                    }}
+                                >
+                                    Write back to dbt
+                                </Menu.Item>
+                            )}
 
                         <Menu.Item
                             color="red"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Hiding option to write back bin dimensions until known limitations are addressed or mitigated.

### Known limitations

#### Fixed number of bins

This bin type cannot be moved to dbt as it requires a CTE to pre-calculate the values.
We recommend users moving the bin logic to dbt and creating a new dimension in dbt.

#### Preview binning SQL

When writing back a bin dimension, the SQL shown in the preview may not have the correct column references and syntax.
Please ensure the SQL is correct before merging the pull request.

Example preview:
```
order_id_test_bin:
  label: Test bin
  type: string
  sql: >-
    /* This is a preview! Replace column references and confirm SQL before using in production. */
    CONCAT(FLOOR(${reference_column} / 10) * 10, ' - ',
    (FLOOR(${reference_column} / 10) + 1) * 10 - 1)
```

#### Replace custom dimensions with new dimension

This is not possible at the moment. If you have a custom dimension that you want to replace with a new dimension, you will need to manually update the chart configuration.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
