### PR TITLE
fix: sidebar search react max depth error

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -164,6 +164,11 @@ const TableTreeSections: FC<Props> = ({
         }, {});
     }, [metrics, additionalMetrics]);
 
+    const searchResults = useMemo(
+        () => getSearchResults(dimensions, searchQuery),
+        [dimensions, searchQuery],
+    );
+
     return (
         <>
             {missingFields && missingFields.all.length > 0 && (
@@ -215,8 +220,7 @@ const TableTreeSections: FC<Props> = ({
                 </>
             )}
 
-            {isSearching &&
-            getSearchResults(dimensions, searchQuery).size === 0 ? null : (
+            {isSearching && searchResults.length === 0 ? null : (
                 <Group mt="sm" mb="xs" position={'apart'}>
                     <Text fw={600} color="blue.9">
                         Dimensions
@@ -266,8 +270,7 @@ const TableTreeSections: FC<Props> = ({
                 </Center>
             )}
 
-            {isSearching &&
-            getSearchResults(metrics, searchQuery).size === 0 ? null : (
+            {isSearching && searchResults.length === 0 ? null : (
                 <Group position="apart" mt="sm" mb="xs" pr="sm">
                     <Text fw={600} color="yellow.9">
                         Metrics
@@ -310,10 +313,7 @@ const TableTreeSections: FC<Props> = ({
             ) : null}
 
             {hasCustomMetrics &&
-            !(
-                isSearching &&
-                getSearchResults(customMetrics, searchQuery).size === 0
-            ) ? (
+            !(isSearching && searchResults.length === 0) ? (
                 <Group position="apart" mt="sm" mb="xs" pr="sm">
                     <Group>
                         <Text fw={600} color="yellow.9">
@@ -389,10 +389,7 @@ const TableTreeSections: FC<Props> = ({
 
             {hasCustomDimensions &&
             customDimensionsMap &&
-            !(
-                isSearching &&
-                getSearchResults(customDimensionsMap, searchQuery).size === 0
-            ) ? (
+            !(isSearching && searchResults.length === 0) ? (
                 <Group position="apart" mt="sm" mb="xs" pr="sm">
                     <Group>
                         <Text fw={600} color="blue.9">

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -67,7 +67,7 @@ const TreeSingleNode: FC<Props> = memo(({ node }) => {
     const [isMenuOpen, toggleMenu] = useToggle(false);
 
     const isSelected = selectedItems.has(node.key);
-    const isVisible = !isSearching || searchResults.has(node.key);
+    const isVisible = !isSearching || searchResults.includes(node.key);
 
     const item = itemsMap[node.key];
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
@@ -48,5 +48,5 @@ export type TreeProviderProps = {
 export type TableTreeContext = TreeProviderProps & {
     nodeMap: NodeMap;
     isSearching: boolean;
-    searchResults: Set<string>;
+    searchResults: string[];
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -42,7 +42,7 @@ const ExploreTree: FC<ExploreTreeProps> = ({
     const [search, setSearch] = useState<string>('');
     const isSearching = !!search && search !== '';
 
-    const searchHasResults = useCallback(
+    const searchResults = useCallback(
         (table: CompiledTable) => {
             const allValues = Object.values({
                 ...table.dimensions,
@@ -55,7 +55,7 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                 return { ...acc, [getItemId(item)]: item };
             }, {});
 
-            return getSearchResults(allFields, search).size > 0;
+            return getSearchResults(allFields, search);
         },
         [additionalMetrics, search],
     );
@@ -70,9 +70,10 @@ const ExploreTree: FC<ExploreTreeProps> = ({
             })
             .filter(
                 (table) =>
-                    !(isSearching && !searchHasResults(table)) && !table.hidden,
+                    !(isSearching && searchResults(table).length === 0) &&
+                    !table.hidden,
             );
-    }, [explore, searchHasResults, isSearching]);
+    }, [explore, isSearching, searchResults]);
 
     return (
         <>


### PR DESCRIPTION
Closes: [#14032](https://github.com/lightdash/lightdash/issues/14032)

### Description:

this PR tries to eliminate react max depth error by
- removing forEach and mutations from tree components
- changing search result Set to be array of strings instead of a set

```
React ErrorBoundary Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
  at div (<anonymous>)
  at div (<anonymous>)
  at div (<anonymous>)
  at ExploreTree (../../src/components/Explorer/ExploreTree/index.tsx:34:5)
  at ItemDetailProvider (../../src/components/Explorer/ExploreTree/TableTree/ItemDetailProvider.tsx:11:65)
...
(45 additional frame(s) were not displayed)

Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
  at Array.forEach (<anonymous>)
  at Array.forEach (<anonymous>)
...
(45 additional frame(s) were not displayed)
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
