### PR TITLE
chore: remove prepareWarehouse call when fetching results

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -329,11 +329,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         const connection = await this.getConnection();
 
         try {
-            await this.prepareWarehouse(connection, {
-                timezone,
-                tags,
-            });
-
             const start = (queryArgs.page - 1) * queryArgs.pageSize;
             const end = start + queryArgs.pageSize - 1;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
- There's no need to prepare warehouse when just fetching results from an async query.

#### Example:
- Start of week set to `tuesday`

##### Running on both query trigger and result fetch functions:

![image (2)](https://github.com/user-attachments/assets/0a7a8886-dc37-432d-88af-0ffeea2ba4c0)

##### Running just on query trigger

![image (3)](https://github.com/user-attachments/assets/a0a3b22e-8d23-4ff0-9d80-39dbbce61dee)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
