### PR TITLE
fix: support ENCRYPTED PRIVATE KEY format in profiles.yml

### DIFF
--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -31,7 +31,7 @@ export const renderProfilesYml = (
     // Fix multiline privatekey strings
     // Prevents error: Error: error:1E08010C:DECODER routines::unsupported
     const privateKeyRegex =
-        /-----BEGIN PRIVATE KEY-----[\s\S]*?-----END PRIVATE KEY-----/g;
+        /(-----BEGIN(?:\s+ENCRYPTED)?\s+PRIVATE KEY-----[\s\S]*?-----END(?:\s+ENCRYPTED)?\s+PRIVATE KEY-----)/g;
     return rendered.replace(privateKeyRegex, (match) =>
         match.replace(/\n/g, '\\n'),
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
- Updated regex pattern for private key detection
  - Previously only matched `-----BEGIN PRIVATE KEY-----`
  - Now also supports `-----BEGIN ENCRYPTED PRIVATE KEY-----`

## Testing Checklist
- [ ] Standard private keys (BEGIN PRIVATE KEY) are processed correctly as before
- [ ] Encrypted private keys (BEGIN ENCRYPTED PRIVATE KEY) are processed correctly

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
