### PR TITLE
fix: optimize query that counts charts per catalog field

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -801,7 +801,10 @@ export class CatalogService<
         catalogFieldMap: CatalogFieldMap,
     ) {
         const chartUsagesForFields =
-            await this.savedChartModel.getChartCountPerField(projectUuid);
+            await this.savedChartModel.getChartCountPerField(
+                projectUuid,
+                Object.keys(catalogFieldMap),
+            );
 
         const chartUsageUpdates = chartUsagesForFields
             .map<ChartUsageIn | undefined>(({ fieldId, count }) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#3142](https://github.com/lightdash/lightdash-internal-work/issues/3142)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Optimize query that counts charts for each catalog field:
- remove unnecessary joins
- remove seq scans
- filter by fields available in the catalog

Before:

<img width="1342" alt="Screenshot 2025-04-10 at 15 06 46" src="https://github.com/user-attachments/assets/fd6b9b9a-c82f-4362-8534-20220f2e949a" />

After:

<img width="939" alt="Screenshot 2025-04-10 at 15 19 15" src="https://github.com/user-attachments/assets/0fafd481-3a3d-4b79-b776-9f7ee63d338f" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
