### PR TITLE
feat: allow exporting a dashboard tab

### DIFF
--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -175,6 +175,7 @@ dashboardRouter.post(
                     req.body.queryFilters,
                     req.body.gridWidth,
                     req.user!,
+                    req.body.selectedTabs,
                 );
 
             res.json({

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -137,16 +137,23 @@ export class UnfurlService extends BaseService {
         this.downloadFileModel = downloadFileModel;
     }
 
-    static async waitForAllPaginatedResultsResponse(
+    private async waitForAllPaginatedResultsResponse(
         page: playwright.Page,
         expectedResponses: number,
         timeout: number,
     ) {
         let responseCount = 0;
 
+        this.logger.info(
+            `Waiting for ${expectedResponses} paginated responses with timeout ${timeout}ms`,
+        );
+
         const responsePromise = new Promise<void>((resolve, reject) => {
             const responseHandler = async (response: playwright.Response) => {
                 if (response.url().match(paginatedQueryEndpointRegex)) {
+                    this.logger.debug(
+                        `Received paginated response: ${response.url()}`,
+                    );
                     const body = await response.body();
                     const json = JSON.parse(body.toString()) as {
                         status: 'ok';
@@ -158,10 +165,26 @@ export class UnfurlService extends BaseService {
                         !json.results.nextPage
                     ) {
                         responseCount += 1;
+                        this.logger.info(
+                            `Paginated response is complete. Count: ${responseCount}/${expectedResponses}`,
+                        );
                         if (responseCount === expectedResponses) {
+                            this.logger.info(
+                                `All ${expectedResponses} paginated responses received, resolving promise`,
+                            );
                             page.off('response', responseHandler); // Clean up the listener
                             resolve();
                         }
+                    } else {
+                        this.logger.debug(
+                            `Paginated response is not complete. Status: ${
+                                json.results.status
+                            }, hasNextPage: ${
+                                'nextPage' in json.results
+                                    ? !!json.results.nextPage
+                                    : 'N/A'
+                            }`,
+                        );
                     }
                 }
             };
@@ -170,6 +193,9 @@ export class UnfurlService extends BaseService {
 
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
+                this.logger.info(
+                    `Timeout after ${timeout}ms. Expected ${expectedResponses} but only received ${responseCount} responses.`,
+                );
                 reject(
                     new Error(
                         `Timeout after ${timeout}ms. Expected ${expectedResponses} but only received ${responseCount} responses.`,
@@ -181,15 +207,18 @@ export class UnfurlService extends BaseService {
         return Promise.race([responsePromise, timeoutPromise]);
     }
 
-    static async waitForPaginatedResultsResponse(page: playwright.Page) {
-        return UnfurlService.waitForAllPaginatedResultsResponse(
+    private async waitForPaginatedResultsResponse(page: playwright.Page) {
+        return this.waitForAllPaginatedResultsResponse(
             page,
             1,
             RESPONSE_TIMEOUT_MS,
         );
     }
 
-    async getTitleAndDescription(parsedUrl: ParsedUrl): Promise<
+    async getTitleAndDescription(
+        parsedUrl: ParsedUrl,
+        selectedTabs?: string[],
+    ): Promise<
         Pick<
             Unfurl,
             'title' | 'description' | 'chartType' | 'organizationUuid'
@@ -208,15 +237,24 @@ export class UnfurlService extends BaseService {
                 const dashboard = await this.dashboardModel.getById(
                     parsedUrl.dashboardUuid,
                 );
+
+                // Filter tiles based on selected tabs if they exist
+                const filteredTiles =
+                    selectedTabs && selectedTabs.length > 0
+                        ? dashboard.tiles.filter((tile) =>
+                              selectedTabs.includes(tile.tabUuid || ''),
+                          )
+                        : dashboard.tiles;
+
                 return {
                     title: dashboard.name,
                     description: dashboard.description,
                     organizationUuid: dashboard.organizationUuid,
                     resourceUuid: dashboard.uuid,
-                    chartTileUuids: dashboard.tiles
+                    chartTileUuids: filteredTiles
                         .filter(isDashboardChartTileType)
                         .map((t) => t.properties.savedChartUuid),
-                    sqlChartTileUuids: dashboard.tiles
+                    sqlChartTileUuids: filteredTiles
                         .filter(isDashboardSqlChartTile)
                         .map((t) => t.properties.savedSqlUuid),
                 };
@@ -257,7 +295,10 @@ export class UnfurlService extends BaseService {
         }
     }
 
-    async unfurlDetails(originUrl: string): Promise<Unfurl | undefined> {
+    async unfurlDetails(
+        originUrl: string,
+        selectedTabs: string[] = [],
+    ): Promise<Unfurl | undefined> {
         const parsedUrl = await this.parseUrl(originUrl);
 
         if (
@@ -275,7 +316,7 @@ export class UnfurlService extends BaseService {
             chartType,
             resourceUuid,
             ...rest
-        } = await this.getTitleAndDescription(parsedUrl);
+        } = await this.getTitleAndDescription(parsedUrl, selectedTabs);
 
         return {
             title,
@@ -320,6 +361,7 @@ export class UnfurlService extends BaseService {
         selector = undefined,
         context,
         contextId,
+        selectedTabs,
     }: {
         url: string;
         lightdashPage?: LightdashPage;
@@ -330,9 +372,10 @@ export class UnfurlService extends BaseService {
         selector?: string;
         context: ScreenshotContext;
         contextId?: unknown;
+        selectedTabs?: string[];
     }): Promise<{ imageUrl?: string; pdfPath?: string }> {
         const cookie = await this.getUserCookie(authUserUuid);
-        const details = await this.unfurlDetails(url);
+        const details = await this.unfurlDetails(url, selectedTabs);
 
         const buffer = await this.saveScreenshot({
             authUserUuid,
@@ -350,6 +393,7 @@ export class UnfurlService extends BaseService {
             sqlChartTileUuids: details?.sqlChartTileUuids,
             context,
             contextId,
+            selectedTabs,
         });
 
         let imageUrl;
@@ -386,6 +430,7 @@ export class UnfurlService extends BaseService {
         queryFilters: string,
         gridWidth: number | undefined,
         user: SessionUser,
+        selectedTabs?: string[],
     ): Promise<string> {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
         const { isPrivate } = await this.spaceModel.get(dashboard.spaceUuid);
@@ -393,12 +438,33 @@ export class UnfurlService extends BaseService {
             user.userUuid,
             dashboard.spaceUuid,
         );
+
+        // Create a new URLSearchParams object for query filters
+        const selectedTabsParams = new URLSearchParams();
+        const selectedTabsList =
+            selectedTabs ??
+            dashboard.tiles
+                .map((tile) => tile.tabUuid)
+                .filter((tabUuid) => !!tabUuid);
+
+        if (selectedTabsList.length > 0)
+            selectedTabsParams.set(
+                'selectedTabs',
+                JSON.stringify(selectedTabsList),
+            );
+
         const { organizationUuid, projectUuid, name, minimalUrl, pageType } = {
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
             name: dashboard.name,
             minimalUrl: new URL(
-                `/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}${queryFilters}`,
+                `/minimal/projects/${
+                    dashboard.projectUuid
+                }/dashboards/${dashboardUuid}${queryFilters}${
+                    selectedTabsParams.toString()
+                        ? `${selectedTabsParams.toString()}`
+                        : ''
+                }`,
                 this.lightdashConfig.headlessBrowser.internalLightdashHost,
             ).href,
             pageType: LightdashPage.DASHBOARD,
@@ -418,6 +484,14 @@ export class UnfurlService extends BaseService {
             throw new ForbiddenError();
         }
 
+        this.logger.info(
+            `Exporting dashboard ${name} with minimalUrl ${minimalUrl}${
+                selectedTabs
+                    ? ` and selected tabs: ${selectedTabs.join(', ')}`
+                    : ''
+            }`,
+        );
+
         const unfurlImage = await this.unfurlImage({
             url: minimalUrl,
             lightdashPage: pageType,
@@ -425,6 +499,7 @@ export class UnfurlService extends BaseService {
             authUserUuid: user.userUuid,
             gridWidth,
             context: ScreenshotContext.EXPORT_DASHBOARD,
+            selectedTabs,
         });
         if (unfurlImage.imageUrl === undefined) {
             throw new Error('Unable to unfurl image');
@@ -449,6 +524,7 @@ export class UnfurlService extends BaseService {
         retries = SCREENSHOT_RETRIES,
         context,
         contextId,
+        selectedTabs,
     }: {
         imageId: string;
         cookie: string;
@@ -466,7 +542,32 @@ export class UnfurlService extends BaseService {
         retries?: number;
         context: ScreenshotContext;
         contextId?: unknown;
+        selectedTabs?: string[];
     }): Promise<Buffer | undefined> {
+        console.log('params', {
+            imageId,
+            cookie,
+            url,
+            lightdashPage,
+            chartType,
+            organizationUuid,
+            authUserUuid,
+            gridWidth,
+            resourceUuid,
+            resourceName,
+            selector,
+            chartTileUuids,
+            sqlChartTileUuids,
+            retries,
+            context,
+            contextId,
+            selectedTabs,
+        });
+        this.logger.info(
+            `with tiles ${JSON.stringify(chartTileUuids)} and ${JSON.stringify(
+                sqlChartTileUuids,
+            )}`,
+        );
         if (this.lightdashConfig.headlessBrowser?.host === undefined) {
             this.logger.error(
                 `Can't get screenshot if HEADLESS_BROWSER_HOST env variable is not defined`,
@@ -653,11 +754,29 @@ export class UnfurlService extends BaseService {
                                 | Promise<unknown>
                                 | undefined;
                             if (chartTileUuids) {
+                                this.logger.info(
+                                    `Dashboard screenshot: Found ${
+                                        chartTileUuids.length
+                                    } chart tiles, with values: ${JSON.stringify(
+                                        chartTileUuids,
+                                    )}`,
+                                );
+
+                                const nonNullChartTileUuids =
+                                    chartTileUuids.filter((id) => id !== null);
+                                this.logger.info(
+                                    `Dashboard screenshot: ${nonNullChartTileUuids.length} non-null chart tiles out of ${chartTileUuids.length} total tiles`,
+                                );
+
                                 const legacyExploreChartResultsPromises =
                                     chartTileUuids.map((id) => {
-                                        if (page) {
+                                        if (page && id) {
                                             const responsePattern = new RegExp(
                                                 `${id}/chart-and-results`,
+                                            );
+
+                                            this.logger.debug(
+                                                `Dashboard screenshot: Waiting for response pattern ${responsePattern} for chart ID ${id}`,
                                             );
 
                                             return page?.waitForResponse(
@@ -670,10 +789,23 @@ export class UnfurlService extends BaseService {
                                         }
                                         return undefined;
                                     });
+
+                                const validPromisesCount =
+                                    legacyExploreChartResultsPromises.filter(
+                                        (p) => p !== undefined,
+                                    ).length;
+                                this.logger.info(
+                                    `Dashboard screenshot: Created ${validPromisesCount} legacy response promises out of ${legacyExploreChartResultsPromises.length} chart tiles`,
+                                );
+
                                 const expectedPaginatedResponses =
                                     chartTileUuids.length;
+                                this.logger.info(
+                                    `Dashboard screenshot: Expecting ${expectedPaginatedResponses} paginated responses`,
+                                );
+
                                 const paginatedQueryPromise =
-                                    UnfurlService.waitForAllPaginatedResultsResponse(
+                                    this.waitForAllPaginatedResultsResponse(
                                         page,
                                         expectedPaginatedResponses,
                                         expectedPaginatedResponses *
@@ -706,6 +838,14 @@ export class UnfurlService extends BaseService {
                                 sqlChartTileUuids?.filter(
                                     (id): id is string => !!id,
                                 );
+
+                            this.logger.info(
+                                `Dashboard screenshot: SQL chart tiles - original count: ${
+                                    sqlChartTileUuids?.length || 0
+                                }, filtered count: ${
+                                    filteredSqlChartTileUuids?.length || 0
+                                }`,
+                            );
 
                             const hasSqlCharts =
                                 filteredSqlChartTileUuids &&
@@ -772,9 +912,7 @@ export class UnfurlService extends BaseService {
                                 },
                             ); // NOTE: No await here
                             const paginatedQueryPromise =
-                                UnfurlService.waitForPaginatedResultsResponse(
-                                    page,
-                                ); // NOTE: No await here
+                                this.waitForPaginatedResultsResponse(page); // NOTE: No await here
 
                             chartResultsPromises = [
                                 Promise.race([
@@ -791,9 +929,7 @@ export class UnfurlService extends BaseService {
                                 },
                             ); // NOTE: No await here
                             const paginatedQueryPromise =
-                                UnfurlService.waitForPaginatedResultsResponse(
-                                    page,
-                                ); // NOTE: No await here
+                                this.waitForPaginatedResultsResponse(page); // NOTE: No await here
 
                             chartResultsPromises = [
                                 Promise.race([
@@ -940,6 +1076,7 @@ export class UnfurlService extends BaseService {
                             retries,
                             context,
                             contextId,
+                            selectedTabs,
                         });
                     }
 

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -1,17 +1,27 @@
-import { type Dashboard } from '@lightdash/common';
+import { FeatureFlags, type Dashboard } from '@lightdash/common';
 import {
     Alert,
     Box,
     Button,
+    Checkbox,
     Group,
+    Input,
     Modal,
+    MultiSelect,
+    Paper,
     SegmentedControl,
     Stack,
-    Title,
+    Text,
     Tooltip,
     type ModalProps,
 } from '@mantine/core';
-import { IconCsv, IconEyeCog, IconFileExport } from '@tabler/icons-react';
+import {
+    IconCsv,
+    IconFileExport,
+    IconHelpCircle,
+    IconLayoutDashboard,
+    IconScreenshot,
+} from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { useLocation } from 'react-router';
 import { PreviewAndCustomizeScreenshot } from '../../../features/preview';
@@ -20,6 +30,7 @@ import {
     useExportCsvDashboard,
     useExportDashboard,
 } from '../../../hooks/dashboard/useDashboard';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../MantineIcon';
 
@@ -49,7 +60,7 @@ const CsvExport: FC<CsvExportProps & Pick<ModalProps, 'onClose'>> = ({
                     granularity.
                 </Alert>
             )}
-            <Group position="right" pb="md" px="md" spacing="lg">
+            <Group position="right" spacing="lg">
                 <Button variant="outline" onClick={onClose}>
                     Cancel
                 </Button>
@@ -92,76 +103,214 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
     const location = useLocation();
     const exportDashboardMutation = useExportDashboard();
 
+    const isDashboardTabsEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardTabs,
+    );
+    const isDashboardTabsAvailable =
+        dashboard?.tabs !== undefined && dashboard.tabs.length > 0;
+
+    const [allTabsSelected, setAllTabsSelected] = useState(true);
+    const [selectedTabs, setSelectedTabs] = useState<string[]>(
+        dashboard?.tabs?.map((tab) => tab.uuid) || [],
+    );
+
+    // Helper function to create consistent cache keys
+    const getPreviewKey = useCallback(
+        (width: string) => {
+            return `${width}-${selectedTabs.join('-')}`;
+        },
+        [selectedTabs],
+    );
+
+    // Get the current preview based on the key
+    const currentPreview = previewChoice
+        ? previews[getPreviewKey(previewChoice)]
+        : undefined;
+
     const handleExportClick = useCallback(() => {
-        if (previewChoice && previews[previewChoice])
-            return window.open(exportDashboardMutation.data, '_blank');
+        if (previewChoice && previews[getPreviewKey(previewChoice)]) {
+            return window.open(
+                previews[getPreviewKey(previewChoice)],
+                '_blank',
+            );
+        }
+
+        const queryParams = new URLSearchParams(location.search);
 
         exportDashboardMutation.mutate({
             dashboard,
             gridWidth: undefined,
-            queryFilters: location.search,
+            queryFilters: `?${queryParams.toString()}`,
+            selectedTabs:
+                isDashboardTabsEnabled &&
+                isDashboardTabsAvailable &&
+                !allTabsSelected
+                    ? selectedTabs
+                    : undefined,
         });
     }, [
-        dashboard,
-        exportDashboardMutation,
-        location.search,
         previewChoice,
         previews,
+        getPreviewKey,
+        exportDashboardMutation,
+        location.search,
+        dashboard,
+        isDashboardTabsEnabled,
+        isDashboardTabsAvailable,
+        allTabsSelected,
+        selectedTabs,
     ]);
 
     const handlePreviewClick = useCallback(async () => {
+        const queryParams = new URLSearchParams(location.search);
+
         const url = await exportDashboardMutation.mutateAsync({
             dashboard,
             gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
-            queryFilters: location.search,
+            queryFilters: `?${queryParams.toString()}`,
             isPreview: true,
+            selectedTabs:
+                isDashboardTabsEnabled &&
+                isDashboardTabsAvailable &&
+                !allTabsSelected
+                    ? selectedTabs
+                    : undefined,
         });
-        setPreviews((prev) => ({
-            ...prev,
-            ...(previewChoice ? { [previewChoice]: url } : {}),
-        }));
+
+        // Store the preview with the proper key
+        if (previewChoice) {
+            const key = getPreviewKey(previewChoice);
+            setPreviews((prev) => ({
+                ...prev,
+                [key]: url,
+            }));
+        }
     }, [
-        dashboard,
-        exportDashboardMutation,
         location.search,
+        exportDashboardMutation,
+        dashboard,
         previewChoice,
-        setPreviews,
+        isDashboardTabsEnabled,
+        isDashboardTabsAvailable,
+        allTabsSelected,
+        selectedTabs,
+        getPreviewKey,
     ]);
+
     return (
         <Stack>
-            <Box p="md">
+            <Stack spacing="xs" px="md">
+                {isDashboardTabsEnabled && isDashboardTabsAvailable && (
+                    <Stack spacing="xs">
+                        <Input.Label>
+                            <Group spacing="xs">
+                                Tabs
+                                <Tooltip
+                                    withinPortal={true}
+                                    maw={400}
+                                    variant="xs"
+                                    multiline
+                                    label="Select all tabs to include all tabs in the export. If you don't select this option, only selected tabs will be included."
+                                >
+                                    <MantineIcon
+                                        icon={IconHelpCircle}
+                                        size="md"
+                                        display="inline"
+                                        color="gray"
+                                    />
+                                </Tooltip>
+                            </Group>
+                        </Input.Label>
+                        <Checkbox
+                            size="sm"
+                            label="Include all tabs"
+                            labelPosition="right"
+                            checked={allTabsSelected}
+                            onChange={(e) => {
+                                setAllTabsSelected(e.target.checked);
+                                if (e.target.checked) {
+                                    setSelectedTabs(
+                                        dashboard?.tabs?.map(
+                                            (tab) => tab.uuid,
+                                        ) || [],
+                                    );
+                                } else {
+                                    setSelectedTabs([
+                                        dashboard?.tabs?.[0]?.uuid,
+                                    ]);
+                                }
+                            }}
+                        />
+                        {!allTabsSelected && (
+                            <MultiSelect
+                                placeholder="Select tabs to include in the export"
+                                value={selectedTabs}
+                                data={(dashboard?.tabs || []).map((tab) => ({
+                                    value: tab.uuid,
+                                    label: tab.name,
+                                }))}
+                                clearButtonProps={{
+                                    style: {
+                                        display:
+                                            selectedTabs.length > 1
+                                                ? 'block'
+                                                : 'none',
+                                    },
+                                }}
+                                clearable={selectedTabs.length > 1}
+                                searchable
+                                onChange={setSelectedTabs}
+                                required
+                            />
+                        )}
+                    </Stack>
+                )}
+
                 <PreviewAndCustomizeScreenshot
                     containerWidth={gridWidth}
                     exportMutation={exportDashboardMutation}
-                    previews={previews}
-                    setPreviews={setPreviews}
                     previewChoice={previewChoice}
                     setPreviewChoice={setPreviewChoice}
                     onPreviewClick={handlePreviewClick}
+                    currentPreview={currentPreview}
                 />
-            </Box>
+            </Stack>
 
-            <Group position="right" pb="md" px="md" spacing="lg">
-                <Button variant="outline" onClick={onClose}>
-                    Cancel
-                </Button>
-
-                <Group spacing="xs">
-                    <Button
-                        loading={exportDashboardMutation.isLoading}
-                        onClick={handleExportClick}
-                        leftIcon={
-                            <MantineIcon
-                                icon={
-                                    previewChoice ? IconEyeCog : IconFileExport
-                                }
-                            />
-                        }
-                    >
-                        Export dashboard
+            <Box
+                sx={(theme) => ({
+                    borderTop: `1px solid ${theme.colors.gray[2]}`,
+                    padding: theme.spacing.sm,
+                    backgroundColor: theme.white,
+                    position: 'sticky',
+                    bottom: 0,
+                    width: '100%',
+                    zIndex: 10,
+                })}
+            >
+                <Group position="right" spacing="lg">
+                    <Button variant="outline" onClick={onClose}>
+                        Cancel
                     </Button>
+
+                    <Group spacing="xs">
+                        <Button
+                            loading={exportDashboardMutation.isLoading}
+                            onClick={handleExportClick}
+                            leftIcon={
+                                <MantineIcon
+                                    icon={
+                                        previewChoice
+                                            ? IconScreenshot
+                                            : IconFileExport
+                                    }
+                                />
+                            }
+                        >
+                            Export dashboard
+                        </Button>
+                    </Group>
                 </Group>
-            </Group>
+            </Box>
         </Stack>
     );
 };
@@ -175,21 +324,36 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
     const [exportType, setExportType] = useState<string>('image');
 
     return (
-        <>
-            <Modal
-                size="xl"
-                yOffset="3vh"
-                opened={opened}
-                onClose={onClose}
-                title={<Title order={5}>Export dashboard</Title>}
-                styles={{
-                    body: {
-                        padding: 0,
-                    },
+        <Modal.Root opened={opened} onClose={onClose} size="xl" yOffset="3vh">
+            <Modal.Overlay />
+            <Modal.Content
+                sx={{
+                    maxWidth: '800px',
+                    margin: '0 auto',
+                    display: 'flex',
+                    flexDirection: 'column',
                 }}
             >
+                <Modal.Header
+                    sx={(theme) => ({
+                        borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                        padding: theme.spacing.sm,
+                    })}
+                >
+                    <Group spacing="xs">
+                        <Paper p="xs" withBorder radius="sm">
+                            <MantineIcon icon={IconLayoutDashboard} size="sm" />
+                        </Paper>
+                        <Text color="dark.7" fw={700} fz="md">
+                            Export dashboard
+                        </Text>
+                    </Group>
+                    <Modal.CloseButton />
+                </Modal.Header>
+
                 <SegmentedControl
                     ml="md"
+                    mt="xs"
                     data={[
                         {
                             label: 'Image',
@@ -216,7 +380,7 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                         gridWidth={gridWidth}
                     />
                 )}
-            </Modal>
-        </>
+            </Modal.Content>
+        </Modal.Root>
     );
 };

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -114,6 +114,16 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
         dashboard?.tabs?.map((tab) => tab.uuid) || [],
     );
 
+    // Check if the selected tabs have tiles so we can disable the export button if not
+    const hasTilesInSelectedTabs = useCallback(() => {
+        if (allTabsSelected) {
+            return dashboard.tiles.length > 0;
+        }
+        return dashboard.tiles.some((tile) =>
+            selectedTabs.includes(tile.tabUuid || ''),
+        );
+    }, [allTabsSelected, dashboard.tiles, selectedTabs]);
+
     // Helper function to create consistent cache keys
     const getPreviewKey = useCallback(
         (width: string) => {
@@ -261,6 +271,11 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
                                 searchable
                                 onChange={setSelectedTabs}
                                 required
+                                error={
+                                    !hasTilesInSelectedTabs()
+                                        ? 'There are no tiles in the selected tab(s)'
+                                        : undefined
+                                }
                             />
                         )}
                     </Stack>
@@ -273,6 +288,7 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
                     setPreviewChoice={setPreviewChoice}
                     onPreviewClick={handlePreviewClick}
                     currentPreview={currentPreview}
+                    disabled={!hasTilesInSelectedTabs()}
                 />
             </Stack>
 
@@ -296,6 +312,7 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
                         <Button
                             loading={exportDashboardMutation.isLoading}
                             onClick={handleExportClick}
+                            disabled={!hasTilesInSelectedTabs()}
                             leftIcon={
                                 <MantineIcon
                                     icon={

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mantine/core';
 import { IconEye, IconEyeClosed } from '@tabler/icons-react';
 import { type UseMutationResult } from '@tanstack/react-query';
-import { useState, type Dispatch, type FC, type SetStateAction } from 'react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { CUSTOM_WIDTH_OPTIONS } from '../../scheduler/constants';
 
@@ -29,13 +29,12 @@ type PreviewAndCustomizeScreenshotProps = {
             isPreview?: boolean | undefined;
         }
     >;
-    previews: Record<string, string>;
-    setPreviews: Dispatch<SetStateAction<Record<string, string>>>;
     previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;
     setPreviewChoice: (
         prev: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined,
     ) => void;
     onPreviewClick?: () => Promise<void>;
+    currentPreview?: string;
 };
 
 export const PreviewAndCustomizeScreenshot: FC<
@@ -43,10 +42,10 @@ export const PreviewAndCustomizeScreenshot: FC<
 > = ({
     containerWidth,
     exportMutation,
-    previews,
     previewChoice,
     setPreviewChoice,
     onPreviewClick,
+    currentPreview,
 }) => {
     const [isImageModalOpen, setIsImageModalOpen] = useState(false);
 
@@ -89,12 +88,9 @@ export const PreviewAndCustomizeScreenshot: FC<
                     <Stack>
                         <Card withBorder p={0}>
                             <Image
-                                src={previewChoice && previews[previewChoice]}
+                                src={currentPreview}
                                 onClick={() => {
-                                    if (
-                                        previewChoice &&
-                                        previews[previewChoice]
-                                    )
+                                    if (currentPreview)
                                         setIsImageModalOpen(true);
                                 }}
                                 width={350}
@@ -102,11 +98,9 @@ export const PreviewAndCustomizeScreenshot: FC<
                                 styles={{
                                     root: {
                                         objectPosition: 'top',
-                                        cursor:
-                                            previewChoice &&
-                                            previews[previewChoice]
-                                                ? 'pointer'
-                                                : 'default',
+                                        cursor: currentPreview
+                                            ? 'pointer'
+                                            : 'default',
                                     },
                                 }}
                                 withPlaceholder
@@ -133,7 +127,11 @@ export const PreviewAndCustomizeScreenshot: FC<
                             variant="default"
                             leftIcon={<MantineIcon icon={IconEye} />}
                             disabled={!previewChoice}
-                            onClick={onPreviewClick}
+                            onClick={async () => {
+                                if (onPreviewClick) {
+                                    await onPreviewClick();
+                                }
+                            }}
                         >
                             Generate preview
                         </Button>
@@ -147,7 +145,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                 opened={isImageModalOpen}
             >
                 <Image
-                    src={exportMutation.data}
+                    src={currentPreview}
                     onClick={() => {
                         setIsImageModalOpen(false);
                     }}

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -35,6 +35,7 @@ type PreviewAndCustomizeScreenshotProps = {
     ) => void;
     onPreviewClick?: () => Promise<void>;
     currentPreview?: string;
+    disabled?: boolean;
 };
 
 export const PreviewAndCustomizeScreenshot: FC<
@@ -46,6 +47,7 @@ export const PreviewAndCustomizeScreenshot: FC<
     setPreviewChoice,
     onPreviewClick,
     currentPreview,
+    disabled = false,
 }) => {
     const [isImageModalOpen, setIsImageModalOpen] = useState(false);
 
@@ -126,7 +128,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                             size="xs"
                             variant="default"
                             leftIcon={<MantineIcon icon={IconEye} />}
-                            disabled={!previewChoice}
+                            disabled={!previewChoice || disabled}
                             onClick={async () => {
                                 if (onPreviewClick) {
                                     await onPreviewClick();

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -25,7 +25,6 @@ export const SchedulerPreview: FC<Props> = ({
     customViewportWidth,
     onChange,
 }) => {
-    const [previews, setPreviews] = useState<Record<string, string>>({});
     const [previewChoice, setPreviewChoice] = useState<
         typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined
     >(customViewportWidth?.toString() ?? CUSTOM_WIDTH_OPTIONS[1].value);
@@ -51,17 +50,12 @@ export const SchedulerPreview: FC<Props> = ({
     }, [dashboard.filters, schedulerFilters]);
 
     const handlePreviewClick = useCallback(async () => {
-        const url = await exportDashboardMutation.mutateAsync({
+        await exportDashboardMutation.mutateAsync({
             dashboard,
             gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
             queryFilters: getSchedulerFilterOverridesQueryString(),
             isPreview: true,
         });
-
-        setPreviews((prev) => ({
-            ...prev,
-            ...(previewChoice ? { [previewChoice]: url } : {}),
-        }));
     }, [
         dashboard,
         exportDashboardMutation,
@@ -87,8 +81,6 @@ export const SchedulerPreview: FC<Props> = ({
             </Group>
             <PreviewAndCustomizeScreenshot
                 exportMutation={exportDashboardMutation}
-                previews={previews}
-                setPreviews={setPreviews}
                 previewChoice={previewChoice}
                 setPreviewChoice={(pc: string | undefined) => {
                     setPreviewChoice(() => {

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -89,11 +89,12 @@ const exportDashboard = async (
     id: string,
     gridWidth: number | undefined,
     queryFilters: string,
+    selectedTabs?: string[],
 ) =>
     lightdashApi<string>({
         url: `/dashboards/${id}/export`,
         method: 'POST',
-        body: JSON.stringify({ queryFilters, gridWidth }),
+        body: JSON.stringify({ queryFilters, gridWidth, selectedTabs }),
     });
 
 export const useDashboardsAvailableFilters = (
@@ -141,6 +142,7 @@ export const useExportDashboard = () => {
             gridWidth: number | undefined;
             queryFilters: string;
             isPreview?: boolean;
+            selectedTabs?: string[];
         }
     >(
         (data) =>
@@ -148,6 +150,7 @@ export const useExportDashboard = () => {
                 data.dashboard.uuid,
                 data.gridWidth,
                 data.queryFilters,
+                data.selectedTabs,
             ),
         {
             mutationKey: ['export_dashboard'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/13738

### Description:

- redid the modal layout to be the same as the color palette ones. Modals will look like this one from now on - will implement something in storybook later 
- users can select tab 1, tab 2.
- If they select multiple tabs, it will include them all in one page. 
- Added a bit more logging to a few parts of the screenshot experience

Demo

<img width="801" alt="Screenshot 2025-03-21 at 16 56 47" src="https://github.com/user-attachments/assets/5436d715-c0b4-4148-ac8e-6ebed5d88150" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
