### PR TITLE
fix: Spotlight canvas nodes comparing to previous month incorrectly

### DIFF
--- a/packages/backend/src/controllers/metricsExplorerController.ts
+++ b/packages/backend/src/controllers/metricsExplorerController.ts
@@ -90,6 +90,7 @@ export class MetricsExplorerController extends BaseController {
         @Path() metric: string,
         @Request() req: express.Request,
         @Query() timeFrame: TimeFrames,
+        @Query() granularity: TimeFrames,
         @Query() startDate: string,
         @Query() endDate: string,
         @Body()
@@ -107,6 +108,7 @@ export class MetricsExplorerController extends BaseController {
                 explore,
                 metric,
                 timeFrame,
+                granularity,
                 startDate,
                 endDate,
                 body?.comparisonType,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10347,7 +10347,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10357,7 +10357,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10367,7 +10367,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10380,7 +10380,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -25565,6 +25565,12 @@ export function RegisterRoutes(app: Router) {
         timeFrame: {
             in: 'query',
             name: 'timeFrame',
+            required: true,
+            ref: 'TimeFrames',
+        },
+        granularity: {
+            in: 'query',
+            name: 'granularity',
             required: true,
             ref: 'TimeFrames',
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11121,22 +11121,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15760,7 +15760,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1552.4",
+        "version": "0.1558.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -21515,6 +21515,14 @@
                     {
                         "in": "query",
                         "name": "timeFrame",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/TimeFrames"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "granularity",
                         "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/TimeFrames"

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -1029,7 +1029,7 @@ export class CatalogService<
                     | undefined;
 
                 // If no default time dimension is defined, we can use the available time dimensions so the user can see what time dimensions are available
-                if (!defaultTimeDimension) {
+                if (!defaultTimeDimension || timeIntervalOverride) {
                     availableTimeDimensions =
                         getAvailableTimeDimensionsFromTables(tables);
                 }
@@ -1038,7 +1038,7 @@ export class CatalogService<
                     | MetricWithAssociatedTimeDimension['timeDimension']
                     | undefined;
 
-                if (defaultTimeDimension) {
+                if (defaultTimeDimension && !timeIntervalOverride) {
                     timeDimension = {
                         field: defaultTimeDimension.field,
                         interval: defaultTimeDimension.interval,

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -649,9 +649,12 @@ export class MetricsExplorerService<
         let compareDateRange: MetricExplorerDateRange | undefined;
 
         if (comparisonType === MetricTotalComparisonType.PREVIOUS_PERIOD) {
+            const grain =
+                timeFrame === TimeFrames.DAY ? TimeFrames.MONTH : undefined;
+
             compareDateRange = [
-                getDateCalcUtils(timeFrame).back(dateRange[0]),
-                getDateCalcUtils(timeFrame).back(dateRange[1]),
+                getDateCalcUtils(timeFrame, grain).back(dateRange[0]),
+                getDateCalcUtils(timeFrame, grain).back(dateRange[1]),
             ];
 
             const compareMetricQuery = {

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -566,6 +566,7 @@ export class MetricsExplorerService<
         exploreName: string,
         metricName: string,
         timeFrame: TimeFrames,
+        granularity: TimeFrames,
         startDate: string,
         endDate: string,
         comparisonType: MetricTotalComparisonType = MetricTotalComparisonType.NONE,
@@ -578,6 +579,7 @@ export class MetricsExplorerService<
                     exploreName,
                     metricName,
                     timeFrame,
+                    granularity,
                     startDate,
                     endDate,
                     comparisonType,
@@ -599,6 +601,7 @@ export class MetricsExplorerService<
         exploreName: string,
         metricName: string,
         timeFrame: TimeFrames,
+        granularity: TimeFrames,
         startDate: string,
         endDate: string,
         comparisonType: MetricTotalComparisonType = MetricTotalComparisonType.NONE,
@@ -608,7 +611,7 @@ export class MetricsExplorerService<
             projectUuid,
             exploreName,
             metricName,
-            timeFrame,
+            granularity,
         );
 
         if (!metric.timeDimension) {
@@ -649,12 +652,9 @@ export class MetricsExplorerService<
         let compareDateRange: MetricExplorerDateRange | undefined;
 
         if (comparisonType === MetricTotalComparisonType.PREVIOUS_PERIOD) {
-            const grain =
-                timeFrame === TimeFrames.DAY ? TimeFrames.MONTH : undefined;
-
             compareDateRange = [
-                getDateCalcUtils(timeFrame, grain).back(dateRange[0]),
-                getDateCalcUtils(timeFrame, grain).back(dateRange[1]),
+                getDateCalcUtils(timeFrame, granularity).back(dateRange[0]),
+                getDateCalcUtils(timeFrame, granularity).back(dateRange[1]),
             ];
 
             const compareMetricQuery = {

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -135,7 +135,6 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
                 back: (date: Date) => dayjs(date).subtract(1, 'year').toDate(),
             };
         case TimeFrames.DAY:
-            throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         case TimeFrames.WEEK:
             throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         default:

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -133,6 +133,17 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
                 back: (date: Date) => dayjs(date).subtract(1, 'year').toDate(),
             };
         case TimeFrames.DAY:
+            if (grain === TimeFrames.MONTH) {
+                return {
+                    forward: (date: Date) =>
+                        dayjs(date).add(1, 'month').toDate(),
+                    back: (date: Date) =>
+                        dayjs(date).subtract(1, 'month').toDate(),
+                };
+            }
+            throw new Error(
+                `Timeframe "${timeFrame}" with grain ${grain} is not supported yet`,
+            );
         case TimeFrames.WEEK:
             throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         default:
@@ -444,9 +455,10 @@ export const getDefaultMetricTreeNodeDateRange = (
 
     switch (timeFrame) {
         case TimeFrames.DAY:
+            // Current month to date
             return [
-                now.startOf('day').subtract(1, 'day').toDate(),
-                now.endOf('day').subtract(1, 'day').toDate(),
+                now.startOf('day').startOf('month').toDate(),
+                now.endOf('day').toDate(),
             ];
         case TimeFrames.WEEK:
             return [now.startOf('isoWeek').toDate(), now.toDate()];

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -102,10 +102,21 @@ export const getFieldIdForDateDimension = (
 export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
     switch (timeFrame) {
         case TimeFrames.MONTH:
-            if (grain)
+            if (grain === TimeFrames.DAY) {
+                return {
+                    forward: (date: Date) =>
+                        dayjs(date).add(1, 'month').toDate(),
+                    back: (date: Date) =>
+                        dayjs(date).subtract(1, 'month').toDate(),
+                };
+            }
+
+            if (grain) {
                 throw new Error(
-                    `Timeframe "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
+                    `Granularity "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
                 );
+            }
+
             return {
                 forward: (date: Date) => dayjs(date).add(1, 'month').toDate(),
                 back: (date: Date) => dayjs(date).subtract(1, 'month').toDate(),
@@ -133,17 +144,7 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
                 back: (date: Date) => dayjs(date).subtract(1, 'year').toDate(),
             };
         case TimeFrames.DAY:
-            if (grain === TimeFrames.MONTH) {
-                return {
-                    forward: (date: Date) =>
-                        dayjs(date).add(1, 'month').toDate(),
-                    back: (date: Date) =>
-                        dayjs(date).subtract(1, 'month').toDate(),
-                };
-            }
-            throw new Error(
-                `Timeframe "${timeFrame}" with grain ${grain} is not supported yet`,
-            );
+            throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         case TimeFrames.WEEK:
             throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         default:
@@ -455,10 +456,9 @@ export const getDefaultMetricTreeNodeDateRange = (
 
     switch (timeFrame) {
         case TimeFrames.DAY:
-            // Current month to date
             return [
-                now.startOf('day').startOf('month').toDate(),
-                now.endOf('day').toDate(),
+                now.startOf('day').subtract(1, 'day').toDate(),
+                now.endOf('day').subtract(1, 'day').toDate(),
             ];
         case TimeFrames.WEEK:
             return [now.startOf('isoWeek').toDate(), now.toDate()];

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -102,16 +102,7 @@ export const getFieldIdForDateDimension = (
 export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
     switch (timeFrame) {
         case TimeFrames.MONTH:
-            if (grain === TimeFrames.DAY) {
-                return {
-                    forward: (date: Date) =>
-                        dayjs(date).add(1, 'month').toDate(),
-                    back: (date: Date) =>
-                        dayjs(date).subtract(1, 'month').toDate(),
-                };
-            }
-
-            if (grain) {
+            if (grain && grain !== TimeFrames.DAY) {
                 throw new Error(
                     `Granularity "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
                 );

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -6,7 +6,7 @@ import {
     friendlyName,
     getDefaultMetricTreeNodeDateRange,
     MetricTotalComparisonType,
-    type TimeFrames,
+    TimeFrames,
 } from '@lightdash/common';
 import {
     Badge,
@@ -86,6 +86,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
         exploreName: data.tableName,
         metricName: data.metricName,
         timeFrame: data.timeFrame,
+        granularity: TimeFrames.DAY, // TODO: this should be dynamic
         comparisonType: MetricTotalComparisonType.PREVIOUS_PERIOD,
         dateRange,
         options: {

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -1,6 +1,6 @@
 import Dagre from '@dagrejs/dagre';
 import {
-    DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+    TimeFrames,
     type CatalogField,
     type CatalogMetricsTreeEdge,
 } from '@lightdash/common';
@@ -84,7 +84,7 @@ enum STATIC_NODE_TYPES {
     UNCONNECTED = 'UNCONNECTED',
 }
 
-const DEFAULT_TIME_FRAME = DEFAULT_METRICS_EXPLORER_TIME_INTERVAL; // TODO: this should be dynamic
+const DEFAULT_TIME_FRAME = TimeFrames.DAY; // TODO: this should be dynamic
 
 type MetricTreeNode = ExpandedNodeData | CollapsedNodeData | FreeGroupNodeData;
 

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -84,7 +84,7 @@ enum STATIC_NODE_TYPES {
     UNCONNECTED = 'UNCONNECTED',
 }
 
-const DEFAULT_TIME_FRAME = TimeFrames.DAY; // TODO: this should be dynamic
+const DEFAULT_TIME_FRAME = TimeFrames.MONTH; // TODO: this should be dynamic
 
 type MetricTreeNode = ExpandedNodeData | CollapsedNodeData | FreeGroupNodeData;
 

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -27,9 +27,11 @@ type RunMetricExplorerQueryArgs = {
 const getUrlParams = ({
     dateRange,
     timeFrame,
+    granularity,
 }: {
     dateRange: MetricExplorerDateRange;
     timeFrame?: TimeFrames;
+    granularity?: TimeFrames;
 }) => {
     const params = new URLSearchParams();
 
@@ -48,6 +50,11 @@ const getUrlParams = ({
     // Add time frame param
     if (timeFrame) {
         params.append('timeFrame', timeFrame);
+    }
+
+    // Add granularity param
+    if (granularity) {
+        params.append('granularity', granularity);
     }
 
     return params.toString();
@@ -131,6 +138,7 @@ type RunMetricTotalArgs = {
     metricName: string;
     dateRange: MetricExplorerDateRange;
     timeFrame: TimeFrames;
+    granularity: TimeFrames;
     comparisonType: MetricTotalComparisonType;
 };
 
@@ -140,11 +148,13 @@ const postRunMetricTotal = async ({
     metricName,
     dateRange,
     timeFrame,
+    granularity,
     comparisonType,
 }: RunMetricTotalArgs) => {
     const queryString = getUrlParams({
         dateRange,
         timeFrame,
+        granularity,
     });
 
     return lightdashApi<ApiMetricsExplorerTotalResults['results']>({
@@ -164,6 +174,7 @@ export const useRunMetricTotal = ({
     metricName,
     dateRange,
     timeFrame,
+    granularity,
     comparisonType,
     options,
 }: Partial<RunMetricTotalArgs> & {
@@ -178,6 +189,7 @@ export const useRunMetricTotal = ({
             dateRange?.[0],
             dateRange?.[1],
             timeFrame,
+            granularity,
             comparisonType,
         ],
         queryFn: () =>
@@ -187,6 +199,7 @@ export const useRunMetricTotal = ({
                 metricName: metricName!,
                 dateRange: dateRange!,
                 timeFrame: timeFrame!,
+                granularity: granularity!,
                 comparisonType: comparisonType!,
             }),
         ...options,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14110

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Canvas nodes in spotlight weren't comparing periods correctly.

Whole this month (effectively month to date)  would get compared to whole previous month. So say it was Apr 5, 5 days would get compared to whole March.

Example of metric queries run _before_:

```sql
-- Previous period
SELECT
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"

WHERE ((
  ((DATE_TRUNC('MONTH', "orders".order_date)) >= ('2025-03-01') AND (DATE_TRUNC('MONTH', "orders".order_date)) <= ('2025-03-05'))
))

LIMIT 1;

-- Current period
SELECT
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"

WHERE ((
  ((DATE_TRUNC('MONTH', "orders".order_date)) >= ('2025-04-01') AND (DATE_TRUNC('MONTH', "orders".order_date)) <= ('2025-04-05'))
))

LIMIT 1;
```

After:

```sql
-- Previous period
SELECT
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"

WHERE ((
  ((DATE_TRUNC('DAY', "orders".order_date)) >= ('2025-03-01') AND (DATE_TRUNC('DAY', "orders".order_date)) <= ('2025-03-05'))
))


LIMIT 1;


-- Current period (assuming Apr 5 today)
SELECT
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"

WHERE ((
  ((DATE_TRUNC('DAY', "orders".order_date)) >= ('2025-04-01') AND (DATE_TRUNC('DAY', "orders".order_date)) <= ('2025-04-05'))
))


LIMIT 1;
```

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
