### PR TITLE
fix: make query history error column text type

### DIFF
--- a/packages/backend/src/database/migrations/20250328163817_change_query_history_error_column_type.ts
+++ b/packages/backend/src/database/migrations/20250328163817_change_query_history_error_column_type.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const QUERY_HISTORY_TABLE = 'query_history';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.text('error').nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.string('error').nullable().alter();
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14209 

### Description:

- Changes `error` column type to be text instead of string

Before:
![image](https://github.com/user-attachments/assets/2f1dec0d-65ac-44f0-8c70-9c85d0e6e590)

After:
![image](https://github.com/user-attachments/assets/2d33be0c-0221-4ce2-b7e6-c021edc5e9e9)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
