### PR TITLE
fix: warehouse wait for query completion

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -182,9 +182,13 @@ describe('SnowflakeWarehouseClient', () => {
 
             // Ensure that in this case we don't execute any query, we just fetch results
             expect(executeMock).toHaveBeenLastCalledWith({
-                sqlText:
+                sqlText: [
+                    "ALTER SESSION SET QUERY_TAG = '{}';",
+                    "ALTER SESSION SET TIMEZONE = 'UTC';",
                     'ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;',
+                ].join('\n'),
                 complete: expect.any(Function),
+                parameters: { MULTI_STATEMENT_COUNT: 3 },
             });
 
             expect(getResultsFromQueryIdMock).toHaveBeenCalledWith({

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -222,37 +222,36 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             tags?: Record<string, string>;
         },
     ) {
+        const sqlStatements: string[] = [];
+
         if (this.connectionOptions.warehouse) {
             // eslint-disable-next-line no-console
             console.debug(
                 `Running snowflake query on warehouse: ${this.connectionOptions.warehouse}`,
             );
-            await this.executeStatement(
-                connection,
+            sqlStatements.push(
                 `USE WAREHOUSE ${this.connectionOptions.warehouse};`,
             );
         }
+
         if (isWeekDay(this.startOfWeek)) {
             const snowflakeStartOfWeekIndex = this.startOfWeek + 1; // 1 (Monday) to 7 (Sunday):
-            await this.executeStatement(
-                connection,
+            sqlStatements.push(
                 `ALTER SESSION SET WEEK_START = ${snowflakeStartOfWeekIndex};`,
             );
         }
+
         if (options?.tags) {
-            await this.executeStatement(
-                connection,
+            sqlStatements.push(
                 `ALTER SESSION SET QUERY_TAG = '${JSON.stringify(
                     options?.tags,
                 )}';`,
             );
         }
+
         const timezoneQuery = options?.timezone || 'UTC';
         console.debug(`Setting Snowflake session timezone to ${timezoneQuery}`);
-        await this.executeStatement(
-            connection,
-            `ALTER SESSION SET TIMEZONE = '${timezoneQuery}';`,
-        );
+        sqlStatements.push(`ALTER SESSION SET TIMEZONE = '${timezoneQuery}';`);
 
         /**
          * Force QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE to avoid casing inconsistencies
@@ -261,9 +260,14 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         console.debug(
             'Setting Snowflake session QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE',
         );
-        await this.executeStatement(
-            connection,
+        sqlStatements.push(
             `ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;`,
+        );
+
+        await this.executeStatements(
+            connection,
+            sqlStatements.join('\n'),
+            sqlStatements.length,
         );
     }
 
@@ -551,13 +555,20 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private async executeStatement(connection: Connection, sqlText: string) {
+    private async executeStatements(
+        connection: Connection,
+        sqlText: string,
+        statementsCount: number = 1,
+    ) {
         return new Promise<{
             fields: Record<string, { type: DimensionType }>;
             rows: AnyType[];
         }>((resolve, reject) => {
             connection.execute({
                 sqlText,
+                ...(statementsCount > 1
+                    ? { parameters: { MULTI_STATEMENT_COUNT: statementsCount } }
+                    : {}),
                 complete: (err, stmt, data) => {
                     if (err) {
                         reject(err);
@@ -599,7 +610,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         });
 
         try {
-            return await this.executeStatement(connection, sqlText);
+            return await this.executeStatements(connection, sqlText);
         } catch (e) {
             console.error(
                 `\nError running catalog query for table ${database}.${schema}.${table}:`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14072](https://github.com/lightdash/lightdash/issues/14072)

### Description:

- Uses on complete for Bigquery job completion
- Runs warehouse prepare statement in multi statement call for snowflake

Note: checked again snowflake for different ways of getting total rows, and the current way was the only where this was possible

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
