### PR TITLE
fix: wait for pagination feature flag to be fetched before running the hook

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -55,9 +55,11 @@ const getChartAndResults = async ({
 };
 
 const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
-    const { data: queryPaginationEnabled } = useFeatureFlag(
-        FeatureFlags.QueryPagination,
-    );
+    const {
+        data: queryPaginationEnabled,
+        isFetched: isQueryPaginationFetched,
+    } = useFeatureFlag(FeatureFlags.QueryPagination);
+
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const invalidateCache = useDashboardContext((c) => c.invalidateCache);
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
@@ -185,7 +187,7 @@ const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
                 ? queryKey.concat([granularity])
                 : queryKey,
         queryFn: fetchChartAndResults,
-        enabled: !!chartUuid && !!dashboardUuid,
+        enabled: !!chartUuid && !!dashboardUuid && isQueryPaginationFetched,
         retry: false,
         refetchOnMount: false,
     });


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/pull/14224, [Decrease amount of requests while waiting for paginated results](https://github.com/lightdash/lightdash/issues/14299)

### Description:

- While hook was loading, data from feature flag hook was undefined therefore it was requesting `chart-and-results`. When it was successful it changed the key and refetched using pagination query. Now it waits for it to be fetched (also works with errors, which will have fetched true and data: undefined)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
