### PR TITLE
fix(refactor): query results hook

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -38,7 +38,16 @@ export const ExplorerResults = memo(() => {
     const resultsData = useExplorerContext(
         (context) => context.queryResults.data,
     );
-    const status = useExplorerContext((context) => context.queryResults.status);
+    const status = useExplorerContext((context) => {
+        // Don't return context.queryResults.status because we changed from mutation to query so 'loading' as a different meaning
+        if (context.queryResults.isFetching) {
+            return 'loading';
+        } else if (context.queryResults.status === 'loading') {
+            return 'idle';
+        } else {
+            return context.queryResults.status;
+        }
+    });
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -42,7 +42,7 @@ const VisualizationCard: FC<{
     );
 
     const isLoadingQueryResults = useExplorerContext(
-        (context) => context.queryResults.isLoading,
+        (context) => context.queryResults.isFetching,
     );
     const queryResults = useExplorerContext(
         (context) => context.queryResults.data,

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -32,7 +32,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
         (context) => context.state.isValidQuery,
     );
     const isLoading = useExplorerContext(
-        (context) => context.queryResults.isLoading,
+        (context) => context.queryResults.isFetching,
     );
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -87,7 +87,9 @@ export const useUpdateMutation = (uuid: string) => {
                 await queryClient.invalidateQueries(['projects']);
                 await queryClient.invalidateQueries(['project', uuid]);
                 await queryClient.invalidateQueries(['tables']);
-                await queryClient.invalidateQueries(['queryResults']);
+                await queryClient.invalidateQueries(['query-all-results'], {
+                    exact: false,
+                });
                 await queryClient.invalidateQueries(['status']);
             },
             onError: ({ error }) => {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -259,7 +259,7 @@ export const useQueryResults = (data: QueryResultsProps | null) => {
         forbiddenToastTitle: 'Error running query',
     });
     const result = useQuery<ApiQueryResults, ApiError>({
-        enabled: true,
+        enabled: !!data,
         queryKey: ['query-all-results', data],
         queryFn: () => {
             if (data?.chartUuid && data?.chartVersionUuid) {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -1,4 +1,5 @@
 import {
+    ParameterError,
     type ApiChartAndResults,
     type ApiError,
     type ApiQueryResults,
@@ -7,8 +8,8 @@ import {
     type MetricQuery,
     type SortField,
 } from '@lightdash/common';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -16,27 +17,24 @@ import {
     convertDateDashboardFilters,
     convertDateFilters,
 } from '../utils/dateFilter';
-import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
-type QueryResultsProps = {
+export type QueryResultsProps = {
     projectUuid: string;
     tableId: string;
     query?: MetricQuery;
     csvLimit?: number | null; //giving null returns all results (no limit)
     chartUuid?: string;
+    chartVersionUuid?: string;
     dateZoomGranularity?: DateGranularity;
     context?: string;
 };
 
 const getChartResults = async ({
     chartUuid,
-    invalidateCache,
     context,
 }: {
     chartUuid?: string;
-    invalidateCache?: boolean;
-    dashboardSorts?: SortField[];
     context?: string;
 }) => {
     return lightdashApi<ApiQueryResults>({
@@ -44,9 +42,7 @@ const getChartResults = async ({
             context ? `?context=${context}` : ''
         }`,
         method: 'POST',
-        body: JSON.stringify({
-            ...(invalidateCache && { invalidateCache: true }),
-        }),
+        body: undefined,
     });
 };
 
@@ -108,74 +104,6 @@ const getQueryResults = async ({
             context,
         }),
     });
-};
-
-export const useQueryResults = (props?: {
-    chartUuid?: string;
-    isViewOnly?: boolean;
-    dateZoomGranularity?: DateGranularity;
-    context?: string;
-}) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
-    const setErrorResponse = useQueryError({
-        forceToastOnForbidden: true,
-        forbiddenToastTitle: 'Error running query',
-    });
-
-    const fetchQuery =
-        props?.isViewOnly === true ? getChartResults : getQueryResults;
-    const mutation = useMutation<ApiQueryResults, ApiError, QueryResultsProps>(
-        fetchQuery,
-        {
-            mutationKey: ['queryResults'],
-            onError: (error) => {
-                setErrorResponse(error);
-            },
-        },
-    );
-
-    const { mutateAsync } = mutation;
-
-    const mutateAsyncOverride = useCallback(
-        async (tableName: string, metricQuery: MetricQuery) => {
-            const fields = new Set([
-                ...metricQuery.dimensions,
-                ...metricQuery.metrics,
-                ...metricQuery.tableCalculations.map(({ name }) => name),
-            ]);
-            const isValidQuery = fields.size > 0;
-            if (!!tableName && isValidQuery && projectUuid) {
-                await mutateAsync({
-                    projectUuid,
-                    tableId: tableName,
-                    query: metricQuery,
-                    chartUuid: props?.chartUuid,
-                    dateZoomGranularity: props?.dateZoomGranularity,
-                    context: props?.context,
-                });
-            } else {
-                console.warn(
-                    `Can't make SQL request, invalid state`,
-                    tableName,
-                    isValidQuery,
-                    metricQuery,
-                );
-                return Promise.reject();
-            }
-        },
-        [
-            mutateAsync,
-            projectUuid,
-            props?.chartUuid,
-            props?.dateZoomGranularity,
-            props?.context,
-        ],
-    );
-
-    return useMemo(
-        () => ({ ...mutation, mutateAsync: mutateAsyncOverride }),
-        [mutation, mutateAsyncOverride],
-    );
 };
 
 const getUnderlyingDataResults = async ({
@@ -325,40 +253,38 @@ const getChartVersionResults = async (
     });
 };
 
-export const useChartVersionResultsMutation = (
-    chartUuid: string | undefined,
-    versionUuid?: string,
-) => {
-    const { showToastApiError } = useToaster();
-    const mutation = useMutation<ApiQueryResults, ApiError>(
-        () =>
-            chartUuid && versionUuid
-                ? getChartVersionResults(chartUuid, versionUuid)
-                : Promise.reject(),
-        {
-            mutationKey: ['chartVersionResults', chartUuid, versionUuid],
-            onError: ({ error }) => {
-                showToastApiError({
-                    title: 'Error running query',
-                    apiError: error,
-                });
-            },
-        },
-    );
-    const { mutateAsync } = mutation;
-    // needs these args to work with ExplorerProvider
-    const mutateAsyncOverride = useCallback(
-        async (_tableName: string, _metricQuery: MetricQuery) => {
-            await mutateAsync();
-        },
-        [mutateAsync],
-    );
+export const useQueryResults = (data: QueryResultsProps | null) => {
+    const setErrorResponse = useQueryError({
+        forceToastOnForbidden: true,
+        forbiddenToastTitle: 'Error running query',
+    });
+    const result = useQuery<ApiQueryResults, ApiError>({
+        enabled: true,
+        queryKey: ['query-all-results', data],
+        queryFn: () => {
+            if (data?.chartUuid && data?.chartVersionUuid) {
+                return getChartVersionResults(
+                    data.chartUuid,
+                    data.chartVersionUuid,
+                );
+            } else if (data?.chartUuid) {
+                return getChartResults(data);
+            } else if (data) {
+                return getQueryResults(data);
+            }
 
-    return useMemo(
-        () => ({
-            ...mutation,
-            mutateAsync: mutateAsyncOverride,
-        }),
-        [mutation, mutateAsyncOverride],
-    );
+            return Promise.reject(
+                new ParameterError('Missing QueryResultsProps'),
+            );
+        },
+    });
+
+    // On Error
+    useEffect(() => {
+        if (result.error) {
+            setErrorResponse(result.error);
+        }
+    }, [result.error, setErrorResponse]);
+
+    return result;
 };

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -30,7 +30,6 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
-import { useChartVersionResultsMutation } from '../hooks/useQueryResults';
 import {
     useChartHistory,
     useChartVersion,
@@ -63,11 +62,6 @@ const ChartHistory = () => {
     }, [selectedVersionUuid, historyQuery.data]);
 
     const chartVersionQuery = useChartVersion(
-        savedQueryUuid,
-        selectedVersionUuid,
-    );
-
-    const queryResults = useChartVersionResultsMutation(
         savedQueryUuid,
         selectedVersionUuid,
     );
@@ -252,7 +246,14 @@ const ChartHistory = () => {
             {chartVersionQuery.data && (
                 <ExplorerProvider
                     key={selectedVersionUuid}
-                    queryResults={queryResults}
+                    viewModeQueryArgs={
+                        savedQueryUuid && selectedVersionUuid
+                            ? {
+                                  chartUuid: savedQueryUuid,
+                                  chartVersionUuid: selectedVersionUuid,
+                              }
+                            : undefined
+                    }
                     initialState={{
                         shouldFetchResults: true,
                         previouslyFetchedState: undefined,

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -13,7 +13,6 @@ import {
     useExplorerRoute,
     useExplorerUrlState,
 } from '../hooks/useExplorerRoute';
-import { useQueryResults } from '../hooks/useQueryResults';
 import useApp from '../providers/App/useApp';
 import ExplorerProvider from '../providers/Explorer/ExplorerProvider';
 import useExplorerContext from '../providers/Explorer/useExplorerContext';
@@ -50,8 +49,6 @@ const ExplorerPage = memo(() => {
 
     const dateZoomGranularity = useDateZoomGranularitySearch();
 
-    const queryResults = useQueryResults({ dateZoomGranularity });
-
     const cannotViewProject = user.data?.ability?.cannot(
         'view',
         subject('Project', {
@@ -75,8 +72,8 @@ const ExplorerPage = memo(() => {
         <ExplorerProvider
             isEditMode={true}
             initialState={explorerUrlState}
-            queryResults={queryResults}
             defaultLimit={health.data?.query.defaultLimit}
+            dateZoomGranularity={dateZoomGranularity}
         >
             <ExplorerWithUrlParams />
         </ExplorerProvider>

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
 import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
-import { useQueryResults } from '../hooks/useQueryResults';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useSearchParams from '../hooks/useSearchParams';
 import useApp from '../providers/App/useApp';
@@ -31,7 +30,7 @@ const MinimalExplorer: FC = () => {
     );
 
     const isLoadingQueryResults = useExplorerContext(
-        (context) => context.queryResults.isLoading,
+        (context) => context.queryResults.isFetching,
     );
 
     if (!savedChart || health.isInitialLoading || !health.data) {
@@ -76,13 +75,6 @@ const MinimalSavedExplorer: FC = () => {
 
     const dateZoomGranularity = useDateZoomGranularitySearch();
 
-    const queryResults = useQueryResults({
-        chartUuid: savedQueryUuid,
-        isViewOnly: true,
-        dateZoomGranularity,
-        context,
-    });
-
     if (isInitialLoading) {
         return null;
     }
@@ -93,7 +85,12 @@ const MinimalSavedExplorer: FC = () => {
 
     return (
         <ExplorerProvider
-            queryResults={queryResults}
+            viewModeQueryArgs={
+                savedQueryUuid
+                    ? { chartUuid: savedQueryUuid, context }
+                    : undefined
+            }
+            dateZoomGranularity={dateZoomGranularity}
             savedChart={data}
             initialState={
                 data

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -11,7 +11,6 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useChartPinningMutation } from '../hooks/pinning/useChartPinningMutation';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
-import { useQueryResults } from '../hooks/useQueryResults';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import ExplorerProvider from '../providers/Explorer/ExplorerProvider';
@@ -32,11 +31,6 @@ const SavedExplorer = () => {
 
     const { data, isInitialLoading, error } = useSavedQuery({
         id: savedQueryUuid,
-    });
-
-    const queryResults = useQueryResults({
-        chartUuid: savedQueryUuid,
-        isViewOnly: !isEditMode,
     });
 
     const { mutate: togglePinChart } = useChartPinningMutation();
@@ -84,8 +78,10 @@ const SavedExplorer = () => {
 
     return (
         <ExplorerProvider
-            queryResults={queryResults}
             isEditMode={isEditMode}
+            viewModeQueryArgs={
+                savedQueryUuid ? { chartUuid: savedQueryUuid } : undefined
+            }
             initialState={
                 data
                     ? {

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1591,9 +1591,17 @@ const ExplorerProvider: FC<
         if (unsavedChartVersion.metricQuery.sorts.length <= 0 && defaultSort) {
             setSortFields([defaultSort]);
         } else {
+            // force new results even when query is the same
+            clearQueryResults();
             runQuery();
         }
-    }, [defaultSort, runQuery, unsavedChartVersion, setSortFields]);
+    }, [
+        unsavedChartVersion.metricQuery.sorts.length,
+        defaultSort,
+        setSortFields,
+        clearQueryResults,
+        runQuery,
+    ]);
 
     const actions = useMemo(
         () => ({

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1,6 +1,6 @@
 import {
-    ChartType,
     assertUnreachable,
+    ChartType,
     convertFieldRefToFieldId,
     deepEqual,
     getFieldRef,
@@ -15,6 +15,7 @@ import {
     type ChartConfig,
     type CustomDimension,
     type CustomFormat,
+    type DateGranularity,
     type FieldId,
     type Metric,
     type MetricQuery,
@@ -32,14 +33,15 @@ import {
     useMemo,
     useReducer,
     useRef,
+    useState,
     type FC,
 } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import useDefaultSortField from '../../hooks/useDefaultSortField';
 import {
-    type useChartVersionResultsMutation,
-    type useQueryResults,
+    useQueryResults,
+    type QueryResultsProps,
 } from '../../hooks/useQueryResults';
 import ExplorerContext from './context';
 import {
@@ -1023,9 +1025,10 @@ const ExplorerProvider: FC<
         initialState?: ExplorerReduceState;
         savedChart?: SavedChart;
         defaultLimit?: number;
-        queryResults: ReturnType<
-            typeof useQueryResults | typeof useChartVersionResultsMutation
-        >;
+        viewModeQueryArgs?:
+            | { chartUuid: string; context?: string }
+            | { chartUuid: string; chartVersionUuid: string };
+        dateZoomGranularity?: DateGranularity;
     }>
 > = ({
     isEditMode = false,
@@ -1033,7 +1036,8 @@ const ExplorerProvider: FC<
     savedChart,
     defaultLimit,
     children,
-    queryResults,
+    viewModeQueryArgs,
+    dateZoomGranularity,
 }) => {
     const defaultStateWithConfig = useMemo(
         () => ({
@@ -1490,41 +1494,59 @@ const ExplorerProvider: FC<
     );
 
     // Fetch query results after state update
-    const { mutateAsync: mutateAsyncQuery, reset: resetQueryResults } =
-        queryResults;
+    const [validQueryArgs, setValidQueryArgs] =
+        useState<QueryResultsProps | null>(null);
+    const queryResults = useQueryResults(validQueryArgs);
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { remove: clearQueryResults } = queryResults;
+    const resetQueryResults = useCallback(() => {
+        setValidQueryArgs(null);
+        clearQueryResults();
+    }, [clearQueryResults]);
 
-    const mutateAsync = useCallback(async () => {
-        try {
-            const result = await mutateAsyncQuery(
-                unsavedChartVersion.tableName,
-                unsavedChartVersion.metricQuery,
-            );
-
+    const runQuery = useCallback(() => {
+        const fields = new Set([
+            ...unsavedChartVersion.metricQuery.dimensions,
+            ...unsavedChartVersion.metricQuery.metrics,
+            ...unsavedChartVersion.metricQuery.tableCalculations.map(
+                ({ name }) => name,
+            ),
+        ]);
+        const hasFields = fields.size > 0;
+        if (!!unsavedChartVersion.tableName && hasFields && projectUuid) {
+            setValidQueryArgs({
+                projectUuid,
+                tableId: unsavedChartVersion.tableName,
+                query: unsavedChartVersion.metricQuery,
+                ...(isEditMode ? {} : viewModeQueryArgs),
+                dateZoomGranularity,
+            });
             dispatch({
                 type: ActionType.SET_PREVIOUSLY_FETCHED_STATE,
                 payload: cloneDeep(unsavedChartVersion.metricQuery),
             });
-
-            return result;
-        } catch (e) {
-            console.error(e);
+        } else {
+            console.warn(
+                `Can't make SQL request, invalid state`,
+                unsavedChartVersion.tableName,
+                hasFields,
+                unsavedChartVersion.metricQuery,
+            );
         }
     }, [
-        mutateAsyncQuery,
-        unsavedChartVersion.tableName,
         unsavedChartVersion.metricQuery,
+        unsavedChartVersion.tableName,
+        projectUuid,
+        isEditMode,
+        viewModeQueryArgs,
+        dateZoomGranularity,
     ]);
 
     useEffect(() => {
         if (!state.shouldFetchResults) return;
-
-        async function fetchResults() {
-            await mutateAsync();
-            dispatch({ type: ActionType.SET_FETCH_RESULTS_FALSE });
-        }
-
-        void fetchResults();
-    }, [mutateAsync, state.shouldFetchResults]);
+        runQuery();
+        dispatch({ type: ActionType.SET_FETCH_RESULTS_FALSE });
+    }, [runQuery, state.shouldFetchResults]);
 
     const clearExplore = useCallback(async () => {
         resetCachedChartConfig();
@@ -1569,9 +1591,9 @@ const ExplorerProvider: FC<
         if (unsavedChartVersion.metricQuery.sorts.length <= 0 && defaultSort) {
             setSortFields([defaultSort]);
         } else {
-            return mutateAsync();
+            runQuery();
         }
-    }, [defaultSort, mutateAsync, unsavedChartVersion, setSortFields]);
+    }, [defaultSort, runQuery, unsavedChartVersion, setSortFields]);
 
     const actions = useMemo(
         () => ({

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1493,7 +1493,6 @@ const ExplorerProvider: FC<
         ],
     );
 
-    // Fetch query results after state update
     const [validQueryArgs, setValidQueryArgs] =
         useState<QueryResultsProps | null>(null);
     const queryResults = useQueryResults(validQueryArgs);
@@ -1504,6 +1503,7 @@ const ExplorerProvider: FC<
         clearQueryResults();
     }, [clearQueryResults]);
 
+    // Prepares and executes query if all required parameters exist
     const runQuery = useCallback(() => {
         const fields = new Set([
             ...unsavedChartVersion.metricQuery.dimensions,

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -23,10 +23,7 @@ import {
     type TableChartConfig,
     type TimeZone,
 } from '@lightdash/common';
-import {
-    type useChartVersionResultsMutation,
-    type useQueryResults,
-} from '../../hooks/useQueryResults';
+import { type useQueryResults } from '../../hooks/useQueryResults';
 
 export enum ExplorerSection {
     FILTERS = 'FILTERS',
@@ -273,9 +270,7 @@ export interface ExplorerState extends ExplorerReduceState {
 
 export interface ExplorerContextType {
     state: ExplorerState;
-    queryResults: ReturnType<
-        typeof useQueryResults | typeof useChartVersionResultsMutation
-    >;
+    queryResults: ReturnType<typeof useQueryResults>;
     actions: {
         clearExplore: () => void;
         clearQuery: () => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Refactor query handling for Explorer, Chart and ChartHistory  

Main changes:
- Unify hook/query to get results for explore, chart and chart version.
- Switch `useQueryResults` from using `useMutation` to use `useQuery`.
- Removed `useQueryResults` `ExplorerProvider` property in favor of directly passing required props like `dateZoomGranularity` and `viewModeQueryArgs`.

Demo create chart:

https://github.com/user-attachments/assets/17523d5d-d003-4d7d-abdb-f8eddbe9dffd

Demo chart history:

https://github.com/user-attachments/assets/6bf3ecdb-d627-4eaf-915b-3a5541113bf5

Demo create dashboard chart:

https://github.com/user-attachments/assets/875a6937-1146-401f-8fc6-7d8086239f10



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
