### PR TITLE
fix: sql chart tile loading state

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -109,10 +109,14 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                 title={tile.properties.title || tile.properties.chartName || ''}
                 {...rest}
             >
-                <SuboptimalState
-                    icon={IconAlertCircle}
-                    title={chartError?.error?.message || 'Error fetching chart'}
-                />
+                {!isChartLoading && (
+                    <SuboptimalState
+                        icon={IconAlertCircle}
+                        title={
+                            chartError?.error?.message || 'Error fetching chart'
+                        }
+                    />
+                )}
             </TileBase>
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixes the loading state for SQL chart tiles. Before they were showing an error during loading. Now they just show the loading state. 

Before:
![be4](https://github.com/user-attachments/assets/2196ea56-f2b4-4881-8d27-c29eebb955d4)

After
![after](https://github.com/user-attachments/assets/510adf3e-0ce4-4789-93b7-2ba3ae9fc6f0)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
