### PR TITLE
feat: include row totals on pivot csv

### DIFF
--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -11,7 +11,6 @@ export type PivotConfig = {
     metricsAsRows: boolean;
     columnOrder?: string[];
     hiddenMetricFieldIds?: string[];
-    summableMetricFieldIds?: string[];
     columnTotals?: boolean;
     rowTotals?: boolean;
 };
@@ -85,5 +84,7 @@ export const getPivotConfig = (
                   savedChart.chartConfig,
               ),
               columnOrder: savedChart.tableConfig.columnOrder,
+              rowTotals:
+                  savedChart.chartConfig.config?.showRowCalculation ?? false,
           }
         : undefined;

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -7,7 +7,6 @@ import {
     isFilterableItem,
     isMetric,
     isNumericItem,
-    isSummable,
     isTableCalculation,
     itemsInMetricQuery,
     type ApiQueryResults,
@@ -314,23 +313,6 @@ const useTableConfig = (
             );
         });
 
-        const summableMetricFieldIds = selectedItemIds?.filter((fieldId) => {
-            const field = getField(fieldId);
-
-            if (isDimension(field)) {
-                return false;
-            }
-
-            if (
-                hiddenMetricFieldIds &&
-                hiddenMetricFieldIds.includes(fieldId)
-            ) {
-                return false;
-            }
-
-            return isSummable(field);
-        });
-
         worker
             .pivotQueryResults({
                 pivotConfig: {
@@ -338,7 +320,6 @@ const useTableConfig = (
                     metricsAsRows,
                     columnOrder,
                     hiddenMetricFieldIds,
-                    summableMetricFieldIds,
                     columnTotals: tableChartConfig?.showColumnCalculation,
                     rowTotals: tableChartConfig?.showRowCalculation,
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14001](https://github.com/lightdash/lightdash/issues/14001)

### Description:

**Example 1**
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/a5c8cf88-08c3-4db4-8f26-fa05783aa1ac" />
[metrics as rows.csv](https://github.com/user-attachments/files/19533498/metrics.as.rows.csv)

**Example 2**
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/4ce6683c-dc0a-4ff2-bee0-d99b17caa407" />
[simple table.csv](https://github.com/user-attachments/files/19533499/simple.table.csv)

**Example 3**

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/37a30833-f97b-41d2-8078-c5d8ea89485f" />

[row totals table.csv](https://github.com/user-attachments/files/19533500/row.totals.table.csv)




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
