### PR TITLE
fix: revert check for groups in series coloring

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -203,12 +203,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
      */
     const getSeriesColor = useCallback(
         (seriesLike: SeriesLike) => {
-            if (seriesLike.color && !isGroupedSeries(seriesLike)) {
-                // It doesn't make sense to use the color if it's a grouped series
-                // Grouped series colors should be in metadata
-                // this is likely to be a an leftover from a non-grouped chart
-                return seriesLike.color;
-            }
+            if (seriesLike.color) return seriesLike.color;
 
             // Check if color is stored in metadata
             const serieId = calculateSeriesLikeIdentifier(seriesLike).join('.');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Reverts a change to ungrouped color picking

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
