### PR TITLE
feat: indicate when there are no dashboards avialable for embedding

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
@@ -31,15 +31,22 @@ const EmbedDashboardsForm: FC<{
                         value: dashboard.uuid,
                         label: dashboard.name,
                     }))}
-                    disabled={disabled}
+                    disabled={disabled || dashboards.length === 0}
                     defaultValue={[]}
-                    placeholder="Select a dashboard..."
+                    placeholder={
+                        dashboards.length === 0
+                            ? 'No dashboards available to embed'
+                            : 'Select a dashboard...'
+                    }
                     searchable
                     withinPortal
                     {...form.getInputProps('dashboardUuids')}
                 />
                 <Flex justify="flex-end" gap="sm">
-                    <Button type="submit" disabled={disabled}>
+                    <Button
+                        type="submit"
+                        disabled={disabled || dashboards.length === 0}
+                    >
                         Save changes
                     </Button>
                 </Flex>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14107  

### Description:

A user reported not being able to interact with the allowed dashboards dropdown. One way this could happen is if they have not access to any dashboards. This PR disables the allowed dashboards dropdown when the user has not dashboards available. And shows a message that should make it clear what's wrong. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
