### PR TITLE
fix: optimize sql runner search

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTables.tsx
@@ -80,13 +80,12 @@ export const useTables = ({ projectUuid, search }: GetTablesParams) => {
 
                     return {
                         schema,
-                        tables: fuseResult.reduce<typeof tables>(
-                            (acc, tableName) => {
+                        tables: fuseResult
+                            .slice(0, 100)
+                            .reduce<typeof tables>((acc, tableName) => {
                                 acc[tableName] = tables[tableName];
                                 return acc;
-                            },
-                            {},
-                        ),
+                            }, {}),
                     };
                 })
                 .filter(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
issues 

- because of the search hook, we were doing the `select` on every rerender : fixed by moving the filtering and select into a memo 
- table was using search, not debounced search, so it was rendering too often 
- when search happens, we expand all tables, but when characters were deleted, we were showing all items without filtering, causing too many items to render 
- 
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
