### PR TITLE
feat: auto focus OTP pin input

### DIFF
--- a/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
@@ -88,6 +88,7 @@ const VerifyEmailForm: FC<{ isLoading?: boolean }> = ({ isLoading }) => {
                         }
                         {...form.getInputProps('code')}
                         data-testid="pin-input"
+                        autoFocus
                     />
                     <Text ta="center" color="red.7">
                         {errorMessage?.toString()}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Nice to have auto-focus on OTP input so that you can just type in your pin as soon as you land on the page


Demo: https://cln.sh/b7bxS4DD
<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
