### PR TITLE
chore: throw ReadFileError on pdf image buffer read

### DIFF
--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -14,6 +14,7 @@ export const IGNORE_ERRORS = [
     'TokenError',
     'AuthorizationError',
     'SshTunnelError',
+    'ReadFileError',
 ];
 
 Sentry.init({

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -427,3 +427,14 @@ export class SshTunnelError extends LightdashError {
         });
     }
 }
+
+export class ReadFileError extends LightdashError {
+    constructor(message: string, data: { [key: string]: AnyType } = {}) {
+        super({
+            message,
+            name: 'ReadFileError',
+            statusCode: 404,
+            data,
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Ignore ReadFileError's in Sentry when a pdf is being added as an attachment to a scheduled delivery. 

Example: 
https://lightdash.sentry.io/issues/6363169049/events/e7584f5750f74c92a49a82e3ff0e88de?environment=cloud_beta&project=5959292&referrer=alert-rule-issue-list

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
