### PR TITLE
fix: in the current filter stop autofocus when there's a value

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -297,7 +297,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                     }
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
-                    autoFocus={true}
+                    autoFocus={!rule.settings?.unitOfTime}
                     completed={false}
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -170,6 +170,7 @@ const FilterRuleForm: FC<Props> = ({
                         closeOnItemClick
                         withArrow
                         arrowPosition="center"
+                        withinPortal
                     >
                         <Menu.Target>
                             <Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14256 

### Description:

- Only autofocus select when there's no value selected. This is because there are multiple components with autofocus and there are conflicts

**After**
https://github.com/user-attachments/assets/9a9f9ac3-d992-4e78-9e5d-c5f96ef8a3ec



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
