### PR TITLE
feat: nested spaces (backend)

### DIFF
--- a/examples/api/nested-spaces.http
+++ b/examples/api/nested-spaces.http
@@ -1,0 +1,28 @@
+### Login
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+### Create Parent Space
+POST http://localhost:8080/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces
+Content-Type: application/json
+
+{
+  "name": "Parent Space",
+  "isPrivate": false
+}
+
+### Create Child Space
+POST http://localhost:8080/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces
+Content-Type: application/json
+
+{
+  "name": "Child Space",
+  "isPrivate": false,
+  "parentSpaceUuid": "75f97040-ffb4-4557-bcf0-fc344d238235"
+}
+

--- a/examples/api/nested-spaces.http
+++ b/examples/api/nested-spaces.http
@@ -23,6 +23,18 @@ Content-Type: application/json
 {
   "name": "Child Space",
   "isPrivate": false,
-  "parentSpaceUuid": "75f97040-ffb4-4557-bcf0-fc344d238235"
+  "parentSpaceUuid": "PARENT_SPACE_UUID"
 }
 
+### Create Grandchild Space
+POST http://localhost:8080/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces
+Content-Type: application/json
+
+{
+  "name": "Grandchild Space",
+  "isPrivate": false,
+  "parentSpaceUuid": "CHILD_SPACE_UUID"
+}
+
+### Get All spaces in project
+GET http://localhost:8080/api/v1/projects/3675b69e-8324-4110-bdca-059031aa8da3/spaces

--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -11,11 +11,19 @@ export type DbSpace = {
     created_by_user_id?: number;
     search_vector: string;
     slug: string;
+    parent_space_uuid: string | null;
+    path: string;
 };
 
 export type CreateDbSpace = Pick<
     DbSpace,
-    'name' | 'project_id' | 'is_private' | 'created_by_user_id' | 'slug'
+    | 'name'
+    | 'project_id'
+    | 'is_private'
+    | 'created_by_user_id'
+    | 'slug'
+    | 'parent_space_uuid'
+    | 'path'
 >;
 
 export type UpdateDbSpace = Partial<Pick<DbSpace, 'name' | 'is_private'>>;

--- a/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
+++ b/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
@@ -10,7 +10,7 @@ export async function up(knex: Knex): Promise<void> {
         table.uuid('parent_space_uuid').nullable();
         // Enables much faster queries for finding all descendants or ancestors
         // Examples: https://www.postgresql.org/docs/current/ltree.html#LTREE-EXAMPLE
-        table.specificType('path', 'ltree').nullable();
+        table.specificType('path', 'ltree').notNullable().defaultTo('');
 
         table
             .foreign('parent_space_uuid')
@@ -34,7 +34,7 @@ export async function up(knex: Knex): Promise<void> {
             path: knex.raw('text2ltree(slug)'),
         })
         .from(SpacesTableName)
-        .whereNull('path');
+        .where('path', '=', '');
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
+++ b/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
@@ -1,0 +1,48 @@
+import { Knex } from 'knex';
+
+const SpacesTableName = 'spaces';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.uuid('parent_space_uuid').nullable();
+        // Enables much faster queries for finding all descendants or ancestors
+        // Examples: https://www.postgresql.org/docs/current/ltree.html#LTREE-EXAMPLE
+        table.specificType('path', 'ltree').nullable();
+
+        table
+            .foreign('parent_space_uuid')
+            .references('space_uuid')
+            .inTable(SpacesTableName)
+            .onDelete('CASCADE');
+    });
+
+    // Reference: https://www.postgresql.org/docs/current/ltree.html#LTREE-INDEXES
+    await knex.raw(
+        `CREATE INDEX spaces_path_idx ON ${SpacesTableName} USING gist (path)`, // Gist is a GiST index for path, which is a path in a tree
+    );
+    await knex.raw(
+        `CREATE INDEX spaces_parent_space_uuid_index ON ${SpacesTableName} USING btree (parent_space_uuid)`, // Btree is a B-tree index for parent_space_uuid, which is a UUID
+    );
+
+    // Updates path for existing spaces (root spaces have their own slug as path)
+    // Uses text2ltree to convert the slug to a ltree path (reference: https://www.postgresql.org/docs/current/ltree.html#LTREE-OPS-FUNCS)
+    await knex
+        .update({
+            path: knex.raw('text2ltree(slug)'),
+        })
+        .from(SpacesTableName)
+        .whereNull('path');
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.dropIndex('path', 'spaces_path_idx');
+        table.dropIndex('parent_space_uuid', 'spaces_parent_space_uuid_index');
+    });
+
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.dropForeign(['parent_space_uuid']);
+        table.dropColumn('parent_space_uuid');
+        table.dropColumn('path');
+    });
+}

