### PR TITLE
feat: allow showing html images in fields (#12724)

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -438,6 +438,7 @@ export const renderFilterRuleSql = (
         : field.compiledSql;
 
     switch (fieldType) {
+        case DimensionType.HTML:
         case DimensionType.STRING:
         case MetricType.STRING: {
             return renderStringFilterSql(

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -179,6 +179,7 @@ const convertDimension = (
             ? { urls: column.meta.dimension.urls }
             : {}),
         ...(isAdditionalDimension ? { isAdditionalDimension } : {}),
+        html: column.meta.dimension?.html,
         groups,
         isIntervalBase,
         ...(column.meta.dimension && column.meta.dimension.tags

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -73,7 +73,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["string", "number", "boolean", "date", "timestamp"]
+                    "enum": ["string", "number", "boolean", "date", "timestamp", "html"]
                 },
                 "description": {
                     "type": "string"
@@ -123,6 +123,9 @@
                 },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
+                },
+                "html": {
+                    "type": "string"
                 }
             }
         },

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -172,6 +172,7 @@ export const getBasicType = (
 ): string => {
     const { type } = field;
     switch (type) {
+        case DimensionType.HTML:
         case DimensionType.STRING:
         case MetricType.STRING:
             return 'string';

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -123,6 +123,7 @@ type DbtColumnLightdashConfig = {
 export type DbtColumnLightdashDimension = {
     name?: string;
     label?: string;
+    html?: string;
     type?: DimensionType;
     description?: string;
     sql?: string;

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -265,6 +265,7 @@ export interface Field {
     urls?: FieldUrl[];
     index?: number;
     tags?: string[];
+    html?: string;
 }
 
 export const isField = (field: AnyType): field is Field =>
@@ -315,6 +316,7 @@ export enum DimensionType {
     TIMESTAMP = 'timestamp',
     DATE = 'date',
     BOOLEAN = 'boolean',
+    HTML = 'html',
 }
 
 export interface Dimension extends Field {
@@ -329,6 +331,7 @@ export interface Dimension extends Field {
     timeIntervalBaseDimensionName?: string;
     isAdditionalDimension?: boolean;
     colors?: Record<string, string>;
+    html?: string;
     isIntervalBase?: boolean;
 }
 
@@ -363,7 +366,8 @@ export interface FilterableDimension extends Dimension {
         | DimensionType.NUMBER
         | DimensionType.DATE
         | DimensionType.TIMESTAMP
-        | DimensionType.BOOLEAN;
+        | DimensionType.BOOLEAN
+    | DimensionType.HTML;
 }
 
 export type FieldRef = string;

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -114,6 +114,7 @@ export const getFilterTypeFromItem = (item: FilterableField): FilterType => {
     const type = getItemType(item);
     switch (type) {
         case DimensionType.STRING:
+        case DimensionType.HTML:
         case MetricType.STRING:
         case TableCalculationType.STRING:
             return FilterType.STRING;

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -703,6 +703,8 @@ export function formatItemValue(
                         return `${value}`;
                     }
                     break;
+                case DimensionType.HTML:
+                    return item.html
                 default:
             }
         }

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -21,6 +21,7 @@ import { Td } from '../Table.styles';
 import { type CellContextMenuProps } from '../types';
 import CellMenu from './CellMenu';
 import CellTooltip from './CellTooltip';
+import { renderTemplatedUrl } from '@lightdash/common';
 
 interface CommonBodyCellProps {
     cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>;
@@ -133,19 +134,22 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 onMouseEnter={canHaveTooltip ? openTooltip : undefined}
                 onMouseLeave={canHaveTooltip ? closeTooltip : undefined}
             >
-                <span
-                    style={{
-                        textDecoration: hasUrls ? 'underline' : 'none',
-                        textDecorationStyle: 'dotted',
-                        whiteSpace:
-                            typeof displayValue === 'string' &&
-                            displayValue.includes('\n')
-                                ? 'pre-line'
-                                : 'nowrap',
-                    }}
-                >
+                {item?.type === 'html' ?
+                    <div dangerouslySetInnerHTML={{ __html: renderTemplatedUrl(item.html, cell.getValue()?.value, {}) }}></div>
+                    :
+                    <span
+                        style={{
+                            textDecoration: hasUrls ? 'underline' : 'none',
+                            textDecorationStyle: 'dotted',
+                            whiteSpace:
+                                typeof displayValue === 'string' &&
+                                displayValue.includes('\n')
+                                    ? 'pre-line'
+                                    : 'nowrap',
+                        }}
+                    >
                     {children}
-                </span>
+                </span>}
             </Td>
 
             {shouldRenderMenu ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12724

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Hello!

This is my first contribution to this project. It's in a rough draft state, as I would first like to get your feedback if this is in general the right direction to tackle the given issue (its Slack link is older than 90 days so I cannot access the thread, sadly).

<img width="1461" alt="image" src="https://github.com/user-attachments/assets/470d5deb-fc55-4ddd-ad14-5b4b2043df81" />

The configuration is very similar to the Looker example suggested by the issue, the one from the screenshot is using this:
```yml
        meta:
          dimension:
            type: html
            html: <img src="https://placehold.co/150x100?text=${value.raw}"/> ;
```

I'll highly appreciate your guidance on which other places should reflect this change (probably using the `dangerouslySetInnerHtml` prop, like I tried in the BodyCell component).

Then, I'll polish up the code and update / add tests, and documentation.

Thank you, this project is incredible and the DX is *really* good, I was able to draft this in ~1 hour after starting playing with it 🚀 👏 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
