### PR TITLE
fix: No Query result when viewing underlying data in dashboard

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1820,6 +1820,29 @@ export class ProjectService extends BaseService {
             };
         }
 
+        const compliedQuery = await this.compileQuery(
+            user,
+            metricQueryWithDashboardOverrides,
+            projectUuid,
+            explore.name,
+        );
+
+        const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
+            context,
+            query: metricQueryWithDashboardOverrides,
+        };
+
+        const { queryUuid } = await this.queryHistoryModel.create({
+            projectUuid,
+            organizationUuid,
+            createdByUserUuid: user.userUuid,
+            context,
+            fields: compliedQuery.fields,
+            compiledSql: compliedQuery.query,
+            requestParameters,
+            metricQuery: metricQueryWithDashboardOverrides,
+        });
+
         return {
             chart: { ...savedChart, isPrivate: space.isPrivate, access },
             explore,
@@ -1828,6 +1851,7 @@ export class ProjectService extends BaseService {
             rows,
             appliedDashboardFilters,
             fields,
+            queryUuid,
         };
     }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -510,6 +510,7 @@ export type ApiChartAndResults = {
     cacheMetadata: CacheMetadata;
     rows: ResultRow[];
     fields: ItemsMap;
+    queryUuid: string;
 };
 
 export type ApiSqlQueryResults = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14212 


### Description:

No query results are displayed when viewing underlying data in the dashboard because `executeAsyncUnderlyingDataQuery` expects an `underlyingDataSourceQueryUuid`, which is not returned by `getChartAndResults`.

I did a quick fix to generate the `queryUuid` and include it in the result.

I noticed that `queryUuid` is used for async requests. 
If converting `getChartAndResults` to `executeAsyncChartAndResults` is necessary, I’m happy to make that change.

https://github.com/user-attachments/assets/6cc6a54e-1d06-451f-841d-85d3a848d695

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
