### PR TITLE
fix: unmount dashboard if uuid changes

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,6 +1,6 @@
 import { Stack } from '@mantine/core';
 import { type FC } from 'react';
-import { Navigate, Outlet, type RouteObject } from 'react-router';
+import { Navigate, Outlet, useParams, type RouteObject } from 'react-router';
 import AppRoute from './components/AppRoute';
 import ForbiddenPanel from './components/ForbiddenPanel';
 import JobDetailsDrawer from './components/JobDetailsDrawer';
@@ -45,11 +45,13 @@ import { TrackPage } from './providers/Tracking/TrackingProvider';
 import { PageName } from './types/Events';
 
 const DashboardPageWrapper: FC = () => {
+    const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
+
     return (
         <>
             <NavBar />
             <TrackPage name={PageName.DASHBOARD}>
-                <Dashboard />
+                <Dashboard key={dashboardUuid} />
             </TrackPage>
         </>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14175](https://github.com/lightdash/lightdash/issues/14175)

### Description:

Passes `key` with dashboardUuid in `Routes` so that the component remounts with new data
This seems like the cleanest solution (instead of manipulating the way that `setDashboardTiles` is called in `Dashboard.tsx)

Follow steps from ticket to see that the dashboard changes based on the param. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
