### PR TITLE
(feedback wanted) Remove the need for explicit build step when modifying @lightdash/common

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@lightdash/common",
     "version": "0.1537.1",
-    "main": "dist/cjs/index.js",
+    "main": "src/index.ts",
     "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "types": "src/index.ts",
     "files": [
         "dist/**/*"
     ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

As mentioned [in this article](https://turbo.build/blog/you-might-not-need-typescript-project-references#internal-typescript-packages), it is possible to avoid the need for an extra build step when developing an internal package in a monorepo-like setup. When I was working on https://github.com/lightdash/lightdash/pull/14090, I realized that for re-running a test through my WebStorm IDE, I needed to rebuild this package manually which slowed me down.

Please see the aforementioned article for the Caveats section, possibly something there will be a dealbreaker for your setup and I'm just seeing it overly simplistically. 🙏 

OTOH, if the suggested approach proves viable, I could perform this modification in other internal packages' package.json files too, to provide equal DX everywhere.

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
