### PR TITLE
fix: remove sorts from subtotals queries

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6047,6 +6047,7 @@ export class ProjectService extends BaseService {
                             ...subtotalDimensions,
                             ...(pivotDimensions || []), // we always need to include the pivot dimensions in the subtotal query
                         ],
+                        sorts: [],
                     });
                 } catch (e) {
                     this.logger.error(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- When running the subtotals queries on the backend we were still passing sorts, this meant that if we were sorting by the last dimension (which gets removed from the subtotal groups) the query would fail: see known limitations in: https://github.com/lightdash/lightdash/pull/13847

**Before**

![image](https://github.com/user-attachments/assets/5d560224-5a3a-4c1e-99cf-ad353554e55e)
![image](https://github.com/user-attachments/assets/984616ae-c995-4001-a2f2-f919989c438a)


**After**

![image](https://github.com/user-attachments/assets/c0896061-0674-4a27-b727-1a1b18ec4f35)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
