### PR TITLE
fix: enable useDashboardChart regardless of feature flag value, the c…

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -185,7 +185,7 @@ const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
                 ? queryKey.concat([granularity])
                 : queryKey,
         queryFn: fetchChartAndResults,
-        enabled: !!chartUuid && !!dashboardUuid && !!queryPaginationEnabled,
+        enabled: !!chartUuid && !!dashboardUuid,
         retry: false,
         refetchOnMount: false,
     });


### PR DESCRIPTION
…heck is done internally

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14223 

### Description:

- The hook for dashboard charts was disabled when result of feature flag check was empty. This happens when there's an error making a request to `api/v2/feature-flag/query-pagination`.

**Steps to reproduce**
- Force the 404 error when getting the feature flag value in FeatureFlagModel
```typescript
    public async get(args: FeatureFlagLogicArgs): Promise<FeatureFlag> {
        const handler = this.featureFlagHandlers[args.featureFlagId];
        // if (handler) {
        //     return handler(args);
        // }
        // // Default to check Posthog feature flag
        // if (args.user && isFeatureFlags(args.featureFlagId)) {
        //     return FeatureFlagModel.getPosthogFeatureFlag(
        //         args.user,
        //         args.featureFlagId,
        //     );
        // }
        throw new NotFoundError(`Feature flag ${args.featureFlagId} not found`);
    }
```
- Open a dashboard

**Before**
![image](https://github.com/user-attachments/assets/1777a3e0-eb78-44e5-b5da-8d2b7a0531e9)

**After**
![image](https://github.com/user-attachments/assets/73c885a8-55d7-40a8-b7ab-d8c0404037f7)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
