### PR TITLE
feat: improve on-hover of metric detail 

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -457,6 +457,10 @@ export const isMetric = (
 export const isNonAggregateMetric = (field: Field): boolean =>
     isMetric(field) && NonAggregateMetricTypes.includes(field.type);
 
+export const isCompiledMetric = (
+    field: ItemsMap[string] | AdditionalMetric | undefined,
+): field is CompiledMetric => isMetric(field) && 'compiledSql' in field;
+
 export interface Metric extends Field {
     fieldType: FieldType.METRIC;
     type: MetricType;

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -174,6 +174,10 @@ export const timeframeToUnitOfTime = (timeframe: TimeFrames) => {
     }
 };
 
+export const isWithValueFilter = (filterOperator: FilterOperator) =>
+    filterOperator !== FilterOperator.NULL &&
+    filterOperator !== FilterOperator.NOT_NULL;
+
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     field: FilterableField,
     filterRule: T,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -1,8 +1,14 @@
-import { friendlyName } from '@lightdash/common';
+import {
+    friendlyName,
+    isDateFilterRule,
+    type CompiledMetric,
+} from '@lightdash/common';
+import { isWithValueFilter } from '@lightdash/common/src';
 import {
     Anchor,
     Badge,
     Box,
+    Button,
     Code,
     Divider,
     Group,
@@ -10,13 +16,15 @@ import {
     Stack,
     Text,
     Title,
+    Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { IconTable } from '@tabler/icons-react';
+import { IconCode, IconTable } from '@tabler/icons-react';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
-import { type FC, type PropsWithChildren } from 'react';
+import { Fragment, useState, type FC, type PropsWithChildren } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
 import { rehypeRemoveHeaderLinks } from '../../../../utils/markdownUtils';
+import { filterOperatorLabel } from '../../../common/Filters/FilterInputs/constants';
 import MantineIcon from '../../../common/MantineIcon';
 import { useItemDetail } from './useItemDetails';
 
@@ -57,6 +65,9 @@ export const ItemDetailPreview: FC<{
     metricInfo?: {
         type: string;
         sql: string;
+        compiledSql: string;
+        name: string;
+        filters?: CompiledMetric['filters'];
     };
 }> = ({ description, onViewDescription, metricInfo }) => {
     /**
@@ -71,17 +82,20 @@ export const ItemDetailPreview: FC<{
         (description && description.length > 180) ||
         (description && description.split('\n').length > 2);
 
+    const [showCompiled, setShowCompiled] = useState(false);
+
     return (
         <Stack spacing="xs">
             {metricInfo && (
                 <>
-                    <Group spacing="xs">
-                        <Text fz="xs" fw={500} c="dark.7">
-                            Type:
+                    <Group spacing="xs" position="apart">
+                        <Text fz="sm" fw={500} c="dark.7">
+                            {metricInfo.name}
                         </Text>
                         <Badge
                             radius="sm"
                             color="indigo"
+                            p={2}
                             sx={(theme) => ({
                                 boxShadow: theme.shadows.subtle,
                                 border: `1px solid ${theme.colors.indigo[1]}`,
@@ -90,13 +104,6 @@ export const ItemDetailPreview: FC<{
                             {friendlyName(metricInfo.type)}
                         </Badge>
                     </Group>
-                    <Divider color="gray.2" />
-                    <Stack spacing="xs">
-                        <Text fz="xs" fw={500} c="dark.7">
-                            SQL
-                        </Text>
-                        <Code>{metricInfo.sql}</Code>
-                    </Stack>
                 </>
             )}
             {description && (
@@ -112,7 +119,14 @@ export const ItemDetailPreview: FC<{
                     }}
                 >
                     <Stack spacing="xs">
-                        {metricInfo && <Divider color="gray.2" />}
+                        {metricInfo && (
+                            <>
+                                <Divider color="gray.2" />
+                                <Text fz="xs" fw={500} c="dark.7">
+                                    Description
+                                </Text>
+                            </>
+                        )}
 
                         <ItemDetailMarkdown source={description} />
                     </Stack>
@@ -130,6 +144,101 @@ export const ItemDetailPreview: FC<{
                         Read full description
                     </Anchor>
                 </Box>
+            )}
+            {metricInfo && (
+                <>
+                    <Divider color="gray.2" />
+                    <Stack spacing="xs">
+                        <Group spacing="xs" align="center" position="apart">
+                            <Text fz="xs" fw={500} c="dark.7">
+                                SQL
+                            </Text>
+                            <Tooltip
+                                variant="xs"
+                                position="right"
+                                label={
+                                    showCompiled
+                                        ? 'Show original SQL'
+                                        : 'Show compiled SQL'
+                                }
+                            >
+                                <Button
+                                    compact
+                                    variant="subtle"
+                                    color="gray"
+                                    onClick={() =>
+                                        setShowCompiled(!showCompiled)
+                                    }
+                                    size="xs"
+                                    leftIcon={<MantineIcon icon={IconCode} />}
+                                >
+                                    {showCompiled
+                                        ? 'Original SQL'
+                                        : 'Compiled SQL'}
+                                </Button>
+                            </Tooltip>
+                        </Group>
+                        <Code style={{ flex: 1 }}>
+                            {showCompiled
+                                ? metricInfo.compiledSql
+                                : metricInfo.sql}
+                        </Code>
+                        {metricInfo.filters &&
+                            metricInfo.filters.length > 0 && (
+                                <>
+                                    <Divider color="gray.2" />
+                                    <Text fz="xs" fw={500} c="dark.7">
+                                        Filters
+                                    </Text>
+                                    {metricInfo.filters.map((filter) => {
+                                        const operationLabel =
+                                            filterOperatorLabel[
+                                                filter.operator
+                                            ];
+
+                                        return (
+                                            <Group key={filter.id} spacing={4}>
+                                                <Code fz="xs" fw={500}>
+                                                    {filter.target.fieldRef}
+                                                </Code>
+                                                <Text fz="xs" fw={500}>
+                                                    {operationLabel}
+                                                </Text>
+                                                {}
+                                                <Code fz="xs">
+                                                    {isWithValueFilter(
+                                                        filter.operator,
+                                                    )
+                                                        ? filter.values
+                                                              ?.map(
+                                                                  (value) =>
+                                                                      value,
+                                                              )
+                                                              .join(', ')
+                                                        : ''}
+                                                    {isDateFilterRule(
+                                                        filter,
+                                                    ) && (
+                                                        <Fragment>
+                                                            {' '}
+                                                            {filter.settings
+                                                                ?.completed
+                                                                ? 'completed'
+                                                                : ''}
+                                                            {
+                                                                filter.settings
+                                                                    ?.unitOfTime
+                                                            }
+                                                        </Fragment>
+                                                    )}
+                                                </Code>
+                                            </Group>
+                                        );
+                                    })}
+                                </>
+                            )}
+                    </Stack>
+                </>
             )}
         </Stack>
     );

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -1,9 +1,9 @@
 import {
     friendlyName,
     isDateFilterRule,
+    isWithValueFilter,
     type CompiledMetric,
 } from '@lightdash/common';
-import { isWithValueFilter } from '@lightdash/common/src';
 import {
     Anchor,
     Badge,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -166,9 +166,12 @@ export const ItemDetailPreview: FC<{
                                     compact
                                     variant="subtle"
                                     color="gray"
-                                    onClick={() =>
-                                        setShowCompiled(!showCompiled)
-                                    }
+                                    onClick={(
+                                        e: React.MouseEvent<HTMLButtonElement>,
+                                    ) => {
+                                        e.stopPropagation();
+                                        setShowCompiled(!showCompiled);
+                                    }}
                                     size="xs"
                                     leftIcon={<MantineIcon icon={IconCode} />}
                                 >
@@ -178,7 +181,7 @@ export const ItemDetailPreview: FC<{
                                 </Button>
                             </Tooltip>
                         </Group>
-                        <Code style={{ flex: 1 }}>
+                        <Code maw={400}>
                             {showCompiled
                                 ? metricInfo.compiledSql
                                 : metricInfo.sql}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -1,6 +1,7 @@
 import {
     getItemId,
     isAdditionalMetric,
+    isCompiledMetric,
     isCustomDimension,
     isDimension,
     isField,
@@ -12,7 +13,6 @@ import {
     type AdditionalMetric,
     type Item,
 } from '@lightdash/common';
-import { isCompiledMetric } from '@lightdash/common/src';
 import {
     ActionIcon,
     Group,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -76,7 +76,11 @@ const TreeSingleNode: FC<Props> = memo(({ node }) => {
         if (isCompiledMetric(item)) {
             return {
                 type: item.type,
-                sql: item.compiledSql,
+                sql: item.sql,
+                compiledSql: item.compiledSql,
+                filters: item.filters,
+                table: item.table,
+                name: item.name,
             };
         }
         return undefined;
@@ -202,7 +206,7 @@ const TreeSingleNode: FC<Props> = memo(({ node }) => {
                         position="right"
                         radius="md"
                         /** Ensures the hover card does not overlap with the right-hand menu. */
-                        offset={80}
+                        offset={70}
                     >
                         <HoverCard.Target>
                             <Highlight
@@ -217,6 +221,11 @@ const TreeSingleNode: FC<Props> = memo(({ node }) => {
                         <HoverCard.Dropdown
                             hidden={!isHover}
                             p="xs"
+                            miw={400}
+                            mah={500}
+                            sx={{
+                                overflow: 'auto',
+                            }}
                             /**
                              * Takes up space to the right, so it's OK to go fairly wide in the interest
                              * of readability.

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -1,12 +1,12 @@
 import {
     formatItemValue,
+    getSubtotalKey,
     isCustomDimension,
     isField,
     type ApiQueryResults,
     type ItemsMap,
     type ResultRow,
 } from '@lightdash/common';
-import { getSubtotalKey } from '@lightdash/common/src/utils/subtotals';
 import { Text } from '@mantine/core';
 import type { CellContext } from '@tanstack/react-table';
 import {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13709 
Closes: #14061

### Description:

This PR does a few things

### Fix 

Fixes on-hover of metric-model-level it not showing the metric info 

Test with field  `completion_percentage` metric in orders
On **main**, if you hover, you can't see the metric info
On this **branch**, you can.

### Show name, and compiled sql on click

Displays yml reference on the dropdown up top
Users can now see the sql + the compiled sql if they click on it
Moved description above the sql

### Show filters

You can test this with many filters. Try it out with the following yml in `schema.yml` > compled_order_count

```yml
completed_order_count:
              label: Completed order count
              description: Total number of completed orders
              type: count_distinct
              filters:
                - is_completed: "true"
                - order_date_day: "2018-02-10"
                - order_date_week: "inThePast 14 months"
                - customers.customer_id: "1"
                - status: "!false"
                - status: "katie"
                - status: "!john"
                - status: "%gmail%"
                - status: "!%avenue%"
                - status: "jo%"
                - status: "%son"
                - amount: "> 4"
                - amount: ">= 100"
                - amount: "< 10"
                - amount: "<= 50"
                - order_date_month: "inThePast 14 months"
                - order_date_day: "inTheNext 30 days"
                - order_id: "null"
                - order_id: "!null"
```


Demo:


https://github.com/user-attachments/assets/05bbac8f-ed4f-43b3-be54-5e71771c84a8



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
