### PR TITLE
feat: allow color palette override

### DIFF
--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -189,12 +189,12 @@ export class OrganizationModel {
 
     static mapDBObjectToOrganization(
         data: DbOrganization,
-        palette?: DbOrganizationColorPalette,
+        palette?: DbOrganizationColorPalette['colors'],
     ): Organization {
         return {
             organizationUuid: data.organization_uuid,
             name: data.organization_name,
-            chartColors: palette?.colors ?? undefined,
+            chartColors: palette ?? undefined,
             defaultProjectUuid: data.default_project_uuid
                 ? data.default_project_uuid
                 : undefined,
@@ -217,12 +217,23 @@ export class OrganizationModel {
             throw new NotFoundError(`No organization found`);
         }
 
+        // If default color palette is configured, always override the active palette
+        if (
+            this.lightdashConfig?.appearance?.defaultColorPalette &&
+            this.lightdashConfig.appearance.defaultColorPalette.length > 0
+        ) {
+            return OrganizationModel.mapDBObjectToOrganization(
+                org,
+                this.lightdashConfig.appearance.defaultColorPalette,
+            );
+        }
+
         const [palette] = await this.database(OrganizationColorPaletteTableName)
             .where('color_palette_uuid', org.color_palette_uuid)
             .andWhere('organization_uuid', organizationUuid)
             .select('*');
 
-        return OrganizationModel.mapDBObjectToOrganization(org, palette);
+        return OrganizationModel.mapDBObjectToOrganization(org, palette.colors);
     }
 
     async create(data: CreateOrganization): Promise<Organization> {
@@ -240,32 +251,6 @@ export class OrganizationModel {
                 colors: palette.colors,
             })),
         );
-
-        // If default color palette is configured, set it as the active palette
-        if (
-            this.lightdashConfig?.appearance?.defaultColorPalette &&
-            this.lightdashConfig.appearance.defaultColorPalette.length > 0
-        ) {
-            const defaultPaletteName =
-                this.lightdashConfig.appearance.defaultColorPaletteName ||
-                'Default (Custom)';
-
-            const defaultPalette = await this.createColorPalette(
-                org.organization_uuid,
-                {
-                    name: defaultPaletteName,
-                    colors: this.lightdashConfig.appearance.defaultColorPalette,
-                },
-            );
-
-            // Set it as the active palette
-            if (defaultPalette) {
-                await this.setActiveColorPalette(
-                    org.organization_uuid,
-                    defaultPalette.colorPaletteUuid,
-                );
-            }
-        }
 
         return OrganizationModel.mapDBObjectToOrganization(org);
     }
@@ -298,7 +283,10 @@ export class OrganizationModel {
                 .andWhere('organization_uuid', organizationUuid)
                 .select('*');
 
-            return OrganizationModel.mapDBObjectToOrganization(org, palette);
+            return OrganizationModel.mapDBObjectToOrganization(
+                org,
+                palette.colors,
+            );
         }
 
         return OrganizationModel.mapDBObjectToOrganization(org);

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -973,6 +973,21 @@ export class SavedChartModel {
                     config: savedQuery.chart_config,
                 } as ChartConfig;
 
+                const getColorPalette = () => {
+                    if (
+                        this.lightdashConfig.appearance.defaultColorPalette &&
+                        this.lightdashConfig.appearance.defaultColorPalette
+                            .length > 0
+                    ) {
+                        return this.lightdashConfig.appearance
+                            .defaultColorPalette;
+                    }
+                    if (savedQuery.color_palette) {
+                        return savedQuery.color_palette;
+                    }
+                    return ECHARTS_DEFAULT_COLORS;
+                };
+
                 return {
                     uuid: savedQuery.saved_query_uuid,
                     projectUuid: savedQuery.project_uuid,
@@ -1052,8 +1067,7 @@ export class SavedChartModel {
                     pinnedListOrder: null,
                     dashboardUuid: savedQuery.dashboard_uuid,
                     dashboardName: savedQuery.dashboardName,
-                    colorPalette:
-                        savedQuery.color_palette ?? ECHARTS_DEFAULT_COLORS,
+                    colorPalette: getColorPalette(),
                     slug: savedQuery.slug,
                 };
             },

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -144,6 +144,14 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.extendedUsageAnalytics.enabled,
             hasCacheAutocompleResults:
                 this.lightdashConfig.resultsCache.autocompleteEnabled || false,
