### PR TITLE
chore: make common tests fast + watchable in dev

### DIFF
--- a/packages/common/jest.config.dev.js
+++ b/packages/common/jest.config.dev.js
@@ -1,0 +1,20 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    automock: false,
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    maxWorkers: '50%',
+    transform: {
+        '^.+\\.ts$': ['ts-jest', {
+            transpileOnly: true,
+            isolatedModules: true,
+        }]
+    },
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1'
+    },
+    watchPlugins: [
+        'jest-watch-typeahead/filename',
+        'jest-watch-typeahead/testname'
+    ]
+}; 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,6 +46,7 @@
         "format": "pnpm run formatter ./src --check",
         "fix-format": "pnpm run formatter ./src --write",
         "test": "TZ=UTC jest",
+        "test:dev": "TZ=UTC jest --config jest.config.dev.js --onlyChanged --watch",
         "release": "pnpm publish --no-git-checks"
     }
 }


### PR DESCRIPTION
Makes test skip compile and uses the watch plugin when running tests in dev. Much faster!