### PR TITLE
fix: handle missing authentication type in snowflake credentials check

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -140,7 +140,8 @@ const credentialsTarget = (
                 },
             };
             if (
-                credentials.authenticationType === 'password' &&
+                (!credentials.authenticationType ||
+                    credentials.authenticationType === 'password') &&
                 credentials.password
             ) {
                 result.target.password = envVarReference('password');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14131

Related to:  #14084

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Backwards compatibility reasons treat empty `authenticationType` field as `authenticationType: 'password'`
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
