### PR TITLE
feat: add applied dashboard filters to response

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14248,6 +14248,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                appliedDashboardFilters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DashboardFilters' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 queryUuid: { dataType: 'string', required: true },
             },
             validators: {},

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15062,11 +15062,19 @@
             },
             "ApiExecuteAsyncQueryResults": {
                 "properties": {
+                    "appliedDashboardFilters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DashboardFilters"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "queryUuid": {
                         "type": "string"
                     }
                 },
-                "required": ["queryUuid"],
+                "required": ["appliedDashboardFilters", "queryUuid"],
                 "type": "object"
             },
             "ApiExecuteAsyncQueryResponse": {
@@ -15715,7 +15723,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1537.3",
+        "version": "0.1538.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2217,7 +2217,7 @@ export class ProjectService extends BaseService {
             query_context: context,
         };
 
-        return this.executeAsyncQuery(
+        const { queryUuid } = await this.executeAsyncQuery(
             {
                 user,
                 metricQuery,
@@ -2229,6 +2229,11 @@ export class ProjectService extends BaseService {
             },
             requestParameters,
         );
+
+        return {
+            queryUuid,
+            appliedDashboardFilters: null,
+        };
     }
 
     async executeAsyncSavedChartQuery({
@@ -2307,7 +2312,7 @@ export class ProjectService extends BaseService {
             query_context: context,
         };
 
-        return this.executeAsyncQuery(
+        const { queryUuid } = await this.executeAsyncQuery(
             {
                 user,
                 projectUuid,
@@ -2319,6 +2324,11 @@ export class ProjectService extends BaseService {
             },
             requestParameters,
         );
+
+        return {
+            queryUuid,
+            appliedDashboardFilters: null,
+        };
     }
 
     async executeAsyncDashboardChartQuery({
@@ -2385,7 +2395,7 @@ export class ProjectService extends BaseService {
         );
 
         const tables = Object.keys(explore.tables);
-        const appliedDashboardFilters = {
+        const appliedDashboardFilters: DashboardFilters = {
             dimensions: getDashboardFilterRulesForTables(
                 tables,
                 dashboardFilters.dimensions,
@@ -2451,7 +2461,7 @@ export class ProjectService extends BaseService {
             query_context: context,
         };
 
-        return this.executeAsyncQuery(
+        const { queryUuid } = await this.executeAsyncQuery(
             {
                 user,
                 projectUuid,
@@ -2464,6 +2474,11 @@ export class ProjectService extends BaseService {
             },
             requestParameters,
         );
+
+        return {
+            queryUuid,
+            appliedDashboardFilters,
+        };
     }
 
     private async runQueryAndFormatRows({

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -473,6 +473,7 @@ export type ApiQueryResults = {
 
 export type ApiExecuteAsyncQueryResults = {
     queryUuid: string;
+    appliedDashboardFilters: DashboardFilters | null;
 };
 
 export type ApiGetAsyncQueryResults =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#14072](https://github.com/lightdash/lightdash/issues/14072)

### Description:

- Returns applied dashboard filters to execute query response. Returning `null` shows intent that this is not dashboard chart async query

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
