### PR TITLE
chore: Refactor ContentPanel, detach tabs

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanelTabs.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanelTabs.tsx
@@ -1,0 +1,229 @@
+import { isVizTableConfig } from '@lightdash/common';
+import {
+    Group,
+    Indicator,
+    Paper,
+    SegmentedControl,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { IconChartHistogram, IconCodeCircle } from '@tabler/icons-react';
+import type { EChartsInstance } from 'echarts-for-react';
+import { useCallback, useMemo, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    cartesianChartSelectors,
+    selectCompleteConfigByKind,
+    selectPivotChartDataByKind,
+} from '../../../components/DataViz/store/selectors';
+import RunSqlQueryButton from '../../../components/SqlRunner/RunSqlQueryButton';
+import { DEFAULT_SQL_LIMIT } from '../constants';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+    EditorTabs,
+    selectActiveChartType,
+    selectActiveEditorTab,
+    selectLimit,
+    selectProjectUuid,
+    selectSavedSqlChart,
+    selectSql,
+    selectSqlQueryResults,
+    setActiveEditorTab,
+    setSqlLimit,
+} from '../store/sqlRunnerSlice';
+import { runSqlQuery } from '../store/thunks';
+import { ChartDownload } from './Download/ChartDownload';
+import { ResultsDownloadFromUrl } from './Download/ResultsDownloadFromUrl';
+import { SqlQueryHistory } from './SqlQueryHistory';
+
+export const ContentPanelTabs: FC<{
+    activeEchartsInstance: EChartsInstance;
+}> = ({ activeEchartsInstance }) => {
+    // State we need from redux
+    const savedSqlChart = useAppSelector(selectSavedSqlChart);
+    const sql = useAppSelector(selectSql);
+    const selectedChartType = useAppSelector(selectActiveChartType);
+    const limit = useAppSelector(selectLimit);
+    const activeEditorTab = useAppSelector(selectActiveEditorTab);
+    const isLoadingSqlQuery = useAppSelector(
+        (state) => state.sqlRunner.queryIsLoading,
+    );
+    const projectUuid = useAppSelector(selectProjectUuid);
+    const pivotedChartInfo = useAppSelector((state) =>
+        selectPivotChartDataByKind(state, selectedChartType),
+    );
+    // So we can dispatch to redux
+    const dispatch = useAppDispatch();
+
+    // state for helping highlight errors in the editor
+    const mode = useAppSelector((state) => state.sqlRunner.mode);
+    const currentVizConfig = useAppSelector((state) =>
+        selectCompleteConfigByKind(state, selectedChartType),
+    );
+
+    const handleRunQuery = useCallback(
+        async (sqlToUse: string) => {
+            if (!sqlToUse) return;
+
+            await dispatch(
+                runSqlQuery({
+                    sql: sqlToUse,
+                    limit: DEFAULT_SQL_LIMIT,
+                    projectUuid,
+                }),
+            );
+        },
+        [dispatch, projectUuid],
+    );
+
+    const hasUnrunChanges = useAppSelector(
+        (state) => state.sqlRunner.hasUnrunChanges,
+    );
+    const hasErrors = useAppSelector(
+        (state) =>
+            !!cartesianChartSelectors.getErrors(state, selectedChartType),
+    );
+    const queryResults = useAppSelector(selectSqlQueryResults);
+
+    const canSetSqlLimit = useMemo(
+        () => activeEditorTab === EditorTabs.VISUALIZATION,
+        [activeEditorTab],
+    );
+
+    const resultsFileUrl = useMemo(() => queryResults?.fileUrl, [queryResults]);
+
+    return (
+        <Paper
+            shadow="none"
+            radius={0}
+            px="md"
+            py={6}
+            bg="gray.1"
+            sx={(theme) => ({
+                borderWidth: '0 0 1px 1px',
+                borderStyle: 'solid',
+                borderColor: theme.colors.gray[3],
+            })}
+        >
+            <Group position="apart">
+                <Group position="apart">
+                    <Indicator
+                        color="red.6"
+                        offset={10}
+                        disabled={!hasErrors || mode === 'virtualView'}
+                    >
+                        <SegmentedControl
+                            display={
+                                mode === 'virtualView' ? 'none' : undefined
+                            }
+                            styles={(theme) => ({
+                                root: {
+                                    backgroundColor: theme.colors.gray[2],
+                                },
+                            })}
+                            size="sm"
+                            radius="md"
+                            data={[
+                                {
+                                    value: EditorTabs.SQL,
+                                    label: (
+                                        <Tooltip
+                                            disabled={!hasUnrunChanges}
+                                            variant="xs"
+                                            withinPortal
+                                            label="You haven't run this query yet."
+                                        >
+                                            <Group spacing={4} noWrap>
+                                                <MantineIcon
+                                                    color="gray.6"
+                                                    icon={IconCodeCircle}
+                                                />
+                                                <Text>SQL</Text>
+                                            </Group>
+                                        </Tooltip>
+                                    ),
+                                },
+
+                                {
+                                    value: EditorTabs.VISUALIZATION,
+                                    label: (
+                                        <Tooltip
+                                            disabled={!!queryResults?.results}
+                                            variant="xs"
+                                            withinPortal
+                                            label="Run a query to see the chart"
+                                        >
+                                            <Group spacing={4} noWrap>
+                                                <MantineIcon
+                                                    color="gray.6"
+                                                    icon={IconChartHistogram}
+                                                />
+                                                <Text>Chart</Text>
+                                            </Group>
+                                        </Tooltip>
+                                    ),
+                                },
+                            ]}
+                            value={activeEditorTab}
+                            onChange={(value: EditorTabs) => {
+                                if (isLoadingSqlQuery) {
+                                    return;
+                                }
+
+                                if (
+                                    value === EditorTabs.VISUALIZATION &&
+                                    !queryResults?.results
+                                ) {
+                                    return;
+                                }
+
+                                dispatch(setActiveEditorTab(value));
+                            }}
+                        />
+                    </Indicator>
+                </Group>
+                <Group spacing="xs">
+                    {activeEditorTab === EditorTabs.SQL && <SqlQueryHistory />}
+                    <RunSqlQueryButton
+                        isLoading={isLoadingSqlQuery}
+                        disabled={!sql}
+                        onSubmit={() => handleRunQuery(sql)}
+                        {...(canSetSqlLimit
+                            ? {
+                                  onLimitChange: (l) =>
+                                      dispatch(setSqlLimit(l)),
+                                  limit,
+                              }
+                            : {})}
+                    />
+                    {activeEditorTab === EditorTabs.VISUALIZATION &&
+                    !isVizTableConfig(currentVizConfig) &&
+                    selectedChartType ? (
+                        <ChartDownload
+                            fileUrl={pivotedChartInfo?.data?.chartFileUrl}
+                            columnNames={
+                                pivotedChartInfo?.data?.columns?.map(
+                                    (c) => c.reference,
+                                ) ?? []
+                            }
+                            chartName={savedSqlChart?.name}
+                            echartsInstance={activeEchartsInstance}
+                        />
+                    ) : (
+                        mode === 'default' && (
+                            <ResultsDownloadFromUrl
+                                fileUrl={resultsFileUrl}
+                                columnNames={
+                                    queryResults?.columns.map(
+                                        (c) => c.reference,
+                                    ) ?? []
+                                }
+                                chartName={savedSqlChart?.name}
+                            />
+                        )
+                    )}
+                </Group>
+            </Group>
+        </Paper>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes (partially): #11635 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

- Simply detaches the tabs from the ContentPanel component, no logic changes
- `activeEchartsInstance` needs to be passed to tabs, as it is used to enable chart copying/downloading. Re-renders are still there, so nothing new under the sun.
- I will detach other components mentioned in the issue in follow up prs.

<!-- Even better add a screenshot / gif / loom -->

I mean, the screenshot is not really useful since nothing changes 😆 but here they are:

<img width="1400" alt="image" src="https://github.com/user-attachments/assets/444b9a6f-1d51-4876-b653-7fec9996e74c" />

here's the copied chart:

![image](https://github.com/user-attachments/assets/066bfc5e-0485-47b2-b5c4-4a42dee37101)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
