### PR TITLE
fix: cartesian chart stacking x y same dimension

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -82,7 +82,9 @@ export const Layout: FC<Props> = ({ items }) => {
         const { dirtyLayout } = visualizationConfig.chartConfig;
 
         return items.filter(
-            (item) => !dirtyLayout?.yField?.includes(getItemId(item)),
+            (item) =>
+                !dirtyLayout?.yField?.includes(getItemId(item)) &&
+                getItemId(item) !== dirtyLayout?.xField,
         );
     }, [isCartesianChart, items, visualizationConfig]);
 
@@ -162,9 +164,9 @@ export const Layout: FC<Props> = ({ items }) => {
             <Config>
                 <Config.Section>
                     <Config.Group>
-                        <Config.Heading>{`${
-                            validConfig?.layout.flipAxes ? 'Y' : 'X'
-                        }-axis`}</Config.Heading>
+                        <Config.Heading>
+                            {validConfig?.layout.flipAxes ? 'Y' : 'X'}-axis
+                        </Config.Heading>
                         <Group spacing="two">
                             <Tooltip variant="xs" label="Flip Axes">
                                 <ActionIcon
@@ -207,9 +209,9 @@ export const Layout: FC<Props> = ({ items }) => {
             <Config>
                 <Config.Section>
                     <Config.Group>
-                        <Config.Heading>{`${
-                            validConfig?.layout.flipAxes ? 'X' : 'Y'
-                        }-axis`}</Config.Heading>
+                        <Config.Heading>
+                            {validConfig?.layout.flipAxes ? 'X' : 'Y'}-axis
+                        </Config.Heading>
                         {availableYFields.length > 0 && (
                             <AddButton
                                 onClick={() =>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -328,10 +328,15 @@ const useCartesianChartConfig = ({
     );
 
     const setXField = useCallback((xField: string | undefined) => {
-        setDirtyLayout((prev) => ({
-            ...prev,
-            xField,
-        }));
+        setDirtyLayout((prev) => {
+            // Don't allow setting the same field for X and Y
+            if (xField && prev?.yField?.includes(xField)) return prev;
+
+            return {
+                ...prev,
+                xField,
+            };
+        });
     }, []);
 
     const setShowGridX = useCallback((show: boolean) => {
@@ -366,10 +371,15 @@ const useCartesianChartConfig = ({
         });
     }, []);
     const addSingleSeries = useCallback((yField: string) => {
-        setDirtyLayout((prev) => ({
-            ...prev,
-            yField: [...(prev?.yField || []), yField],
-        }));
+        setDirtyLayout((prev) => {
+            // Don't allow setting the same field as X and Y
+            if (yField === prev?.xField) return prev;
+
+            return {
+                ...prev,
+                yField: [...(prev?.yField || []), yField],
+            };
+        });
     }, []);
 
     const removeSingleSeries = useCallback((index: number) => {
@@ -405,12 +415,17 @@ const useCartesianChartConfig = ({
     }, []);
 
     const updateYField = useCallback((index: number, fieldId: string) => {
-        setDirtyLayout((prev) => ({
-            ...prev,
-            yField: prev?.yField?.map((field, i) => {
-                return i === index ? fieldId : field;
-            }),
-        }));
+        setDirtyLayout((prev) => {
+            // Don't allow setting the same field as X and Y
+            if (fieldId === prev?.xField) return prev;
+
+            return {
+                ...prev,
+                yField: prev?.yField?.map((field, i) => {
+                    return i === index ? fieldId : field;
+                }),
+            };
+        });
     }, []);
 
     const setType = useCallback(


### PR DESCRIPTION
Closes: [#14033](https://github.com/lightdash/lightdash/issues/14033)

### Description:

See the stack trace in the original linked issue.  
FYI, the error is coming from the ECharts library because stacking is handled when the same dimension is used on both the X and Y axes.  

This PR prevents setting the same fields in both the X and Y dimensions.

repro steps:

https://github.com/user-attachments/assets/cfe01a5f-1269-49eb-83b8-98b94d372426

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
