### PR TITLE
fix: filters on dashboards as code

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1,0 +1,149 @@
+// CoderService.test.ts
+import {
+    AnyType,
+    DashboardAsCode,
+    DashboardChartTileProperties,
+    DashboardDAO,
+    DashboardFilterRule,
+    DashboardTile,
+    DashboardTileTarget,
+} from '@lightdash/common';
+import { CoderService } from './CoderService';
+
+describe('CoderService.getFiltersWithTileSlugs', () => {
+    it('should convert tile UUIDs to slugs in filters', () => {
+        const mockDashboard: DashboardDAO = {
+            filters: {
+                dimensions: [
+                    {
+                        tileTargets: {
+                            'uuid-1': {
+                                fieldId: 'field-1',
+                            } as DashboardTileTarget,
+                            'uuid-2': {
+                                fieldId: 'field-2',
+                            } as DashboardTileTarget,
+                        },
+                    },
+                ],
+            },
+            tiles: [
+                { uuid: 'uuid-1', properties: { chartSlug: 'slug-1' } },
+                { uuid: 'uuid-2', properties: { chartSlug: 'slug-2' } },
+            ],
+        } as AnyType; // Use 'as any' to bypass type checks for simplicity
+
+        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+        expect(
+            (result.dimensions[0] as DashboardFilterRule).tileTargets,
+        ).toEqual({
+            'slug-1': { fieldId: 'field-1' },
+            'slug-2': { fieldId: 'field-2' },
+        });
+    });
+
+    it('should handle filters with no tile targets', () => {
+        const mockDashboard: DashboardDAO = {
+            filters: {
+                dimensions: [
+                    {
+                        tileTargets: {},
+                    },
+                ],
+            },
+            tiles: [],
+        } as AnyType;
+
+        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+        expect(
+            (result.dimensions[0] as DashboardFilterRule).tileTargets,
+        ).toEqual({});
+    });
+
+    it('should skip tile targets with no matching slug', () => {
+        const mockDashboard: DashboardDAO = {
+            filters: {
+                dimensions: [
+                    {
+                        tileTargets: {
+                            'uuid-1': {
+                                fieldId: 'field-1',
+                            } as DashboardTileTarget,
+                        },
+                    },
+                ],
+            },
+            tiles: [],
+        } as AnyType;
+
+        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+        expect(
+            (result.dimensions[0] as DashboardFilterRule).tileTargets,
+        ).toEqual({});
+    });
+});
+
+/*
+
+describe('CoderService', () => {
+    describe('getFiltersWithTileUuids', () => {
+        it('should convert tile slugs to UUIDs in filters', () => {
+            const dashboardAsCode = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'chart-slug-1': { someTargetProperty: 'value1' },
+                                'chart-slug-2': { someTargetProperty: 'value2' },
+                            },
+                        },
+                     ],
+                } ,
+                // ... other properties
+            };
+
+            const tilesWithUuids = [
+                { uuid: 'uuid-1', properties: { chartSlug: 'chart-slug-1' } },
+                { uuid: 'uuid-2', properties: { chartSlug: 'chart-slug-2' } },
+            ];
+
+            const result = CoderService.getFiltersWithTileUuids(dashboardAsCode as AnyType, tilesWithUuids as AnyType);
+
+            expect(result.dimensions[0].tileTargets).toEqual({
+                'uuid-1': { someTargetProperty: 'value1' },
+                'uuid-2': { someTargetProperty: 'value2' },
+            });
+            expect(result.dimensions[0].id).toBe('mock-uuid');
+        });
+
+        it('should log an error if a tile slug does not match any UUID', () => {
+            console.error = jest.fn();
+
+            const dashboardAsCode = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'chart-slug-3': { someTargetProperty: 'value3' },
+                            },
+                        },
+                    ],
+                },
+                // ... other properties
+            };
+
+            const tilesWithUuids= [
+                { uuid: 'uuid-1', properties: { chartSlug: 'chart-slug-1' } },
+                { uuid: 'uuid-2', properties: { chartSlug: 'chart-slug-2' } },
+            ];
+
+            const result = CoderService.getFiltersWithTileUuids(dashboardAsCode as AnyType, tilesWithUuids as AnyType);
+
+            expect(console.error).toHaveBeenCalledWith('Tile with slug chart-slug-3 not found in tilesWithUuids');
+            expect(result.dimensions[0].tileTargets).toEqual({});
+        });
+    });
+}); */

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1,94 +1,103 @@
 // CoderService.test.ts
 import {
     AnyType,
-    DashboardAsCode,
-    DashboardChartTileProperties,
     DashboardDAO,
     DashboardFilterRule,
-    DashboardTile,
     DashboardTileTarget,
+    DashboardTileTypes,
 } from '@lightdash/common';
 import { CoderService } from './CoderService';
 
