### PR TITLE
fix: wait for all rows to be fetched before getting expected series map for cartesian

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
@@ -628,6 +628,7 @@ export const useCartesianChartConfigParamsMock = {
             tableCalculations: [],
             additionalMetrics: [],
         },
+        hasFetchedAllRows: true,
     },
     columnOrder: [
         'orders_customer_id',

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -846,7 +846,7 @@ const useCartesianChartConfig = ({
     );
     // Generate expected series
     useEffect(() => {
-        if (isCompleteLayout(dirtyLayout) && resultsData) {
+        if (isCompleteLayout(dirtyLayout) && resultsData?.hasFetchedAllRows) {
             setDirtyEchartsConfig((prev) => {
                 const defaultCartesianType =
                     prev?.series?.[0]?.type || CartesianSeriesType.BAR;


### PR DESCRIPTION
… map for cartesian

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14281 

Introduced by: https://github.com/lightdash/lightdash/pull/14166/files#diff-b03fcc24642214a50cfe6ba2a9b7033fa210d120b9ef872f3da83f325c0de636

### Description:

- `getExpectedSeriesMap` needs rows to exist to produce appropriate series for merging. Uses `hasFetchedAllRows` to run the logic

**Before**

https://github.com/user-attachments/assets/b71b1660-bc9f-4422-a2cd-0666c11ca91a

**After**

https://github.com/user-attachments/assets/8788a372-3a4b-4d7e-9e3b-4ee9c9f178f6



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
