### PR TITLE
chore: add SlackError class

### DIFF
--- a/packages/backend/src/clients/Slack/Slackbot.ts
+++ b/packages/backend/src/clients/Slack/Slackbot.ts
@@ -2,14 +2,15 @@ import {
     AnyType,
     getErrorMessage,
     LightdashMode,
+    ScreenshotError,
     SlackInstallationNotFoundError,
 } from '@lightdash/common';
-import * as Sentry from '@sentry/node';
 import { App, ExpressReceiver, LogLevel } from '@slack/bolt';
 import { Express } from 'express';
 import { nanoid } from 'nanoid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import { slackErrorHandler } from '../../errors';
 import Logger from '../../logging/logger';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import {
@@ -235,8 +236,9 @@ export class SlackBot {
                         appProfilePhotoUrl,
                     });
                 }
-
-                Sentry.captureException(e);
+                if (!(e instanceof ScreenshotError)) {
+                    slackErrorHandler(e, 'Unable to unfurl slack URL');
+                }
 
                 this.analytics.track({
                     event: 'share_slack.unfurl_error',

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -363,6 +363,20 @@ export class SlackInstallationNotFoundError extends LightdashError {
     }
 }
 
+export class SlackError extends LightdashError {
+    constructor(
+        message: string = 'Slack API error occurred',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'SlackError',
+            statusCode: 400,
+            data,
+        });
+    }
+}
+
 export class UnexpectedGoogleSheetsError extends LightdashError {
     constructor(
         message = 'Unexpected error in Google sheets client',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://lightdash.sentry.io/issues/6367790428/?environment=cloud_beta&query=missing_scope&referrer=issue-stream&sort=date&statsPeriod=30d&stream_index=0

### Description:

Followed suggestion here: https://github.com/slackapi/node-slack-sdk/blob/039bd050cd736d666d063397067cb014adf23711/packages/web-api/README.md?plain=1#L142

I would like to group first, then figure out which SlackError's to filter out on the UI and alerting in Sentry

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
