### PR TITLE
fix: show metric info for meta-level metrics

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -457,6 +457,10 @@ export const isMetric = (
 export const isNonAggregateMetric = (field: Field): boolean =>
     isMetric(field) && NonAggregateMetricTypes.includes(field.type);
 
+export const isCompiledMetric = (
+    field: ItemsMap[string] | AdditionalMetric | undefined,
+): field is CompiledMetric => isMetric(field) && 'compiledSql' in field;
+
 export interface Metric extends Field {
     fieldType: FieldType.METRIC;
     type: MetricType;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Test with `completion_percentage` metric in `orders`

On main, if you hover, you can't see the metric info
On this branch, you can. 

Also added `compiledSql` instead of the `sql` so that users can see what exactly we're using.

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/8eb858b6-eeda-4f67-be72-9e255e9e9db5" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
