### PR TITLE
feat: lazy load explore visualization

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -1,5 +1,5 @@
 import { Center, Loader, Text } from '@mantine/core';
-import { Suspense, lazy, type FC } from 'react';
+import { Suspense, lazy, useEffect, type FC } from 'react';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
 import { isCustomVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -14,7 +14,14 @@ type Props = {
 };
 
 const CustomVisualization: FC<Props> = (props) => {
-    const { isLoading, visualizationConfig } = useVisualizationContext();
+    const { isLoading, visualizationConfig, resultsData } =
+        useVisualizationContext();
+
+    useEffect(() => {
+        // Load all the rows
+        resultsData?.setFetchAll(true);
+        return () => resultsData?.setFetchAll(false);
+    }, [resultsData]);
 
     if (isLoading) {
         return <Text>Loading...</Text>;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -48,7 +48,7 @@ const ResultsCard: FC = memo(() => {
         (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
     );
 
-    const disabled = totalResults <= 0;
+    const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const getCsvLink = async (csvLimit: number | null, onlyRaw: boolean) => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -5,14 +5,7 @@ import {
     NotFoundError,
 } from '@lightdash/common';
 import { useDisclosure } from '@mantine/hooks';
-import {
-    type FC,
-    memo,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
+import { type FC, memo, useCallback, useMemo, useState } from 'react';
 import { downloadCsv } from '../../../api/csv';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import { type EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
@@ -51,25 +44,7 @@ const VisualizationCard: FC<{
         (context) =>
             context.query.isFetching || context.queryResults.isFetchingRows,
     );
-    const setFetchAll = useExplorerContext(
-        (context) => context.queryResults.setFetchAll,
-    );
-    const queryResults = useExplorerContext((context) => context.queryResults);
-
-    const resultsData = useMemo(
-        () =>
-            queryResults.hasFetchedAllRows
-                ? {
-                      metricQuery: queryResults.metricQuery,
-                      cacheMetadata: {
-                          cacheHit: false,
-                      },
-                      rows: queryResults.rows,
-                      fields: queryResults.fields,
-                  }
-                : undefined,
-        [queryResults],
-    );
+    const resultsData = useExplorerContext((context) => context.queryResults);
 
     const setPivotFields = useExplorerContext(
         (context) => context.actions.setPivotFields,
@@ -100,12 +75,6 @@ const VisualizationCard: FC<{
         () => expandedSections.includes(ExplorerSection.VISUALIZATION),
         [expandedSections],
     );
-
-    useEffect(() => {
-        // TODO: next PR should support pagination for table viz
-        // Forcing to fetch all rows for now
-        setFetchAll(isOpen);
-    }, [setFetchAll, isOpen]);
 
     const toggleSection = useCallback(
         () => toggleExpandedSection(ExplorerSection.VISUALIZATION),

--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -45,7 +45,7 @@ type FunnelChartProps = Omit<EChartsReactProps, 'option'> & {
 const EchartOptions: Opts = { renderer: 'svg' };
 
 const FunnelChart: FC<FunnelChartProps> = memo((props) => {
-    const { chartRef, isLoading } = useVisualizationContext();
+    const { chartRef, isLoading, resultsData } = useVisualizationContext();
 
     const funnelChartOptions = useEchartsFunnelConfig(props.isInDashboard);
     const { user } = useApp();
@@ -57,6 +57,12 @@ const FunnelChart: FC<FunnelChartProps> = memo((props) => {
         value: FunnelChartContextMenuProps['value'];
         rows: FunnelChartContextMenuProps['rows'];
     }>();
+
+    useEffect(() => {
+        // Load all the rows
+        resultsData?.setFetchAll(true);
+        return () => resultsData?.setFetchAll(false);
+    }, [resultsData]);
 
     useEffect(() => {
         const listener = () => chartRef.current?.getEchartsInstance().resize();

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -3,7 +3,6 @@ import {
     ChartType,
     FeatureFlags,
     isDimension,
-    type ApiQueryResults,
     type ChartConfig,
     type DashboardFilters,
     type PivotValue,
@@ -31,6 +30,7 @@ import {
 } from '../../hooks/useChartColorConfig/utils';
 import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
+import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
 import { type EchartSeriesClickEvent } from '../SimpleChart';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
 import VisualizationCartesianConfig from './VisualizationConfigCartesian';
@@ -45,7 +45,7 @@ type Props = {
     minimal?: boolean;
     chartConfig: ChartConfig;
     initialPivotDimensions: string[] | undefined;
-    resultsData: ApiQueryResults | undefined;
+    resultsData: InfiniteQueryResults;
     isLoading: boolean;
     columnOrder: string[];
     onSeriesContextMenu?: (
@@ -96,7 +96,7 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
             setEchartsRef(chartRef as RefObject<EChartsReact | null>);
     }, [chartRef, setEchartsRef]);
     const [lastValidResultsData, setLastValidResultsData] =
-        useState<ApiQueryResults>();
+        useState<InfiniteQueryResults>();
 
     const { validPivotDimensions, setPivotDimensions } = usePivotDimensions(
         initialPivotDimensions,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -1,13 +1,10 @@
-import {
-    type ApiQueryResults,
-    type ChartType,
-    type ItemsMap,
-} from '@lightdash/common';
+import { type ChartType, type ItemsMap } from '@lightdash/common';
 import type EChartsReact from 'echarts-for-react';
 import { createContext, type RefObject } from 'react';
 import { type CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { type EChartSeries } from '../../hooks/echarts/useEchartsCartesianConfig';
 import { type SeriesLike } from '../../hooks/useChartColorConfig/types';
+import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
 import { type EchartSeriesClickEvent } from '../SimpleChart';
 import { type VisualizationConfig } from './types';
 
@@ -15,7 +12,7 @@ type VisualizationContext = {
     minimal: boolean;
     chartRef: RefObject<EChartsReact | null>;
     pivotDimensions: string[] | undefined;
-    resultsData: ApiQueryResults | undefined;
+    resultsData: InfiniteQueryResults | undefined;
     isLoading: boolean;
     columnOrder: string[];
     itemsMap: ItemsMap | undefined;

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -1,6 +1,5 @@
 import {
     ChartType,
-    type ApiQueryResults,
     type CustomDimension,
     type DashboardFilters,
     type Dimension,
@@ -17,9 +16,10 @@ import type useBigNumberConfig from '../../hooks/useBigNumberConfig';
 import type useCustomVisualizationConfig from '../../hooks/useCustomVisualizationConfig';
 import type useFunnelChartConfig from '../../hooks/useFunnelChartConfig';
 import type usePieChartConfig from '../../hooks/usePieChartConfig';
+import type { InfiniteQueryResults } from '../../hooks/useQueryResults';
 
 export type VisualizationConfigCommon<T extends VisualizationConfig> = {
-    resultsData: ApiQueryResults | undefined;
+    resultsData: InfiniteQueryResults | undefined;
     initialChartConfig: T['chartConfig']['validConfig'] | undefined;
     onChartConfigChange?: (chartConfig: {
         type: T['chartType'];

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -92,7 +92,7 @@ type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
 };
 
 const SimpleChart: FC<SimpleChartProps> = memo((props) => {
-    const { chartRef, isLoading, onSeriesContextMenu, itemsMap } =
+    const { chartRef, isLoading, onSeriesContextMenu, itemsMap, resultsData } =
         useVisualizationContext();
 
     const [selectedLegends, setSelectedLegends] = useState({});
@@ -110,6 +110,12 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
         selectedLegendsUpdated,
         props.isInDashboard,
     );
+
+    useEffect(() => {
+        // Load all the rows
+        resultsData?.setFetchAll(true);
+        return () => resultsData?.setFetchAll(false);
+    }, [resultsData]);
 
     useEffect(() => {
         const listener = () => {

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -44,7 +44,7 @@ type SimplePieChartProps = Omit<EChartsReactProps, 'option'> & {
 const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
-    const { chartRef, isLoading } = useVisualizationContext();
+    const { chartRef, isLoading, resultsData } = useVisualizationContext();
 
     const pieChartOptions = useEchartsPieConfig(props.isInDashboard);
     const { user } = useApp();
@@ -55,6 +55,12 @@ const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
         value: PieChartContextMenuProps['value'];
         rows: PieChartContextMenuProps['rows'];
     }>();
+
+    useEffect(() => {
+        // Load all the rows
+        resultsData?.setFetchAll(true);
+        return () => resultsData?.setFetchAll(false);
+    }, [resultsData]);
 
     useEffect(() => {
         const listener = () => chartRef.current?.getEchartsInstance().resize();

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -29,8 +29,13 @@ const SimpleTable: FC<SimpleTableProps> = ({
     minimal = false,
     ...rest
 }) => {
-    const { isLoading, columnOrder, itemsMap, visualizationConfig } =
-        useVisualizationContext();
+    const {
+        isLoading,
+        columnOrder,
+        itemsMap,
+        visualizationConfig,
+        resultsData,
+    } = useVisualizationContext();
 
     if (!isTableVisualizationConfig(visualizationConfig)) return null;
 
@@ -113,9 +118,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 className={className}
                 status="success"
                 data={rows}
-                totalRowsCount={rows.length || 0}
-                isFetchingRows={false}
-                fetchMoreRows={() => undefined}
+                totalRowsCount={resultsData?.totalResults || 0}
+                isFetchingRows={!!resultsData?.isFetchingRows}
+                fetchMoreRows={resultsData?.fetchMoreRows || (() => undefined)}
                 columns={columns}
                 columnOrder={columnOrder}
                 hideRowNumbers={hideRowNumbers}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -30,7 +30,7 @@ const ConditionalFormattingList = ({}) => {
     }, [visualizationConfig]);
 
     const activeFields = useMemo(() => {
-        if (!resultsData) return new Set<string>();
+        if (!resultsData?.metricQuery) return new Set<string>();
         return new Set([
             ...resultsData.metricQuery.dimensions,
             ...resultsData.metricQuery.metrics,

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -23,9 +23,9 @@ const GeneralSettings: FC = () => {
     } = useVisualizationContext();
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const { showToastError } = useToaster();
-    const {
-        metricQuery: { dimensions },
-    } = resultsData || { metricQuery: { dimensions: [] as string[] } };
+    const { dimensions } = resultsData?.metricQuery || {
+        dimensions: [] as string[],
+    };
 
     const isTableConfig = isTableVisualizationConfig(visualizationConfig);
 

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
@@ -62,35 +62,20 @@ export const simpleSeriesMapArgs: GetExpectedSeriesMapArgs = {
     defaultCartesianType: CartesianSeriesType.BAR,
     defaultAreaStyle: undefined,
     isStacked: false,
-    resultsData: {
-        metricQuery: {
-            exploreName: '',
-            dimensions: ['dimension_x'],
-            metrics: [],
-            filters: {},
-            sorts: [],
-            limit: 10,
-            tableCalculations: [],
+    rows: [
+        {
+            dimension_x: { value: { raw: 'a', formatted: 'a' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
+            my_second_metric: { value: { raw: 'a', formatted: 'a' } },
         },
-        cacheMetadata: {
-            cacheHit: false,
+        {
+            dimension_x: { value: { raw: 'b', formatted: 'b' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
+            my_second_metric: { value: { raw: 'a', formatted: 'a' } },
         },
-        rows: [
-            {
-                dimension_x: { value: { raw: 'a', formatted: 'a' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-                my_second_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-            {
-                dimension_x: { value: { raw: 'b', formatted: 'b' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-                my_second_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-        ],
-        fields: {},
-    },
+    ],
     pivotKeys: undefined,
     yFields: ['my_metric', 'my_second_metric'],
     xField: 'my_dimension',
@@ -218,47 +203,32 @@ export const multiPivotSeriesMapArgs: GetExpectedSeriesMapArgs = {
     ...simpleSeriesMapArgs,
     pivotKeys: ['dimension_x', 'dimension_y'],
     yFields: ['my_metric'],
-    resultsData: {
-        metricQuery: {
-            exploreName: '',
-            dimensions: ['dimension_x', 'dimension_y'],
-            metrics: [],
-            filters: {},
-            sorts: [],
-            limit: 10,
-            tableCalculations: [],
+    rows: [
+        {
+            dimension_x: { value: { raw: 'a', formatted: 'a' } },
+            dimension_y: { value: { raw: 'a', formatted: 'a' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
         },
-        cacheMetadata: {
-            cacheHit: false,
+        {
+            dimension_x: { value: { raw: 'b', formatted: 'b' } },
+            dimension_y: { value: { raw: 'b', formatted: 'b' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
         },
-        rows: [
-            {
-                dimension_x: { value: { raw: 'a', formatted: 'a' } },
-                dimension_y: { value: { raw: 'a', formatted: 'a' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-            {
-                dimension_x: { value: { raw: 'b', formatted: 'b' } },
-                dimension_y: { value: { raw: 'b', formatted: 'b' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-            {
-                dimension_x: { value: { raw: 'a', formatted: 'a' } },
-                dimension_y: { value: { raw: 'b', formatted: 'b' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-            {
-                dimension_x: { value: { raw: 'b', formatted: 'b' } },
-                dimension_y: { value: { raw: 'a', formatted: 'a' } },
-                my_dimension: { value: { raw: 'a', formatted: 'a' } },
-                my_metric: { value: { raw: 'a', formatted: 'a' } },
-            },
-        ],
-        fields: {},
-    },
+        {
+            dimension_x: { value: { raw: 'a', formatted: 'a' } },
+            dimension_y: { value: { raw: 'b', formatted: 'b' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
+        },
+        {
+            dimension_x: { value: { raw: 'b', formatted: 'b' } },
+            dimension_y: { value: { raw: 'a', formatted: 'a' } },
+            my_dimension: { value: { raw: 'a', formatted: 'a' } },
+            my_metric: { value: { raw: 'a', formatted: 'a' } },
+        },
+    ],
 };
 
 export const expectedMultiPivotedSeriesMap: Record<string, Series> = {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -7,7 +7,6 @@ import {
     isNumericItem,
     XAxisSort,
     XAxisSortType,
-    type ApiQueryResults,
     type CartesianChart,
     type CompleteCartesianChartLayout,
     type EchartsGrid,
@@ -25,6 +24,7 @@ import {
     getMarkLineAxis,
     type ReferenceLineField,
 } from '../../components/common/ReferenceLine';
+import type { InfiniteQueryResults } from '../useQueryResults';
 import {
     getExpectedSeriesMap,
     mergeExistingAndExpectedSeries,
@@ -42,7 +42,7 @@ export type CartesianTypeOptions = {
 type Args = {
     initialChartConfig: CartesianChart | undefined;
     pivotKeys: string[] | undefined;
-    resultsData: ApiQueryResults | undefined;
+    resultsData: InfiniteQueryResults | undefined;
     setPivotDimensions: React.Dispatch<
         React.SetStateAction<string[] | undefined>
     >;
@@ -542,7 +542,7 @@ const useCartesianChartConfig = ({
         // This is computed on first load and also when the table calculation is updated in edit mode
         if (stacking === false) return;
         const tableCalculation =
-            resultsData?.metricQuery.tableCalculations?.find(
+            resultsData?.metricQuery?.tableCalculations?.find(
                 (tc) => tc.name === dirtyLayout?.xField,
             );
         if (tableCalculation) {
@@ -551,7 +551,7 @@ const useCartesianChartConfig = ({
         }
     }, [
         dirtyLayout?.xField,
-        resultsData?.metricQuery.tableCalculations,
+        resultsData?.metricQuery?.tableCalculations,
         stacking,
         setStacking,
     ]);
@@ -564,17 +564,17 @@ const useCartesianChartConfig = ({
 
     const sortedDimensions = useMemo(() => {
         return sortDimensions(
-            resultsData?.metricQuery.dimensions || [],
+            resultsData?.metricQuery?.dimensions || [],
             itemsMap,
             columnOrder,
         );
-    }, [resultsData?.metricQuery.dimensions, itemsMap, columnOrder]);
+    }, [resultsData?.metricQuery?.dimensions, itemsMap, columnOrder]);
 
     const [availableFields, availableDimensions, availableMetrics] =
         useMemo(() => {
-            const metrics = resultsData?.metricQuery.metrics || [];
+            const metrics = resultsData?.metricQuery?.metrics || [];
             const tableCalculations =
-                resultsData?.metricQuery.tableCalculations.map(
+                resultsData?.metricQuery?.tableCalculations.map(
                     ({ name }) => name,
                 ) || [];
 
@@ -866,7 +866,7 @@ const useCartesianChartConfig = ({
                     availableDimensions,
                     isStacked,
                     pivotKeys,
-                    resultsData,
+                    rows: resultsData.rows,
                     xField: dirtyLayout.xField,
                     yFields: dirtyLayout.yField,
                     defaultLabel,

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -4,9 +4,9 @@ import {
     getItemId,
     getSeriesId,
     isDimension,
-    type ApiQueryResults,
     type CartesianSeriesType,
     type ItemsMap,
+    type ResultRow,
     type Series,
 } from '@lightdash/common';
 import { getPivotedData } from '../plottedData/getPlottedData';
@@ -17,7 +17,7 @@ export type GetExpectedSeriesMapArgs = {
     defaultCartesianType: CartesianSeriesType;
     defaultAreaStyle: Series['areaStyle'];
     isStacked: boolean;
-    resultsData: ApiQueryResults;
+    rows: ResultRow[];
     pivotKeys: string[] | undefined;
     yFields: string[];
     xField: string;
@@ -31,7 +31,7 @@ export const getExpectedSeriesMap = ({
     defaultCartesianType,
     defaultAreaStyle,
     isStacked,
-    resultsData,
+    rows,
     pivotKeys,
     yFields,
     xField,
@@ -50,7 +50,7 @@ export const getExpectedSeriesMap = ({
     };
     if (pivotKeys && pivotKeys.length > 0) {
         const { rowKeyMap } = getPivotedData(
-            resultsData.rows,
+            rows,
             pivotKeys,
             yFields.filter((yField) => !availableDimensions.includes(yField)),
             yFields.filter((yField) => availableDimensions.includes(yField)),

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -3,7 +3,6 @@ import {
     getSubtotalKey,
     isCustomDimension,
     isField,
-    type ApiQueryResults,
     type ItemsMap,
     type ResultRow,
 } from '@lightdash/common';
@@ -20,11 +19,12 @@ import {
     type TableHeader,
 } from '../../components/common/Table/types';
 import { getFormattedValueCell } from '../useColumns';
+import { type InfiniteQueryResults } from '../useQueryResults';
 
 type Args = {
     itemsMap: ItemsMap;
     selectedItemIds: string[];
-    resultsData: ApiQueryResults;
+    resultsData: InfiniteQueryResults;
     isColumnVisible: (key: string) => boolean;
     isColumnFrozen: (key: string) => boolean;
     showTableNames: boolean;

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -10,7 +10,6 @@ import {
     isSummable,
     isTableCalculation,
     itemsInMetricQuery,
-    type ApiQueryResults,
     type ColumnProperties,
     type ConditionalFormattingConfig,
     type ConditionalFormattingMinMaxMap,
@@ -29,6 +28,7 @@ import {
 } from '../../components/common/Table/types';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
+import { type InfiniteQueryResults } from '../useQueryResults';
 import getDataAndColumns from './getDataAndColumns';
 
 const createWorker = createWorkerFactory(
@@ -37,7 +37,7 @@ const createWorker = createWorkerFactory(
 
 const useTableConfig = (
     tableChartConfig: TableChart | undefined,
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
     itemsMap: ItemsMap | undefined,
     columnOrder: string[],
     pivotDimensions: string[] | undefined,
@@ -211,7 +211,7 @@ const useTableConfig = (
               }
             : {
                   metricQuery: resultsData?.metricQuery,
-                  explore: resultsData?.metricQuery.exploreName,
+                  explore: resultsData?.metricQuery?.exploreName,
                   fieldIds: selectedItemIds,
                   itemsMap,
                   showColumnCalculation:
@@ -221,7 +221,7 @@ const useTableConfig = (
 
     const { data: groupedSubtotals } = useCalculateSubtotals({
         metricQuery: resultsData?.metricQuery,
-        explore: resultsData?.metricQuery.exploreName,
+        explore: resultsData?.metricQuery?.exploreName,
         showSubtotals,
         columnOrder,
         pivotDimensions,
@@ -286,7 +286,7 @@ const useTableConfig = (
         if (
             !pivotDimensions ||
             pivotDimensions.length === 0 ||
-            !resultsData ||
+            !resultsData?.metricQuery ||
             resultsData.rows.length === 0
         ) {
             setPivotTableData({

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -16,13 +16,13 @@ import {
     isNumericItem,
     isTableCalculation,
     valueIsNaN,
-    type ApiQueryResults,
     type BigNumber,
     type CompactOrAlias,
     type ItemsMap,
     type TableCalculationMetadata,
 } from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type InfiniteQueryResults } from './useQueryResults';
 
 export const calculateComparisonValue = (
     a: number,
@@ -113,7 +113,7 @@ const getItemPriority = (item: ItemsMap[string]): number => {
 
 const useBigNumberConfig = (
     bigNumberConfigData: BigNumber | undefined,
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
     itemsMap: ItemsMap | undefined,
     tableCalculationsMetadata?: TableCalculationMetadata[],
 ) => {

--- a/packages/frontend/src/hooks/useCustomVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useCustomVisualizationConfig.ts
@@ -1,9 +1,6 @@
-import {
-    type ApiQueryResults,
-    type CustomVis,
-    type ResultRow,
-} from '@lightdash/common';
+import { type CustomVis, type ResultRow } from '@lightdash/common';
 import { useEffect, useMemo, useState } from 'react';
+import { type InfiniteQueryResults } from './useQueryResults';
 
 const convertRowsToSeries = (rows: ResultRow[]) => {
     return rows.map((row) => {
@@ -29,7 +26,7 @@ export interface CustomVisualizationConfigAndData {
 
 const useCustomVisualizationConfig = (
     chartConfig: CustomVis | undefined,
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
 ): CustomVisualizationConfigAndData => {
     const [visSpec, setVisSpec] = useState<string | undefined>();
     const [visSpecObject, setVisSpecObject] = useState();

--- a/packages/frontend/src/hooks/useFunnelChartConfig.ts
+++ b/packages/frontend/src/hooks/useFunnelChartConfig.ts
@@ -5,7 +5,6 @@ import {
     isField,
     isMetric,
     isTableCalculation,
-    type ApiQueryResults,
     type FunnelChart,
     type ItemsMap,
     type Metric,
@@ -15,6 +14,7 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type FunnelSeriesDataPoint } from './echarts/useEchartsFunnelConfig';
+import { type InfiniteQueryResults } from './useQueryResults';
 
 type FunnelChartConfig = {
     validConfig: FunnelChart;
@@ -47,7 +47,7 @@ type FunnelChartConfig = {
 };
 
 export type FunnelChartConfigFn = (
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
     funnelChartConfig: FunnelChart | undefined,
     itemsMap: ItemsMap | undefined,
     numericFields: Record<string, Metric | TableCalculation>,

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -6,7 +6,6 @@ import {
     isHexCodeColor,
     isMetric,
     isTableCalculation,
-    type ApiQueryResults,
     type CustomDimension,
     type Dimension,
     type ItemsMap,
@@ -27,6 +26,7 @@ import omitBy from 'lodash/omitBy';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type InfiniteQueryResults } from './useQueryResults';
 
 type PieChartConfig = {
     validConfig: PieChart;
@@ -85,7 +85,7 @@ type PieChartConfig = {
 };
 
 export type PieChartConfigFn = (
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
     pieChartConfig: PieChart | undefined,
     itemsMap: ItemsMap | undefined,
     dimensions: Record<string, CustomDimension | Dimension>,

--- a/packages/frontend/src/hooks/usePivotDimensions.ts
+++ b/packages/frontend/src/hooks/usePivotDimensions.ts
@@ -1,16 +1,16 @@
-import { type ApiQueryResults } from '@lightdash/common';
 import { useMemo, useState } from 'react';
+import { type InfiniteQueryResults } from './useQueryResults';
 
 const usePivotDimensions = (
     initialPivotDimensions: string[] | undefined,
-    resultsData: ApiQueryResults | undefined,
+    resultsData: InfiniteQueryResults | undefined,
 ) => {
     const [dirtyPivotDimensions, setPivotDimensions] = useState(
         initialPivotDimensions,
     );
 
     const validPivotDimensions = useMemo(() => {
-        if (resultsData) {
+        if (resultsData?.metricQuery) {
             const availableDimensions = resultsData.metricQuery.dimensions;
 
             if (

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -6,6 +6,7 @@ import {
     assertUnreachable,
     type DashboardFilters,
     type DateGranularity,
+    DEFAULT_RESULTS_PAGE_SIZE,
     type ExecuteAsyncQueryRequestParams,
     FeatureFlags,
     type MetricQuery,
@@ -135,8 +136,6 @@ export const getQueryPaginatedResults = async (
     };
 };
 
-const DEFAULT_PAGE_SIZE = 20;
-
 /**
  * Run query & get first results page
  */
@@ -154,7 +153,7 @@ const getFirstPage = async (
     // Wait for first page
     while (!firstPage || firstPage.status === QueryHistoryStatus.PENDING) {
         firstPage = await lightdashApi<ApiGetAsyncQueryResults>({
-            url: `/projects/${projectUuid}/query/${query.queryUuid}?pageSize=${DEFAULT_PAGE_SIZE}`,
+            url: `/projects/${projectUuid}/query/${query.queryUuid}?pageSize=${DEFAULT_RESULTS_PAGE_SIZE}`,
             version: 'v2',
             method: 'GET',
             body: undefined,
@@ -247,7 +246,7 @@ export const useQueryResults = (data: QueryResultsProps | null) => {
                     data?.projectUuid,
                     result.data.queryUuid,
                     1,
-                    DEFAULT_PAGE_SIZE,
+                    DEFAULT_RESULTS_PAGE_SIZE,
                 ],
                 result.data,
             );
@@ -387,7 +386,7 @@ export const useInfiniteQueryResults = (
         queryUuid: undefined,
         projectUuid: undefined,
         page: 1,
-        pageSize: DEFAULT_PAGE_SIZE,
+        pageSize: DEFAULT_RESULTS_PAGE_SIZE,
     });
     const [fetchedPages, setFetchedPages] = useState<ReadyQueryResultsPage[]>(
         [],
@@ -456,7 +455,7 @@ export const useInfiniteQueryResults = (
             queryUuid,
             projectUuid,
             page: 1,
-            pageSize: DEFAULT_PAGE_SIZE,
+            pageSize: DEFAULT_RESULTS_PAGE_SIZE,
         });
     }, [projectUuid, queryUuid]);
 

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -467,6 +467,14 @@ export const useInfiniteQueryResults = (
         }
     }, [fetchAll, fetchMoreRows]);
 
+    const hasFetchedAllRows = useMemo(() => {
+        if (fetchedPages.length === 0) {
+            return false;
+        }
+
+        return fetchedRows.length >= fetchedPages[0].totalResults;
+    }, [fetchedRows, fetchedPages]);
+
     return useMemo(
         () => ({
             projectUuid,
@@ -474,8 +482,7 @@ export const useInfiniteQueryResults = (
             metricQuery: fetchedPages[0]?.metricQuery,
             fields: fetchedPages[0]?.fields,
             totalResults: fetchedPages[0]?.totalResults,
-            hasFetchedAllRows:
-                fetchedRows.length >= fetchedPages[0]?.totalResults,
+            hasFetchedAllRows,
             rows: fetchedRows,
             isFetchingRows,
             fetchMoreRows,
@@ -485,10 +492,10 @@ export const useInfiniteQueryResults = (
             projectUuid,
             queryUuid,
             fetchedPages,
+            hasFetchedAllRows,
             fetchedRows,
             isFetchingRows,
             fetchMoreRows,
-            setFetchAll,
         ],
     );
 };

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -135,7 +135,7 @@ export const getQueryPaginatedResults = async (
     };
 };
 
-const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_PAGE_SIZE = 20;
 
 /**
  * Run query & get first results page
@@ -356,11 +356,24 @@ const getResultsPage = async (
     }
 };
 
+export type InfiniteQueryResults = Partial<
+    Pick<
+        ReadyQueryResultsPage,
+        'metricQuery' | 'queryUuid' | 'totalResults' | 'fields'
+    >
+> & {
+    projectUuid?: string;
+    rows: ResultRow[];
+    isFetchingRows: boolean;
+    fetchMoreRows: () => void;
+    setFetchAll: (value: boolean) => void;
+};
+
 // This hook lazy load results has they are needed in the UI
 export const useInfiniteQueryResults = (
     projectUuid?: string,
     queryUuid?: string,
-) => {
+): InfiniteQueryResults => {
     const setErrorResponse = useQueryError({
         forceToastOnForbidden: true,
         forbiddenToastTitle: 'Error running query',

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -1,5 +1,5 @@
 import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
-import { type FC, useEffect, useMemo } from 'react';
+import { type FC } from 'react';
 import { useParams } from 'react-router';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
@@ -20,30 +20,7 @@ const themeOverride: MantineThemeOverride = {
 };
 const MinimalExplorer: FC = () => {
     const { health } = useApp();
-    const setFetchAll = useExplorerContext(
-        (context) => context.queryResults.setFetchAll,
-    );
-    const queryResults = useExplorerContext((context) => context.queryResults);
-    const resultsData = useMemo(
-        () =>
-            queryResults.hasFetchedAllRows
-                ? {
-                      metricQuery: queryResults.metricQuery,
-                      cacheMetadata: {
-                          cacheHit: false,
-                      },
-                      rows: queryResults.rows,
-                      fields: queryResults.fields,
-                  }
-                : undefined,
-        [queryResults],
-    );
-
-    useEffect(() => {
-        // TODO: next PR should support pagination for table viz
-        // Forcing to fetch all rows for now
-        setFetchAll(true);
-    }, [setFetchAll]);
+    const resultsData = useExplorerContext((context) => context.queryResults);
 
     const savedChart = useExplorerContext(
         (context) => context.state.savedChart,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#13916](https://github.com/lightdash/lightdash/issues/13916)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Move fetch call to viz components. At the moment they all fetch all rows beside the big number viz. 
Dashboard tiles are still loading all rows and mocking pagination methods(eg: fetchAll, fetchMoreRows)

Following PRs:
- add virtualization to table viz + load more pages as it scrolls
- lazy load viz in dashboard tiles

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
