### PR TITLE
fix: handle unauthorized and invalid_grant errors from google

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -54,32 +54,27 @@ export class GoogleDriveClient {
         }
     }
 
-    private static async changeTabTitle(
-        sheets: sheets_v4.Sheets,
-        fileId: string,
-        title: string,
-    ) {
-        const spreadsheet = await sheets.spreadsheets.get({
-            spreadsheetId: fileId,
-        });
-        await sheets.spreadsheets.batchUpdate({
-            spreadsheetId: fileId,
-            requestBody: {
-                requests: [
-                    {
-                        updateSheetProperties: {
-                            properties: {
-                                sheetId:
-                                    spreadsheet.data.sheets?.[0].properties
-                                        ?.sheetId,
-                                title,
-                            },
-                            fields: 'title',
-                        },
-                    },
-                ],
-            },
-        });
+    private static async catchForbiddenError<T>(promise: Promise<T>) {
+        try {
+            return await promise;
+        } catch (err: AnyType) {
+            if (err?.response?.status === 401) {
+                throw new ForbiddenError(
+                    `Failed to authorize: ${err.response.data?.error}: ${err.response.data?.error_description}`,
+                );
+            }
+
+            if (
+                err?.response?.status === 400 &&
+                err?.response?.data?.error === 'invalid_grant'
+            ) {
+                throw new ForbiddenError(
+                    `Failed to refresh token: ${err.response.data.error}: ${err.response.data.error_description}`,
+                );
+            }
+
+            throw err;
+        }
     }
 
     async createNewTab(refreshToken: string, fileId: string, tabName: string) {
@@ -91,8 +86,8 @@ export class GoogleDriveClient {
 
         // Creates a new tab in the sheet
         const tabTitle = tabName.replaceAll(':', '.'); // we can't use ranges with colons in their tab ids
-        await sheets.spreadsheets
-            .batchUpdate({
+        await GoogleDriveClient.catchForbiddenError(
+            sheets.spreadsheets.batchUpdate({
                 spreadsheetId: fileId,
                 requestBody: {
                     requests: [
@@ -105,20 +100,20 @@ export class GoogleDriveClient {
                         },
                     ],
                 },
-            })
-            .catch((error) => {
-                if (
-                    error.code === 400 &&
-                    error.errors[0]?.message.includes(tabName)
-                ) {
-                    Logger.debug(
-                        `Google sheet tab already exists, we will overwrite it: ${error.errors[0]?.message}`,
-                    );
-                } else if (error.code === 500) {
-                    // This is a transient error, we will retry the request later
-                    throw new GoogleSheetsTransientError(error);
-                }
-            });
+            }),
+        ).catch((error) => {
+            if (
+                error.code === 400 &&
+                error?.errors[0]?.message.includes(tabName)
+            ) {
+                Logger.debug(
+                    `Google sheet tab already exists, we will overwrite it: ${error.errors[0]?.message}`,
+                );
+            } else if (error.code === 500) {
+                // This is a transient error, we will retry the request later
+                throw new GoogleSheetsTransientError(error);
+            }
+        });
 
         return tabTitle;
     }
@@ -130,13 +125,15 @@ export class GoogleDriveClient {
         const auth = await this.getCredentials(refreshToken);
         const sheets = google.sheets({ version: 'v4', auth });
 
-        const response = await sheets.spreadsheets.create({
-            requestBody: {
-                properties: {
-                    title,
+        const response = await GoogleDriveClient.catchForbiddenError(
+            sheets.spreadsheets.create({
+                requestBody: {
+                    properties: {
+                        title,
+                    },
                 },
-            },
-        });
+            }),
+        );
         return response.data;
     }
 
@@ -171,14 +168,16 @@ export class GoogleDriveClient {
             ...tabsUpdated,
         ];
 
-        await sheets.spreadsheets.values.update({
-            spreadsheetId: fileId,
-            range: `${metadataTabName}!A1`,
-            valueInputOption: 'USER_ENTERED',
-            requestBody: {
-                values: metadata,
-            },
-        });
+        await GoogleDriveClient.catchForbiddenError(
+            sheets.spreadsheets.values.update({
+                spreadsheetId: fileId,
+                range: `${metadataTabName}!A1`,
+                valueInputOption: 'USER_ENTERED',
+                requestBody: {
+                    values: metadata,
+                },
+            }),
+        );
     }
 
     private static async clearTabName(
@@ -190,9 +189,11 @@ export class GoogleDriveClient {
         // So instead we select all the cells in the first tab by its name
         try {
             if (tabName === undefined) {
-                const spreadsheet = await sheets.spreadsheets.get({
-                    spreadsheetId: fileId,
-                });
+                const spreadsheet = await GoogleDriveClient.catchForbiddenError(
+                    sheets.spreadsheets.get({
+                        spreadsheetId: fileId,
+                    }),
+                );
                 const firstSheetName =
                     spreadsheet.data.sheets?.[0].properties?.title;
                 if (!firstSheetName) {
@@ -201,17 +202,21 @@ export class GoogleDriveClient {
                     );
                 }
                 Logger.debug(`Clearing first sheet name ${firstSheetName}`);
-                await sheets.spreadsheets.values.clear({
-                    spreadsheetId: fileId,
-                    range: firstSheetName,
-                });
+                await GoogleDriveClient.catchForbiddenError(
+                    sheets.spreadsheets.values.clear({
+                        spreadsheetId: fileId,
+                        range: firstSheetName,
+                    }),
+                );
             } else {
                 Logger.debug(`Clearing sheet name ${tabName}`);
 
-                await sheets.spreadsheets.values.clear({
-                    spreadsheetId: fileId,
-                    range: tabName,
-                });
+                await GoogleDriveClient.catchForbiddenError(
+                    sheets.spreadsheets.values.clear({
+                        spreadsheetId: fileId,
+                        range: tabName,
+                    }),
+                );
             }
         } catch (error) {
             Logger.error('Unable to clear the sheet', error);
@@ -345,13 +350,15 @@ export class GoogleDriveClient {
             `Writing ${results.length} rows and ${results[0].length} columns to Google sheets`,
         );
 
-        await sheets.spreadsheets.values.update({
-            spreadsheetId: fileId,
-            range: sanitizedTabName ? `${sanitizedTabName}!A1` : 'A1',
-            valueInputOption: 'RAW',
-            requestBody: {
-                values: results,
-            },
-        });
+        await GoogleDriveClient.catchForbiddenError(
+            sheets.spreadsheets.values.update({
+                spreadsheetId: fileId,
+                range: sanitizedTabName ? `${sanitizedTabName}!A1` : 'A1',
+                valueInputOption: 'RAW',
+                requestBody: {
+                    values: results,
+                },
+            }),
+        );
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13884


### Description:
<!-- Add a description of the changes proposed in the pull request. -->
The problem was that:

1.  [`GoogleDriveClient#getCredentials` method](https://github.com/lightdash/lightdash/blob/eeb6b20382a475c8ee27d2e949640353d46c5a5f/packages/backend/src/clients/Google/GoogleDriveClient.ts#L39-L55) is not actually checking wether existing credentials are valid, only checks if they exist
2. Each different request to google could throw an 401/400 error
3. The errors thrown were not `ForbiddenError`s  thus they weren't caught by [`shouldDisableSync`](https://github.com/lightdash/lightdash/blob/ab042358d45223ef15492715417ab47d6c19cb4c/packages/backend/src/scheduler/SchedulerTask.ts#L1992-L1995) and sync was not disabled

As a solution I wrapped each google api call in a try/catch that properly handles the errors
<!-- Even better add a screenshot / gif / loom -->

Before:
![image](https://github.com/user-attachments/assets/74a45a65-ca0a-4816-9082-985d88933cfb)

After:
![image](https://github.com/user-attachments/assets/69ad917f-0c60-4528-baef-f08ba5088447)


To reproduce:
1. Setup `Google Sheets Sync` on a chart
2. Manually revoke Lightdash app from the google accounts
3. Wait for sync worker to run and you'll get `invalid_grant` error
### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
