### PR TITLE
fix: use only valid pivot dimensions when computing chart series

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -81,6 +81,7 @@ import { type EChartSeries } from '../../hooks/echarts/useEchartsCartesianConfig
 import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
 import useToaster from '../../hooks/toaster/useToaster';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { useDuplicateChartMutation } from '../../hooks/useSavedQuery';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import { Can } from '../../providers/Ability';
@@ -191,6 +192,7 @@ const ExportGoogleSheet: FC<{ savedChart: SavedChart; disabled?: boolean }> = ({
  */
 const computeDashboardChartSeries = (
     chart: ApiChartAndResults['chart'],
+    validPivotDimensions: string[] | undefined,
     resultData: ApiQueryResults | undefined,
 ) => {
     if (!resultData?.fields || !chart.chartConfig || !resultData) {
@@ -208,7 +210,7 @@ const computeDashboardChartSeries = (
             defaultCartesianType: CartesianSeriesType.BAR,
             availableDimensions: chart.metricQuery.dimensions,
             isStacked: false,
-            pivotKeys: chart.pivotConfig?.columns,
+            pivotKeys: validPivotDimensions,
             resultsData: resultData,
             xField: chart.chartConfig.config.layout.xField,
             yFields: chart.chartConfig.config.layout.yField,
@@ -264,9 +266,18 @@ const ValidDashboardChartTile: FC<{
         [rows, metricQuery, cacheMetadata, fields],
     );
 
+    const { validPivotDimensions } = usePivotDimensions(
+        chart.pivotConfig?.columns,
+        resultData,
+    );
+
     const computedSeries: Series[] = useMemo(() => {
-        return computeDashboardChartSeries(chart, resultData);
-    }, [resultData, chart]);
+        return computeDashboardChartSeries(
+            chart,
+            validPivotDimensions,
+            resultData,
+        );
+    }, [resultData, chart, validPivotDimensions]);
 
     if (health.isInitialLoading || !health.data) {
         return null;
@@ -318,9 +329,18 @@ const ValidDashboardChartTileMinimal: FC<{
         [rows, metricQuery, cacheMetadata, fields],
     );
 
+    const { validPivotDimensions } = usePivotDimensions(
+        chart.pivotConfig?.columns,
+        resultData,
+    );
+
     const computedSeries: Series[] = useMemo(() => {
-        return computeDashboardChartSeries(chart, resultData);
-    }, [resultData, chart]);
+        return computeDashboardChartSeries(
+            chart,
+            validPivotDimensions,
+            resultData,
+        );
+    }, [resultData, chart, validPivotDimensions]);
 
     if (health.isInitialLoading || !health.data) {
         return null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14206
Relates to: https://github.com/lightdash/lightdash/issues/13950

### Description:
- After fixing series with transparent colors, we were passing pivot dimensions before sanitization by the usePivotDimensions hook which caused a bug when a chart was saved with a pivot dimension but didn't have it in the results.

**Steps to reproduce:**
1. Create cartesian chart with grouped dimension
2. Remove the dimension in the group and save chart (don't run query) - this will cause the config to have a pivot dimension but no matching selected dimension
3. Add chart to dashboard
4. Open dashboard

**Before**
![image](https://github.com/user-attachments/assets/da80932a-5231-43e0-aead-cb6a9df86419)

**After**
![image](https://github.com/user-attachments/assets/02ed035b-3bef-4550-a4df-17dd8f86621f)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
