### PR TITLE
fix: simplify color on pivots, unify logic with pie charts

### DIFF
--- a/packages/frontend/src/hooks/useChartColorConfig/utils.ts
+++ b/packages/frontend/src/hooks/useChartColorConfig/utils.ts
@@ -14,59 +14,17 @@ export const isGroupedSeries = (series: SeriesLike) => {
 };
 
 export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
-    const baseField =
-        (series as EChartSeries).pivotReference?.field ??
-        (series as Series).encode.yRef?.field;
-
     const pivotValues = (
         (series as EChartSeries)?.pivotReference?.pivotValues ??
         (series as Series)?.encode.yRef.pivotValues ??
         []
     ).map(({ value }) => `${value}`);
 
-    const pivotValuesSubPath =
-        pivotValues && pivotValues.length > 0
-            ? `${pivotValues.join('.')}`
-            : null;
+    const pivotFields = (
+        (series as EChartSeries)?.pivotReference?.pivotValues ??
+        (series as Series)?.encode.yRef.pivotValues ??
+        []
+    ).map(({ field }) => `${field}`);
 
-    /**
-     * When dealing with flipped axis, Echarts will include the pivot value as
-     * part of the field identifier - we want to remove it for the purposes of
-     * color mapping if that's the case, so that we continue to have a mapping
-     * that looks like:
-     *
-     *  basefield->pivot_value
-     *
-     * instead of:
-     *
-     *  basefield.pivot_value -> pivot_value
-     *
-     * (which would be a grouping of 1 per pivot value, causing all values to
-     * be assigned the first color)
-     */
-    const baseFieldPathParts = baseField.split('.');
-
-    const baseFieldPath =
-        pivotValuesSubPath && baseFieldPathParts.at(-1) === pivotValuesSubPath
-            ? baseFieldPathParts.slice(0, -1).join('.')
-            : baseField;
-
-    const completeIdentifier = pivotValuesSubPath
-        ? pivotValuesSubPath
-        : baseFieldPath;
-
-    return [
-        `${baseFieldPath}${
-            /**
-             * If we have more than one pivot value, we append the number of pivot values
-             * to the group identifier, giving us a unique group per number of values.
-             *
-             * This is not critical, but gives us better serial color assignment when
-             * switching between number of groups, since we're not tacking each group
-             * configuration on top of eachother (under the same identifier).
-             */
-            pivotValues.length === 1 ? '' : `${`_n${pivotValues.length}`}`
-        }`,
-        completeIdentifier,
-    ];
+    return [pivotFields.join('.'), pivotValues.join('.')];
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->


### What the goal is 
For calculate color method, make logic consistent for barchars and pie charts for the same groups

Before

![Screenshot from 2025-03-20 09-44-54](https://github.com/user-attachments/assets/906c3607-0d51-457e-b16c-2b84f33aebe4)

AFter

![Screenshot from 2025-03-20 14-19-07](https://github.com/user-attachments/assets/d5b41f15-20e4-4696-8767-6641b9227f46)


### Description:

The first thing I noticed, is that the method that was calculating the color (based on the serie/pivot) was different for pie charts and bar charts 

Pie charts

![image](https://github.com/user-attachments/assets/744ace60-46ea-470c-a43a-20a0784572aa)


![Screenshot from 2025-03-20 14-23-23](https://github.com/user-attachments/assets/1aab48ae-5f15-49a5-8354-da5225db914f)

Bar charts 

![Screenshot from 2025-03-20 14-23-14](https://github.com/user-attachments/assets/254878ac-ff00-409e-be82-4c9a3ab9b8ad)

This is because we were using on barcharts pivot field, rather than pivotValue[].field. After updating this, the logic was a lot simpler. 

![Screenshot from 2025-03-20 14-26-38](https://github.com/user-attachments/assets/80f1bad0-decc-44dc-9555-d903079a6d53)

It even works for charts with multigropus

![Screenshot from 2025-03-20 14-29-29](https://github.com/user-attachments/assets/76dfe669-0a8e-4755-a362-1edaed59174d)
![Screenshot from 2025-03-20 14-26-58](https://github.com/user-attachments/assets/96bfc363-71e7-48b3-945d-3b1605f02817)

<!-- Add a description of the changes proposed in the pull request. -->
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
