### PR TITLE
fix: keep the selected tab on dashbaord edit

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -511,13 +511,23 @@ const Dashboard: FC = () => {
         void Promise.resolve().then(() => {
             return navigate(
                 {
-                    pathname: `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                    pathname:
+                        dashboardTabs.length > 0
+                            ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTab?.uuid}`
+                            : `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
                     search: '',
                 },
                 { replace: true },
             );
         });
-    }, [projectUuid, dashboardUuid, resetDashboardFilters, navigate]);
+    }, [
+        projectUuid,
+        dashboardUuid,
+        resetDashboardFilters,
+        navigate,
+        activeTab?.uuid,
+        dashboardTabs.length,
+    ]);
 
     if (dashboardError) {
         return <ErrorState error={dashboardError.error} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This makes it so that dashboards stay on the selected tab when entering edit more. Before, if you clicked edit, it put you on the first tab, losing context.

**Before:**
![before](https://github.com/user-attachments/assets/418b11af-17f2-4b9a-b328-ce07209f56a0)

**After:**
![Kapture 2025-03-12 at 12 23 07](https://github.com/user-attachments/assets/745980cf-c6e5-4e5b-885b-46e59105d68b)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
