### PR TITLE
feat: allow default color palette on org creation

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -186,4 +186,5 @@ export const lightdashConfigMock: LightdashConfig = {
     contentAsCode: {
         maxDownloads: 100,
     },
+    appearance: {},
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -8,6 +8,10 @@ import {
     ParseError,
     SentryConfig,
 } from '@lightdash/common';
+import {
+    cleanColorArray,
+    getInvalidHexColors,
+} from '@lightdash/common/src/utils/colors';
 import { type ClientAuthMethod } from 'openid-client';
 import { VERSION } from '../version';
 
@@ -89,6 +93,36 @@ const getArrayFromCommaSeparatedList = (envVar: string) => {
         .split(',')
         .map((domain) => domain.trim())
         .filter((domain) => domain.length > 0);
+};
+
+export const getHexColorsFromEnvironmentVariable = (
+    colorPalette: string | undefined,
+): string[] | undefined => {
+    if (!colorPalette) {
+        return undefined;
+    }
+
+    const hexColors = cleanColorArray(colorPalette.split(','));
+
+    // Validate that all colors are valid hex codes
+    const invalidColors = getInvalidHexColors(hexColors);
+
+    if (invalidColors.length > 0) {
+        throw new ParseError(
+            `Cannot parse environment variable "DEFAULT_COLOR_PALETTE_COLORS". All values must be valid hex colors (e.g. #FF0000) but found invalid colors: ${invalidColors.join(
+                ', ',
+            )}`,
+        );
+    }
+
+    // Validate that there are exactly 20 colors
+    if (hexColors.length !== 20) {
+        throw new ParseError(
+            `Cannot parse environment variable "DEFAULT_COLOR_PALETTE_COLORS". Must contain exactly 20 colors, but found ${hexColors.length} colors.`,
+        );
+    }
+
+    return hexColors;
 };
 
 /**
@@ -288,6 +322,11 @@ export type LightdashConfig = {
     };
     customVisualizations: {
         enabled: boolean;
+    };
+    // This is the default color palette for the organization
+    appearance: {
+        defaultColorPalette?: string[];
+        defaultColorPaletteName?: string;
     };
     s3?: S3Config;
     headlessBrowser: HeadlessBrowserConfig;
@@ -928,6 +967,13 @@ export const parseConfig = (): LightdashConfig => {
             maxDownloads:
                 getIntegerFromEnvironmentVariable('MAX_DOWNLOADS_AS_CODE') ||
                 100,
+        },
+        appearance: {
+            defaultColorPalette: getHexColorsFromEnvironmentVariable(
+                process.env.DEFAULT_COLOR_PALETTE_COLORS || undefined,
+            ),
+            // not required if defaultColorPalette is set
+            defaultColorPaletteName: process.env.DEFAULT_COLOR_PALETTE_NAME,
         },
     };
 };

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -314,7 +314,7 @@ export class ModelRepository
     public getOrganizationModel(): OrganizationModel {
         return this.getModel(
             'organizationModel',
-            () => new OrganizationModel(this.database),
+            () => new OrganizationModel(this.database, this.lightdashConfig),
         );
     }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -261,6 +261,7 @@ export * from './utils/api';
 export { default as assertUnreachable } from './utils/assertUnreachable';
 export * from './utils/catalogMetricsTree';
 export * from './utils/charts';
+export * from './utils/colors';
 export * from './utils/conditionalFormatting';
 export * from './utils/convertCustomDimensionsToYaml';
 export * from './utils/convertCustomMetricsToYaml';

--- a/packages/common/src/utils/colors.test.ts
+++ b/packages/common/src/utils/colors.test.ts
@@ -1,0 +1,108 @@
+import { cleanColorArray, getInvalidHexColors, isHexCodeColor } from './colors';
+
+describe('isHexCodeColor', () => {
+    it('should return true for valid 3-digit hex colors', () => {
+        const validColors = ['#123', '#abc', '#ABC', '#f00', '#0F0', '#00f'];
+
+        validColors.forEach((color) => {
+            expect(isHexCodeColor(color)).toBe(true);
+        });
+    });
+
+    it('should return true for valid 6-digit hex colors', () => {
+        const validColors = [
+            '#123456',
+            '#abcdef',
+            '#ABCDEF',
+            '#ff0000',
+            '#00FF00',
+            '#0000ff',
+        ];
+
+        validColors.forEach((color) => {
+            expect(isHexCodeColor(color)).toBe(true);
+        });
+    });
+
+    it('should return false for invalid hex colors', () => {
+        const invalidColors = [
+            'red', // named color
+            '#1234', // 4 digits
+            '#12345', // 5 digits
+            '#1234567', // 7 digits
+            '123456', // missing #
+            '#12345g', // invalid character
+            '#GHIJKL', // invalid characters
+            'rgb(255,0,0)', // rgb format
+            'rgba(255,0,0,0.5)', // rgba format
+            '#', // just the hash
+            '', // empty string
+            ' #123456', // leading space
+            '#123456 ', // trailing space
+        ];
+
+        invalidColors.forEach((color) => {
+            expect(isHexCodeColor(color)).toBe(false);
+        });
+    });
+});
+
+describe('getInvalidHexColors', () => {
+    it('should return an empty array when all colors are valid', () => {
+        const validColors = ['#123', '#456789', '#abc', '#def012'];
+
+        expect(getInvalidHexColors(validColors)).toEqual([]);
+    });
+
+    it('should return an array of invalid colors', () => {
+        const mixedColors = ['#123', 'red', '#456789', '#12', 'blue'];
+        const expectedInvalidColors = ['red', '#12', 'blue'];
+
+        expect(getInvalidHexColors(mixedColors)).toEqual(expectedInvalidColors);
+    });
+
+    it('should return all colors when all are invalid', () => {
+        const invalidColors = ['red', 'green', 'blue'];
+
+        expect(getInvalidHexColors(invalidColors)).toEqual(invalidColors);
+    });
+
+    it('should handle an empty array', () => {
+        expect(getInvalidHexColors([])).toEqual([]);
+    });
+});
+
+describe('cleanColorArray', () => {
+    it('should trim whitespace from color strings', () => {
+        const colorsWithWhitespace = [' #123 ', '  #456789', '#abc  '];
+        const expectedCleanedColors = ['#123', '#456789', '#abc'];
+
+        expect(cleanColorArray(colorsWithWhitespace)).toEqual(
+            expectedCleanedColors,
+        );
+    });
+
+    it('should filter out empty strings', () => {
+        const colorsWithEmpty = ['#123', '', '  ', '#456789'];
+        const expectedCleanedColors = ['#123', '#456789'];
+
+        expect(cleanColorArray(colorsWithEmpty)).toEqual(expectedCleanedColors);
+    });
+
+    it('should handle an array with only empty strings', () => {
+        const onlyEmptyStrings = ['', '  ', '   '];
+
+        expect(cleanColorArray(onlyEmptyStrings)).toEqual([]);
+    });
+
+    it('should handle an empty array', () => {
+        expect(cleanColorArray([])).toEqual([]);
+    });
+
+    it('should preserve invalid hex colors (validation is not its responsibility)', () => {
+        const mixedColors = [' #123 ', 'red', '  #456789', 'blue  '];
+        const expectedCleanedColors = ['#123', 'red', '#456789', 'blue'];
+
+        expect(cleanColorArray(mixedColors)).toEqual(expectedCleanedColors);
+    });
+});

--- a/packages/common/src/utils/colors.ts
+++ b/packages/common/src/utils/colors.ts
@@ -1,0 +1,20 @@
+const IS_HEX_CODE_COLOR_REGEX = /^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/;
+
+export const isHexCodeColor = (color: string): boolean =>
+    IS_HEX_CODE_COLOR_REGEX.test(color);
+
+/**
+ * Validates an array of hex color codes
+ * @param colors Array of strings to validate as hex colors
+ * @returns Array of invalid colors found, empty if all are valid
+ */
+export const getInvalidHexColors = (colors: string[]): string[] =>
+    colors.filter((color) => !isHexCodeColor(color));
+
+/**
+ * Processes an array of strings, trimming and filtering out empty values
+ * @param colors Array of strings to process
+ * @returns Cleaned array of strings
+ */
+export const cleanColorArray = (colors: string[]): string[] =>
+    colors.map((color) => color.trim()).filter((color) => color.length > 0);

--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -1,3 +1,4 @@
+import { isHexCodeColor } from '@lightdash/common';
 import {
     ColorSwatch,
     ColorPicker as MantineColorPicker,
@@ -8,7 +9,6 @@ import {
 } from '@mantine/core';
 import { IconHash } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { isHexCodeColor } from '../../utils/colorUtils';
 import MantineIcon from '../common/MantineIcon';
 
 interface Props {

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -6,6 +6,7 @@ import {
     getItemId,
     isDimension,
     isField,
+    isHexCodeColor,
     isNumericItem,
     isSummable,
     type ConditionalFormattingConfig,
@@ -38,7 +39,7 @@ import {
     formatCellContent,
     getFormattedValueCell,
 } from '../../../hooks/useColumns';
-import { getColorFromRange, isHexCodeColor } from '../../../utils/colorUtils';
+import { getColorFromRange } from '../../../utils/colorUtils';
 import { getConditionalRuleLabel } from '../Filters/FilterInputs/utils';
 import Table from '../LightTable';
 import { CELL_HEIGHT } from '../LightTable/constants';

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -3,6 +3,7 @@ import {
     PieChartLegendPositionDefault,
     formatItemValue,
     isField,
+    isHexCodeColor,
     isMetric,
     isTableCalculation,
     type ApiQueryResults,
@@ -26,7 +27,6 @@ import omitBy from 'lodash/omitBy';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { isHexCodeColor } from '../utils/colorUtils';
 
 type PieChartConfig = {
     validConfig: PieChart;

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -1,13 +1,10 @@
 import {
+    isHexCodeColor,
     type ConditionalFormattingColorRange,
     type ConditionalFormattingMinMax,
 } from '@lightdash/common';
 import Color from 'colorjs.io';
 
-const IS_HEX_CODE_COLOR_REGEX = /^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/;
-export const isHexCodeColor = (color: string): boolean => {
-    return IS_HEX_CODE_COLOR_REGEX.test(color);
-};
 export const readableColor = (backgroundColor: string) => {
     if (!isHexCodeColor(backgroundColor)) {
         return 'black';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14007

### Description:

env vars to test locally
```
export ALLOW_MULTIPLE_ORGS=true
export DEFAULT_COLOR_PALETTE_NAME="Rainbow Spectrum"
export DEFAULT_COLOR_PALETTE_COLORS=#FF0000,#FF3300,#FF6600,#FF9900,#FFCC00,#FFFF00,#CCFF00,#99FF00,#66FF00,#33FF00,#00FF00,#00FF33,#00FF66,#00FF99,#00FFCC,#00FFFF,#0099FF,#0066FF,#0033FF,#0000FF
```

how to test
- logout
- go to /register
- set up quick postgres project
- go to Settings > Appearance
- see color palette set as default

demo
<img width="1912" alt="Screenshot 2025-03-12 at 14 49 25" src="https://github.com/user-attachments/assets/df2abe93-9863-4c1c-aa3c-1beadbc6d2f0" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
