### PR TITLE
fix: run postbuild after BE sourcemaps build

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -165,7 +165,7 @@ COPY packages/backend/src/ ./packages/backend/src
 # Conditionally build backend with sourcemaps if Sentry environment variables are set
 RUN if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ] && [ -n "${SENTRY_FRONTEND_PROJECT}" ] && [ -n "${SENTRY_BACKEND_PROJECT}" ] && [ -n "${SENTRY_ENVIRONMENT}" ]; then \
     echo "Building backend with sourcemaps for Sentry"; \
-    pnpm -F backend build-sourcemaps; \
+    pnpm -F backend build-sourcemaps && pnpm -F backend postbuild; \
     else \
     echo "Building backend without sourcemaps"; \
     pnpm -F backend build; \


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14075

### Description:

Now that the command to run `build-sourcemaps` is a different name form `build` we have to run `postbuild` explicitly to copy over the html assets (related to email templates)

<img width="799" alt="Screenshot 2025-03-14 at 10 55 59" src="https://github.com/user-attachments/assets/e9bb591b-3c32-43ce-8d14-b509cc24cb16" />

And checked that the docker image contains the html files

<img width="956" alt="image" src="https://github.com/user-attachments/assets/3018e845-b351-47ae-a105-37c703ab396e" />


(can provide a test script and env vars to test locally)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
