### PR TITLE
fix: fix snowflake password and encryption override

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -148,15 +148,11 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
         let authenticationOptions: Partial<ConnectionOptions> = {};
 
+        // if authenticationType is undefined, we assume it is a password authentication, for backwards compatibility
         if (
-            credentials.password &&
-            credentials.authenticationType === 'password'
+            credentials.privateKey &&
+            credentials.authenticationType === 'private_key'
         ) {
-            authenticationOptions = {
-                password: credentials.password,
-                authenticator: 'SNOWFLAKE',
-            };
-        } else if (credentials.privateKey) {
             if (!credentials.privateKeyPass) {
                 authenticationOptions = {
                     privateKey: credentials.privateKey,
@@ -183,6 +179,11 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                     authenticator: 'SNOWFLAKE_JWT',
                 };
             }
+        } else if (credentials.password) {
+            authenticationOptions = {
+                password: credentials.password,
+                authenticator: 'SNOWFLAKE',
+            };
         }
 
         this.connectionOptions = {

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -148,7 +148,15 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
         let authenticationOptions: Partial<ConnectionOptions> = {};
 
-        if (credentials.privateKey) {
+        if (
+            credentials.password &&
+            credentials.authenticationType === 'password'
+        ) {
+            authenticationOptions = {
+                password: credentials.password,
+                authenticator: 'SNOWFLAKE',
+            };
+        } else if (credentials.privateKey) {
             if (!credentials.privateKeyPass) {
                 authenticationOptions = {
                     privateKey: credentials.privateKey,
@@ -175,11 +183,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                     authenticator: 'SNOWFLAKE_JWT',
                 };
             }
-        } else if (credentials.password) {
-            authenticationOptions = {
-                password: credentials.password,
-                authenticator: 'SNOWFLAKE',
-            };
         }
 
         this.connectionOptions = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/14205

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
What the issue was: 

It is possible to have a private key already, and if that exists, we prioritize private_key over password, even if password authentication type was selected 

Before
![Screenshot from 2025-03-28 14-59-36](https://github.com/user-attachments/assets/2914d819-65d1-4313-823e-d7ea1d35b6f3)

After

![Screenshot from 2025-03-28 15-03-51](https://github.com/user-attachments/assets/d1a4de4b-c5fc-4a57-b6f5-0acdf29e2a91)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
