### PR TITLE
feat: lazy load rows for results table

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -476,16 +476,18 @@ export type ApiExecuteAsyncQueryResults = {
     appliedDashboardFilters: DashboardFilters | null;
 };
 
+export type ReadyQueryResultsPage = ResultsPaginationMetadata<ResultRow> & {
+    queryUuid: string;
+    rows: ResultRow[];
+    fields: ItemsMap;
+    initialQueryExecutionMs: number;
+    resultsPageExecutionMs: number;
+    metricQuery: MetricQuery;
+    status: QueryHistoryStatus.READY;
+};
+
 export type ApiGetAsyncQueryResults =
-    | (ResultsPaginationMetadata<ResultRow> & {
-          queryUuid: string;
-          rows: ResultRow[];
-          fields: ItemsMap;
-          initialQueryExecutionMs: number;
-          resultsPageExecutionMs: number;
-          metricQuery: MetricQuery;
-          status: QueryHistoryStatus.READY;
-      })
+    | ReadyQueryResultsPage
     | {
           status: QueryHistoryStatus.PENDING | QueryHistoryStatus.CANCELLED;
           queryUuid: string;

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
@@ -12,8 +12,8 @@ export const useDataForFiltersProvider = () => {
         (context) => context.state.unsavedChartVersion.tableName,
     );
 
-    const queryResults = useExplorerContext(
-        (context) => context.queryResults.data,
+    const fetchedRows = useExplorerContext(
+        (context) => context.queryResults.fetchedRows,
     );
 
     const { data: exploreData } = useExplore(tableName);
@@ -35,7 +35,7 @@ export const useDataForFiltersProvider = () => {
 
     const fieldsWithSuggestions = useFieldsWithSuggestions({
         exploreData,
-        queryResults,
+        rows: fetchedRows,
         customDimensions,
         additionalMetrics,
         tableCalculations,

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -28,8 +28,8 @@ const ExplorerHeader: FC = memo(() => {
     );
     const showLimitWarning = useExplorerContext(
         (context) =>
-            context.queryResults.data &&
-            context.queryResults.data.rows.length >=
+            context.query.data &&
+            context.query.data.totalResults >=
                 context.state.unsavedChartVersion.metricQuery.limit,
     );
     const limit = useExplorerContext(

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -142,8 +142,8 @@ const FiltersCard: FC = memo(() => {
         (context) =>
             context.state.unsavedChartVersion.metricQuery.tableCalculations,
     );
-    const queryResults = useExplorerContext(
-        (context) => context.queryResults.data,
+    const fetchedRows = useExplorerContext(
+        (context) => context.queryResults.fetchedRows,
     );
     const setFilters = useExplorerContext(
         (context) => context.actions.setFilters,
@@ -161,7 +161,7 @@ const FiltersCard: FC = memo(() => {
     );
     const fieldsWithSuggestions = useFieldsWithSuggestions({
         exploreData: data,
-        queryResults,
+        rows: fetchedRows,
         customDimensions,
         additionalMetrics,
         tableCalculations,

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
@@ -1,24 +1,24 @@
 import {
-    DimensionType,
     convertAdditionalMetric,
+    DimensionType,
     getItemId,
     getResultValueArray,
     getVisibleFields,
     isCustomSqlDimension,
     isFilterableField,
     type AdditionalMetric,
-    type ApiQueryResults,
     type CustomDimension,
     type Explore,
     type FilterableField,
     type Metric,
+    type ResultRow,
     type TableCalculation,
 } from '@lightdash/common';
 import { useEffect, useState } from 'react';
 
 interface FieldsWithSuggestionsHookParams {
     exploreData: Explore | undefined;
-    queryResults: ApiQueryResults | undefined;
+    rows: ResultRow[] | undefined;
     customDimensions: CustomDimension[] | undefined;
     additionalMetrics: AdditionalMetric[] | undefined;
     tableCalculations: TableCalculation[] | undefined;
@@ -32,7 +32,7 @@ export type FieldsWithSuggestions = Record<string, FieldWithSuggestions>;
 
 export const useFieldsWithSuggestions = ({
     exploreData,
-    queryResults,
+    rows,
     customDimensions,
     additionalMetrics,
     tableCalculations,
@@ -73,9 +73,9 @@ export const useFieldsWithSuggestions = ({
                             const currentSuggestions =
                                 prev[getItemId(field)]?.suggestions || [];
                             const newSuggestions: string[] =
-                                (queryResults &&
+                                (rows &&
                                     getResultValueArray(
-                                        queryResults.rows,
+                                        rows,
                                         true,
                                     ).results.reduce<string[]>((acc, row) => {
                                         const value = row[getItemId(field)];
@@ -106,7 +106,7 @@ export const useFieldsWithSuggestions = ({
         }
     }, [
         exploreData,
-        queryResults,
+        rows,
         additionalMetrics,
         tableCalculations,
         customDimensions,

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -35,17 +35,26 @@ export const ExplorerResults = memo(() => {
     const explorerColumnOrder = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
     );
-    const resultsData = useExplorerContext(
-        (context) => context.queryResults.data,
+    const fetchedRows = useExplorerContext(
+        (context) => context.queryResults.fetchedRows,
+    );
+    const totalRows = useExplorerContext(
+        (context) => context.queryResults.totalRows,
+    );
+    const isFetchingRows = useExplorerContext(
+        (context) => context.queryResults.isFetchingRows,
+    );
+    const fetchMoreRows = useExplorerContext(
+        (context) => context.queryResults.fetchMoreRows,
     );
     const status = useExplorerContext((context) => {
         // Don't return context.queryResults.status because we changed from mutation to query so 'loading' as a different meaning
-        if (context.queryResults.isFetching) {
+        if (context.query.isFetching) {
             return 'loading';
-        } else if (context.queryResults.status === 'loading') {
+        } else if (context.query.status === 'loading') {
             return 'idle';
         } else {
-            return context.queryResults.status;
+            return context.query.status;
         }
     });
     const setColumnOrder = useExplorerContext(
@@ -154,7 +163,10 @@ export const ExplorerResults = memo(() => {
             <Box px="xs" py="lg">
                 <Table
                     status={status}
-                    data={resultsData?.rows || []}
+                    data={fetchedRows || []}
+                    totalRowsCount={totalRows || 0}
+                    isFetchingRows={isFetchingRows}
+                    fetchMoreRows={fetchMoreRows}
                     columns={columns}
                     columnOrder={explorerColumnOrder}
                     onColumnOrderChange={setColumnOrder}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -35,10 +35,7 @@ const ResultsCard: FC = memo(() => {
     );
 
     const rows = useExplorerContext(
-        (context) => context.queryResults.data?.rows,
-    );
-    const resultsData = useExplorerContext(
-        (context) => context.queryResults.data,
+        (context) => context.queryResults.fetchedRows,
     );
     const toggleExpandedSection = useExplorerContext(
         (context) => context.actions.toggleExpandedSection,
@@ -51,7 +48,7 @@ const ResultsCard: FC = memo(() => {
         (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
     );
 
-    const disabled = !resultsData || resultsData.rows.length <= 0;
+    const disabled = rows.length <= 0;
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const getCsvLink = async (csvLimit: number | null, onlyRaw: boolean) => {

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -132,16 +132,12 @@ const SavedChartsHeader: FC<SavedChartsHeaderProps> = ({
     );
     const reset = useExplorerContext((context) => context.actions.reset);
 
-    const resultsData = useExplorerContext(
-        (context) => context.queryResults.data,
+    const itemsMap = useExplorerContext(
+        (context) => context.query.data?.fields,
     );
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
     );
-
-    const itemsMap = useMemo(() => {
-        return resultsData?.fields;
-    }, [resultsData]);
 
     const { clearDashboardStorage } = useDashboardStorage();
     const [isRenamingChart, setIsRenamingChart] = useState(false);

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -52,8 +52,8 @@ const VisualizationCard: FC<{
         (context) =>
             context.query.isFetching || context.queryResults.isFetchingRows,
     );
-    const fetchAllRows = useExplorerContext(
-        (context) => context.queryResults.fetchAllRows,
+    const setFetchAll = useExplorerContext(
+        (context) => context.queryResults.setFetchAll,
     );
     const queryResults = useExplorerContext(
         (context): ApiQueryResults | undefined => {
@@ -104,12 +104,10 @@ const VisualizationCard: FC<{
     );
 
     useEffect(() => {
-        if (isOpen) {
-            // TODO: next PR should support pagination for table viz
-            // Forcing to fetch all rows for now
-            fetchAllRows();
-        }
-    }, [fetchAllRows, isOpen]);
+        // TODO: next PR should support pagination for table viz
+        // Forcing to fetch all rows for now
+        setFetchAll(isOpen);
+    }, [setFetchAll, isOpen]);
 
     const toggleSection = useCallback(
         () => toggleExpandedSection(ExplorerSection.VISUALIZATION),

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -53,12 +53,7 @@ const VisualizationCard: FC<{
             context.query.isFetching || context.queryResults.isFetchingRows,
     );
     const fetchAllRows = useExplorerContext(
-        (context) => () =>
-            context.query.data
-                ? context.queryResults.fetchMoreRows(
-                      context.query.data?.totalResults,
-                  )
-                : undefined,
+        (context) => context.queryResults.fetchAllRows,
     );
     const queryResults = useExplorerContext(
         (context): ApiQueryResults | undefined => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,11 +1,19 @@
 import {
+    type ApiQueryResults,
     ECHARTS_DEFAULT_COLORS,
     getHiddenTableFields,
     getPivotConfig,
     NotFoundError,
 } from '@lightdash/common';
 import { useDisclosure } from '@mantine/hooks';
-import { memo, useCallback, useMemo, useState, type FC } from 'react';
+import {
+    type FC,
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { downloadCsv } from '../../../api/csv';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import { type EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
@@ -41,10 +49,34 @@ const VisualizationCard: FC<{
     );
 
     const isLoadingQueryResults = useExplorerContext(
-        (context) => context.queryResults.isFetching,
+        (context) =>
+            context.query.isFetching || context.queryResults.isFetchingRows,
+    );
+    const fetchAllRows = useExplorerContext(
+        (context) => () =>
+            context.query.data
+                ? context.queryResults.fetchMoreRows(
+                      context.query.data?.totalResults,
+                  )
+                : undefined,
     );
     const queryResults = useExplorerContext(
-        (context) => context.queryResults.data,
+        (context): ApiQueryResults | undefined => {
+            const loadedAllRows =
+                context.query.data &&
+                context.queryResults.fetchedRows.length >=
+                    context.query.data?.totalResults;
+            if (context.query.data && loadedAllRows) {
+                return {
+                    metricQuery: context.query.data.metricQuery,
+                    cacheMetadata: {
+                        cacheHit: false,
+                    },
+                    rows: context.queryResults.fetchedRows,
+                    fields: context.query.data.fields,
+                };
+            }
+        },
     );
     const setPivotFields = useExplorerContext(
         (context) => context.actions.setPivotFields,
@@ -75,6 +107,15 @@ const VisualizationCard: FC<{
         () => expandedSections.includes(ExplorerSection.VISUALIZATION),
         [expandedSections],
     );
+
+    useEffect(() => {
+        if (isOpen) {
+            // TODO: next PR should support pagination for table viz
+            // Forcing to fetch all rows for now
+            fetchAllRows();
+        }
+    }, [fetchAllRows, isOpen]);
+
     const toggleSection = useCallback(
         () => toggleExpandedSection(ExplorerSection.VISUALIZATION),
         [toggleExpandedSection],

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -32,7 +32,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const { projectUuid } = useParams<{ projectUuid: string }>();
 
         const queryUuid = useExplorerContext(
-            (context) => context.queryResults?.data?.queryUuid,
+            (context) => context.query?.data?.queryUuid,
         );
 
         const { data: projects } = useProjects({ refetchOnMount: false });

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataResultsTable.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataResultsTable.tsx
@@ -65,6 +65,9 @@ const UnderlyingDataResultsTable: FC<{
                 <Table
                     status={'success'}
                     data={resultsData?.rows || []}
+                    totalRowsCount={resultsData?.rows.length || 0}
+                    isFetchingNextPage={false}
+                    fetchMoreRows={() => undefined}
                     columns={columns.sort(sortByUnderlyingValues)}
                     pagination={{
                         show: true,

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataResultsTable.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataResultsTable.tsx
@@ -66,7 +66,7 @@ const UnderlyingDataResultsTable: FC<{
                     status={'success'}
                     data={resultsData?.rows || []}
                     totalRowsCount={resultsData?.rows.length || 0}
-                    isFetchingNextPage={false}
+                    isFetchingRows={false}
                     fetchMoreRows={() => undefined}
                     columns={columns.sort(sortByUnderlyingValues)}
                     pagination={{

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -31,9 +31,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
     );
-    const isLoading = useExplorerContext(
-        (context) => context.queryResults.isFetching,
-    );
+    const isLoading = useExplorerContext((context) => context.query.isFetching);
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,
     );

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -114,7 +114,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 status="success"
                 data={rows}
                 totalRowsCount={rows.length || 0}
-                isFetchingNextPage={false}
+                isFetchingRows={false}
                 fetchMoreRows={() => undefined}
                 columns={columns}
                 columnOrder={columnOrder}

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -113,6 +113,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 className={className}
                 status="success"
                 data={rows}
+                totalRowsCount={rows.length || 0}
+                isFetchingNextPage={false}
+                fetchMoreRows={() => undefined}
                 columns={columns}
                 columnOrder={columnOrder}
                 hideRowNumbers={hideRowNumbers}

--- a/packages/frontend/src/components/common/PaginateControl.tsx
+++ b/packages/frontend/src/components/common/PaginateControl.tsx
@@ -39,8 +39,14 @@ const PaginateControl: FC<PaginateControlProps> = ({
                 onPreviousPage={onPreviousPage}
             >
                 <Group spacing="xs" position="center">
-                    <Pagination.Previous icon={IconChevronLeft} />
-                    <Pagination.Next icon={IconChevronRight} />
+                    <Pagination.Previous
+                        icon={IconChevronLeft}
+                        disabled={!hasPreviousPage}
+                    />
+                    <Pagination.Next
+                        icon={IconChevronRight}
+                        disabled={!hasNextPage}
+                    />
                 </Group>
             </Pagination.Root>
         </Group>

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -18,7 +18,11 @@ import { type ProviderProps, type TableColumn } from './types';
 const rowColumn: TableColumn = {
     id: ROW_NUMBER_COLUMN_ID,
     header: '#',
-    cell: (props) => props.row.index + 1,
+    cell: (props) => {
+        const { pageIndex, pageSize } = props.table.getState().pagination;
+        const pageStartIndex = pageIndex * pageSize;
+        return pageStartIndex + props.row.index + 1;
+    },
     footer: 'Total',
     meta: {
         width: 30,

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -135,9 +135,9 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         const nextPagesRowCount =
             currentPageRowCount + pageSize * pageThreshold;
         if (data.length < nextPagesRowCount) {
-            fetchMoreRows(Math.min(nextPagesRowCount, totalRowsCount));
+            fetchMoreRows();
         }
-    }, [data.length, fetchMoreRows, paginationState, totalRowsCount]);
+    }, [data.length, fetchMoreRows, paginationState]);
 
     const pageRows = useMemo(() => {
         // calculate page rows from data and pagination state

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -52,6 +52,9 @@ export const columnHelper = createColumnHelper<ResultRow>();
 
 export type ProviderProps = {
     data: ResultRow[];
+    totalRowsCount: number;
+    isFetchingRows: boolean;
+    fetchMoreRows: (lastRowToFetch: number) => void;
     columns: Array<TableColumn | TableHeader>;
     headerContextMenu?: FC<React.PropsWithChildren<HeaderProps>>;
     cellContextMenu?: FC<React.PropsWithChildren<CellContextMenuProps>>;

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -54,7 +54,7 @@ export type ProviderProps = {
     data: ResultRow[];
     totalRowsCount: number;
     isFetchingRows: boolean;
-    fetchMoreRows: (lastRowToFetch: number) => void;
+    fetchMoreRows: () => void;
     columns: Array<TableColumn | TableHeader>;
     headerContextMenu?: FC<React.PropsWithChildren<HeaderProps>>;
     cellContextMenu?: FC<React.PropsWithChildren<CellContextMenuProps>>;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlRunnerShareUrl.ts
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlRunnerShareUrl.ts
@@ -95,9 +95,7 @@ export const useSqlRunnerShareUrl = (
         if (data?.params) {
             try {
                 const sqlRunnerParams = JSON.parse(data.params);
-                console.log('before', sqlRunnerParams);
                 if (isSqlRunnerShareParams(sqlRunnerParams)) {
-                    console.log('new');
                     sqlRunnerState = {
                         ...initialState,
                         ...sqlRunnerParams.sqlRunnerState,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -82,8 +82,11 @@ export const useColumns = (): TableColumn[] => {
     const sorts = useExplorerContext(
         (context) => context.state.unsavedChartVersion.metricQuery.sorts,
     );
-    const resultsData = useExplorerContext(
-        (context) => context.queryResults.data,
+    const resultsMetricQuery = useExplorerContext(
+        (context) => context.query.data?.metricQuery,
+    );
+    const resultsFields = useExplorerContext(
+        (context) => context.query.data?.fields,
     );
 
     const { data: exploreData } = useExplore(tableName, {
@@ -100,11 +103,11 @@ export const useColumns = (): TableColumn[] => {
                     tableCalculations,
                     customDimensions,
                 ),
-                ...(resultsData?.fields || {}),
+                ...(resultsFields || {}),
             };
         }
     }, [
-        resultsData,
+        resultsFields,
         exploreData,
         additionalMetrics,
         tableCalculations,
@@ -145,10 +148,10 @@ export const useColumns = (): TableColumn[] => {
     }, [itemsMap, activeFields]);
 
     const { data: totals } = useCalculateTotal({
-        metricQuery: resultsData?.metricQuery,
+        metricQuery: resultsMetricQuery,
         explore: exploreData?.baseTable,
-        fieldIds: resultsData
-            ? itemsInMetricQuery(resultsData.metricQuery)
+        fieldIds: resultsMetricQuery
+            ? itemsInMetricQuery(resultsMetricQuery)
             : undefined,
         itemsMap: activeItemsMap,
     });

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -36,10 +36,10 @@ export type QueryResultsProps = {
 };
 
 const getUnderlyingDataResults = async ({
-                                            projectUuid,
-                                            tableId,
-                                            query,
-                                        }: {
+    projectUuid,
+    tableId,
+    query,
+}: {
     projectUuid: string;
     tableId: string;
     query: MetricQuery;
@@ -301,12 +301,12 @@ export const useUnderlyingDataResults = (
 
     const queryKey = shouldUsePagination
         ? [
-            'underlyingDataResults',
-            projectUuid,
-            underlyingDataSourceQueryUuid,
-            underlyingDataItemId,
-            query.filters,
-        ]
+              'underlyingDataResults',
+              projectUuid,
+              underlyingDataSourceQueryUuid,
+              underlyingDataItemId,
+              query.filters,
+          ]
         : ['underlyingDataResults', projectUuid, JSON.stringify(query)];
 
     return useQuery<ApiQueryResults, ApiError>({
@@ -330,7 +330,7 @@ export const useUnderlyingDataResults = (
         },
         retry: false,
     });
-}
+};
 /**
  * Get single results page
  */
@@ -492,7 +492,7 @@ export const useInfiniteQueryResults = (
     const isFetchingRows = useMemo(() => {
         return rowIndexToFetch
             ? rowIndexToFetch > fetchedRows.length &&
-            totalRows !== fetchedRows.length
+                  totalRows !== fetchedRows.length
             : false;
     }, [rowIndexToFetch, fetchedRows.length, totalRows]);
 

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -490,11 +490,8 @@ export const useInfiniteQueryResults = (
     }, []);
 
     const isFetchingRows = useMemo(() => {
-        return rowIndexToFetch
-            ? rowIndexToFetch > fetchedRows.length &&
-                  totalRows !== fetchedRows.length
-            : false;
-    }, [rowIndexToFetch, fetchedRows.length, totalRows]);
+        return !!projectUuid && !!queryUuid && !!nextPageToFetch;
+    }, [projectUuid, queryUuid, nextPageToFetch]);
 
     return {
         fetchedRows,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -408,7 +408,6 @@ export const useInfiniteQueryResults = (
     const [fetchedPages, setFetchedPages] = useState<ReadyQueryResultsPage[]>(
         [],
     );
-    const [totalRows, setTotalRows] = useState<number | null>(null);
     const [fetchAll, setFetchAll] = useState(false);
     const [pageToFetch, setPageToFetch] = useState<number>(1);
 
@@ -467,7 +466,6 @@ export const useInfiniteQueryResults = (
     // On success
     useEffect(() => {
         if (nextPage.data) {
-            setTotalRows(nextPage.data.totalResults);
             setFetchedPages((prevState) => [...prevState, nextPage.data]);
         }
     }, [nextPage.data]);
@@ -475,7 +473,6 @@ export const useInfiniteQueryResults = (
     useEffect(() => {
         // Reset pagination state
         setFetchedPages([]);
-        setTotalRows(null);
         setPageToFetch(1);
     }, [projectUuid, queryUuid]);
 
@@ -488,7 +485,7 @@ export const useInfiniteQueryResults = (
 
     return {
         fetchedRows,
-        totalRows,
+        totalRows: nextPage.data?.totalResults,
         isFetchingRows,
         fetchMoreRows,
         fetchAllRows,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -481,7 +481,7 @@ export const useInfiniteQueryResults = (
 
     return {
         fetchedRows,
-        totalRows: nextPage.data?.totalResults,
+        totalRows: fetchedPages[0]?.totalResults,
         isFetchingRows,
         fetchMoreRows,
         setFetchAll,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -418,10 +418,6 @@ export const useInfiniteQueryResults = (
         }
     }, [fetchedPages]);
 
-    const fetchAllRows = useCallback(() => {
-        setFetchAll(true);
-    }, []);
-
     // Aggregate rows from all fetched pages
     const fetchedRows = useMemo(() => {
         const rows: ResultRow[] = [];
@@ -488,6 +484,6 @@ export const useInfiniteQueryResults = (
         totalRows: nextPage.data?.totalResults,
         isFetchingRows,
         fetchMoreRows,
-        fetchAllRows,
+        setFetchAll,
     };
 };

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -12,11 +12,12 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
+    type ReadyQueryResultsPage,
     type ResultRow,
     sleep,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import { convertDateFilters } from '../utils/dateFilter';
@@ -34,53 +35,11 @@ export type QueryResultsProps = {
     context?: string;
 };
 
-const getChartResults = async ({
-    chartUuid,
-    context,
-}: {
-    chartUuid?: string;
-    context?: string;
-}) => {
-    return lightdashApi<ApiQueryResults>({
-        url: `/saved/${chartUuid}/results${
-            context ? `?context=${context}` : ''
-        }`,
-        method: 'POST',
-        body: undefined,
-    });
-};
-
-const getQueryResults = async ({
-    projectUuid,
-    tableId,
-    query,
-    csvLimit,
-    dateZoomGranularity,
-    context,
-}: QueryResultsProps) => {
-    const timezoneFixQuery = query && {
-        ...query,
-        filters: convertDateFilters(query.filters),
-        timezone: query.timezone ?? undefined,
-    };
-
-    return lightdashApi<ApiQueryResults>({
-        url: `/projects/${projectUuid}/explores/${tableId}/runQuery`,
-        method: 'POST',
-        body: JSON.stringify({
-            ...timezoneFixQuery,
-            granularity: dateZoomGranularity,
-            csvLimit,
-            context,
-        }),
-    });
-};
-
 const getUnderlyingDataResults = async ({
-    projectUuid,
-    tableId,
-    query,
-}: {
+                                            projectUuid,
+                                            tableId,
+                                            query,
+                                        }: {
     projectUuid: string;
     tableId: string;
     query: MetricQuery;
@@ -94,17 +53,6 @@ const getUnderlyingDataResults = async ({
         url: `/projects/${projectUuid}/explores/${tableId}/runUnderlyingDataQuery`,
         method: 'POST',
         body: JSON.stringify(timezoneFixQuery),
-    });
-};
-
-const getChartVersionResults = async (
-    chartUuid: string,
-    versionUuid: string,
-) => {
-    return lightdashApi<ApiQueryResults>({
-        url: `/saved/${chartUuid}/version/${versionUuid}/results`,
-        method: 'POST',
-        body: undefined,
     });
 };
 
@@ -208,7 +156,69 @@ export const getQueryPaginatedResults = async (
     };
 };
 
+const DEFAULT_PAGE_SIZE = 500;
+
+/**
+ * Run query & get first results page
+ */
+const getFirstPage = async (
+    projectUuid: string,
+    data: ExecuteAsyncQueryRequestParams,
+): Promise<ReadyQueryResultsPage> => {
+    const query = await lightdashApi<ApiExecuteAsyncQueryResults>({
+        url: `/projects/${projectUuid}/query`,
+        version: 'v2',
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+    let firstPage: ApiGetAsyncQueryResults | undefined;
+    // Wait for first page
+    while (!firstPage || firstPage.status === QueryHistoryStatus.PENDING) {
+        firstPage = await lightdashApi<ApiGetAsyncQueryResults>({
+            url: `/projects/${projectUuid}/query/${query.queryUuid}?pageSize=${DEFAULT_PAGE_SIZE}`,
+            version: 'v2',
+            method: 'GET',
+            body: undefined,
+        });
+
+        const { status } = firstPage;
+
+        switch (status) {
+            case QueryHistoryStatus.CANCELLED:
+                throw <ApiError>{
+                    status: 'error',
+                    error: {
+                        name: 'Error',
+                        statusCode: 500,
+                        message: 'Query cancelled',
+                        data: {},
+                    },
+                };
+            case QueryHistoryStatus.ERROR:
+                throw <ApiError>{
+                    status: 'error',
+                    error: {
+                        name: 'Error',
+                        statusCode: 500,
+                        message: firstPage.error ?? 'Query failed',
+                        data: {},
+                    },
+                };
+            case QueryHistoryStatus.READY:
+                break;
+            case QueryHistoryStatus.PENDING:
+                await sleep(200);
+                break;
+            default:
+                return assertUnreachable(status, 'Unknown query status');
+        }
+    }
+
+    return firstPage as ReadyQueryResultsPage;
+};
+
 export const useQueryResults = (data: QueryResultsProps | null) => {
+    const queryClient = useQueryClient();
     const setErrorResponse = useQueryError({
         forceToastOnForbidden: true,
         forbiddenToastTitle: 'Error running query',
@@ -216,57 +226,54 @@ export const useQueryResults = (data: QueryResultsProps | null) => {
     const { data: queryPaginationEnabled } = useFeatureFlag(
         FeatureFlags.QueryPagination,
     );
-    const result = useQuery<
-        ApiQueryResults & {
-            queryUuid?: string;
-            appliedDashboardFilters?: DashboardFilters | null;
-        },
-        ApiError
-    >({
+    const result = useQuery<ReadyQueryResultsPage, ApiError>({
         enabled: !!data && !!queryPaginationEnabled,
-        queryKey: ['query-all-results', data],
+        queryKey: ['create-query', data],
         queryFn: () => {
             if (data?.chartUuid && data?.chartVersionUuid) {
-                if (queryPaginationEnabled?.enabled) {
-                    return getQueryPaginatedResults(data.projectUuid, {
-                        context: QueryExecutionContext.CHART_HISTORY,
-                        chartUuid: data.chartUuid,
-                        versionUuid: data.chartVersionUuid,
-                    });
-                }
-                return getChartVersionResults(
-                    data.chartUuid,
-                    data.chartVersionUuid,
-                );
+                return getFirstPage(data.projectUuid, {
+                    context: QueryExecutionContext.CHART_HISTORY,
+                    chartUuid: data.chartUuid,
+                    versionUuid: data.chartVersionUuid,
+                });
             } else if (data?.chartUuid) {
-                if (queryPaginationEnabled?.enabled) {
-                    return getQueryPaginatedResults(data.projectUuid, {
-                        context: QueryExecutionContext.CHART,
-                        chartUuid: data.chartUuid,
-                    });
-                }
-                return getChartResults(data);
+                return getFirstPage(data.projectUuid, {
+                    context: QueryExecutionContext.CHART,
+                    chartUuid: data.chartUuid,
+                });
             } else if (data?.query) {
-                if (queryPaginationEnabled?.enabled) {
-                    return getQueryPaginatedResults(data.projectUuid, {
-                        context: QueryExecutionContext.EXPLORE,
-                        query: {
-                            ...data.query,
-                            filters: convertDateFilters(data.query.filters),
-                            timezone: data.query.timezone ?? undefined,
-                            exploreName: data.tableId,
-                            granularity: data.dateZoomGranularity,
-                        },
-                    });
-                }
-                return getQueryResults(data);
+                return getFirstPage(data.projectUuid, {
+                    context: QueryExecutionContext.EXPLORE,
+                    query: {
+                        ...data.query,
+                        filters: convertDateFilters(data.query.filters),
+                        timezone: data.query.timezone ?? undefined,
+                        exploreName: data.tableId,
+                        granularity: data.dateZoomGranularity,
+                    },
+                });
             }
-
             return Promise.reject(
                 new ParameterError('Missing QueryResultsProps'),
             );
         },
     });
+
+    // On Success
+    useEffect(() => {
+        if (result.data) {
+            queryClient.setQueryData(
+                [
+                    'query-page',
+                    data?.projectUuid,
+                    result.data.queryUuid,
+                    1,
+                    DEFAULT_PAGE_SIZE,
+                ],
+                result.data,
+            );
+        }
+    }, [data?.projectUuid, result.data, queryClient]);
 
     // On Error
     useEffect(() => {
@@ -294,12 +301,12 @@ export const useUnderlyingDataResults = (
 
     const queryKey = shouldUsePagination
         ? [
-              'underlyingDataResults',
-              projectUuid,
-              underlyingDataSourceQueryUuid,
-              underlyingDataItemId,
-              query.filters,
-          ]
+            'underlyingDataResults',
+            projectUuid,
+            underlyingDataSourceQueryUuid,
+            underlyingDataItemId,
+            query.filters,
+        ]
         : ['underlyingDataResults', projectUuid, JSON.stringify(query)];
 
     return useQuery<ApiQueryResults, ApiError>({
@@ -323,4 +330,176 @@ export const useUnderlyingDataResults = (
         },
         retry: false,
     });
+}
+/**
+ * Get single results page
+ */
+const getResultsPage = async (
+    projectUuid: string,
+    queryUuid: string,
+    page: number = 1,
+    pageSize: number | null = null,
+): Promise<ReadyQueryResultsPage> => {
+    const searchParams = new URLSearchParams();
+    if (page) {
+        searchParams.set('page', page.toString());
+    }
+    if (pageSize) {
+        searchParams.set('pageSize', pageSize.toString());
+    }
+
+    const urlQueryParams = searchParams.toString();
+    const currentPage = await lightdashApi<ApiGetAsyncQueryResults>({
+        url: `/projects/${projectUuid}/query/${queryUuid}${
+            urlQueryParams ? `?${urlQueryParams}` : ''
+        }`,
+        version: 'v2',
+        method: 'GET',
+        body: undefined,
+    });
+    const { status } = currentPage;
+    switch (status) {
+        case QueryHistoryStatus.CANCELLED:
+            throw <ApiError>{
+                status: 'error',
+                error: {
+                    name: 'Error',
+                    statusCode: 500,
+                    message: 'Query cancelled',
+                    data: {},
+                },
+            };
+        case QueryHistoryStatus.ERROR:
+            throw <ApiError>{
+                status: 'error',
+                error: {
+                    name: 'Error',
+                    statusCode: 500,
+                    message: currentPage.error ?? 'Query failed',
+                    data: {},
+                },
+            };
+        case QueryHistoryStatus.PENDING:
+            throw <ApiError>{
+                status: 'error',
+                error: {
+                    name: 'Error',
+                    statusCode: 500,
+                    message: 'Query pending',
+                    data: {},
+                },
+            };
+        case QueryHistoryStatus.READY:
+            return currentPage;
+        default:
+            return assertUnreachable(status, 'Unknown query status');
+    }
+};
+
+// This hook lazy load results has they are needed in the UI
+export const useInfiniteQueryResults = (
+    projectUuid?: string,
+    queryUuid?: string,
+) => {
+    const [fetchedPages, setFetchedPages] = useState<ReadyQueryResultsPage[]>(
+        [],
+    );
+    const [totalRows, setTotalRows] = useState<number | null>(null);
+    const [rowIndexToFetch, setRowIndexToFetch] = useState<number | null>(null);
+
+    // Aggregate rows from all fetched pages
+    const fetchedRows = useMemo(() => {
+        const rows: ResultRow[] = [];
+        for (const page of fetchedPages) {
+            rows.push(...page.rows);
+        }
+        return rows;
+    }, [fetchedPages]);
+
+    // Find what page to fetch next based on what was fetched already and the row index we want to fetch
+    const nextPageToFetch = useMemo(() => {
+        if (rowIndexToFetch === null) {
+            return null;
+        }
+        const fetchedPagesCount = fetchedPages.length;
+        // get first page
+        if (fetchedPagesCount === 0 || totalRows === null) {
+            return 1;
+        }
+        const fetchedRowsCount = fetchedRows.length;
+        const hasFetchedEnoughRowsForNow = fetchedRowsCount >= rowIndexToFetch;
+        const isFetchComplete = fetchedRowsCount >= totalRows;
+        if (hasFetchedEnoughRowsForNow || isFetchComplete) {
+            return null;
+        }
+        // fetch next page
+        return fetchedPagesCount + 1;
+    }, [rowIndexToFetch, fetchedRows.length, fetchedPages.length, totalRows]);
+
+    useEffect(() => {
+        // Reset pagination state
+        setFetchedPages([]);
+        setTotalRows(null);
+        setRowIndexToFetch(DEFAULT_PAGE_SIZE); // prefetch first page
+    }, [projectUuid, queryUuid]);
+
+    const setErrorResponse = useQueryError({
+        forceToastOnForbidden: true,
+        forbiddenToastTitle: 'Error running query',
+    });
+    const nextPage = useQuery<ReadyQueryResultsPage, ApiError>({
+        enabled: !!projectUuid && !!queryUuid && !!nextPageToFetch,
+        queryKey: [
+            'query-page',
+            projectUuid,
+            queryUuid,
+            nextPageToFetch,
+            DEFAULT_PAGE_SIZE,
+        ],
+        queryFn: () => {
+            return getResultsPage(
+                projectUuid!,
+                queryUuid!,
+                nextPageToFetch!,
+                DEFAULT_PAGE_SIZE,
+            );
+        },
+        staleTime: Infinity, // the data will never be considered stale
+    });
+
+    // On error
+    useEffect(() => {
+        if (nextPage.error) {
+            setErrorResponse(nextPage.error);
+        }
+    }, [nextPage.error, setErrorResponse]);
+
+    // On success
+    useEffect(() => {
+        if (nextPage.data) {
+            setTotalRows(nextPage.data.totalResults);
+            setFetchedPages((prevState) => [...prevState, nextPage.data]);
+        }
+    }, [nextPage.data]);
+
+    const fetchMoreRows = useCallback((rowIndex: number) => {
+        // Update row to fetch if higher than the current value
+        setRowIndexToFetch((prevState) =>
+            prevState ? Math.max(prevState, rowIndex) : rowIndex,
+        );
+    }, []);
+
+    const isFetchingRows = useMemo(() => {
+        return rowIndexToFetch
+            ? rowIndexToFetch > fetchedRows.length &&
+            totalRows !== fetchedRows.length
+            : false;
+    }, [rowIndexToFetch, fetchedRows.length, totalRows]);
+
+    return {
+        fetchedRows,
+        totalRows,
+        isFetchingRows,
+        fetchMoreRows,
+    };
 };

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -493,10 +493,15 @@ export const useInfiniteQueryResults = (
         return !!projectUuid && !!queryUuid && !!nextPageToFetch;
     }, [projectUuid, queryUuid, nextPageToFetch]);
 
+    const fetchAllRows = useCallback(() => {
+        setRowIndexToFetch(totalRows);
+    }, [totalRows]);
+
     return {
         fetchedRows,
         totalRows,
         isFetchingRows,
         fetchMoreRows,
+        fetchAllRows,
     };
 };

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -27,9 +27,7 @@ const MinimalExplorer: FC = () => {
             if (context.query.data) {
                 // TODO: next PR should support pagination for table viz
                 // Forcing to fetch all rows for now
-                context.queryResults.fetchMoreRows(
-                    context.query.data?.totalResults,
-                );
+                context.queryResults.fetchAllRows();
 
                 if (
                     context.queryResults.fetchedRows.length >=

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -27,7 +27,7 @@ const MinimalExplorer: FC = () => {
             if (context.query.data) {
                 // TODO: next PR should support pagination for table viz
                 // Forcing to fetch all rows for now
-                context.queryResults.fetchAllRows();
+                context.queryResults.setFetchAll(true);
 
                 if (
                     context.queryResults.fetchedRows.length >=

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -40,6 +40,7 @@ import { useNavigate, useParams } from 'react-router';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import useDefaultSortField from '../../hooks/useDefaultSortField';
 import {
+    useInfiniteQueryResults,
     useQueryResults,
     type QueryResultsProps,
 } from '../../hooks/useQueryResults';
@@ -1495,9 +1496,13 @@ const ExplorerProvider: FC<
 
     const [validQueryArgs, setValidQueryArgs] =
         useState<QueryResultsProps | null>(null);
-    const queryResults = useQueryResults(validQueryArgs);
+    const query = useQueryResults(validQueryArgs);
+    const queryResults = useInfiniteQueryResults(
+        validQueryArgs?.projectUuid,
+        query.data?.queryUuid,
+    );
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { remove: clearQueryResults } = queryResults;
+    const { remove: clearQueryResults } = query;
     const resetQueryResults = useCallback(() => {
         setValidQueryArgs(null);
         clearQueryResults();
@@ -1683,10 +1688,11 @@ const ExplorerProvider: FC<
     const value: ExplorerContextType = useMemo(
         () => ({
             state,
+            query,
             queryResults,
             actions,
         }),
-        [actions, queryResults, state],
+        [actions, query, queryResults, state],
     );
     return (
         <ExplorerContext.Provider value={value}>

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -23,7 +23,10 @@ import {
     type TableChartConfig,
     type TimeZone,
 } from '@lightdash/common';
-import { type useQueryResults } from '../../hooks/useQueryResults';
+import {
+    type useInfiniteQueryResults,
+    type useQueryResults,
+} from '../../hooks/useQueryResults';
 
 export enum ExplorerSection {
     FILTERS = 'FILTERS',
@@ -270,7 +273,8 @@ export interface ExplorerState extends ExplorerReduceState {
 
 export interface ExplorerContextType {
     state: ExplorerState;
-    queryResults: ReturnType<typeof useQueryResults>;
+    query: ReturnType<typeof useQueryResults>;
+    queryResults: ReturnType<typeof useInfiniteQueryResults>;
     actions: {
         clearExplore: () => void;
         clearQuery: () => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#13916](https://github.com/lightdash/lightdash/issues/13916)<!-- reference the related issue e.g. #150 -->

### Context:

What components display results:
- viz (charts/table/etc)
- results table
- underlying data table

What pages/endpoints use those components but don't support pagination yet:
- embed dashboard
- underlying data ( waiting for [#14041](https://github.com/lightdash/lightdash/issues/14041))

What warehouses ignore `pageSize` endpoint param and return a single page with all the rows:
- trino
- postgres
- databricks

Challenges/Goals:
- keep UI pagination pagination decoupled from API+warehouse pagination
- How to incrementally add lazy load support since the explorer provider, dashboard, viz and table components are all expecting all the rows.

### Changes:

For this PR I'm focusing on the results table in the explorer page:
- refactor `common/Table` component to have manual pagination
- split results hook into 2:
  - one that creates the query and waits for it to be ready
  - one that gets the rows based on UI needs
- lazy load rows for results table
- load all rows for viz 

### Demo

Results table loading prefetching rows for next pages and loads all rows when in scroll mode.

https://github.com/user-attachments/assets/db6d2a30-2249-4316-9b71-83dc8e005b5e

Viz loads all rows for now

https://github.com/user-attachments/assets/1401c2a0-c23d-4795-a033-3426c67ebd52

