### PR TITLE
fix: card action alignment

### DIFF
--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -144,7 +144,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                 {rightHeaderElement && (
                     <>
                         <Box sx={{ flexGrow: 1 }} />
-                        <Group spacing="xs" pos="relative" top={2} right={2}>
+                        <Group spacing="xs" pos="relative" right={2}>
                             {rightHeaderElement}
                         </Group>
                     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Description:

Super minor style fix. It's been bugging me 😄. Card action icons/buttons were not aligned with the header. 

**Before**
<img width="327" alt="b4a" src="https://github.com/user-attachments/assets/5f979159-8f88-4cd3-b839-310b65ca4ab6" />

**After**
<img width="278" alt="Screenshot 2025-04-01 at 17 20 34" src="https://github.com/user-attachments/assets/09aec19f-d92d-41d5-83af-34d2fc8b85e5" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
