### PR TITLE
fix: Use full qualifiedname instead of removing database and schema i…

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -596,11 +596,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         schema: string,
         table: string,
     ) {
-        const sqlText = `SHOW COLUMNS IN TABLE ${table}`;
-        const connection = await this.getConnection({
-            schema,
-            database,
-        });
+        const sqlText = `SHOW COLUMNS IN TABLE ${database}.${schema}.${table}`;
+        const connection = await this.getConnection();
 
         try {
             return await this.executeStatements(connection, sqlText);


### PR DESCRIPTION


### Description:
#### Background

The `SHOW COLUMNS IN TABLE <table_name>` query in Snowflake encounters a syntax error when the table name conflicts with a Snowflake reserved word (e.g., `user`, `account`).

#### Changes

To address this issue, the table name is now fully qualified with the database and schema names. Specifically, the query has been modified as follows:

```sql
-- Before
SHOW COLUMNS IN TABLE ${table}

-- After
SHOW COLUMNS IN TABLE ${database}.${schema}.${table}
```


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
