### PR TITLE
fix: Address `getAuthenticationToken` error when unfurling urls in Slackbot

### DIFF
--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -102,7 +102,7 @@ export class SlackAuthenticationModel {
             )
             .select<(DbSlackAuthTokens & DbUser)[]>('*')
             .where('slack_team_id', teamId);
-        if (isNil(row) || isNil(row.user_uuid)) {
+        if (isNil(row?.user_uuid)) {
             throw new Error(`Could not find user uuid id ${teamId}`);
         }
         return row.user_uuid;

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { Installation, InstallationQuery } from '@slack/bolt';
 import { Knex } from 'knex';
+import isNil from 'lodash/isNil';
 import { DbOrganization } from '../database/entities/organizations';
 import {
     DbSlackAuthTokens,
@@ -101,7 +102,7 @@ export class SlackAuthenticationModel {
             )
             .select<(DbSlackAuthTokens & DbUser)[]>('*')
             .where('slack_team_id', teamId);
-        if (row === undefined) {
+        if (isNil(row) || isNil(row.user_uuid)) {
             throw new Error(`Could not find user uuid id ${teamId}`);
         }
         return row.user_uuid;


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13957

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
`getAuthenticationToken` function was receiving `null` as an argument and failing
https://github.com/lightdash/lightdash/blob/85bc1adad69b46070f8dd7976cf6ffde7b1780dc/packages/backend/src/routers/headlessBrowser.ts#L15

The only way for this to happen is for `getUserUuid` function to return null https://github.com/lightdash/lightdash/blob/3d04a286ff909d5a27fa734bf8775354bb33fc6d/packages/backend/src/clients/Slack/Slackbot.ts#L193

This could happen in cases when user which installed the slack integration got deleted, row got cascaded and `user_uuid` points to `NULL`

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