-describe('CoderService.getFiltersWithTileSlugs', () => {
-    it('should convert tile UUIDs to slugs in filters', () => {
-        const mockDashboard: DashboardDAO = {
-            filters: {
-                dimensions: [
-                    {
-                        tileTargets: {
-                            'uuid-1': {
-                                fieldId: 'field-1',
-                            } as DashboardTileTarget,
-                            'uuid-2': {
-                                fieldId: 'field-2',
-                            } as DashboardTileTarget,
+describe('CoderService', () => {
+    describe('getFiltersWithTileSlugs', () => {
+        it('should convert tile UUIDs to slugs in filters', () => {
+            const mockDashboard: DashboardDAO = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'uuid-1': {
+                                    fieldId: 'field-1',
+                                } as DashboardTileTarget,
+                                'uuid-2': {
+                                    fieldId: 'field-2',
+                                } as DashboardTileTarget,
+                            },
                         },
+                    ],
+                },
+                tiles: [
+                    {
+                        uuid: 'uuid-1',
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: { chartSlug: 'slug-1' },
+                    },
+                    {
+                        uuid: 'uuid-2',
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: { chartSlug: 'slug-2' },
+                    },
+                    {
+                        uuid: 'uuid-3',
+                        type: DashboardTileTypes.MARKDOWN,
+                        properties: {},
                     },
                 ],
-            },
-            tiles: [
-                { uuid: 'uuid-1', properties: { chartSlug: 'slug-1' } },
-                { uuid: 'uuid-2', properties: { chartSlug: 'slug-2' } },
-            ],
-        } as AnyType; // Use 'as any' to bypass type checks for simplicity
+            } as AnyType; // Use 'as any' to bypass type checks for simplicity
 
-        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+            const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
 
-        expect(
-            (result.dimensions[0] as DashboardFilterRule).tileTargets,
-        ).toEqual({
-            'slug-1': { fieldId: 'field-1' },
-            'slug-2': { fieldId: 'field-2' },
+            expect(
+                (result.dimensions[0] as DashboardFilterRule).tileTargets,
+            ).toEqual({
+                'slug-1': { fieldId: 'field-1' },
+                'slug-2': { fieldId: 'field-2' },
+            });
+        });
+
+        it('should handle filters with no tile targets', () => {
+            const mockDashboard: DashboardDAO = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {},
+                        },
+                    ],
+                },
+                tiles: [],
+            } as AnyType;
+
+            const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+            expect(
+                (result.dimensions[0] as DashboardFilterRule).tileTargets,
+            ).toEqual({});
+        });
+
+        it('should skip tile targets with no matching slug', () => {
+            const mockDashboard: DashboardDAO = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'uuid-1': {
+                                    fieldId: 'field-1',
+                                } as DashboardTileTarget,
+                            },
+                        },
+                    ],
+                },
+                tiles: [],
+            } as AnyType;
+
+            const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+            expect(
+                (result.dimensions[0] as DashboardFilterRule).tileTargets,
+            ).toEqual({});
         });
     });
 
