### PR TITLE
fix: remove feature flag for disabling color calculation

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -41,13 +41,6 @@ export enum FeatureFlags {
     ReplaceCustomMetricsOnCompile = 'replace-custom-metrics-on-compile',
 
     /**
-     * Enable the dynamic calculation of series color, when not manually set on the chart config.
-     * This aims to make the colors more consistent, depending on the groups, but this could cause the opposite effect.
-     * For more details, see https://github.com/lightdash/lightdash/issues/13831
-     */
-    CalculateSeriesColor = 'calculate-series-color',
-
-    /**
      * Enable the ability to write back custom bin dimensions to dbt.
      */
     WriteBackCustomBinDimensions = 'write-back-custom-bin-dimensions',

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -1,6 +1,5 @@
 import {
     ChartType,
-    FeatureFlags,
     assertUnreachable,
     isDimension,
     type ApiQueryResults,
@@ -28,7 +27,6 @@ import {
     calculateSeriesLikeIdentifier,
     isGroupedSeries,
 } from '../../hooks/useChartColorConfig/utils';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { type EchartSeriesClickEvent } from '../SimpleChart';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
@@ -194,10 +192,6 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
         [calculateKeyColorAssignment, itemsMap],
     );
 
-    const isCalculateSeriesColorEnabled = useFeatureFlagEnabled(
-        FeatureFlags.CalculateSeriesColor,
-    );
-
     /**
      * Gets a shared color for a given series.
      */
@@ -242,7 +236,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
              * If this series is grouped, figure out a shared color assignment from the series;
              * otherwise, pick a series color from the palette based on its order.
              */
-            return isGroupedSeries(seriesLike) && isCalculateSeriesColorEnabled
+            return isGroupedSeries(seriesLike)
                 ? calculateSeriesColorAssignment(seriesLike)
                 : fallbackColors[
                       // Note: we don't use getSeriesId since we may not be dealing with a Series type here
@@ -250,13 +244,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
                   ];
         },
 
-        [
-            calculateSeriesColorAssignment,
-            fallbackColors,
-            chartConfig,
-            itemsMap,
-            isCalculateSeriesColorEnabled,
-        ],
+        [calculateSeriesColorAssignment, fallbackColors, chartConfig, itemsMap],
     );
 
     const value: Omit<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #13950 

### Description:

Re-enable color calculation and remove the feature flag. Customers were having issues with the version of this code that disabled the color calculation. 

We could also keep this flag and turn it on for everyone until we fix it, but that seems dangerous. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