+            appearance: {
+                defaultColorPalette:
+                    this.lightdashConfig.appearance.defaultColorPalette,
+                defaultColorPaletteName: this.lightdashConfig.appearance
+                    .defaultColorPaletteName
+                    ? this.lightdashConfig.appearance.defaultColorPaletteName
+                    : undefined,
+            },
         };
     }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -940,6 +940,10 @@ export type HealthState = {
     hasHeadlessBrowser: boolean;
     hasExtendedUsageAnalytics: boolean;
     hasCacheAutocompleResults: boolean;
+    appearance: {
+        defaultColorPalette: string[] | undefined;
+        defaultColorPaletteName: string | undefined;
+    };
 };
 
 export enum DBFieldTypes {

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -9,8 +9,14 @@ import {
     Menu,
     Paper,
     Text,
+    Tooltip,
 } from '@mantine/core';
-import { IconDotsVertical, IconEdit, IconTrash } from '@tabler/icons-react';
+import {
+    IconDotsVertical,
+    IconEdit,
+    IconInfoCircle,
+    IconTrash,
+} from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useDeleteColorPalette } from '../../../hooks/appearance/useOrganizationAppearance';
 import MantineIcon from '../../common/MantineIcon';
@@ -18,15 +24,17 @@ import { DeletePaletteModal } from './DeletePaletteModal';
 import { EditPaletteModal } from './EditPaletteModal';
 
 type PaletteItemProps = {
-    palette: OrganizationColorPalette;
+    palette: Omit<OrganizationColorPalette, 'name'> & { name: string };
     isActive: boolean;
-    onSetActive: (uuid: string) => void;
+    onSetActive: ((uuid: string) => void) | undefined;
+    readOnly?: boolean;
 };
 
 export const PaletteItem: FC<PaletteItemProps> = ({
     palette,
     isActive,
     onSetActive,
+    readOnly,
 }) => {
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -64,23 +72,44 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                             ))}
                         </Group>
                         <Text fw={500}>{palette.name}</Text>
+                        {readOnly && (
+                            <Tooltip
+                                label="This palette is read only. It has been configured as the default color palette for your organization. While this is set, you cannot update/edit, or delete this palette."
+                                position="bottom-end"
+                                multiline
+                                maw={200}
+                                variant="xs"
+                            >
+                                <Badge color="gray" variant="light">
+                                    <Group spacing={2}>
+                                        Default
+                                        <MantineIcon
+                                            size="sm"
+                                            icon={IconInfoCircle}
+                                        />
+                                    </Group>
+                                </Badge>
+                            </Tooltip>
+                        )}
                     </Group>
 
                     <Group spacing="xs">
-                        <Button
-                            onClick={() =>
-                                onSetActive(palette.colorPaletteUuid)
-                            }
-                            h={32}
-                            sx={() => ({
-                                visibility:
-                                    isHovered && !isActive
-                                        ? 'visible'
-                                        : 'hidden',
-                            })}
-                        >
-                            Use This Theme
-                        </Button>
+                        {onSetActive && (
+                            <Button
+                                onClick={() =>
+                                    onSetActive(palette.colorPaletteUuid)
+                                }
+                                h={32}
+                                sx={() => ({
+                                    visibility:
+                                        isHovered && !isActive
+                                            ? 'visible'
+                                            : 'hidden',
+                                })}
+                            >
+                                Use This Theme
+                            </Button>
+                        )}
 
                         {isActive && (
                             <Badge color="green" variant="light">
@@ -88,9 +117,13 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                             </Badge>
                         )}
 
-                        <Menu shadow="subtle" position="bottom-end">
+                        <Menu
+                            shadow="subtle"
+                            position="bottom-end"
+                            disabled={readOnly}
+                        >
                             <Menu.Target>
-                                <ActionIcon size="xs">
+                                <ActionIcon size="xs" disabled={readOnly}>
                                     <MantineIcon icon={IconDotsVertical} />
                                 </ActionIcon>
                             </Menu.Target>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #14007

### Description:

Allows overriding the color palette based on the env vars set. 

Example to test this:

```
export DEFAULT_COLOR_PALETTE_NAME="Ocean Depths"
export DEFAULT_COLOR_PALETTE_COLORS=#001F3F,#003366,#004080,#0066CC,#0099FF,#00BFFF,#48D1CC,#5F9EA0,#20B2AA,#40E0D0,#7FFFD4,#00CED1,#87CEEB,#B0E0E6,#ADD8E6,#D3D3D3,#FFFFFF,#000000,#000000,#000000
export ALLOW_MULTIPLE_ORGS=true // if you want to test how it behaves for multiple org instances
```

<img width="978" alt="image" src="https://github.com/user-attachments/assets/c1223b5e-ffee-4e80-8cb8-a9aab1dfb6f4" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