-    it('should handle filters with no tile targets', () => {
-        const mockDashboard: DashboardDAO = {
-            filters: {
-                dimensions: [
-                    {
-                        tileTargets: {},
-                    },
-                ],
-            },
-            tiles: [],
-        } as AnyType;
-
-        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
-
-        expect(
-            (result.dimensions[0] as DashboardFilterRule).tileTargets,
-        ).toEqual({});
-    });
-
-    it('should skip tile targets with no matching slug', () => {
-        const mockDashboard: DashboardDAO = {
-            filters: {
-                dimensions: [
-                    {
-                        tileTargets: {
-                            'uuid-1': {
-                                fieldId: 'field-1',
-                            } as DashboardTileTarget,
-                        },
-                    },
-                ],
-            },
-            tiles: [],
-        } as AnyType;
-
-        const result = CoderService.getFiltersWithTileSlugs(mockDashboard);
-
-        expect(
-            (result.dimensions[0] as DashboardFilterRule).tileTargets,
-        ).toEqual({});
-    });
-});
-
-/*
-
-describe('CoderService', () => {
     describe('getFiltersWithTileUuids', () => {
         it('should convert tile slugs to UUIDs in filters', () => {
             const dashboardAsCode = {
@@ -96,27 +105,48 @@ describe('CoderService', () => {
                     dimensions: [
                         {
                             tileTargets: {
-                                'chart-slug-1': { someTargetProperty: 'value1' },
-                                'chart-slug-2': { someTargetProperty: 'value2' },
+                                'chart-slug-1': {
+                                    someTargetProperty: 'value1',
+                                },
+                                'chart-slug-2': {
+                                    someTargetProperty: 'value2',
+                                },
                             },
                         },
-                     ],
-                } ,
+                    ],
+                },
                 // ... other properties
             };
 
             const tilesWithUuids = [
-                { uuid: 'uuid-1', properties: { chartSlug: 'chart-slug-1' } },
-                { uuid: 'uuid-2', properties: { chartSlug: 'chart-slug-2' } },
+                {
+                    uuid: 'uuid-1',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: { chartSlug: 'chart-slug-1' },
+                },
+                {
+                    uuid: 'uuid-2',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: { chartSlug: 'chart-slug-2' },
+                },
+                {
+                    uuid: 'uuid-3',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: {},
+                },
             ];
 
-            const result = CoderService.getFiltersWithTileUuids(dashboardAsCode as AnyType, tilesWithUuids as AnyType);
+            const result = CoderService.getFiltersWithTileUuids(
+                dashboardAsCode as AnyType,
+                tilesWithUuids as AnyType,
+            );
 
             expect(result.dimensions[0].tileTargets).toEqual({
                 'uuid-1': { someTargetProperty: 'value1' },
                 'uuid-2': { someTargetProperty: 'value2' },
             });
-            expect(result.dimensions[0].id).toBe('mock-uuid');
+            expect(typeof result.dimensions[0].id).toBe('string'); // uuid
+            expect(result.dimensions[0].id.length).toBeGreaterThan(1);
         });
 
         it('should log an error if a tile slug does not match any UUID', () => {
@@ -127,7 +157,12 @@ describe('CoderService', () => {
                     dimensions: [
                         {
                             tileTargets: {
-                                'chart-slug-3': { someTargetProperty: 'value3' },
+                                'chart-slug-1': {
+                                    someTargetProperty: 'value1',
+                                },
+                                'chart-slug-3': {
+                                    someTargetProperty: 'value3',
+                                },
                             },
                         },
                     ],
@@ -135,15 +170,39 @@ describe('CoderService', () => {
                 // ... other properties
             };
 
-            const tilesWithUuids= [
-                { uuid: 'uuid-1', properties: { chartSlug: 'chart-slug-1' } },
-                { uuid: 'uuid-2', properties: { chartSlug: 'chart-slug-2' } },
+            const tilesWithUuids = [
+                {
+                    uuid: 'uuid-1',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: { chartSlug: 'chart-slug-1' },
+                },
+                {
+                    uuid: 'uuid-2',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: { chartSlug: 'chart-slug-2' },
+                },
+                {
+                    uuid: 'uuid-3',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: {},
+                },
             ];
 
-            const result = CoderService.getFiltersWithTileUuids(dashboardAsCode as AnyType, tilesWithUuids as AnyType);
+            const result = CoderService.getFiltersWithTileUuids(
+                dashboardAsCode as AnyType,
+                tilesWithUuids as AnyType,
+            );
 
-            expect(console.error).toHaveBeenCalledWith('Tile with slug chart-slug-3 not found in tilesWithUuids');
-            expect(result.dimensions[0].tileTargets).toEqual({});
+            // We show an error for chart-slug-2
+            expect(console.error).toHaveBeenCalledWith(
+                'Tile with slug chart-slug-3 not found in tilesWithUuids',
+            );
+            // but chart-slug-1 should be fine
+            expect(result.dimensions[0].tileTargets).toEqual({
+                'uuid-1': {
+                    someTargetProperty: 'value1',
+                },
+            });
         });
     });
-}); */
+});

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -12,6 +12,7 @@ import {
     DashboardDAO,
     DashboardTile,
     DashboardTileAsCode,
+    DashboardTileTarget,
     DashboardTileTypes,
     ForbiddenError,
     friendlyName,
@@ -24,6 +25,7 @@ import {
     SpaceSummary,
     UpdatedByUser,
 } from '@lightdash/common';
+import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -47,8 +49,8 @@ type CoderServiceArguments = {
 };
 
 const isChartTile = (
-    tile: DashboardTileAsCode,
-): tile is DashboardTileAsCode & {
+    tile: DashboardTileAsCode | DashboardTile,
+): tile is DashboardTile & {
     properties: { chartSlug: string; hideTitle: boolean };
 } =>
     tile.type === DashboardTileTypes.SAVED_CHART ||
@@ -130,6 +132,114 @@ export class CoderService extends BaseService {
         );
     }
 
