### PR TITLE
fix: revert "fix: simplify color on pivots, unify logic with pie charts"

### DIFF
--- a/packages/frontend/src/hooks/useChartColorConfig/utils.ts
+++ b/packages/frontend/src/hooks/useChartColorConfig/utils.ts
@@ -14,17 +14,59 @@ export const isGroupedSeries = (series: SeriesLike) => {
 };
 
 export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
+    const baseField =
+        (series as EChartSeries).pivotReference?.field ??
+        (series as Series).encode.yRef?.field;
+
     const pivotValues = (
         (series as EChartSeries)?.pivotReference?.pivotValues ??
         (series as Series)?.encode.yRef.pivotValues ??
         []
     ).map(({ value }) => `${value}`);
 
-    const pivotFields = (
-        (series as EChartSeries)?.pivotReference?.pivotValues ??
-        (series as Series)?.encode.yRef.pivotValues ??
-        []
-    ).map(({ field }) => `${field}`);
+    const pivotValuesSubPath =
+        pivotValues && pivotValues.length > 0
+            ? `${pivotValues.join('.')}`
+            : null;
 
-    return [pivotFields.join('.'), pivotValues.join('.')];
+    /**
+     * When dealing with flipped axis, Echarts will include the pivot value as
+     * part of the field identifier - we want to remove it for the purposes of
+     * color mapping if that's the case, so that we continue to have a mapping
+     * that looks like:
+     *
+     *  basefield->pivot_value
+     *
+     * instead of:
+     *
+     *  basefield.pivot_value -> pivot_value
+     *
+     * (which would be a grouping of 1 per pivot value, causing all values to
+     * be assigned the first color)
+     */
+    const baseFieldPathParts = baseField.split('.');
+
+    const baseFieldPath =
+        pivotValuesSubPath && baseFieldPathParts.at(-1) === pivotValuesSubPath
+            ? baseFieldPathParts.slice(0, -1).join('.')
+            : baseField;
+
+    const completeIdentifier = pivotValuesSubPath
+        ? pivotValuesSubPath
+        : baseFieldPath;
+
+    return [
+        `${baseFieldPath}${
+            /**
+             * If we have more than one pivot value, we append the number of pivot values
+             * to the group identifier, giving us a unique group per number of values.
+             *
+             * This is not critical, but gives us better serial color assignment when
+             * switching between number of groups, since we're not tacking each group
+             * configuration on top of eachother (under the same identifier).
+             */
+            pivotValues.length === 1 ? '' : `${`_n${pivotValues.length}`}`
+        }`,
+        completeIdentifier,
+    ];
 };


### PR DESCRIPTION
Reverts lightdash/lightdash#14152

Was initially working well for stacked charts, but some edge cases require the previous logic

before

<img width="884" alt="Screenshot 2025-03-28 at 17 13 05" src="https://github.com/user-attachments/assets/77b114c4-946c-4a0f-a3eb-6dbb4f3192b9" />


after

<img width="806" alt="Screenshot 2025-03-28 at 17 12 46" src="https://github.com/user-attachments/assets/0dda1036-a21d-4147-86e9-aaca87d89d25" />

