### PR TITLE
fix: don't treat all falsey values as undefined in sql-runner

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1444,8 +1444,5 @@ describe('Formatting', () => {
             expect(applyDefaultFormat(1234)).toBe('1,234');
             expect(applyDefaultFormat(-1234)).toBe('-1,234');
         });
-        it('should handle arrays', () => {
-            expect(applyDefaultFormat([1, 2, 3])).toBe('1,2,3');
-        });
     });
 });

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -12,6 +12,7 @@ import {
 import { TimeFrames } from '../types/timeFrames';
 import {
     applyCustomFormat,
+    applyDefaultFormat,
     convertCustomFormatToFormatExpression,
     currencies,
     formatItemValue,
@@ -1421,6 +1422,30 @@ describe('Formatting', () => {
                     formattedValueWithCustomFormat,
                 );
             });
+        });
+    });
+
+    describe.only('applyDefaultFormatting', () => {
+        it('should handle boolean values', () => {
+            expect(applyDefaultFormat(true)).toBe('true');
+            expect(applyDefaultFormat(false)).toBe('false');
+        });
+        it('should handle falsey values', () => {
+            expect(applyDefaultFormat(undefined)).toBe('-');
+            expect(applyDefaultFormat(null)).toBe('∅');
+            expect(applyDefaultFormat(0)).toBe('0');
+            expect(applyDefaultFormat('')).toBe('');
+        });
+        it('should handle strings', () => {
+            expect(applyDefaultFormat('foo')).toBe('foo');
+        });
+        it('should handle numbers', () => {
+            expect(applyDefaultFormat(1234567)).toBe('1,234,567');
+            expect(applyDefaultFormat(1234)).toBe('1,234');
+            expect(applyDefaultFormat(-1234)).toBe('-1,234');
+        });
+        it('should handle arrays', () => {
+            expect(applyDefaultFormat([1, 2, 3])).toBe('1,2,3');
         });
     });
 });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -234,7 +234,7 @@ export function formatNumberValue(
     }
 }
 
-function applyDefaultFormat(value: unknown) {
+export function applyDefaultFormat(value: unknown) {
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (!isNumber(value)) {

--- a/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
@@ -1,4 +1,5 @@
 import { type RawResultRow, type VizColumnsConfig } from '@lightdash/common';
+import { applyDefaultFormat } from '@lightdash/common/src';
 import { stringify } from 'csv-stringify/browser/esm';
 import { useCallback } from 'react';
 import { useAppSelector } from '../store/hooks';
@@ -22,19 +23,7 @@ export const downloadCsv = async (
         );
     }
     const csvBody = rows.map((row) =>
-        csvColumnIds.map((reference) => {
-            const value = row[reference];
-            if (value === null) {
-                return '∅';
-            }
-            if (value === undefined) {
-                return '-';
-            }
-            if (value === false) {
-                return 'false';
-            }
-            return value;
-        }),
+        csvColumnIds.map((reference) => applyDefaultFormat(row[reference])),
     );
     const csvContent: string = await new Promise<string>((resolve, reject) => {
         stringify(

--- a/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
@@ -1,5 +1,5 @@
 import { type RawResultRow, type VizColumnsConfig } from '@lightdash/common';
-import { applyDefaultFormat } from '@lightdash/common/src';
+import { applyDefaultFormat } from '@lightdash/common';
 import { stringify } from 'csv-stringify/browser/esm';
 import { useCallback } from 'react';
 import { useAppSelector } from '../store/hooks';

--- a/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
@@ -1,5 +1,8 @@
-import { type RawResultRow, type VizColumnsConfig } from '@lightdash/common';
-import { applyDefaultFormat } from '@lightdash/common';
+import {
+    type RawResultRow,
+    type VizColumnsConfig,
+    applyDefaultFormat,
+} from '@lightdash/common';
 import { stringify } from 'csv-stringify/browser/esm';
 import { useCallback } from 'react';
 import { useAppSelector } from '../store/hooks';

--- a/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDownloadResults.tsx
@@ -22,7 +22,19 @@ export const downloadCsv = async (
         );
     }
     const csvBody = rows.map((row) =>
-        csvColumnIds.map((reference) => row[reference] || '-'),
+        csvColumnIds.map((reference) => {
+            const value = row[reference];
+            if (value === null) {
+                return '∅';
+            }
+            if (value === undefined) {
+                return '-';
+            }
+            if (value === false) {
+                return 'false';
+            }
+            return value;
+        }),
     );
     const csvContent: string = await new Promise<string>((resolve, reject) => {
         stringify(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14018 

### Description:

SQL runner was rendering all falsey values as `-`. This makes it render 0, null, false and undefined consistently with other places we download csvs. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
