### PR TITLE
feat: allow expanding Custom SQL modal

### DIFF
--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -71,7 +71,7 @@ describe('Table calculations', () => {
         );
         cy.get(`.mantine-Select-input[value='number']`).click();
         cy.contains('string').click();
-        cy.get('form').contains('Save').click({ force: true });
+        cy.get('form').contains('Create').click({ force: true });
         // Check valid results
         cy.contains('rank_1');
         cy.contains('rank_2');
@@ -113,7 +113,7 @@ describe('Table calculations', () => {
             { parseSpecialCharSequences: false },
         );
         // Defaults to number
-        cy.get('form').contains('Save').click({ force: true });
+        cy.get('form').contains('Create').click({ force: true });
         // Check valid results
         cy.contains('100');
         cy.contains('200');

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -20,6 +20,7 @@ import {
     Stack,
     Text,
     TextInput,
+    Tooltip,
     useMantineTheme,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -65,7 +66,7 @@ export const CustomSqlDimensionModal: FC<{
     const editCustomDimension = useExplorerContext(
         (context) => context.actions.editCustomDimension,
     );
-    const [isFullscreen, toggleFullscreen] = useToggle(false);
+    const [isExpanded, toggleExpanded] = useToggle(false);
     const submitButtonRef = useRef<HTMLButtonElement>(null);
 
     const form = useForm<FormValues>({
@@ -180,8 +181,8 @@ export const CustomSqlDimensionModal: FC<{
             centered
             styles={{
                 content: {
-                    minWidth: isFullscreen ? '90vw' : 'auto',
-                    height: isFullscreen ? '70vh' : 'auto',
+                    minWidth: isExpanded ? '90vw' : 'auto',
+                    height: isExpanded ? '70vh' : 'auto',
                 },
             }}
         >
@@ -229,7 +230,7 @@ export const CustomSqlDimensionModal: FC<{
                         sx={{
                             flex: 1,
                             overflow: 'auto',
-                            height: isFullscreen ? '100%' : 'auto',
+                            height: isExpanded ? '100%' : 'auto',
                         }}
                     >
                         <Stack p="sm" spacing="xs">
@@ -270,12 +271,12 @@ export const CustomSqlDimensionModal: FC<{
                                     theme="github"
                                     width="100%"
                                     maxLines={Infinity}
-                                    minLines={isFullscreen ? 25 : 8}
+                                    minLines={isExpanded ? 25 : 8}
                                     setOptions={{
                                         autoScrollEditorIntoView: true,
                                     }}
                                     onLoad={setAceEditor}
-                                    isFullScreen={isFullscreen}
+                                    isFullScreen={isExpanded}
                                     enableLiveAutocompletion
                                     enableBasicAutocompletion
                                     showPrintMargin={false}
@@ -299,18 +300,20 @@ export const CustomSqlDimensionModal: FC<{
                         })}
                     >
                         <Group position="apart">
-                            <ActionIcon
-                                variant="outline"
-                                onClick={toggleFullscreen}
-                            >
-                                <MantineIcon
-                                    icon={
-                                        isFullscreen
-                                            ? IconMinimize
-                                            : IconMaximize
-                                    }
-                                />
-                            </ActionIcon>
+                            <Tooltip label="Expand/Collapse" variant="xs">
+                                <ActionIcon
+                                    variant="outline"
+                                    onClick={toggleExpanded}
+                                >
+                                    <MantineIcon
+                                        icon={
+                                            isExpanded
+                                                ? IconMinimize
+                                                : IconMaximize
+                                        }
+                                    />
+                                </ActionIcon>
+                            </Tooltip>
                             <Group spacing="xs">
                                 <Button
                                     variant="default"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -131,12 +131,8 @@ export const SqlForm: FC<Props> = ({
                 color="violet"
                 styles={{
                     root: {
-                        paddingBottom: isFullScreen
-                            ? theme.spacing.xs
-                            : theme.spacing.sm,
-                        paddingTop: isFullScreen
-                            ? theme.spacing.xs
-                            : theme.spacing.sm,
+                        paddingBottom: theme.spacing.sm,
+                        paddingTop: theme.spacing.sm,
                     },
                     wrapper: {
                         alignItems: 'center',

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -83,7 +83,7 @@ export const SqlForm: FC<Props> = ({
 
     return (
         <>
-            <ScrollArea h={isFullScreen ? '95%' : '150px'}>
+            <ScrollArea h={isFullScreen ? '90%' : '150px'}>
                 <SqlEditor
                     mode="sql"
                     theme="github"
@@ -114,7 +114,6 @@ export const SqlForm: FC<Props> = ({
             </ScrollArea>
 
             <Alert
-                p="xs"
                 radius={0}
                 icon={<MantineIcon icon={IconSparkles} />}
                 title={
@@ -131,6 +130,14 @@ export const SqlForm: FC<Props> = ({
                 }
                 color="violet"
                 styles={{
+                    root: {
+                        paddingBottom: isFullScreen
+                            ? theme.spacing.xs
+                            : theme.spacing.sm,
+                        paddingTop: isFullScreen
+                            ? theme.spacing.xs
+                            : theme.spacing.sm,
+                    },
                     wrapper: {
                         alignItems: 'center',
                     },

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -60,7 +60,7 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const theme = useMantineTheme();
     const { colors } = theme;
-    const [isFullscreen, toggleFullscreen] = useToggle(false);
+    const [isExpanded, toggleExpanded] = useToggle(false);
     const submitButtonRef = useRef<HTMLButtonElement>(null);
 
     const { addToastError } = useToaster();
@@ -174,8 +174,8 @@ const TableCalculationModal: FC<Props> = ({
             centered
             styles={{
                 content: {
-                    minWidth: isFullscreen ? '90vw' : 'auto',
-                    height: isFullscreen ? '80vh' : 'auto',
+                    minWidth: isExpanded ? '90vw' : 'auto',
+                    height: isExpanded ? '80vh' : 'auto',
                 },
             }}
         >
@@ -185,7 +185,7 @@ const TableCalculationModal: FC<Props> = ({
                     margin: '0 auto',
                     display: 'flex',
                     flexDirection: 'column',
-                    maxHeight: isFullscreen ? '90vh' : '60vh',
+                    maxHeight: isExpanded ? '90vh' : '60vh',
                 }}
             >
                 <Modal.Header
@@ -243,7 +243,7 @@ const TableCalculationModal: FC<Props> = ({
                                         borderWidth: 1,
                                         borderStyle: 'solid',
                                         borderTop: 'none',
-                                        height: isFullscreen
+                                        height: isExpanded
                                             ? 'calc(90vh - 400px)'
                                             : 'auto',
                                     },
@@ -256,7 +256,7 @@ const TableCalculationModal: FC<Props> = ({
                                 <Tabs.Panel value="sqlEditor">
                                     <SqlForm
                                         form={form}
-                                        isFullScreen={isFullscreen}
+                                        isFullScreen={isExpanded}
                                         focusOnRender={true}
                                         onCmdEnter={() => {
                                             if (submitButtonRef.current) {
@@ -277,10 +277,11 @@ const TableCalculationModal: FC<Props> = ({
                             </Tabs>
 
                             <Tooltip
-                                position="bottom"
+                                position="right"
                                 withArrow
                                 multiline
                                 maw={400}
+                                variant="xs"
                                 withinPortal
                                 label={
                                     'Manually select the type of the result of this SQL table calculation, this will help us to treat this field correctly in filters or results.'
@@ -289,6 +290,9 @@ const TableCalculationModal: FC<Props> = ({
                                 <Select
                                     label={'Result type'}
                                     id="download-type"
+                                    sx={{
+                                        alignSelf: 'flex-start',
+                                    }}
                                     {...form.getInputProps('type')}
                                     onChange={(value) => {
                                         const tcType = Object.values(
@@ -315,18 +319,20 @@ const TableCalculationModal: FC<Props> = ({
                         })}
                     >
                         <Group position="apart">
-                            <ActionIcon
-                                variant="outline"
-                                onClick={toggleFullscreen}
-                            >
-                                <MantineIcon
-                                    icon={
-                                        isFullscreen
-                                            ? IconMinimize
-                                            : IconMaximize
-                                    }
-                                />
-                            </ActionIcon>
+                            <Tooltip label="Expand/Collapse" variant="xs">
+                                <ActionIcon
+                                    variant="outline"
+                                    onClick={toggleExpanded}
+                                >
+                                    <MantineIcon
+                                        icon={
+                                            isExpanded
+                                                ? IconMinimize
+                                                : IconMaximize
+                                        }
+                                    />
+                                </ActionIcon>
+                            </Tooltip>
 
                             <Group spacing="xs">
                                 <Button

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -1,27 +1,35 @@
 import {
     CustomFormatType,
-    NumberSeparator,
-    TableCalculationType,
     getErrorMessage,
     getItemId,
+    NumberSeparator,
+    TableCalculationType,
     type CustomFormat,
     type TableCalculation,
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     Button,
+    getDefaultZIndex,
     Group,
     Modal,
+    Paper,
     Select,
     Stack,
     Tabs,
+    Text,
     TextInput,
     Tooltip,
     useMantineTheme,
     type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconMaximize, IconMinimize } from '@tabler/icons-react';
+import {
+    IconCalculator,
+    IconMaximize,
+    IconMinimize,
+} from '@tabler/icons-react';
 import { useRef, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
@@ -51,6 +59,7 @@ const TableCalculationModal: FC<Props> = ({
     onClose,
 }) => {
     const theme = useMantineTheme();
+    const { colors } = theme;
     const [isFullscreen, toggleFullscreen] = useToggle(false);
     const submitButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -158,141 +167,191 @@ const TableCalculationModal: FC<Props> = ({
     };
 
     return (
-        <Modal
+        <Modal.Root
             opened={opened}
-            onClose={() => onClose()}
+            onClose={onClose}
             size="xl"
-            title={
-                tableCalculation
-                    ? 'Edit table calculation'
-                    : 'Add table calculation'
-            }
+            centered
             styles={{
-                title: {
-                    fontSize: theme.fontSizes.md,
-                    fontWeight: 700,
-                },
-                body: {
-                    paddingBottom: 0,
-                },
                 content: {
-                    maxHeight: '70vh !important',
+                    minWidth: isFullscreen ? '90vw' : 'auto',
+                    height: isFullscreen ? '80vh' : 'auto',
                 },
             }}
-            fullScreen={isFullscreen}
         >
-            <form name="table_calculation" onSubmit={handleSubmit}>
-                <Stack>
-                    <TextInput
-                        mb="sm"
-                        label="Name"
-                        required
-                        placeholder="E.g. Cumulative order count"
-                        data-testid="table-calculation-name-input"
-                        {...form.getInputProps('name')}
-                    />
+            <Modal.Overlay />
+            <Modal.Content
+                sx={{
+                    margin: '0 auto',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    maxHeight: isFullscreen ? '90vh' : '60vh',
+                }}
+            >
+                <Modal.Header
+                    sx={(themeProps) => ({
+                        borderBottom: `1px solid ${themeProps.colors.gray[2]}`,
+                        padding: themeProps.spacing.sm,
+                    })}
+                >
+                    <Group spacing="xs">
+                        <Paper p="xs" withBorder radius="sm">
+                            <MantineIcon icon={IconCalculator} size="sm" />
+                        </Paper>
+                        <Text color="dark.7" fw={700} fz="md">
+                            {tableCalculation ? 'Edit' : 'Create'} Table
+                            Calculation
+                            {tableCalculation ? (
+                                <Text span fw={400}>
+                                    {' '}
+                                    - {tableCalculation.displayName}
+                                </Text>
+                            ) : null}
+                        </Text>
+                    </Group>
+                    <Modal.CloseButton />
+                </Modal.Header>
 
-                    <Tabs
-                        defaultValue="sqlEditor"
-                        color="indigo"
-                        variant="outline"
-                        radius="xs"
-                        styles={{
-                            panel: {
-                                borderColor: theme.colors.gray[2],
-                                borderWidth: 1,
-                                borderStyle: 'solid',
-                                borderTop: 'none',
-                                height: isFullscreen
-                                    ? 'calc(100vh - 260px)'
-                                    : '100%',
-                            },
+                <form
+                    name="table_calculation"
+                    onSubmit={handleSubmit}
+                    style={{ display: 'contents' }}
+                >
+                    <Modal.Body
+                        p={0}
+                        sx={{
+                            flex: 1,
                         }}
                     >
-                        <Tabs.List>
-                            <Tabs.Tab value="sqlEditor">SQL</Tabs.Tab>
-                            <Tabs.Tab value="format">Format</Tabs.Tab>
-                        </Tabs.List>
-                        <Tabs.Panel value="sqlEditor">
-                            <SqlForm
-                                form={form}
-                                isFullScreen={isFullscreen}
-                                focusOnRender={true}
-                                onCmdEnter={() => {
-                                    if (submitButtonRef.current) {
-                                        submitButtonRef.current.click();
-                                    }
-                                }}
+                        <Stack p="sm" spacing="xs">
+                            <TextInput
+                                label="Name"
+                                required
+                                placeholder="E.g. Cumulative order count"
+                                data-testid="table-calculation-name-input"
+                                {...form.getInputProps('name')}
                             />
-                        </Tabs.Panel>
-                        <Tabs.Panel value="format" p="sm">
-                            <FormatForm
-                                formatInputProps={getFormatInputProps}
-                                setFormatFieldValue={setFormatFieldValue}
-                                format={form.values.format}
-                            />
-                        </Tabs.Panel>
-                    </Tabs>
-                    <Tooltip
-                        position="bottom"
-                        withArrow
-                        multiline
-                        maw={400}
-                        withinPortal
-                        label={
-                            'Manually select the type of the result of this SQL table calculation, this will help us to treat this field correctly in filters or results.'
-                        }
-                    >
-                        <Select
-                            label={'Result type'}
-                            id="download-type"
-                            {...form.getInputProps('type')}
-                            onChange={(value) => {
-                                const tcType = Object.values(
-                                    TableCalculationType,
-                                ).find((type) => type === value);
-                                if (tcType) form.setFieldValue(`type`, tcType);
-                            }}
-                            data={Object.values(TableCalculationType)}
-                        ></Select>
-                    </Tooltip>
-                    <Group
-                        position="apart"
-                        pos="sticky"
-                        bottom={0}
-                        bg="white"
-                        style={{ zIndex: 1 }}
-                        mt="sm"
-                        p={theme.spacing.md}
-                        align="flex-end"
-                    >
-                        <ActionIcon
-                            variant="outline"
-                            onClick={toggleFullscreen}
-                        >
-                            <MantineIcon
-                                icon={
-                                    isFullscreen ? IconMinimize : IconMaximize
-                                }
-                            />
-                        </ActionIcon>
 
-                        <Group>
-                            <Button variant="outline" onClick={onClose}>
-                                Cancel
-                            </Button>
-                            <Button
-                                type="submit"
-                                ref={submitButtonRef}
-                                data-testid="table-calculation-save-button"
+                            <Tabs
+                                defaultValue="sqlEditor"
+                                color="indigo"
+                                variant="outline"
+                                radius="xs"
+                                styles={{
+                                    panel: {
+                                        borderColor: colors.gray[2],
+                                        borderWidth: 1,
+                                        borderStyle: 'solid',
+                                        borderTop: 'none',
+                                        height: isFullscreen
+                                            ? 'calc(90vh - 400px)'
+                                            : 'auto',
+                                    },
+                                }}
                             >
-                                Save
-                            </Button>
+                                <Tabs.List>
+                                    <Tabs.Tab value="sqlEditor">SQL</Tabs.Tab>
+                                    <Tabs.Tab value="format">Format</Tabs.Tab>
+                                </Tabs.List>
+                                <Tabs.Panel value="sqlEditor">
+                                    <SqlForm
+                                        form={form}
+                                        isFullScreen={isFullscreen}
+                                        focusOnRender={true}
+                                        onCmdEnter={() => {
+                                            if (submitButtonRef.current) {
+                                                submitButtonRef.current.click();
+                                            }
+                                        }}
+                                    />
+                                </Tabs.Panel>
+                                <Tabs.Panel value="format" p="sm">
+                                    <FormatForm
+                                        formatInputProps={getFormatInputProps}
+                                        setFormatFieldValue={
+                                            setFormatFieldValue
+                                        }
+                                        format={form.values.format}
+                                    />
+                                </Tabs.Panel>
+                            </Tabs>
+
+                            <Tooltip
+                                position="bottom"
+                                withArrow
+                                multiline
+                                maw={400}
+                                withinPortal
+                                label={
+                                    'Manually select the type of the result of this SQL table calculation, this will help us to treat this field correctly in filters or results.'
+                                }
+                            >
+                                <Select
+                                    label={'Result type'}
+                                    id="download-type"
+                                    {...form.getInputProps('type')}
+                                    onChange={(value) => {
+                                        const tcType = Object.values(
+                                            TableCalculationType,
+                                        ).find((type) => type === value);
+                                        if (tcType)
+                                            form.setFieldValue(`type`, tcType);
+                                    }}
+                                    data={Object.values(TableCalculationType)}
+                                />
+                            </Tooltip>
+                        </Stack>
+                    </Modal.Body>
+
+                    <Box
+                        sx={(themeProps) => ({
+                            borderTop: `1px solid ${themeProps.colors.gray[2]}`,
+                            padding: themeProps.spacing.sm,
+                            backgroundColor: themeProps.white,
+                            position: 'sticky',
+                            bottom: 0,
+                            width: '100%',
+                            zIndex: getDefaultZIndex('modal'),
+                        })}
+                    >
+                        <Group position="apart">
+                            <ActionIcon
+                                variant="outline"
+                                onClick={toggleFullscreen}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isFullscreen
+                                            ? IconMinimize
+                                            : IconMaximize
+                                    }
+                                />
+                            </ActionIcon>
+
+                            <Group spacing="xs">
+                                <Button
+                                    variant="default"
+                                    h={32}
+                                    onClick={onClose}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    h={32}
+                                    type="submit"
+                                    ref={submitButtonRef}
+                                    data-testid="table-calculation-save-button"
+                                >
+                                    {tableCalculation
+                                        ? 'Save changes'
+                                        : 'Create'}
+                                </Button>
+                            </Group>
                         </Group>
-                    </Group>
-                </Stack>
-            </form>
-        </Modal>
+                    </Box>
+                </form>
+            </Modal.Content>
+        </Modal.Root>
     );
 };
 


### PR DESCRIPTION

Closes: [#14172](https://github.com/lightdash/lightdash/issues/14172)

### Description:

Changed Modals to be similar to the standard ones - a good example is PaletteModalBase

Renamed wording "isFullscreen" to "isExpanded" to match what is actually happening

<img width="1022" alt="Screenshot 2025-03-31 at 14 24 06" src="https://github.com/user-attachments/assets/d85e3262-c69f-4647-9d43-bbdda7a60d36" />

<img width="936" alt="Screenshot 2025-03-31 at 14 24 01" src="https://github.com/user-attachments/assets/e5b1b290-d7cd-4c4d-b3dc-4d7e66aa218f" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
