### PR TITLE
fix: nested space promotions

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -860,9 +860,10 @@ export class PromoteService extends BaseService {
             .filter((change) => change.action === PromotionAction.CREATE)
             .map(async (spaceChange) => {
                 const { data: spaceChangeFromBase } = spaceChange;
-                const isNestedSpace = await this.spaceModel.isRootSpace(
+                const isRootSpace = await this.spaceModel.isRootSpace(
                     spaceChangeFromBase.uuid,
                 );
+                const isNestedSpace = !isRootSpace;
 
                 // Create the space (with ancestors if needed, skip existing spaces)
                 const space = await this.spaceModel.createSpaceWithAncestors({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
Fixes the bug with promoting charts in nested spaces leading to only the last space being created on top level

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
