### PR TITLE
fix: clear values on close palette

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -73,6 +73,7 @@ const AppearanceColorSettings: FC = () => {
             </Stack>
 
             <CreatePaletteModal
+                key={`create-palette-modal-${isCreatePaletteModalOpen}`}
                 opened={isCreatePaletteModalOpen}
                 onClose={() => {
                     setIsCreatePaletteModalOpen(false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

The color palette form can be closed with invalid values, which remain when you re-open it. This confused me a little, so I made it clear values on close. 

Another option: we could block closing with invalid values, but then it's a little annoying to have to fix them to bail out of the dialog. 

Here's the issue *without* this change
![Kapture 2025-03-11 at 10 50 17](https://github.com/user-attachments/assets/d6701b1f-ccc3-4f6d-ad3a-01bbcd864130)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