+    static getChartSlugForTileUuid = (
+        dashboard: DashboardDAO,
+        uuid: string,
+    ) => {
+        const tile = dashboard.tiles.find((t) => t.uuid === uuid);
+        if (tile && isChartTile(tile)) {
+            const hasMultipleTilesWithSameChartSlug =
+                dashboard.tiles.filter(
+                    (t) =>
+                        isChartTile(t) &&
+                        t.properties.chartSlug === tile.properties.chartSlug,
+                ).length > 1;
+            if (hasMultipleTilesWithSameChartSlug) {
+                const chartSlugIndex = dashboard.tiles
+                    .filter(
+                        (t) =>
+                            isChartTile(t) &&
+                            t.properties.chartSlug ===
+                                tile.properties.chartSlug,
+                    )
+                    .findIndex((t) => t.uuid === uuid);
+                return `${tile.properties.chartSlug}-${chartSlugIndex + 1}`;
+            }
+            return tile.properties.chartSlug;
+        }
+        return undefined;
+    };
+
+    /* Convert dashboard filters from tile uuids to tile slugs
+     * DashboardDAO to DashboardAsCode
+     */
+    static getFiltersWithTileSlugs(
+        dashboard: DashboardDAO,
+    ): DashboardAsCode['filters'] {
+        const dimensionFiltersWithoutUuids: DashboardAsCode['filters']['dimensions'] =
+            dashboard.filters.dimensions.map((filter) => {
+                const tileTargets = Object.entries(
+                    filter.tileTargets ?? {},
+                ).reduce<Record<string, DashboardTileTarget>>(
+                    (acc, [tileUuid, target]) => {
+                        const tileSlug = CoderService.getChartSlugForTileUuid(
+                            dashboard,
+                            tileUuid,
+                        );
+                        if (!tileSlug) return acc;
+                        return {
+                            ...acc,
+                            [tileSlug]: target,
+                        };
+                    },
+                    {},
+                );
+                return {
+                    ...filter,
+                    id: undefined,
+                    tileTargets,
+                };
+            });
+
+        return {
+            ...dashboard.filters,
+            dimensions: dimensionFiltersWithoutUuids,
+        };
+    }
+
+    /* Convert dashboard filters from tile slugs to tile uuids
+     * DashboardAsCode to DashboardDAO
+     */
+    private static getFiltersWithTileUuids(
+        dashboardAsCode: DashboardAsCode,
+        tilesWithUuids: DashboardTile[],
+    ): DashboardDAO['filters'] {
+        const dimensionFiltersWithUuids: DashboardDAO['filters']['dimensions'] =
+            dashboardAsCode.filters.dimensions.map((filter) => {
+                const tileTargets = Object.entries(
+                    filter.tileTargets ?? {},
+                ).reduce<Record<string, DashboardTileTarget>>(
+                    (acc, [tileSlug, target]) => {
+                        const tileUuid = tilesWithUuids.find(
+                            (t) =>
+                                isChartTile(t) &&
+                                t.properties.chartSlug === tileSlug,
+                        )?.uuid;
+                        if (!tileUuid) {
+                            console.error(
+                                `Tile with slug ${tileSlug} not found in tilesWithUuids`,
+                            );
+                            return acc;
+                        }
+                        return {
+                            ...acc,
+                            [tileUuid]: target,
+                        };
+                    },
+                    {},
+                );
+                return {
+                    ...filter,
+                    id: uuidv4(),
+                    tileTargets,
+                };
+            });
+        return {
+            ...dashboardAsCode.filters,
+            dimensions: dimensionFiltersWithUuids,
+        };
+    }
+
     private static transformDashboard(
         dashboard: DashboardDAO,
         spaceSummary: Pick<SpaceSummary, 'uuid' | 'slug'>[],
@@ -147,6 +257,10 @@ export class CoderService extends BaseService {
                     return {
                         ...tile,
                         uuid: undefined,
+                        tileSlug: CoderService.getChartSlugForTileUuid(
+                            dashboard,
+                            tile.uuid,
+                        ),
                         properties: {
                             title: tile.properties.title,
                             hideTitle: tile.properties.hideTitle,
@@ -170,7 +284,7 @@ export class CoderService extends BaseService {
             updatedAt: dashboard.updatedAt,
             tiles: tilesWithoutUuids,
 
-            filters: dashboard.filters,
+            filters: CoderService.getFiltersWithTileSlugs(dashboard),
             tabs: dashboard.tabs,
             slug: dashboard.slug,
 
@@ -212,6 +326,7 @@ export class CoderService extends BaseService {
                 }
                 return {
                     ...tile,
+                    uuid: uuidv4(),
                     properties: {
                         ...tile.properties,
                         savedChartUuid: savedChart.uuid,
@@ -783,7 +898,15 @@ export class CoderService extends BaseService {
             slug,
             projectUuid,
         });
+        const tilesWithUuids = await this.convertTileWithSlugsToUuids(
+            projectUuid,
+            dashboardAsCode.tiles,
+        );
 
+        const dashboardFilters = CoderService.getFiltersWithTileUuids(
+            dashboardAsCode,
+            tilesWithUuids,
+        );
         // If chart does not exist, we can't use promoteService,
         // since it relies on information it is not available in ChartAsCode, and other uuids
         if (dashboardSummary === undefined) {
@@ -794,16 +917,13 @@ export class CoderService extends BaseService {
                     user,
                 );
 
-            const tilesWithUuids = await this.convertTileWithSlugsToUuids(
-                projectUuid,
-                dashboardAsCode.tiles,
-            );
             const newDashboard = await this.dashboardModel.create(
                 space.uuid,
                 {
                     ...dashboardAsCode,
                     tiles: tilesWithUuids,
                     forceSlug: true,
+                    filters: dashboardFilters,
                 },
                 user,
                 projectUuid,
@@ -835,10 +955,6 @@ export class CoderService extends BaseService {
             `Updating dashboard "${dashboard.name}" on project ${projectUuid}`,
         );
 
-        const tilesWithUuids = await this.convertTileWithSlugsToUuids(
-            projectUuid,
-            dashboardAsCode.tiles,
-        );
         const dashboardWithUuids = {
             ...dashboardAsCode,
             tiles: tilesWithUuids,
@@ -849,6 +965,7 @@ export class CoderService extends BaseService {
                 {
                     ...dashboard,
                     ...dashboardWithUuids,
+                    filters: dashboardFilters,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 },

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -200,7 +200,7 @@ export class CoderService extends BaseService {
     /* Convert dashboard filters from tile slugs to tile uuids
      * DashboardAsCode to DashboardDAO
      */
-    private static getFiltersWithTileUuids(
+    static getFiltersWithTileUuids(
         dashboardAsCode: DashboardAsCode,
         tilesWithUuids: DashboardTile[],
     ): DashboardDAO['filters'] {
@@ -252,7 +252,7 @@ export class CoderService extends BaseService {
         }
 
         const tilesWithoutUuids: DashboardTileAsCode[] = dashboard.tiles.map(
-            (tile) => {
+            (tile): DashboardTileAsCode => {
                 if (isChartTile(tile)) {
                     return {
                         ...tile,
@@ -272,6 +272,7 @@ export class CoderService extends BaseService {
                 // Markdown and loom are returned as they are
                 return {
                     ...tile,
+                    tileSlug: undefined,
                     uuid: undefined,
                 };
             },

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -80,10 +80,7 @@ export type DashboardAsCode = Pick<
     spaceSlug: string;
     downloadedAt?: Date;
     filters: Omit<DashboardFilters, 'dimensions'> & {
-        dimensions: Omit<DashboardFilterRule, 'id'> &
-            {
-                id: DashboardFilterRule['id'] | undefined; // Allows us to remove the uuid from the object
-            }[];
+        dimensions: Omit<DashboardFilterRule, 'id'>[];
     };
 };
 

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -4,6 +4,8 @@ import type {
     Dashboard,
     DashboardAsCodeLanguageMap,
     DashboardChartTileProperties,
+    DashboardFilterRule,
+    DashboardFilters,
     DashboardLoomTileProperties,
     DashboardMarkdownTileProperties,
     DashboardTile,
@@ -59,6 +61,7 @@ export type ApiChartAsCodeUpsertResponse = {
 
 export type DashboardTileAsCode = Omit<DashboardTile, 'properties' | 'uuid'> & {
     uuid: DashboardTile['uuid'] | undefined; // Allows us to remove the uuid from the object
+    tileSlug: string | undefined;
     properties:
         | Pick<
               DashboardChartTileProperties['properties'],
@@ -70,12 +73,18 @@ export type DashboardTileAsCode = Omit<DashboardTile, 'properties' | 'uuid'> & {
 
 export type DashboardAsCode = Pick<
     Dashboard,
-    'name' | 'description' | 'updatedAt' | 'filters' | 'tabs' | 'slug'
+    'name' | 'description' | 'updatedAt' | 'tabs' | 'slug'
 > & {
     tiles: DashboardTileAsCode[];
     version: number;
     spaceSlug: string;
     downloadedAt?: Date;
+    filters: Omit<DashboardFilters, 'dimensions'> & {
+        dimensions: Omit<DashboardFilterRule, 'id'> &
+            {
+                id: DashboardFilterRule['id'] | undefined; // Allows us to remove the uuid from the object
+            }[];
+    };
 };
 
 export type ApiDashboardAsCodeListResponse = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13830

### Description:

Fixed by replacing the tile uuid with a chart slug on `download`, then matching the filter back on `upload`

If there are multiple charts with the same slug, we assign them an index based on their position in the tile list. 


Before:

![Screenshot from 2025-03-10 11-02-55](https://github.com/user-attachments/assets/73b76be0-c21d-4e6e-a912-31ca3de49529)

After:

<!-- Add a description of the changes proposed in the pull request. -->
![Screenshot from 2025-03-10 11-46-17](https://github.com/user-attachments/assets/29dd0161-566d-49f2-a7c3-8591da450486)

Dashboard UI after upload on a different project: 

![Screenshot from 2025-03-10 12-21-16](https://github.com/user-attachments/assets/3f9ec006-d262-4989-88e2-365a9d9a651b)

dashboard filters (uploaded vs original) 
![Screenshot from 2025-03-10 12-21-50](https://github.com/user-attachments/assets/584daaa5-7356-4286-841f-f53c455f5870)

<!-- Even better add a screenshot / gif / loom -->

### Edge case:

Note: There is an edge case where this will not work , since we are relying on the position of the tiles when they are saved. 

Edge case not covered (replication steps) : 
- Have a dashboard with the same `chart` duplicated in different tiles
- Add a dashboard filter
- Deselect one of the filters on one of the duplicated tiles 
- Download code 
- Update the code, and remove one of the duplicated charts from the list of tiles 
- Upload the code
- :fire: now the chart that didn't have a filter applied **might** have the filter applied (since we apply filters by default)  

I belive this is a extreme edge case, and it is not worth fixing.  The fix will force us to persist some index in db when saving the dashboard, since we can't rely on anything else 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
