### PR TITLE
fix: missing show table names in pivoted csv

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -449,6 +449,7 @@ This method can be memory intensive
         onlyRaw,
         truncated,
         customLabels,
+        showTableNames,
     }: {
         name?: string;
         projectUuid: string;
@@ -461,6 +462,7 @@ This method can be memory intensive
         truncated: boolean;
         customLabels: Record<string, string> | undefined;
         metricsAsRows?: boolean;
+        showTableNames: boolean;
     }) {
         return wrapSentryTransaction<AttachmentUrl>(
             'downloadPivotTableCsv',
@@ -483,6 +485,7 @@ This method can be memory intensive
                     onlyRaw,
                     maxColumnLimit:
                         this.lightdashConfig.pivotTable.maxColumnLimit,
+                    showTableNames,
                 });
 
                 const csvContent = await new Promise<string>(
@@ -1096,6 +1099,7 @@ This method can be memory intensive
                     onlyRaw,
                     truncated,
                     customLabels,
+                    showTableNames,
                 });
 
                 this.analytics.track({

--- a/packages/common/src/pivotTable/pivotQueryResults.ts
+++ b/packages/common/src/pivotTable/pivotQueryResults.ts
@@ -798,6 +798,7 @@ export const pivotResultsAsCsv = ({
     onlyRaw,
     maxColumnLimit,
     undefinedCharacter = '',
+    showTableNames,
 }: {
     pivotConfig: PivotConfig;
     rows: ResultRow[];
@@ -807,12 +808,18 @@ export const pivotResultsAsCsv = ({
     onlyRaw: boolean;
     maxColumnLimit: number;
     undefinedCharacter?: string;
+    showTableNames: boolean;
 }) => {
     const getFieldLabel = (fieldId: string) => {
         const customLabel = customLabels?.[fieldId];
         if (customLabel !== undefined) return customLabel;
         const field = itemMap[fieldId];
-        return (field && isField(field) && field?.label) || fieldId;
+        if (field && isField(field)) {
+            return showTableNames
+                ? `${field.tableLabel} ${field.label}`
+                : field.label;
+        }
+        return fieldId;
     };
     const pivotedResults = pivotQueryResults({
         pivotConfig,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13929 

### Description:
When exporting a pivoted CSV with "Show Table Names" enabled, the table names are not appended to the labels. This happens because the showTableNames parameter is not considered while generating the pivoted CSV.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
