### PR TITLE
fix: calculate correct grid taking into account default gap

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/constants.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/constants.ts
@@ -5,3 +5,5 @@ export const defaultGrid = {
     top: '70px', // pixels from top (makes room for legend)
     bottom: '30px', // pixels from bottom (makes room for x-axis)
 } as const;
+
+export const defaultAxisLabelGap = 20;

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1972,24 +1972,20 @@ const useEchartsCartesianConfig = (
 
         // Adds extra gap to grid to make room for axis labels -> there is an open ticket in echarts to fix this: https://github.com/apache/echarts/issues/9265
         // Only works for px values, percentage values are not supported because it cannot use calc()
-        if (
-            gridLeft &&
-            gridRight &&
-            gridLeft.includes('px') &&
-            gridRight.includes('px')
-        ) {
-            return {
-                ...grid,
-                left: `${
-                    parseInt(gridLeft.replace('px', '')) + defaultAxisLabelGap
-                }px`,
-                right: `${
-                    parseInt(gridRight.replace('px', '')) + defaultAxisLabelGap
-                }px`,
-            };
-        }
-
-        return grid;
+        return {
+            ...grid,
+            left: gridLeft.includes('px')
+                ? `${
+                      parseInt(gridLeft.replace('px', '')) + defaultAxisLabelGap
+                  }px`
+                : grid.left,
+            right: gridRight.includes('px')
+                ? `${
+                      parseInt(gridRight.replace('px', '')) +
+                      defaultAxisLabelGap
+                  }px`
+                : grid.right,
+        };
     }, [validCartesianConfig?.eChartsConfig.grid]);
 
     const eChartsOptions = useMemo(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14062

### Description:

- Calculates correct grid taking into account the default gap of the y axis names

**Before**
![image](https://github.com/user-attachments/assets/84f16ba8-12df-4abb-84e9-ae2badc797c3)

**After**
![image](https://github.com/user-attachments/assets/ccfdab07-5b8e-4f4a-a8fc-b2510f022986)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
