### PR TITLE
fix: new dashboard menu item is missing for developers and editors

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -14,6 +14,7 @@ import { memo, useState, type FC } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
 import { useSemanticLayerInfo } from '../../features/semanticViewer/api/hooks';
 import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import useCreateInAnySpaceAccess from '../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import LargeMenuItem from '../common/LargeMenuItem';
@@ -30,11 +31,16 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
     const navigate = useNavigate();
     const location = useLocation();
 
+    const { user } = useApp();
+
+    const userCanCreateDashboards = useCreateInAnySpaceAccess(
+        projectUuid,
+        'Dashboard',
+    );
+
     const isSemanticLayerEnabled = useFeatureFlagEnabled(
         FeatureFlags.SemanticLayerEnabled,
     );
-
-    const { user } = useApp();
 
     const semanticLayerInfoQuery = useSemanticLayerInfo(
         { projectUuid },
@@ -141,13 +147,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             />
                         </Can>
 
-                        <Can
-                            I="create"
-                            this={subject('Dashboard', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
+                        {userCanCreateDashboards && (
                             <LargeMenuItem
                                 title="Dashboard"
                                 description="Arrange multiple charts into a single view."
@@ -155,7 +155,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 icon={IconLayoutDashboard}
                                 data-testid="ExploreMenu/NewDashboardButton"
                             />
-                        </Can>
+                        )}
 
                         <Can
                             I="create"


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/13975

### Description:

![CleanShot 2025-03-07 at 20 50 02@2x](https://github.com/user-attachments/assets/1f76d66d-c887-4cbc-8760-1a82e39a7db0)

![CleanShot 2025-03-07 at 20 50 20@2x](https://github.com/user-attachments/assets/b098041f-8fe8-40a9-937b-61fcc2b66bc2)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
