### PR TITLE
fix: block access to settings routes hidden because of permissions

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -257,7 +257,7 @@ const Settings: FC = () => {
             organization &&
             !organization.needsProject &&
             user?.ability.can(
-                'view',
+                'update',
                 subject('Project', {
                     organizationUuid: organization.organizationUuid,
                     projectUuid: project.projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Currently users with Viewer, Interactive viewer, and Editor permissions have the project settings links hidden from them BUT they can still access the routes. Some of the pages on those routes show sensitive information like the embedding token or who has what access on the project. This disables access to those routes for users who can't see the links. 

We could add more fine-grained access to those pages if there is a need for it, but setting up access such that the available links match the available routes makes more sense than what we currently have. 

<img width="736" alt="Screenshot 2025-03-18 at 18 01 48" src="https://github.com/user-attachments/assets/34c8e12b-1f6d-43bc-9749-d5b84c8e74a3" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
