### PR TITLE
feat: Add private key snowflake UI

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -139,15 +139,17 @@ const credentialsTarget = (
                     [envVar('user')]: credentials.user,
                 },
             };
-            if (credentials.password) {
+            if (
+                credentials.authenticationType === 'password' &&
+                credentials.password
+            ) {
                 result.target.password = envVarReference('password');
                 result.environment[envVar('password')] = credentials.password;
             } else if (credentials.privateKey) {
-                const privateKeyPath = path.join(profilesDir, 'rsa_key.p8');
-                result.target.private_key_path =
-                    envVarReference('privateKeyPath');
-                result.environment[envVar('privateKeyPath')] = privateKeyPath;
-                result.files = { [privateKeyPath]: credentials.privateKey };
+                result.target.private_key = envVarReference('privateKey');
+                result.environment[envVar('privateKey')] =
+                    credentials.privateKey;
+
                 if (credentials.privateKeyPass) {
                     result.target.private_key_passphrase =
                         envVarReference('privateKeyPass');

--- a/packages/cli/src/dbt/targets/snowflake.ts
+++ b/packages/cli/src/dbt/targets/snowflake.ts
@@ -16,6 +16,7 @@ type SnowflakeTarget = {
     user: string;
     password?: string;
     private_key_path?: string;
+    private_key?: string;
     private_key_passphrase?: string;
     role?: string;
     database: string;
@@ -48,6 +49,10 @@ const snowflakeSchema: JSONSchemaType<SnowflakeTarget> = {
             nullable: true,
         },
         private_key_path: {
+            type: 'string',
+            nullable: true,
+        },
+        private_key: {
             type: 'string',
             nullable: true,
         },
@@ -116,6 +121,9 @@ export const convertSnowflakeSchema = async (
                     `Cannot read keyfile for snowflake target at: ${keyfilePath}:\n  ${msg}`,
                 );
             }
+        }
+        if (target.private_key) {
+            privateKey = target.private_key;
         }
 
         return {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -167,6 +167,7 @@ export type CreateSnowflakeCredentials = {
     requireUserCredentials?: boolean;
     privateKey?: string;
     privateKeyPass?: string;
+    authenticationType?: 'password' | 'private_key';
     role?: string;
     database: string;
     warehouse: string;

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -136,6 +136,8 @@ const configureDatabricksWarehouse = (
 const configureSnowflakeWarehouse = (
     config: typeof warehouseConfig['snowflake'],
 ) => {
+    cy.selectMantine('warehouse.authenticationType', 'password');
+
     cy.get('input[name="warehouse.account"]').type(config.account, {
         log: false,
     });

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -136,12 +136,13 @@ const configureDatabricksWarehouse = (
 const configureSnowflakeWarehouse = (
     config: typeof warehouseConfig['snowflake'],
 ) => {
-    cy.selectMantine('warehouse.authenticationType', 'password');
-
     cy.get('input[name="warehouse.account"]').type(config.account, {
         log: false,
     });
     cy.get('input[name="warehouse.user"]').type(config.user, { log: false });
+
+    cy.selectMantine('warehouse.authenticationType', 'Password');
+
     cy.get('input[name="warehouse.password"]').type(config.password, {
         log: false,
     });
@@ -628,7 +629,7 @@ describe('Create projects', () => {
         });
     });
 
-    it('Should create a Snowflake project', () => {
+    it.only('Should create a Snowflake project', () => {
         cy.visit(`/createProject`);
 
         cy.get('[role="button"').contains('Snowflake').click();

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -629,7 +629,7 @@ describe('Create projects', () => {
         });
     });
 
-    it.only('Should create a Snowflake project', () => {
+    it('Should create a Snowflake project', () => {
         cy.visit(`/createProject`);
 
         cy.get('[role="button"').contains('Snowflake').click();

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -57,7 +57,7 @@ const SnowflakeForm: FC<{
         FeatureFlags.PassthroughLogin,
     );
     const authenticationType: string = useWatch({
-        name: 'warehouse.authentication_type',
+        name: 'warehouse.authenticationType',
         defaultValue:
             (savedProject?.warehouseConnection?.type ===
                 WarehouseTypes.SNOWFLAKE &&
@@ -102,6 +102,7 @@ const SnowflakeForm: FC<{
                     defaultValue="private_key"
                     render={({ field }) => (
                         <Select
+                            name={field.name}
                             label="Authentication Type"
                             description="Choose between password or key pair authentication"
                             data={[

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -59,7 +59,9 @@ const SnowflakeForm: FC<{
     const authenticationType: string = useWatch({
         name: 'warehouse.authentication_type',
         defaultValue:
-            savedProject?.warehouseConnection?.authenticationType ||
+            (savedProject?.warehouseConnection?.type ===
+                WarehouseTypes.SNOWFLAKE &&
+                savedProject?.warehouseConnection?.authenticationType) ||
             'private_key',
     });
     const [temporaryFile, setTemporaryFile] = useState<File>();

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -141,30 +141,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
     constructor(credentials: CreateSnowflakeCredentials) {
         super(credentials);
 
-        let privateKey: string | undefined;
-        if (credentials.privateKey) {
-            if (
-                typeof credentials.privateKeyPass === 'string' &&
-                credentials.privateKeyPass.length > 0
-            ) {
-                // Get the private key from the file as an object and
-                // extract the private key from the object as a PEM-encoded string.
-                privateKey = crypto
-                    .createPrivateKey({
-                        key: credentials.privateKey,
-                        format: 'pem',
-                        passphrase: credentials.privateKeyPass,
-                    })
-                    .export({
-                        format: 'pem',
-                        type: 'pkcs8',
-                    })
-                    .toString();
-            } else {
-                privateKey = credentials.privateKey;
-            }
-        }
-
         if (typeof credentials.quotedIdentifiersIgnoreCase !== 'undefined') {
             this.quotedIdentifiersIgnoreCase =
                 credentials.quotedIdentifiersIgnoreCase;
@@ -176,9 +152,9 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 password: credentials.password,
                 authenticator: 'SNOWFLAKE',
             };
-        } else if (privateKey) {
+        } else if (credentials.privateKey) {
             authenticationOptions = {
-                privateKey,
+                privateKey: credentials.privateKey,
                 authenticator: 'SNOWFLAKE_JWT',
             };
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/6424
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

This change is also backwards compatible with `private_key_path` from CLI and passwords in the UI 

![Screenshot from 2025-03-14 16-27-37](https://github.com/user-attachments/assets/32b6aea4-26c6-4cb7-a2d8-212e2efe7b36)

![Screenshot from 2025-03-14 16-46-14](https://github.com/user-attachments/assets/1421cd7d-18df-4dcb-a7c0-aa6edca406bb)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
