### PR TITLE
fix: Enable Private Key Password Option for Snowflake Key Pair Authentication

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -155,6 +155,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         } else if (credentials.privateKey) {
             authenticationOptions = {
                 privateKey: credentials.privateKey,
+                privateKeyPass: credentials.privateKeyPass,
                 authenticator: 'SNOWFLAKE_JWT',
             };
         }


### PR DESCRIPTION

### Description:
In addressing an issue where using an encrypted private key for Snowflake connections resulted in an error, this update adds support for configuring a password for key pair authentication. Previously, the connection options did not include a key pair password, but now this setting is enabled.


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
