### PR TITLE
fix: saving new chart redirects to first tab

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,6 +1,6 @@
 import { Stack } from '@mantine/core';
 import { type FC } from 'react';
-import { Navigate, Outlet, useParams, type RouteObject } from 'react-router';
+import { Navigate, Outlet, type RouteObject } from 'react-router';
 import AppRoute from './components/AppRoute';
 import ForbiddenPanel from './components/ForbiddenPanel';
 import JobDetailsDrawer from './components/JobDetailsDrawer';
@@ -44,15 +44,12 @@ import ViewSqlChart from './pages/ViewSqlChart';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import { PageName } from './types/Events';
 
-const DashboardPageWrapper: FC<{ keyParam: 'dashboardUuid' | 'tabUuid' }> = ({
-    keyParam,
-}) => {
-    const params = useParams<{ dashboardUuid?: string; tabUuid?: string }>();
+const DashboardPageWrapper: FC = () => {
     return (
         <>
             <NavBar />
             <TrackPage name={PageName.DASHBOARD}>
-                <Dashboard key={params[keyParam]} />
+                <Dashboard />
             </TrackPage>
         </>
     );
@@ -204,11 +201,11 @@ const DASHBOARD_ROUTES: RouteObject[] = [
         children: [
             {
                 path: '/projects/:projectUuid/dashboards/:dashboardUuid/:mode?',
-                element: <DashboardPageWrapper keyParam={'dashboardUuid'} />,
+                element: <DashboardPageWrapper />,
             },
             {
                 path: '/projects/:projectUuid/dashboards/:dashboardUuid/:mode/tabs/:tabUuid?',
-                element: <DashboardPageWrapper keyParam={'tabUuid'} />,
+                element: <DashboardPageWrapper />,
             },
         ],
     },

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -225,14 +225,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     );
                                     if (tab) {
                                         setActiveTab(tab);
-                                    }
-                                    if (!isEditMode) {
                                         const newParams = new URLSearchParams(
                                             search,
                                         );
                                         void navigate(
                                             {
-                                                pathname: `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
+                                                pathname: isEditMode
+                                                    ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${tab?.uuid}`
+                                                    : `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
                                                 search: newParams.toString(),
                                             },
                                             { replace: true },

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -19,7 +19,11 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
     const [isCancelling, setIsCancelling] = useState(false);
 
     const { getEditingDashboardInfo } = useDashboardStorage();
-    const { name: dashboardName, dashboardUuid } = getEditingDashboardInfo();
+    const {
+        name: dashboardName,
+        dashboardUuid,
+        activeTabUuid,
+    } = getEditingDashboardInfo();
 
     const action = useMemo(() => {
         if (!savedQueryUuid) {
@@ -74,18 +78,22 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
         // so do not clear the storage here
         setIsCancelling(true);
 
-        //
-        void navigate(
-            `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
-                savedQueryUuid ? 'view' : 'edit'
-            }`,
-        );
+        let returnUrl = `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
+            savedQueryUuid ? 'view' : 'edit'
+        }`;
+
+        console.log('activeTabUuid', activeTabUuid);
+        if (activeTabUuid) {
+            returnUrl += `/tabs/${activeTabUuid}`;
+        }
+
+        void navigate(returnUrl);
 
         setTimeout(() => {
             // Clear the banner after navigating back to dashboard, but only after a delay so that the user can see the banner change
             setIsCancelling(false);
         }, 1000);
-    }, [dashboardUuid, navigate, projectUuid, savedQueryUuid]);
+    }, [dashboardUuid, activeTabUuid, navigate, projectUuid, savedQueryUuid]);
 
     return (
         <>

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -74,6 +74,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
         // so do not clear the storage here
         setIsCancelling(true);
 
+        //
         void navigate(
             `/projects/${projectUuid}/dashboards/${dashboardUuid}/${
                 savedQueryUuid ? 'view' : 'edit'

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -82,7 +82,6 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
             savedQueryUuid ? 'view' : 'edit'
         }`;
 
-        console.log('activeTabUuid', activeTabUuid);
         if (activeTabUuid) {
             returnUrl += `/tabs/${activeTabUuid}`;
         }

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -128,7 +128,9 @@ export const SaveToDashboard: FC<Props> = ({
 
             clearIsEditingDashboardChart();
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                activeTabUuid
+                    ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTabUuid}`
+                    : `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
             );
             showToastSuccess({
                 title: `Success! ${values.name} was added to ${dashboardName}`,

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
@@ -39,6 +39,7 @@ const useDashboardStorage = () => {
         return {
             name: sessionStorage.getItem('fromDashboard'),
             dashboardUuid: sessionStorage.getItem('dashboardUuid'),
+            activeTabUuid: sessionStorage.getItem('activeTabUuid'),
         };
     }, []);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13990 

### Description:

Primarily this makes it so that when you edit a chart on a dashboard tab and go back to the dashboard, you'll be in the tab you were editing. This part is pretty straightforward. 

This required a change to the way the dashboard gets mounted. We were unmounting and remounting the whole dashboard on tab change, when the URL changed. But this meant the context was lost every time you switched tabs, so we couldn't support proper editing across tabs. This 'worked' before because in edit mode we didn't look at the URL for tabs. But it made it impossible to deep link to the tabs during edit. 

This PR changes the router to NOT unmount and remount the dashboard on tab change. This will help perf, and also fixes a couple bugs I saw when editing across tabs, but is definitely a change. As far as I can tell it works well. The old behavior may have been necessary with the old react router, which we have now upgraded. 

To test:
- Make a dashboard with multiple tabs
- Add a new (not saved) chart to a tab other than the default
- Save your chart and go back to the dashboard. 
- You should land on the new tab with the new chart.
- Also note that switching tabs during edit now changes the tabID in the url  

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
