### PR TITLE
fix: returns actual page size in response

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1878,7 +1878,7 @@ export class ProjectService extends BaseService {
             queryUuid: queryHistory.queryUuid,
             fields: queryHistory.fields,
             metricQuery,
-            pageSize: defaultedPageSize,
+            pageSize: rows.length,
             page,
             nextPage,
             previousPage,
@@ -2098,11 +2098,7 @@ export class ProjectService extends BaseService {
                         totalPageCount,
                         totalResults,
                         page,
-                        // This is to take into account the page size override for warehouses that don't support pagination yet
-                        pageSize:
-                            totalPageCount > pageSize
-                                ? totalPageCount
-                                : pageSize,
+                        pageSize: rows.length,
                         nextPage,
                         previousPage,
                         fields: fieldsMap,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
- We were returning the page size sent in the request instead of the actual page size

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
