### PR TITLE
feat: add single-select dashboard filters

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1218,7 +1218,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        disallowMultipleValues: { dataType: 'boolean' },
+                        singleValue: { dataType: 'boolean' },
                         label: {
                             dataType: 'union',
                             subSchemas: [
@@ -10157,7 +10157,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        disallowMultipleValues: { dataType: 'boolean' },
+                        singleValue: { dataType: 'boolean' },
                         label: {
                             dataType: 'union',
                             subSchemas: [
@@ -10254,7 +10254,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                disallowMultipleValues: {
+                singleValue: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'boolean' },
@@ -10323,7 +10323,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10333,7 +10333,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10343,7 +10343,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10356,7 +10356,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1218,6 +1218,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        disallowMultipleValues: { dataType: 'boolean' },
                         label: {
                             dataType: 'union',
                             subSchemas: [
@@ -10156,6 +10157,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        disallowMultipleValues: { dataType: 'boolean' },
                         label: {
                             dataType: 'union',
                             subSchemas: [
@@ -10252,6 +10254,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                disallowMultipleValues: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -10314,7 +10323,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10324,7 +10333,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10334,7 +10343,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10347,7 +10356,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1227,6 +1227,9 @@
                     },
                     {
                         "properties": {
+                            "disallowMultipleValues": {
+                                "type": "boolean"
+                            },
                             "label": {
                                 "type": "string"
                             },
@@ -10974,6 +10977,9 @@
                     },
                     {
                         "properties": {
+                            "disallowMultipleValues": {
+                                "type": "boolean"
+                            },
                             "label": {
                                 "type": "string"
                             },
@@ -11032,6 +11038,9 @@
                     },
                     "tileTargets": {
                         "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
+                    },
+                    "disallowMultipleValues": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["target", "operator"],
@@ -11096,22 +11105,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15732,7 +15741,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1546.0",
+        "version": "0.1548.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1227,7 +1227,7 @@
                     },
                     {
                         "properties": {
-                            "disallowMultipleValues": {
+                            "singleValue": {
                                 "type": "boolean"
                             },
                             "label": {
@@ -10977,7 +10977,7 @@
                     },
                     {
                         "properties": {
-                            "disallowMultipleValues": {
+                            "singleValue": {
                                 "type": "boolean"
                             },
                             "label": {
@@ -11039,7 +11039,7 @@
                     "tileTargets": {
                         "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
                     },
-                    "disallowMultipleValues": {
+                    "singleValue": {
                         "type": "boolean"
                     }
                 },
@@ -11105,22 +11105,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -90,7 +90,7 @@ export type DashboardFilterRule<
 > = FilterRule<O, T, V, S> & {
     tileTargets?: Record<string, DashboardTileTarget>;
     label: undefined | string;
-    disallowMultipleValues?: boolean;
+    singleValue?: boolean;
 };
 
 export type FilterDashboardToRule = DashboardFilterRule & {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -90,6 +90,7 @@ export type DashboardFilterRule<
 > = FilterRule<O, T, V, S> & {
     tileTargets?: Record<string, DashboardTileTarget>;
     label: undefined | string;
+    disallowMultipleValues?: boolean;
 };
 
 export type FilterDashboardToRule = DashboardFilterRule & {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -174,7 +174,7 @@ export const timeframeToUnitOfTime = (timeframe: TimeFrames) => {
     }
 };
 
-export const supportsDisallowMultipleValues = (
+export const supportsSingleValue = (
     filterType: FilterType,
     filterOperator: FilterOperator,
 ) =>

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -174,6 +174,20 @@ export const timeframeToUnitOfTime = (timeframe: TimeFrames) => {
     }
 };
 
+export const supportsDisallowMultipleValues = (
+    filterType: FilterType,
+    filterOperator: FilterOperator,
+) =>
+    [FilterType.STRING, FilterType.NUMBER].includes(filterType) &&
+    [
+        FilterOperator.EQUALS,
+        FilterOperator.NOT_EQUALS,
+        FilterOperator.STARTS_WITH,
+        FilterOperator.ENDS_WITH,
+        FilterOperator.INCLUDE,
+        FilterOperator.NOT_INCLUDE,
+    ].includes(filterOperator);
+
 export const isWithValueFilter = (filterOperator: FilterOperator) =>
     filterOperator !== FilterOperator.NULL &&
     filterOperator !== FilterOperator.NOT_NULL;

--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -131,7 +131,7 @@ describe('Table calculations', () => {
         cy.get(".mantine-Select-input[value='is']").click();
         cy.contains('greater than').click(); // If the type is string, this option will not be available and it will fail when running the query
 
-        cy.findByPlaceholderText('Enter value').clear().type('250');
+        cy.findByPlaceholderText('Enter value(s)').clear().type('250');
         cy.get('button').contains('Run query').click();
 
         cy.contains('Loading results'); // wait for results to load

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -3,6 +3,7 @@ import {
     FilterType,
     getFilterRuleWithDefaultValue,
     getFilterTypeFromItem,
+    supportsDisallowMultipleValues,
     type DashboardFilterRule,
     type FilterRule,
     type FilterableDimension,
@@ -53,21 +54,6 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         () => getFilterOperatorOptions(filterType),
         [filterType],
     );
-
-    // Add a check for operators that can support single value selection
-    const supportsDisallowMultipleValues = useMemo(() => {
-        return (
-            [FilterType.STRING, FilterType.NUMBER].includes(filterType) &&
-            [
-                FilterOperator.EQUALS,
-                FilterOperator.NOT_EQUALS,
-                FilterOperator.STARTS_WITH,
-                FilterOperator.ENDS_WITH,
-                FilterOperator.INCLUDE,
-                FilterOperator.NOT_INCLUDE,
-            ].includes(filterRule.operator)
-        );
-    }, [filterType, filterRule.operator]);
 
     // Set default label when using revert (undo) button
     useEffect(() => {
@@ -150,7 +136,10 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         },
                     }}
                     rightSection={
-                        supportsDisallowMultipleValues &&
+                        supportsDisallowMultipleValues(
+                            filterType,
+                            filterRule.operator,
+                        ) &&
                         isEditMode && (
                             <Button
                                 compact

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -9,6 +9,7 @@ import {
 } from '@lightdash/common';
 import {
     Box,
+    Button,
     Checkbox,
     Select,
     Stack,
@@ -18,10 +19,12 @@ import {
     Tooltip,
     type PopoverProps,
 } from '@mantine/core';
+import { IconHelpCircle } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import FilterInputComponent from '../../common/Filters/FilterInputs';
 import { getFilterOperatorOptions } from '../../common/Filters/FilterInputs/utils';
 import { getPlaceholderByFilterTypeAndOperator } from '../../common/Filters/utils/getPlaceholderByFilterTypeAndOperator';
+import MantineIcon from '../../common/MantineIcon';
 
 interface FilterSettingsProps {
     isEditMode: boolean;
@@ -130,6 +133,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         Value
                     </Text>
                 )}
+
                 <Select
                     size="xs"
                     data={filterOperatorOptions}
@@ -138,6 +142,49 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                     onDropdownClose={popoverProps?.onClose}
                     onChange={handleChangeFilterOperator}
                     value={filterRule.operator}
+                    rightSectionWidth={140}
+                    rightSectionProps={{
+                        style: {
+                            justifyContent: 'flex-end',
+                            marginRight: '8px',
+                        },
+                    }}
+                    rightSection={
+                        supportsDisallowMultipleValues &&
+                        isEditMode && (
+                            <Button
+                                compact
+                                size="xs"
+                                variant={'light'}
+                                rightIcon={
+                                    <Tooltip
+                                        variant="xs"
+                                        label={
+                                            filterRule.disallowMultipleValues
+                                                ? 'Prevent selection of multiple values'
+                                                : 'Allow selection of multiple values'
+                                        }
+                                    >
+                                        <MantineIcon
+                                            size="sm"
+                                            icon={IconHelpCircle}
+                                        />
+                                    </Tooltip>
+                                }
+                                onClick={() => {
+                                    onChangeFilterRule({
+                                        ...filterRule,
+                                        disallowMultipleValues:
+                                            !filterRule.disallowMultipleValues,
+                                    });
+                                }}
+                            >
+                                {filterRule.disallowMultipleValues
+                                    ? 'Single value'
+                                    : 'Multiple values'}
+                            </Button>
+                        )
+                    }
                 />
                 {showAnyValueDisabledInput && !filterRule.required && (
                     <TextInput
@@ -150,6 +197,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         })}
                     />
                 )}
+
                 {(showValueInput || filterRule.required) && (
                     <FilterInputComponent
                         popoverProps={popoverProps}
@@ -244,30 +292,6 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                             }}
                             label="Require value for dashboard to run"
                         />
-
-                        {supportsDisallowMultipleValues && (
-                            <Tooltip
-                                withinPortal
-                                position="right"
-                                label="When enabled, users will only be able to select a single value for this filter, even in view mode"
-                                openDelay={500}
-                            >
-                                <Checkbox
-                                    size="xs"
-                                    checked={
-                                        !!filterRule.disallowMultipleValues
-                                    }
-                                    onChange={(e) => {
-                                        onChangeFilterRule({
-                                            ...filterRule,
-                                            disallowMultipleValues:
-                                                e.currentTarget.checked,
-                                        });
-                                    }}
-                                    label="Limit to single value selection"
-                                />
-                            </Tooltip>
-                        )}
                     </>
                 )}
             </Stack>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -51,6 +51,21 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         [filterType],
     );
 
+    // Add a check for operators that can support single value selection
+    const supportsDisallowMultipleValues = useMemo(() => {
+        return (
+            [FilterType.STRING, FilterType.NUMBER].includes(filterType) &&
+            [
+                FilterOperator.EQUALS,
+                FilterOperator.NOT_EQUALS,
+                FilterOperator.STARTS_WITH,
+                FilterOperator.ENDS_WITH,
+                FilterOperator.INCLUDE,
+                FilterOperator.NOT_INCLUDE,
+            ].includes(filterRule.operator)
+        );
+    }, [filterType, filterRule.operator]);
+
     // Set default label when using revert (undo) button
     useEffect(() => {
         if (filterLabel !== '') {
@@ -229,6 +244,30 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                             }}
                             label="Require value for dashboard to run"
                         />
+
+                        {supportsDisallowMultipleValues && (
+                            <Tooltip
+                                withinPortal
+                                position="right"
+                                label="When enabled, users will only be able to select a single value for this filter, even in view mode"
+                                openDelay={500}
+                            >
+                                <Checkbox
+                                    size="xs"
+                                    checked={
+                                        !!filterRule.disallowMultipleValues
+                                    }
+                                    onChange={(e) => {
+                                        onChangeFilterRule({
+                                            ...filterRule,
+                                            disallowMultipleValues:
+                                                e.currentTarget.checked,
+                                        });
+                                    }}
+                                    label="Limit to single value selection"
+                                />
+                            </Tooltip>
+                        )}
                     </>
                 )}
             </Stack>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -3,7 +3,7 @@ import {
     FilterType,
     getFilterRuleWithDefaultValue,
     getFilterTypeFromItem,
-    supportsDisallowMultipleValues,
+    supportsSingleValue,
     type DashboardFilterRule,
     type FilterRule,
     type FilterableDimension,
@@ -136,10 +136,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                         },
                     }}
                     rightSection={
-                        supportsDisallowMultipleValues(
-                            filterType,
-                            filterRule.operator,
-                        ) &&
+                        supportsSingleValue(filterType, filterRule.operator) &&
                         isEditMode && (
                             <Button
                                 compact
@@ -149,7 +146,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                     <Tooltip
                                         variant="xs"
                                         label={
-                                            filterRule.disallowMultipleValues
+                                            filterRule.singleValue
                                                 ? 'Prevent selection of multiple values'
                                                 : 'Allow selection of multiple values'
                                         }
@@ -163,12 +160,11 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                 onClick={() => {
                                     onChangeFilterRule({
                                         ...filterRule,
-                                        disallowMultipleValues:
-                                            !filterRule.disallowMultipleValues,
+                                        singleValue: !filterRule.singleValue,
                                     });
                                 }}
                             >
-                                {filterRule.disallowMultipleValues
+                                {filterRule.singleValue
                                     ? 'Single value'
                                     : 'Multiple values'}
                             </Button>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -15,6 +15,7 @@ import FilterMultiStringInput from './FilterMultiStringInput';
 import FilterNumberInput from './FilterNumberInput';
 import FilterNumberRangeInput from './FilterNumberRangeInput';
 import FilterStringAutoComplete from './FilterStringAutoComplete';
+
 const DefaultFilterInputs = <T extends ConditionalRule>({
     field,
     filterType,
@@ -28,12 +29,19 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
         ? getField(rule)?.suggestions
         : undefined;
 
+    const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
+
+    // Check if the filter should only allow a single value
+    const disallowMultipleValues =
+        isFilterRule(rule) &&
+        'disallowMultipleValues' in rule &&
+        !!rule.disallowMultipleValues;
+
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
-        disabled: isFilterRule(rule)
-            ? rule.disabled && !rule.values
-            : undefined,
+        disabled: isFilterRuleDisabled,
+        disallowMultipleValues,
     });
 
     switch (rule.operator) {
@@ -76,6 +84,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
                             values={(rule.values || []).filter(isString)}
+                            disallowMultipleValues={disallowMultipleValues}
                             onChange={(values) =>
                                 onChange({
                                     ...rule,
@@ -86,6 +95,46 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                     );
 
                 case FilterType.NUMBER:
+                    if (disallowMultipleValues) {
+                        if (rule.values?.length && rule.values.length > 1) {
+                            onChange({
+                                ...rule,
+                                values: [rule.values[0]],
+                            });
+                        }
+                        return (
+                            <FilterNumberInput
+                                disabled={disabled}
+                                autoFocus={true}
+                                placeholder={placeholder}
+                                value={rule.values?.[0]}
+                                onChange={(newValue) => {
+                                    onChange({
+                                        ...rule,
+                                        values:
+                                            newValue !== null ? [newValue] : [],
+                                    });
+                                }}
+                            />
+                        );
+                    } else {
+                        return (
+                            <TagInput
+                                w="100%"
+                                clearable
+                                autoFocus={true}
+                                size="xs"
+                                disabled={disabled}
+                                placeholder={placeholder}
+                                allowDuplicates={false}
+                                validationRegex={/^-?\d+(\.\d+)?$/}
+                                value={rule.values?.map(String)}
+                                onChange={(values) =>
+                                    onChange({ ...rule, values })
+                                }
+                            />
+                        );
+                    }
                 case FilterType.BOOLEAN:
                 case FilterType.DATE:
                     return (
@@ -97,11 +146,6 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             disabled={disabled}
                             placeholder={placeholder}
                             allowDuplicates={false}
-                            validationRegex={
-                                filterType === FilterType.NUMBER
-                                    ? /^-?\d+(\.\d+)?$/
-                                    : undefined
-                            }
                             value={rule.values?.map(String)}
                             onChange={(values) => onChange({ ...rule, values })}
                         />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -32,16 +32,14 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
     const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
 
     // Check if the filter should only allow a single value
-    const disallowMultipleValues =
-        isFilterRule(rule) &&
-        'disallowMultipleValues' in rule &&
-        !!rule.disallowMultipleValues;
+    const isSingleValue =
+        isFilterRule(rule) && 'singleValue' in rule && !!rule.singleValue;
 
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
         disabled: isFilterRuleDisabled,
-        disallowMultipleValues,
+        singleValue: isSingleValue,
     });
 
     switch (rule.operator) {
@@ -84,7 +82,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
                             values={(rule.values || []).filter(isString)}
-                            disallowMultipleValues={disallowMultipleValues}
+                            singleValue={isSingleValue}
                             onChange={(values) =>
                                 onChange({
                                     ...rule,
@@ -95,7 +93,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
                     );
 
                 case FilterType.NUMBER:
-                    if (disallowMultipleValues) {
+                    if (isSingleValue) {
                         if (rule.values?.length && rule.values.length > 1) {
                             onChange({
                                 ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -37,7 +37,7 @@ type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     values: string[];
     suggestions: string[];
     onChange: (values: string[]) => void;
-    disallowMultipleValues?: boolean;
+    singleValue?: boolean;
 };
 
 // Single value component that mimics a single select behavior - maxSelectedValues={1} behaves weirdly so we don't use it.
@@ -66,7 +66,7 @@ const FilterStringAutoComplete: FC<Props> = ({
     placeholder,
     onDropdownOpen,
     onDropdownClose,
-    disallowMultipleValues,
+    singleValue,
     ...rest
 }) => {
     const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
@@ -122,37 +122,37 @@ const FilterStringAutoComplete: FC<Props> = ({
 
     const handleChange = useCallback(
         (updatedValues: string[]) => {
-            if (disallowMultipleValues && updatedValues.length > 1) {
+            if (singleValue && updatedValues.length > 1) {
                 onChange([updatedValues[updatedValues.length - 1]]);
             } else {
                 onChange(uniq(updatedValues));
             }
         },
-        [onChange, disallowMultipleValues],
+        [onChange, singleValue],
     );
 
     const handleAdd = useCallback(
         (newValue: string) => {
-            if (disallowMultipleValues) {
+            if (singleValue) {
                 handleChange([newValue]);
             } else {
                 handleChange([...values, newValue]);
             }
             return newValue;
         },
-        [handleChange, values, disallowMultipleValues],
+        [handleChange, values, singleValue],
     );
 
     const handleAddMultiple = useCallback(
         (newValues: string[]) => {
-            if (disallowMultipleValues && newValues.length > 0) {
+            if (singleValue && newValues.length > 0) {
                 handleChange([newValues[newValues.length - 1]]);
             } else {
                 handleChange([...values, ...newValues]);
             }
             return newValues;
         },
-        [handleChange, values, disallowMultipleValues],
+        [handleChange, values, singleValue],
     );
 
     const handlePaste = useCallback(
@@ -177,10 +177,10 @@ const FilterStringAutoComplete: FC<Props> = ({
     );
 
     useEffect(() => {
-        if (disallowMultipleValues && values.length > 1) {
+        if (singleValue && values.length > 1) {
             handleChange([values[values.length - 1]]);
         }
-    }, [values, disallowMultipleValues, handleChange]);
+    }, [values, singleValue, handleChange]);
 
     const data = useMemo(() => {
         // Mantine does not show value tag if value is not found in data
@@ -285,9 +285,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                 }
                 disabled={disabled}
                 creatable
-                valueComponent={
-                    disallowMultipleValues ? SingleValueComponent : undefined
-                }
+                valueComponent={singleValue ? SingleValueComponent : undefined}
                 /**
                  * Opts out of Mantine's default condition and always allows adding, as long as not
                  * an empty query.
@@ -317,7 +315,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                 }}
                 disableSelectedItemFiltering
                 searchable
-                clearable={disallowMultipleValues}
+                clearable={singleValue}
                 clearSearchOnChange
                 {...rest}
                 searchValue={search}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -17,6 +17,7 @@ import {
     useCallback,
     useEffect,
     useMemo,
+    useRef,
     useState,
     type FC,
     type ReactNode,
@@ -69,6 +70,7 @@ const FilterStringAutoComplete: FC<Props> = ({
     singleValue,
     ...rest
 }) => {
+    const multiSelectRef = useRef<HTMLInputElement>(null);
     const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
     if (!projectUuid) {
         throw new Error('projectUuid is required in FiltersProvider');
@@ -126,6 +128,9 @@ const FilterStringAutoComplete: FC<Props> = ({
                 onChange([updatedValues[updatedValues.length - 1]]);
             } else {
                 onChange(uniq(updatedValues));
+            }
+            if (singleValue) {
+                multiSelectRef.current?.blur();
             }
         },
         [onChange, singleValue],
@@ -278,6 +283,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             }}
         >
             <MultiSelect
+                ref={multiSelectRef}
                 size="xs"
                 w="100%"
                 placeholder={

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -9,10 +9,12 @@ export const getPlaceholderByFilterTypeAndOperator = ({
     type,
     operator,
     disabled,
+    disallowMultipleValues,
 }: {
     type: FilterType;
     operator: FilterOperator;
     disabled?: boolean;
+    disallowMultipleValues?: boolean;
 }) => {
     if (disabled) return 'any value';
 
@@ -21,10 +23,12 @@ export const getPlaceholderByFilterTypeAndOperator = ({
             switch (operator) {
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
-                    return 'Enter value(s)';
+                    return disallowMultipleValues
+                        ? 'Enter value'
+                        : 'Enter value(s)';
                 case FilterOperator.LESS_THAN:
                 case FilterOperator.GREATER_THAN:
-                    return 'Enter value';
+                    return 'Enter value(s)';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';
@@ -59,9 +63,12 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                     return 'Start typing to filter results';
                 case FilterOperator.STARTS_WITH:
                 case FilterOperator.ENDS_WITH:
+                    return 'Enter value(s)';
                 case FilterOperator.INCLUDE:
                 case FilterOperator.NOT_INCLUDE:
-                    return 'Enter value(s)';
+                    return disallowMultipleValues
+                        ? 'Enter value'
+                        : 'Enter value(s)';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -9,12 +9,12 @@ export const getPlaceholderByFilterTypeAndOperator = ({
     type,
     operator,
     disabled,
-    disallowMultipleValues,
+    singleValue,
 }: {
     type: FilterType;
     operator: FilterOperator;
     disabled?: boolean;
-    disallowMultipleValues?: boolean;
+    singleValue?: boolean;
 }) => {
     if (disabled) return 'any value';
 
@@ -23,9 +23,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
             switch (operator) {
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
-                    return disallowMultipleValues
-                        ? 'Enter value'
-                        : 'Enter value(s)';
+                    return singleValue ? 'Enter value' : 'Enter value(s)';
                 case FilterOperator.LESS_THAN:
                 case FilterOperator.GREATER_THAN:
                     return 'Enter value(s)';
@@ -66,9 +64,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
                     return 'Enter value(s)';
                 case FilterOperator.INCLUDE:
                 case FilterOperator.NOT_INCLUDE:
-                    return disallowMultipleValues
-                        ? 'Enter value'
-                        : 'Enter value(s)';
+                    return singleValue ? 'Enter value' : 'Enter value(s)';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#8138](https://github.com/lightdash/lightdash/issues/8138)

### Description:

Allows the user setting single-select filters when creating them in edit mode so that they're saved permanently on the dashboard (the value can still be overriden, but they won't be able to select multiple)

demo

<img width="482" alt="Screenshot 2025-03-19 at 17 51 01" src="https://github.com/user-attachments/assets/4ef9d613-d6c9-40dd-b1c6-84f763244183" />
<img width="488" alt="Screenshot 2025-03-19 at 17 50 56" src="https://github.com/user-attachments/assets/c1fdc60b-df2d-490a-bf18-10cd900e2b82" />




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