--- a/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
+++ b/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
@@ -3,6 +3,9 @@ import { Knex } from 'knex';
 const SpacesTableName = 'spaces';
 
 export async function up(knex: Knex): Promise<void> {
+    // Install native Postgres extension ltree
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS ltree');
+
     await knex.schema.alterTable(SpacesTableName, (table) => {
         table.uuid('parent_space_uuid').nullable();
         // Enables much faster queries for finding all descendants or ancestors

--- a/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
+++ b/packages/backend/src/database/migrations/20250404110407_nested_spaces.ts
@@ -27,11 +27,11 @@ export async function up(knex: Knex): Promise<void> {
         `CREATE INDEX spaces_parent_space_uuid_index ON ${SpacesTableName} USING btree (parent_space_uuid)`, // Btree is a B-tree index for parent_space_uuid, which is a UUID
     );
 
-    // Updates path for existing spaces (root spaces have their own slug as path)
-    // Uses text2ltree to convert the slug to a ltree path (reference: https://www.postgresql.org/docs/current/ltree.html#LTREE-OPS-FUNCS)
+    // Converts slugs to ltree paths (e.g. '-parent-space4' -> '_parent_space4') so that all root spaces have paths
+    // Uses text2ltree to cast the slug to a ltree path (reference: https://www.postgresql.org/docs/current/ltree.html#LTREE-OPS-FUNCS)
     await knex
         .update({
-            path: knex.raw('text2ltree(slug)'),
+            path: knex.raw(`text2ltree(replace(slug, '-', '_'))`),
         })
         .from(SpacesTableName)
         .where('path', '=', '');

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -3,6 +3,7 @@ import {
     DbtLocalProjectConfig,
     DbtProjectType,
     generateSlug,
+    getLtreePathFromSlug,
     OrganizationMemberRole,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
@@ -199,7 +200,7 @@ export async function seed(knex: Knex): Promise<void> {
             project_id: projectId,
             slug: spaceSlug,
             parent_space_uuid: null,
-            path: spaceSlug,
+            path: getLtreePathFromSlug(spaceSlug),
         })
         .returning(['space_id', 'space_uuid']);
 

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -165,12 +165,16 @@ export async function seed(knex: Knex): Promise<void> {
         warehouse_type: 'postgres',
     });
 
-    const [{ space_id: spaceId, space_uuid: spaceUuid }] = await knex('spaces')
+    const spaceSlug = generateSlug(SEED_SPACE.name);
+
+    const [{ space_uuid: spaceUuid }] = await knex('spaces')
         .insert({
             ...SEED_SPACE,
             is_private: false,
             project_id: projectId,
-            slug: generateSlug(SEED_SPACE.name),
+            slug: spaceSlug,
+            parent_space_uuid: null,
+            path: spaceSlug,
         })
         .returning(['space_id', 'space_uuid']);
 

--- a/packages/backend/src/database/seeds/development/05_nested_spaces.ts
+++ b/packages/backend/src/database/seeds/development/05_nested_spaces.ts
@@ -1,0 +1,168 @@
+/* eslint-disable no-await-in-loop */
+import {
+    CreateSpace,
+    generateSlug,
+    OrganizationMemberRole,
+    SEED_ORG_1_ADMIN,
+    SEED_ORG_1_EDITOR,
+    SEED_PROJECT,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { SpaceModel } from '../../../models/SpaceModel';
+
+type TreeCreateSpace = CreateSpace & { children?: TreeCreateSpace[] };
+
+const tree: TreeCreateSpace[] = [
+    {
+        name: 'Parent Space 1',
+        children: [
+            {
+                name: 'Child Space 1.1',
+                children: [
+                    {
+                        name: 'Grandchild Space 1.1.1',
+                    },
+                    {
+                        name: 'Grandchild Space 1.1.2',
+                    },
+                ],
+            },
+            {
+                name: 'Child Space 1.2',
+                children: [
+                    {
+                        name: 'Grandchild Space 1.2.1',
+                    },
+                    {
+                        name: 'Grandchild Space 1.2.2',
+                        children: [
+                            {
+                                name: 'Great Grandchild Space 1.2.2.1',
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                name: 'Child Space 1.3',
+                children: [
+                    {
+                        name: 'Grandchild Space 1.3.1',
+                        children: [
+                            {
+                                name: 'Great Grandchild Space 1.3.1.1',
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        name: 'Parent Space 2',
+        isPrivate: true,
+        children: [
+            {
+                name: 'Child Space 2.1',
+                children: [
+                    {
+                        name: 'Grandchild Space 2.1.1',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        name: 'Parent Space 3',
+        isPrivate: true,
+        access: [
+            // Admin will automatically be added, we only seed editor
+            {
+                userUuid: SEED_ORG_1_EDITOR.user_uuid,
+                role: SpaceMemberRole.EDITOR,
+            },
+        ],
+        children: [
+            {
+                name: 'Child Space 3.1',
+            },
+        ],
+    },
+] as const;
+
+async function createSpaceTree(
+    spaceModel: SpaceModel,
+    spaces: TreeCreateSpace[],
+    parentSpaceUuid: string | null,
+    opts: {
+        projectUuid: string;
+        userId: number;
+        userUuid: string;
+    },
+) {
+    const ids: string[] = [];
+    for (const space of spaces) {
+        const createdSpace = await spaceModel.createSpace(
+            opts.projectUuid,
+            space.name,
+            opts.userId,
+            space.isPrivate === true, // by default false for seeding purposes
+            generateSlug(space.name),
+            false,
+            parentSpaceUuid,
+        );
+
+        if (space.access)
+            await Promise.all(
+                space.access.map((access) =>
+                    spaceModel.addSpaceAccess(
+                        createdSpace.uuid,
+                        access.userUuid,
+                        access.role,
+                    ),
+                ),
+            );
+
+        await spaceModel.addSpaceAccess(
+            createdSpace.uuid,
+            opts.userUuid,
+            SpaceMemberRole.ADMIN,
+        ); // user who created the space by default would be set to space admin
+
+        if (space.children) {
+            const childIds = await createSpaceTree(
+                spaceModel,
+                space.children,
+                createdSpace.uuid,
+                opts,
+            );
+            ids.push(createdSpace.uuid, ...childIds);
+        } else {
+            ids.push(createdSpace.uuid);
+        }
+    }
+
+    return ids;
+}
+
+export async function seed(knex: Knex): Promise<void> {
+    const spaceModel = new SpaceModel({
+        database: knex,
+    });
+
+    const [user] = await knex('users').where(
+        'user_uuid',
+        SEED_ORG_1_ADMIN.user_uuid,
+    );
+
+    if (!user) {
+        throw new Error(`User ${SEED_ORG_1_ADMIN.user_uuid} not found`);
+    }
+
+    await createSpaceTree(spaceModel, tree, null, {
+        projectUuid: SEED_PROJECT.project_uuid,
+        userId: user.user_id,
+        userUuid: user.user_uuid,
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6689,6 +6689,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                hasParent: { dataType: 'boolean' },
                 slug: { dataType: 'string', required: true },
                 pinnedListOrder: {
                     dataType: 'union',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10389,7 +10389,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10399,7 +10399,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10409,7 +10409,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10422,7 +10422,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6765,6 +6765,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                parentSpaceUuid: { dataType: 'string' },
                 access: {
                     dataType: 'array',
                     array: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7838,56 +7838,60 @@ const models: TsoaRoute.Models = {
         enums: ['no changes', 'create', 'update', 'delete'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                name: { dataType: 'string', required: true },
-                projectUuid: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-                isPrivate: { dataType: 'boolean', required: true },
-                pinnedListUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
+    'Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess-or-parentSpaceUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    isPrivate: { dataType: 'boolean', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    slug: { dataType: 'string', required: true },
+                    access: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
+                    chartCount: { dataType: 'double', required: true },
+                    dashboardCount: { dataType: 'double', required: true },
                 },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                slug: { dataType: 'string', required: true },
-                access: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                chartCount: { dataType: 'double', required: true },
-                dashboardCount: { dataType: 'double', required: true },
+                validators: {},
             },
-            validators: {},
         },
-    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_SpaceSummary.userAccess_': {
+    'Omit_SpaceSummary.userAccess-or-parentSpaceUuid_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__',
+            ref: 'Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess-or-parentSpaceUuid__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PromotedSpace: {
         dataType: 'refAlias',
-        type: { ref: 'Omit_SpaceSummary.userAccess_', validators: {} },
+        type: {
+            ref: 'Omit_SpaceSummary.userAccess-or-parentSpaceUuid_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__': {
@@ -9098,6 +9102,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        parentSpaceUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         dashboardCount: { dataType: 'double', required: true },
                         chartCount: { dataType: 'double', required: true },
                         access: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7374,6 +7374,9 @@
             },
             "Space": {
                 "properties": {
+                    "hasParent": {
+                        "type": "boolean"
+                    },
                     "slug": {
                         "type": "string"
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15808,7 +15808,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1567.2",
+        "version": "0.1568.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8706,7 +8706,7 @@
                 "enum": ["no changes", "create", "update", "delete"],
                 "type": "string"
             },
-            "Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__": {
+            "Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess-or-parentSpaceUuid__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -8766,12 +8766,12 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_SpaceSummary.userAccess_": {
-                "$ref": "#/components/schemas/Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess__",
+            "Omit_SpaceSummary.userAccess-or-parentSpaceUuid_": {
+                "$ref": "#/components/schemas/Pick_SpaceSummary.Exclude_keyofSpaceSummary.userAccess-or-parentSpaceUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "PromotedSpace": {
-                "$ref": "#/components/schemas/Omit_SpaceSummary.userAccess_"
+                "$ref": "#/components/schemas/Omit_SpaceSummary.userAccess-or-parentSpaceUuid_"
             },
             "Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__": {
                 "properties": {
@@ -9974,6 +9974,10 @@
                     },
                     {
                         "properties": {
+                            "parentSpaceUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
                             "dashboardCount": {
                                 "type": "number",
                                 "format": "double"
@@ -9992,7 +9996,12 @@
                                 "$ref": "#/components/schemas/SpaceShare"
                             }
                         },
-                        "required": ["dashboardCount", "chartCount", "access"],
+                        "required": [
+                            "parentSpaceUuid",
+                            "dashboardCount",
+                            "chartCount",
+                            "access"
+                        ],
                         "type": "object"
                     }
                 ]

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11172,22 +11172,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15805,7 +15805,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1563.2",
+        "version": "0.1567.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7471,6 +7471,9 @@
             },
             "CreateSpace": {
                 "properties": {
+                    "parentSpaceUuid": {
+                        "type": "string"
+                    },
                     "access": {
                         "items": {
                             "$ref": "#/components/schemas/Pick_SpaceShare.userUuid-or-role_"

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -133,6 +133,8 @@ export const spaceEntry: SpaceTable['base'] = {
     project_id: 0,
     organization_uuid: 'organizationUuid',
     search_vector: '',
+    parent_space_uuid: null,
+    path: 'space-name',
 };
 export const savedChartEntry: SavedChartTable['base'] = {
     saved_query_id: 0,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -85,7 +85,7 @@ import {
     SavedChartCustomSqlDimensionsTableName,
 } from '../../database/entities/savedCharts';
 import { DbSavedSql, InsertSql } from '../../database/entities/savedSql';
-import { DbSpace } from '../../database/entities/spaces';
+import { DbSpace, SpaceTableName } from '../../database/entities/spaces';
 import { DbUser } from '../../database/entities/users';
 import { WarehouseCredentialTableName } from '../../database/entities/warehouseCredentials';
 import Logger from '../../logging/logger';
@@ -424,11 +424,15 @@ export class ProjectModel {
                 data.warehouseConnection,
             );
 
-            await trx('spaces').insert({
+            const slug = generateSlug('Shared');
+
+            await trx(SpaceTableName).insert({
                 project_id: project.project_id,
                 name: 'Shared',
                 is_private: false,
-                slug: generateSlug('Shared'),
+                slug,
+                parent_space_uuid: null,
+                path: slug,
             });
 
             return project.project_uuid;

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -273,6 +273,7 @@ const getAllSpaces = async (
             `${PinnedListTableName}.pinned_list_uuid`,
             `${PinnedSpaceTableName}.space_uuid`,
             `${PinnedSpaceTableName}.order`,
+            `${SpaceTableName}.project_id`,
             `${SpaceTableName}.parent_space_uuid`,
             `${SpaceTableName}.path`,
             `${SpaceTableName}.is_private`,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -850,6 +850,9 @@ export class SpaceModel {
                 ),
             ]);
 
+        console.log('access 👇');
+        console.log(groupBy(access, 'space_uuid'));
+
         return Object.entries(groupBy(access, 'space_uuid')).reduce<
             Record<string, SpaceShare[]>
         >((acc, [spaceUuid, spaceAccess]) => {

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1456,6 +1456,10 @@ export class SpaceModel {
                 `${SpaceTableName}.space_uuid`,
                 `${OrganizationTableName}.organization_uuid`,
                 `${ProjectTableName}.project_uuid`,
+                `${SpaceTableName}.parent_space_uuid`,
+                `${SpaceTableName}.path`,
+                `${SpaceTableName}.project_id`,
+                `${SpaceTableName}.is_private`,
             );
 
         const spaceAccessMap = new Map();

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -81,10 +81,53 @@ export class SpaceModel {
         this.MOST_POPULAR_OR_RECENTLY_UPDATED_LIMIT = 10;
     }
 
+    /**
+     * Nested spaces MVP - get is_private from root space
+     * Returns a raw SQL expression to determine if a space is private.
+     * For nested spaces, it checks the root space's privacy setting.
+     * @returns SQL string for determining privacy setting
+     */
+    static getRootSpaceIsPrivateQuery(): string {
+        return `
+            CASE
+                WHEN ${SpaceTableName}.parent_space_uuid IS NOT NULL THEN
+                    (SELECT ps.is_private 
+                     FROM ${SpaceTableName} ps 
+                     WHERE ps.path @> ${SpaceTableName}.path 
+                     AND nlevel(ps.path) = 1
+                     LIMIT 1)
+                ELSE
+                    ${SpaceTableName}.is_private
+            END
+        `;
+    }
+
+    /**
+     * Nested spaces MVP - get access list from root space
+     * Returns a raw SQL expression to get user access for a space.
+     * For nested spaces, it retrieves access from the root space.
+     * @returns SQL string for retrieving access information
+     */
+    static getRootSpaceAccessQuery(sharedWithTableName: string): string {
+        return `
+            CASE
+                WHEN ${SpaceTableName}.parent_space_uuid IS NOT NULL THEN
+                    (SELECT COALESCE(json_agg(sua.user_uuid) FILTER (WHERE sua.user_uuid IS NOT NULL), '[]')
+                     FROM ${SpaceUserAccessTableName} sua
+                     JOIN ${SpaceTableName} root_space ON sua.space_uuid = root_space.space_uuid
+                     WHERE root_space.path @> ${SpaceTableName}.path
+                     AND nlevel(root_space.path) = 1
+                     LIMIT 1)
+                ELSE
+                    COALESCE(json_agg(${sharedWithTableName}.user_uuid) FILTER (WHERE ${sharedWithTableName}.user_uuid IS NOT NULL), '[]')
+            END
+        `;
+    }
+
     static async getSpaceIdAndName(db: Knex, spaceUuid: string | undefined) {
         if (spaceUuid === undefined) return undefined;
 
-        const [space] = await db('spaces')
+        const [space] = await db(SpaceTableName)
             .select(['space_id', 'name'])
             .where('space_uuid', spaceUuid);
         return { spaceId: space.space_id, name: space.name };
@@ -99,12 +142,16 @@ export class SpaceModel {
             Pick<DbPinnedList, 'pinned_list_uuid'> &
             Pick<DBPinnedSpace, 'order'>
     > {
-        const space = await db('spaces')
-            .innerJoin('projects', 'projects.project_id', 'spaces.project_id')
+        const space = await db(SpaceTableName)
             .innerJoin(
-                'organizations',
-                'organizations.organization_id',
-                'projects.organization_id',
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
             )
             .leftJoin(
                 PinnedSpaceTableName,
@@ -122,7 +169,7 @@ export class SpaceModel {
                 `${SpaceTableName}.space_uuid`,
             )
             .leftJoin(
-                'users',
+                UserTableName,
                 `${SpaceUserAccessTableName}.user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
@@ -132,17 +179,19 @@ export class SpaceModel {
                     .orWhere(`${SpaceTableName}.is_private`, false);
             })
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            // Nested spaces MVP - only consider root spaces
+            .whereNull(`${SpaceTableName}.parent_space_uuid`)
             .select<
                 (DbSpace &
                     Pick<DbPinnedList, 'pinned_list_uuid'> &
                     Pick<DBPinnedSpace, 'order'>)[]
             >([
-                'spaces.space_id',
-                'spaces.space_uuid',
-                'spaces.name',
-                'spaces.created_at',
-                'spaces.project_id',
-                'organizations.organization_uuid',
+                `${SpaceTableName}.space_id`,
+                `${SpaceTableName}.space_uuid`,
+                `${SpaceTableName}.name`,
+                `${SpaceTableName}.created_at`,
+                `${SpaceTableName}.project_id`,
+                `${OrganizationTableName}.organization_uuid`,
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedSpaceTableName}.order`,
             ])
@@ -173,13 +222,13 @@ export class SpaceModel {
         const savedQueries = await this.database('saved_queries')
             .leftJoin(
                 SpaceTableName,
-                `saved_queries.space_id`,
+                `${SavedChartsTableName}.space_id`,
                 `${SpaceTableName}.space_id`,
             )
             .leftJoin(
-                'users',
-                'saved_queries.last_version_updated_by_user_uuid',
-                'users.user_uuid',
+                UserTableName,
+                `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
             )
             .leftJoin(
                 PinnedChartTableName,
@@ -226,28 +275,32 @@ export class SpaceModel {
                     dashboard_uuid: string;
                     dashboard_name: string;
                     slug: string;
+                    is_private: boolean;
                 }[]
             >([
-                `saved_queries.saved_query_uuid`,
-                `saved_queries.name`,
-                `saved_queries.description`,
-                `saved_queries.last_version_updated_at as created_at`,
-                `users.user_uuid`,
-                `users.first_name`,
-                `users.last_name`,
+                `${SavedChartsTableName}.saved_query_uuid`,
+                `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.description`,
+                `${SavedChartsTableName}.last_version_updated_at as created_at`,
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.order`,
-                `saved_queries.last_version_chart_kind as chart_kind`,
+                `${SavedChartsTableName}.last_version_chart_kind as chart_kind`,
                 this.database.raw(
-                    `(SELECT ${SavedChartVersionsTableName}.chart_type FROM ${SavedChartVersionsTableName} WHERE ${SavedChartVersionsTableName}.saved_query_id = saved_queries.saved_query_id ORDER BY ${SavedChartVersionsTableName}.created_at DESC LIMIT 1) as chart_type`,
+                    `(SELECT ${SavedChartVersionsTableName}.chart_type FROM ${SavedChartVersionsTableName} WHERE ${SavedChartVersionsTableName}.saved_query_id = ${SavedChartsTableName}.saved_query_id ORDER BY ${SavedChartVersionsTableName}.created_at DESC LIMIT 1) as chart_type`,
                 ),
-                `saved_queries.views_count`,
-                `saved_queries.first_viewed_at`,
+                `${SavedChartsTableName}.views_count`,
+                `${SavedChartsTableName}.first_viewed_at`,
                 `${ProjectTableName}.project_uuid`,
                 `${OrganizationTableName}.organization_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.name as dashboard_name`,
-                `saved_queries.slug`,
+                `${SavedChartsTableName}.slug`,
+                this.database.raw(
+                    `${SpaceModel.getRootSpaceIsPrivateQuery()} AS is_private`,
+                ),
             ])
             .orderBy('saved_queries.last_version_updated_at', 'desc')
             .where('saved_queries.space_id', space.space_id);
@@ -304,16 +357,16 @@ export class SpaceModel {
                 name: 'SpaceModel.find',
             },
             async () => {
-                const query = this.database('spaces')
+                const query = this.database(SpaceTableName)
                     .innerJoin(
-                        'projects',
-                        'projects.project_id',
-                        'spaces.project_id',
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
                     )
                     .innerJoin(
-                        'organizations',
-                        'organizations.organization_id',
-                        'projects.organization_id',
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
                     )
                     .leftJoin(
                         PinnedSpaceTableName,
@@ -328,31 +381,31 @@ export class SpaceModel {
                     .leftJoin(
                         `${SpaceUserAccessTableName}`,
                         `${SpaceUserAccessTableName}.space_uuid`,
-                        'spaces.space_uuid',
+                        `${SpaceTableName}.space_uuid`,
                     )
                     .leftJoin(
-                        'users as shared_with',
+                        `${UserTableName} as shared_with`,
                         `${SpaceUserAccessTableName}.user_uuid`,
                         'shared_with.user_uuid',
                     )
                     .groupBy(
                         `${PinnedListTableName}.pinned_list_uuid`,
                         `${PinnedSpaceTableName}.order`,
-                        'organizations.organization_uuid',
-                        'projects.project_uuid',
-                        'spaces.space_uuid',
-                        'spaces.space_id',
+                        `${OrganizationTableName}.organization_uuid`,
+                        `${ProjectTableName}.project_uuid`,
+                        `${SpaceTableName}.space_uuid`,
+                        `${SpaceTableName}.space_id`,
                     )
                     .select({
-                        organizationUuid: 'organizations.organization_uuid',
-                        projectUuid: 'projects.project_uuid',
-                        uuid: 'spaces.space_uuid',
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        uuid: `${SpaceTableName}.space_uuid`,
                         name: this.database.raw('max(spaces.name)'),
                         isPrivate: this.database.raw(
-                            'bool_or(spaces.is_private)',
+                            SpaceModel.getRootSpaceIsPrivateQuery(),
                         ),
                         access: this.database.raw(
-                            "COALESCE(json_agg(shared_with.user_uuid) FILTER (WHERE shared_with.user_uuid IS NOT NULL), '[]')",
+                            SpaceModel.getRootSpaceAccessQuery('shared_with'),
                         ),
                         pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
                         pinnedListOrder: `${PinnedSpaceTableName}.order`,
@@ -372,28 +425,34 @@ export class SpaceModel {
                             .whereRaw(
                                 `${DashboardsTableName}.space_id = ${SpaceTableName}.space_id`,
                             ),
-                        slug: 'spaces.slug',
+                        slug: `${SpaceTableName}.slug`,
                     });
                 if (filters.projectUuid) {
                     void query.where(
-                        'projects.project_uuid',
+                        `${ProjectTableName}.project_uuid`,
                         filters.projectUuid,
                     );
                 }
                 if (filters.projectUuids) {
                     void query.whereIn(
-                        'projects.project_uuid',
+                        `${ProjectTableName}.project_uuid`,
                         filters.projectUuids,
                     );
                 }
                 if (filters.spaceUuid) {
-                    void query.where('spaces.space_uuid', filters.spaceUuid);
+                    void query.where(
+                        `${SpaceTableName}.space_uuid`,
+                        filters.spaceUuid,
+                    );
                 }
                 if (filters.spaceUuids) {
-                    void query.whereIn('spaces.space_uuid', filters.spaceUuids);
+                    void query.whereIn(
+                        `${SpaceTableName}.space_uuid`,
+                        filters.spaceUuids,
+                    );
                 }
                 if (filters.slug) {
-                    void query.where('spaces.slug', filters.slug);
+                    void query.where(`${SpaceTableName}.slug`, filters.slug);
                 }
                 return query;
             },
@@ -406,11 +465,15 @@ export class SpaceModel {
         Omit<Space, 'queries' | 'dashboards' | 'access' | 'groupsAccess'>
     > {
         const [row] = await this.database(SpaceTableName)
-            .leftJoin('projects', 'projects.project_id', 'spaces.project_id')
             .leftJoin(
-                'organizations',
-                'organizations.organization_id',
-                'projects.organization_id',
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .leftJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
             )
             .leftJoin(
                 PinnedSpaceTableName,
@@ -430,10 +493,12 @@ export class SpaceModel {
                     Pick<DbPinnedList, 'pinned_list_uuid'> &
                     Pick<DBPinnedSpace, 'order'>)[]
             >([
-                'spaces.*',
-
-                'projects.project_uuid',
-                'organizations.organization_uuid',
+                `${SpaceTableName}.*`,
+                this.database.raw(
+                    `${SpaceModel.getRootSpaceIsPrivateQuery()} AS is_private`,
+                ),
+                `${ProjectTableName}.project_uuid`,
+                `${OrganizationTableName}.organization_uuid`,
 
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedSpaceTableName}.order`,
@@ -452,6 +517,7 @@ export class SpaceModel {
             pinnedListUuid: row.pinned_list_uuid,
             pinnedListOrder: row.order,
             slug: row.slug,
+            hasParent: row.parent_space_uuid !== null,
         };
     }
 
@@ -757,13 +823,13 @@ export class SpaceModel {
                     space_group_roles: (SpaceMemberRole | null)[];
                 }[]
             >([
-                `spaces.space_uuid`,
-                `users.user_uuid`,
-                `users.first_name`,
-                `users.last_name`,
-                `emails.email`,
-                `spaces.is_private`,
-                `space_user_access.space_role`,
+                `${SpaceTableName}.space_uuid`,
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${EmailTableName}.email`,
+                `${SpaceTableName}.is_private`,
+                `${SpaceUserAccessTableName}.space_role`,
                 this.database.raw(
                     `CASE WHEN ${SpaceUserAccessTableName}.user_uuid IS NULL AND ( ${SpaceGroupAccessTableName}.group_uuid IS NULL ) THEN false ELSE true end as user_with_direct_access`,
                 ),
@@ -881,6 +947,10 @@ export class SpaceModel {
     }
 
     private async _getGroupAccess(spaceUuid: string): Promise<SpaceGroup[]> {
+        // Get the root space UUID
+        const rootSpaceUuid = await this.getSpaceRoot(spaceUuid);
+        const spaceUuidToUse = rootSpaceUuid ?? spaceUuid;
+
         const access = await this.database
             .table(SpaceGroupAccessTableName)
             .select({
@@ -893,7 +963,7 @@ export class SpaceModel {
                 `${GroupTableName}.group_uuid`,
                 `${SpaceGroupAccessTableName}.group_uuid`,
             )
-            .where('space_uuid', spaceUuid);
+            .where('space_uuid', spaceUuidToUse);
         return access;
     }
 
@@ -901,12 +971,15 @@ export class SpaceModel {
         userUuid: string,
         spaceUuid: string,
     ): Promise<SpaceShare[]> {
+        // Get the root space UUID if the space is nested
+        const rootSpaceUuid = await this.getSpaceRoot(spaceUuid);
+        const spaceUuidToUse = rootSpaceUuid ?? spaceUuid;
         return (
             (
-                await this._getSpaceAccess([spaceUuid], {
+                await this._getSpaceAccess([spaceUuidToUse], {
                     userUuid,
                 })
-            )[spaceUuid] ?? []
+            )[spaceUuidToUse] ?? []
         );
     }
 
@@ -914,9 +987,41 @@ export class SpaceModel {
         userUuid: string,
         spaceUuids: string[],
     ): Promise<Record<string, SpaceShare[]>> {
-        return this._getSpaceAccess(spaceUuids, {
+        // Get a normalized list of root space UUIDs if the spaces are nested
+        const spacesWithRootSpaceUuid = await Promise.all(
+            spaceUuids.map(async (spaceUuid) => {
+                const root = await this.getSpaceRoot(spaceUuid);
+
+                return { rootSpaceUuid: root, spaceUuid };
+            }),
+        );
+
+        const rootSpaceUuids = spacesWithRootSpaceUuid
+            .map(({ rootSpaceUuid }) => rootSpaceUuid)
+            .filter((rootSpaceUuid) => rootSpaceUuid !== undefined);
+
+        // Fetch access for all root spaces - we can get the access for all descendants from this
+        const rootSpacesAccess = await this._getSpaceAccess(rootSpaceUuids, {
             userUuid,
         });
+
+        return Object.entries(rootSpacesAccess).reduce<
+            Record<string, SpaceShare[]>
+        >((acc, [spaceUuid, spaceAccess]) => {
+            // Get descendants of a current space and return the access of the root space for all descendants
+            const descendants = spacesWithRootSpaceUuid.filter(
+                ({ rootSpaceUuid }) => rootSpaceUuid === spaceUuid,
+            );
+            // Add the access of the root space for all descendants
+            descendants.forEach(({ spaceUuid: s }) => {
+                acc[s] = spaceAccess;
+            });
+
+            // Otherwise, return the access of the root space
+            acc[spaceUuid] = spaceAccess;
+
+            return acc;
+        }, {});
     }
 
     private async getSpaceCharts(
@@ -945,9 +1050,9 @@ export class SpaceModel {
                 `${SpaceTableName}.space_uuid`,
             )
             .leftJoin(
-                'users',
+                UserTableName,
                 `${chartTable}.last_version_updated_by_user_uuid`,
-                'users.user_uuid',
+                `${UserTableName}.user_uuid`,
             )
             /* .leftJoin(
             PinnedChartTableName,
@@ -1001,9 +1106,9 @@ export class SpaceModel {
                 `${chartTable}.name`,
                 `${chartTable}.description`,
                 `${chartTable}.last_version_updated_at as created_at`,
-                `users.user_uuid`,
-                `users.first_name`,
-                `users.last_name`,
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
                 `${chartTable}.views_count`,
                 `${chartTable}.first_viewed_at`,
                 `${chartTable}.last_version_chart_kind as chart_kind`,
@@ -1117,17 +1222,17 @@ export class SpaceModel {
             mostPopular?: boolean;
         },
     ): Promise<SpaceQuery[]> {
-        let spaceQueriesQuery = this.database('saved_queries')
+        let spaceQueriesQuery = this.database(SavedChartsTableName)
             .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
             .leftJoin(
                 SpaceTableName,
-                `saved_queries.space_id`,
+                `${SavedChartsTableName}.space_id`,
                 `${SpaceTableName}.space_id`,
             )
             .leftJoin(
-                'users',
-                'saved_queries.last_version_updated_by_user_uuid',
-                'users.user_uuid',
+                UserTableName,
+                `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
             )
             .leftJoin(
                 PinnedChartTableName,
@@ -1179,18 +1284,18 @@ export class SpaceModel {
                     slug: string;
                 }[]
             >([
-                `saved_queries.saved_query_uuid`,
-                `saved_queries.name`,
-                `saved_queries.description`,
-                `saved_queries.last_version_updated_at as created_at`,
-                `users.user_uuid`,
-                `users.first_name`,
-                `users.last_name`,
-                `saved_queries.views_count`,
-                `saved_queries.first_viewed_at`,
-                `saved_queries.last_version_chart_kind as chart_kind`,
+                `${SavedChartsTableName}.saved_query_uuid`,
+                `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.description`,
+                `${SavedChartsTableName}.last_version_updated_at as created_at`,
+                `${UserTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${SavedChartsTableName}.views_count`,
+                `${SavedChartsTableName}.first_viewed_at`,
+                `${SavedChartsTableName}.last_version_chart_kind as chart_kind`,
                 this.database.raw(
-                    `(SELECT ${SavedChartVersionsTableName}.chart_type FROM ${SavedChartVersionsTableName} WHERE ${SavedChartVersionsTableName}.saved_query_id = saved_queries.saved_query_id ORDER BY ${SavedChartVersionsTableName}.created_at DESC LIMIT 1) as chart_type`,
+                    `(SELECT ${SavedChartVersionsTableName}.chart_type FROM ${SavedChartVersionsTableName} WHERE ${SavedChartVersionsTableName}.saved_query_id = ${SavedChartsTableName}.saved_query_id ORDER BY ${SavedChartVersionsTableName}.created_at DESC LIMIT 1) as chart_type`,
                 ),
                 `${PinnedListTableName}.pinned_list_uuid`,
                 `${PinnedChartTableName}.order`,
@@ -1210,7 +1315,7 @@ export class SpaceModel {
                 `${OrganizationTableName}.organization_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.name as dashboard_name`,
-                `saved_queries.slug`,
+                `${SavedChartsTableName}.slug`,
             ]);
 
         if (filters?.recentlyUpdated || filters?.mostPopular) {
@@ -1234,7 +1339,7 @@ export class SpaceModel {
         } else {
             spaceQueriesQuery = spaceQueriesQuery.orderBy([
                 {
-                    column: `saved_queries.last_version_updated_at`,
+                    column: `${SavedChartsTableName}.last_version_updated_at`,
                     order: 'desc',
                 },
             ]);
@@ -1301,37 +1406,43 @@ export class SpaceModel {
             Pick<SpaceSummary, 'isPrivate' | 'organizationUuid' | 'projectUuid'>
         >
     > {
-        const spaces = await this.database('spaces')
-            .innerJoin('projects', 'projects.project_id', 'spaces.project_id')
+        const spaces = await this.database(SpaceTableName)
             .innerJoin(
-                'organizations',
-                'organizations.organization_id',
-                'projects.organization_id',
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
             )
             .leftJoin(
-                'space_user_access',
-                'space_user_access.space_uuid',
-                'spaces.space_uuid',
+                SpaceUserAccessTableName,
+                `${SpaceUserAccessTableName}.space_uuid`,
+                `${SpaceTableName}.space_uuid`,
             )
             .leftJoin(
-                'users as shared_with',
-                'space_user_access.user_uuid',
-                'shared_with.user_uuid',
+                `${UserTableName} as shared_with`,
+                `${SpaceUserAccessTableName}.user_uuid`,
+                `shared_with.user_uuid`,
             )
-            .whereIn('spaces.space_uuid', spaceUuids)
+            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
             .select({
-                spaceUuid: 'spaces.space_uuid',
-                organizationUuid: 'organizations.organization_uuid',
-                projectUuid: 'projects.project_uuid',
-                isPrivate: this.database.raw('bool_or(spaces.is_private)'),
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                isPrivate: this.database.raw(
+                    SpaceModel.getRootSpaceIsPrivateQuery(),
+                ),
                 access: this.database.raw(
-                    "COALESCE(json_agg(shared_with.user_uuid) FILTER (WHERE shared_with.user_uuid IS NOT NULL), '[]')",
+                    SpaceModel.getRootSpaceAccessQuery('shared_with'),
                 ),
             })
             .groupBy(
-                'spaces.space_uuid',
-                'organizations.organization_uuid',
-                'projects.project_uuid',
+                `${SpaceTableName}.space_uuid`,
+                `${OrganizationTableName}.organization_uuid`,
+                `${ProjectTableName}.project_uuid`,
             );
 
         const spaceAccessMap = new Map();
@@ -1348,6 +1459,8 @@ export class SpaceModel {
 
     async getFullSpace(spaceUuid: string): Promise<Space> {
         const space = await this.get(spaceUuid);
+        const rootSpaceUuid = await this.getSpaceRoot(spaceUuid);
+        const spaceUuidToQueryForAccess = rootSpaceUuid ?? spaceUuid;
         return {
             organizationUuid: space.organizationUuid,
             name: space.name,
@@ -1359,9 +1472,12 @@ export class SpaceModel {
             queries: await this.getSpaceQueries([space.uuid]),
             dashboards: await this.getSpaceDashboards([space.uuid]),
             access:
-                (await this._getSpaceAccess([space.uuid]))[space.uuid] ?? [],
-            groupsAccess: await this._getGroupAccess(space.uuid),
+                (await this._getSpaceAccess([spaceUuidToQueryForAccess]))[
+                    spaceUuidToQueryForAccess
+                ] ?? [],
+            groupsAccess: await this._getGroupAccess(spaceUuidToQueryForAccess),
             slug: space.slug,
+            hasParent: space.hasParent,
         };
     }
 
@@ -1415,7 +1531,7 @@ export class SpaceModel {
         parentSpaceUuid: string | null = null,
     ): Promise<Space> {
         return this.database.transaction(async (trx) => {
-            const [project] = await trx('projects')
+            const [project] = await trx(ProjectTableName)
                 .select('project_id')
                 .where('project_uuid', projectUuid);
 
@@ -1527,5 +1643,50 @@ export class SpaceModel {
             .where('space_uuid', spaceUuid)
             .andWhere('group_uuid', groupUuid)
             .delete();
+    }
+
+    /**
+     * Gets the root space UUID for a given space UUID
+     *
+     * This method uses PostgreSQL's ltree extension to find the root space of a hierarchy.
+     * The spaces are stored in a tree structure where:
+     * - Root spaces have a path with a single level (e.g., "my-space")
+     * - Child spaces have paths that include their parent hierarchy (e.g., "my-space.my-child-space")
+     * @param spaceUuid Space UUID to get the root for
+     * @returns Root space UUID (or the same UUID if it's already a root or has no hierarchy)
+     */
+    async getSpaceRoot(spaceUuid: string): Promise<string | undefined> {
+        const result = await this.database(SpaceTableName)
+            .select<{ root_space_uuid: string; is_self_root: boolean }>(
+                this.database.raw(`
+                CASE 
+                    WHEN path IS NOT NULL THEN 
+                        (SELECT root_space.space_uuid 
+                        FROM spaces root_space 
+                        -- Using subpath(path, 0, 1) to extract the first element of the path
+                        -- This gets just the root part of the path
+                        WHERE subpath(root_space.path, 0, 1) = subpath(${SpaceTableName}.path, 0, 1)
+                        -- nlevel(path) = 1 finds only root nodes (first level in hierarchy)
+                        AND nlevel(root_space.path) = 1)
+                    ELSE space_uuid 
+                END as root_space_uuid,
+                -- Check if this space is its own root (either it's a root space or has no hierarchy)
+                CASE 
+                    WHEN path IS NOT NULL THEN 
+                        (nlevel(path) = 1 OR space_uuid = (
+                            SELECT root_space.space_uuid 
+                            FROM spaces root_space 
+                            WHERE subpath(root_space.path, 0, 1) = subpath(${SpaceTableName}.path, 0, 1)
+                            AND nlevel(root_space.path) = 1
+                        ))
+                    ELSE true
+                END as is_self_root
+            `),
+            )
+            .where('space_uuid', spaceUuid)
+            .first();
+
+        // Return undefined if the space is its own root
+        return result?.is_self_root ? undefined : result?.root_space_uuid;
     }
 }

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1365,6 +1365,46 @@ export class SpaceModel {
         };
     }
 
+    /**
+     * Generates a slug for a space.
+     * @param slug - The slug to generate.
+     * @param trx - The transaction to use.
+     * @param parentSpaceUuid - The uuid of the parent space.
+     * @returns The slug.
+     */
+    static async getSpaceSlug({
+        slug,
+        trx,
+        parentSpaceUuid,
+    }: {
+        slug: string;
+        trx: Knex;
+        parentSpaceUuid: string | null;
+    }) {
+        if (parentSpaceUuid) {
+            const [parentSpace] = await trx(SpaceTableName)
+                .select('slug')
+                .where('space_uuid', parentSpaceUuid);
+            if (!parentSpace) {
+                throw new NotFoundError(
+                    `Parent space with uuid ${parentSpaceUuid} does not exist`,
+                );
+            }
+            return `${parentSpace.slug}/${slug}`;
+        }
+
+        return generateUniqueSlug(trx, SpaceTableName, slug);
+    }
+
+    /**
+     * Converts a slug to a path of type ltree.
+     * @param slug - The slug to convert. eg. "my-space/my-sub-space"
+     * @returns The path. eg. "my-space.my-sub-space"
+     */
+    static async getSpacePath({ slug }: { slug: string }) {
+        return slug.replace(/\//g, '.');
+    }
+
     async createSpace(
         projectUuid: string,
         name: string,
@@ -1372,11 +1412,24 @@ export class SpaceModel {
         isPrivate: boolean,
         slug: string,
         forceSameSlug: boolean = false,
+        parentSpaceUuid: string | null = null,
     ): Promise<Space> {
         return this.database.transaction(async (trx) => {
             const [project] = await trx('projects')
                 .select('project_id')
                 .where('project_uuid', projectUuid);
+
+            const spaceSlug = forceSameSlug
+                ? slug
+                : await SpaceModel.getSpaceSlug({
+                      slug,
+                      parentSpaceUuid,
+                      trx,
+                  });
+
+            const spacePath = await SpaceModel.getSpacePath({
+                slug: spaceSlug,
+            });
 
             const [space] = await trx(SpaceTableName)
                 .insert({
@@ -1384,9 +1437,9 @@ export class SpaceModel {
                     is_private: isPrivate,
                     name,
                     created_by_user_id: userId,
-                    slug: forceSameSlug
-                        ? slug
-                        : await generateUniqueSlug(trx, SpaceTableName, slug),
+                    slug: spaceSlug,
+                    parent_space_uuid: parentSpaceUuid,
+                    path: spacePath,
                 })
                 .returning('*');
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -857,17 +857,22 @@ export class CoderService extends BaseService {
         }
 
         console.info(`Creating new public space with slug ${spaceSlug}`);
-        const newSpace = await this.spaceModel.createSpace(
+
+        const isNestedSpace = spaceSlug.includes('/');
+        const newSpace = await this.spaceModel.createSpaceWithAncestors({
+            isNestedSpace,
             projectUuid,
-            friendlyName(spaceSlug),
-            user.userId,
-            false,
-            spaceSlug,
-            true, // forceSameSlug
-        );
+            name: friendlyName(spaceSlug),
+            userId: user.userId,
+            isPrivate: false,
+            slug: spaceSlug,
+            forceSameSlug: true,
+        });
+
         return {
             space: {
                 ...newSpace,
+                parentSpaceUuid: null,
                 chartCount: 0,
                 dashboardCount: 0,
                 access: [],

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -54,6 +54,8 @@ export const space: SpaceTable['base'] = {
     project_id: 0,
     organization_uuid: user.organizationUuid!,
     search_vector: '',
+    parent_space_uuid: null,
+    path: 'space-name',
 };
 
 export const publicSpace: Space = {

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -64,6 +64,7 @@ export const promotedSpace: PromotedChart['space'] = {
     chartCount: 0,
     dashboardCount: 0,
     slug: 'jaffle-shop',
+    parentSpaceUuid: null,
 };
 
 export const upstreamSpace: UpstreamChart['space'] = {
@@ -78,6 +79,7 @@ export const upstreamSpace: UpstreamChart['space'] = {
     chartCount: 0,
     dashboardCount: 0,
     slug: 'jaffle-shop',
+    parentSpaceUuid: null,
 };
 
 export const upstreamFullSpace: Space = {

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -439,7 +439,11 @@ describe('PromoteService promoting and mutating changes', () => {
         expect(changes.dashboards.length).toBe(1);
         expect(changes.spaces[0].action).toBe('no changes');
 
-        const newChanges = await service.upsertSpaces(user, changes);
+        const newChanges = await service.upsertSpaces(
+            user,
+            promotedDashboard.projectUuid,
+            changes,
+        );
 
         expect(changes).toEqual(newChanges);
     });
@@ -462,7 +466,11 @@ describe('PromoteService promoting and mutating changes', () => {
             promotedDashboard.dashboard.spaceUuid,
         );
 
-        const newChanges = await service.upsertSpaces(user, changes);
+        const newChanges = await service.upsertSpaces(
+            user,
+            promotedDashboard.projectUuid,
+            changes,
+        );
 
         expect(spaceModel.createSpace).toHaveBeenCalledTimes(1);
         expect(spaceModel.addSpaceAccess).toHaveBeenCalledTimes(0);
@@ -511,7 +519,11 @@ describe('PromoteService promoting and mutating changes', () => {
         expect(changes.spaces[0].action).toBe('create');
         expect(changes.spaces[0].data.isPrivate).toBe(true);
 
-        await service.upsertSpaces(user, changes);
+        await service.upsertSpaces(
+            user,
+            promotedDashboardWithNewPrivateSpace.projectUuid,
+            changes,
+        );
 
         expect(spaceModel.createSpace).toHaveBeenCalledTimes(1);
         expect(spaceModel.createSpace).toHaveBeenCalledWith(
@@ -543,7 +555,11 @@ describe('PromoteService promoting and mutating changes', () => {
         expect(changes.spaces[0].action).toBe('update');
         expect(changes.spaces[0].data.isPrivate).toBe(false); // Existing space is not private, so it should be kept that way
 
-        await service.upsertSpaces(user, changes);
+        await service.upsertSpaces(
+            user,
+            promotedDashboardWithNewPrivateSpace.projectUuid,
+            changes,
+        );
 
         expect(spaceModel.update).toHaveBeenCalledTimes(1);
         expect(spaceModel.update).toHaveBeenCalledWith('upstream-space-uuid', {

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -33,10 +33,12 @@ const spaceModel = {
     find: jest.fn(async () => [existingUpstreamChart.space]),
     getUserSpaceAccess: jest.fn(async () => []),
     createSpace: jest.fn(async () => existingUpstreamChart.space),
+    createSpaceWithAncestors: jest.fn(async () => existingUpstreamChart.space),
     getFullSpace: jest.fn(async () => upstreamFullSpace),
     addSpaceAccess: jest.fn(async () => {}),
     addSpaceGroupAccess: jest.fn(async () => {}),
     update: jest.fn(async () => {}),
+    isRootSpace: jest.fn(async () => true),
 };
 const dashboardModel = {
     create: jest.fn(async () => existingUpstreamDashboard.dashboard),
@@ -472,7 +474,8 @@ describe('PromoteService promoting and mutating changes', () => {
             changes,
         );
 
-        expect(spaceModel.createSpace).toHaveBeenCalledTimes(1);
+        // expect(spaceModel.createSpace).toHaveBeenCalledTimes(1);
+        expect(spaceModel.createSpaceWithAncestors).toHaveBeenCalledTimes(1);
         expect(spaceModel.addSpaceAccess).toHaveBeenCalledTimes(0);
         expect(spaceModel.addSpaceGroupAccess).toHaveBeenCalledTimes(0);
 

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -860,9 +860,10 @@ export class PromoteService extends BaseService {
             .filter((change) => change.action === PromotionAction.CREATE)
             .map(async (spaceChange) => {
                 const { data: spaceChangeFromBase } = spaceChange;
-                const isNestedSpace = await this.spaceModel.isRootSpace(
+                const isRootSpace = await this.spaceModel.isRootSpace(
                     spaceChangeFromBase.uuid,
                 );
+                const isNestedSpace = !isRootSpace;
 
                 // Create the space (with ancestors if needed, skip existing spaces)
                 const space = await this.spaceModel.createSpaceWithAncestors({

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -41,6 +41,11 @@ describe('SpaceService', () => {
     });
 
     describe('_userCanActionSpace', () => {
+        beforeEach(() => {
+            jest.spyOn(SpaceModel.prototype, 'getSpaceRoot').mockImplementation(
+                async (spaceUuid) => spaceUuid,
+            );
+        });
         describe('organization admins', () => {
             it.each([
                 {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -205,6 +205,11 @@ export class SpaceService extends BaseService {
             user.userUuid,
             spaceUuid,
         );
+        // Nested Spaces MVP - disables nested spaces' access changes
+        const hasRootSpace = await this.spaceModel.getSpaceRoot(spaceUuid);
+        if (hasRootSpace && 'isPrivate' in updateSpace) {
+            throw new ForbiddenError(`Can't change privacy for a nested space`);
+        }
         if (
             user.ability.cannot(
                 'manage',
@@ -276,6 +281,13 @@ export class SpaceService extends BaseService {
             user.userUuid,
             spaceUuid,
         );
+        // Nested Spaces MVP - disables nested spaces' access changes
+        const hasRootSpace = await this.spaceModel.getSpaceRoot(spaceUuid);
+        if (hasRootSpace) {
+            throw new ForbiddenError(
+                `Can't change user access to a nested space`,
+            );
+        }
         if (
             user.ability.cannot(
                 'manage',
@@ -305,6 +317,13 @@ export class SpaceService extends BaseService {
             user.userUuid,
             spaceUuid,
         );
+        // Nested Spaces MVP - disables nested spaces' access changes
+        const hasRootSpace = await this.spaceModel.getSpaceRoot(spaceUuid);
+        if (hasRootSpace) {
+            throw new ForbiddenError(
+                `Can't change user access to a nested space`,
+            );
+        }
         if (
             user.ability.cannot(
                 'manage',
@@ -331,6 +350,13 @@ export class SpaceService extends BaseService {
             user.userUuid,
             spaceUuid,
         );
+        // Nested Spaces MVP - disables nested spaces' access changes
+        const hasRootSpace = await this.spaceModel.getSpaceRoot(spaceUuid);
+        if (hasRootSpace) {
+            throw new ForbiddenError(
+                `Can't change group access to a nested space`,
+            );
+        }
         if (
             user.ability.cannot(
                 'manage',
@@ -360,6 +386,13 @@ export class SpaceService extends BaseService {
             user.userUuid,
             spaceUuid,
         );
+        // Nested Spaces MVP - disables nested spaces' access changes
+        const hasRootSpace = await this.spaceModel.getSpaceRoot(spaceUuid);
+        if (hasRootSpace) {
+            throw new ForbiddenError(
+                `Can't change group access to a nested space`,
+            );
+        }
         if (
             user.ability.cannot(
                 'manage',

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -161,8 +161,11 @@ export class SpaceService extends BaseService {
             user.userId,
             space.isPrivate !== false,
             generateSlug(space.name),
+            false,
+            space.parentSpaceUuid,
         );
 
+        // Nested spaces MVP: Nested spaces inherit access from their root space, but don't need to have that access added to them explicitly
         if (space.access)
             await Promise.all(
                 space.access.map((access) =>

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -395,6 +395,23 @@ export const SEED_ORG_1_ADMIN_EMAIL = {
 export const SEED_ORG_1_ADMIN_PASSWORD = {
     password: 'demo_password!',
 };
+
+export const SEED_ORG_1_EDITOR = {
+    user_uuid: '80fb8b59-d6b7-4ed6-b969-9849310f3e53',
+    first_name: 'Editor',
+    last_name: 'User',
+    is_marketing_opted_in: true,
+    is_tracking_anonymized: false,
+    is_setup_complete: true,
+    is_active: true,
+};
+export const SEED_ORG_1_EDITOR_EMAIL = {
+    email: 'demo2@lightdash.com',
+    is_primary: true,
+};
+export const SEED_ORG_1_EDITOR_PASSWORD = {
+    password: 'demo_password!',
+};
 // Another user
 export const SEED_ORG_2 = {
     organization_uuid: '42339eef-359e-4ec4-b810-54ef0b4e3446',

--- a/packages/common/src/types/promotion.ts
+++ b/packages/common/src/types/promotion.ts
@@ -9,7 +9,10 @@ export enum PromotionAction {
     DELETE = 'delete',
 }
 
-export type PromotedSpace = Omit<SpaceSummary, 'userAccess'>;
+export type PromotedSpace = Omit<
+    SpaceSummary,
+    'userAccess' | 'parentSpaceUuid'
+>;
 export type PromotedDashboard = DashboardDAO & {
     spaceSlug: string;
 };

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -41,6 +41,7 @@ export type CreateSpace = {
     name: string;
     isPrivate?: boolean;
     access?: Pick<SpaceShare, 'userUuid' | 'role'>[];
+    parentSpaceUuid?: string;
 };
 
 export type UpdateSpace = {

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -18,6 +18,8 @@ export type Space = {
     pinnedListUuid: string | null;
     pinnedListOrder: number | null;
     slug: string;
+    // Nested Spaces MVP - disables nested spaces' access changes
+    hasParent?: boolean;
 };
 
 export type SpaceSummary = Pick<

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -37,6 +37,7 @@ export type SpaceSummary = Pick<
     access: string[];
     chartCount: number;
     dashboardCount: number;
+    parentSpaceUuid: string | null;
 };
 
 export type CreateSpace = {

--- a/packages/common/src/utils/slug.test.ts
+++ b/packages/common/src/utils/slug.test.ts
@@ -1,6 +1,7 @@
 import {
     generateSlug,
     getLabelFromSlug,
+    getLtreePathFromSlug,
     getParentSlug,
     getSlugsWithHierarchy,
 } from './slugs';
@@ -129,6 +130,48 @@ describe('Slug', () => {
             expect(
                 getLabelFromSlug('grandparent-space/parent-space/child-space'),
             ).toEqual('child-space');
+        });
+    });
+
+    describe('getLtreePathFromSlug', () => {
+        test('should convert simple slug to ltree path', () => {
+            expect(getLtreePathFromSlug('my-space')).toEqual('my_space');
+        });
+
+        test('should convert hierarchical slug to ltree path', () => {
+            expect(getLtreePathFromSlug('parent-space/child-space')).toEqual(
+                'parent_space.child_space',
+            );
+        });
+
+        test('should handle deeply nested slugs', () => {
+            expect(
+                getLtreePathFromSlug(
+                    'grandparent-space/parent-space/child-space',
+                ),
+            ).toEqual('grandparent_space.parent_space.child_space');
+        });
+
+        test('should remove non-alphanumeric characters except underscores', () => {
+            expect(getLtreePathFromSlug('my!space@name')).toEqual(
+                'my_space_name',
+            );
+            expect(getLtreePathFromSlug('my space name')).toEqual(
+                'my_space_name',
+            );
+            expect(getLtreePathFromSlug('my_space_name')).toEqual(
+                'my_space_name',
+            );
+        });
+
+        test('should handle mixed case slugs', () => {
+            expect(getLtreePathFromSlug('MySpace/ChildSpace')).toEqual(
+                'myspace.childspace',
+            );
+        });
+
+        test('should handle empty slug', () => {
+            expect(getLtreePathFromSlug('')).toEqual('');
         });
     });
 });

--- a/packages/common/src/utils/slug.test.ts
+++ b/packages/common/src/utils/slug.test.ts
@@ -1,4 +1,9 @@
-import { generateSlug } from './slugs';
+import {
+    generateSlug,
+    getLabelFromSlug,
+    getParentSlug,
+    getSlugsWithHierarchy,
+} from './slugs';
 
 describe('Slug', () => {
     test('should generate space slugs', async () => {
@@ -64,5 +69,66 @@ describe('Slug', () => {
 
         // Handle japanese characters
         expect(generateSlug('ライトダッシュ').length).toEqual(5);
+    });
+
+    describe('getSlugsWithHierarchy', () => {
+        test('should return array with single slug for non-hierarchical slug', () => {
+            expect(getSlugsWithHierarchy('my-space')).toEqual(['my-space']);
+        });
+
+        test('should return array with hierarchical slugs', () => {
+            expect(getSlugsWithHierarchy('parent-space/child-space')).toEqual([
+                'parent-space',
+                'parent-space/child-space',
+            ]);
+        });
+
+        test('should handle multiple levels of hierarchy', () => {
+            expect(
+                getSlugsWithHierarchy(
+                    'grandparent-space/parent-space/child-space',
+                ),
+            ).toEqual([
+                'grandparent-space',
+                'grandparent-space/parent-space',
+                'grandparent-space/parent-space/child-space',
+            ]);
+        });
+    });
+
+    describe('getParentSlug', () => {
+        test('should return empty string for non-hierarchical slug', () => {
+            expect(getParentSlug('my-space')).toEqual('');
+        });
+
+        test('should return parent slug for hierarchical slug', () => {
+            expect(getParentSlug('parent-space/child-space')).toEqual(
+                'parent-space',
+            );
+        });
+
+        test('should return parent path for deeply nested slug', () => {
+            expect(
+                getParentSlug('grandparent-space/parent-space/child-space'),
+            ).toEqual('grandparent-space/parent-space');
+        });
+    });
+
+    describe('getLabelFromSlug', () => {
+        test('should return same slug for non-hierarchical slug', () => {
+            expect(getLabelFromSlug('my-space')).toEqual('my-space');
+        });
+
+        test('should return last part of hierarchical slug', () => {
+            expect(getLabelFromSlug('parent-space/child-space')).toEqual(
+                'child-space',
+            );
+        });
+
+        test('should return last part of deeply nested slug', () => {
+            expect(
+                getLabelFromSlug('grandparent-space/parent-space/child-space'),
+            ).toEqual('child-space');
+        });
     });
 });

--- a/packages/common/src/utils/slugs.ts
+++ b/packages/common/src/utils/slugs.ts
@@ -17,3 +17,34 @@ export const generateSlug = (name: string) => {
     }
     return sanitizedSlug;
 };
+
+/**
+ * Get all slugs with hierarchy for a given slug
+ * For example, "parent-space/child-space" will return ["parent-space", "parent-space/child-space"]
+ * @param slug - The slug to get the hierarchy for
+ * @returns An array of slugs with hierarchy
+ */
+export const getSlugsWithHierarchy = (slug: string) =>
+    slug.split('/').reduce<string[]>((acc, s) => {
+        if (acc.length === 0) {
+            return [s];
+        }
+        return [...acc, `${acc[acc.length - 1]}/${s}`];
+    }, []);
+
+/**
+ * Get the parent slug from a slug with hierarchy
+ * For example, "parent-space/child-space" will return "parent-space"
+ * @param slug - The slug to get the parent slug from
+ * @returns The parent slug
+ */
+export const getParentSlug = (slug: string) =>
+    slug.split('/').slice(0, -1).join('/');
+
+/**
+ * Get the label from a slug with hierarchy
+ * For example, "parent-space/child-space" will return "child-space"
+ * @param slug - The slug to get the label from
+ * @returns The label
+ */
+export const getLabelFromSlug = (slug: string) => slug.split('/').pop() ?? slug;

--- a/packages/common/src/utils/slugs.ts
+++ b/packages/common/src/utils/slugs.ts
@@ -48,3 +48,17 @@ export const getParentSlug = (slug: string) =>
  * @returns The label
  */
 export const getLabelFromSlug = (slug: string) => slug.split('/').pop() ?? slug;
+
+/**
+ * Get the ltree path from a slug with hierarchy
+ * For example, "parent-space/child-space" will return "parent_space.child_space"
+ * Verifies that each slug is a valid PostgreSQL ltree label (A-Za-z0-9_)
+ * @param slug - The slug to get the ltree path from
+ * @returns The ltree path
+ */
+export const getLtreePathFromSlug = (slug: string) => {
+    const slugs = slug.split('/');
+    const sanitizedSlugs = slugs.map(sanitizeSlug);
+
+    return sanitizedSlugs.join('.').replace(/-/g, '_');
+};

--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -8,6 +8,7 @@ import {
     Stack,
     Text,
     Title,
+    Tooltip,
     useMantineTheme,
 } from '@mantine/core';
 import { IconFolderShare, IconLock, IconUsers } from '@tabler/icons-react';
@@ -40,21 +41,37 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
 
     return (
         <>
-            <Button
-                leftIcon={
-                    selectedAccess.value === SpaceAccessType.PRIVATE ? (
-                        <IconLock size={18} />
-                    ) : (
-                        <IconUsers size={18} />
-                    )
+            <Tooltip
+                multiline
+                maw={300}
+                disabled={!space.hasParent}
+                label={
+                    'This is a nested space. Access changes are not supported yet - they will be inherited from the root space'
                 }
-                onClick={() => {
-                    setIsOpen(true);
-                }}
-                variant="default"
+                variant="xs"
+                position="bottom"
             >
-                Share
-            </Button>
+                <Box>
+                    <Button
+                        leftIcon={
+                            selectedAccess.value === SpaceAccessType.PRIVATE ? (
+                                <IconLock size={18} />
+                            ) : (
+                                <IconUsers size={18} />
+                            )
+                        }
+                        onClick={() => {
+                            if (!space.hasParent) {
+                                setIsOpen(true);
+                            }
+                        }}
+                        disabled={space.hasParent}
+                        variant="default"
+                    >
+                        Share
+                    </Button>
+                </Box>
+            </Tooltip>
 
             <Modal
                 size="xl"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- Adds DB migration to support nested spaces

This PR adds 2 columns to `spaces` table
- `parent_space_uuid` that contains the direct parent of a space
- `path`, and `ltree` containing the hierarchy of spaces. `parent-slug.child-slug.grandchild-slug`


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
