### PR TITLE
feat: add updated_at column to results cache and return in cache metadata

### DIFF
--- a/packages/backend/src/database/entities/resultsCache.ts
+++ b/packages/backend/src/database/entities/resultsCache.ts
@@ -3,17 +3,24 @@ import { Knex } from 'knex';
 export type DbResultsCache = {
     cache_key: string;
     project_uuid: string;
+    created_at: Date;
+    updated_at: Date;
     expires_at: Date;
     total_row_count: number | null;
 };
 
+export type DbResultsCacheIn = Omit<
+    DbResultsCache,
+    'created_at' | 'updated_at'
+>;
+
 export type DbResultsCacheUpdate =
     | Pick<DbResultsCache, 'total_row_count'>
-    | Pick<DbResultsCache, 'expires_at'>;
+    | Pick<DbResultsCache, 'expires_at' | 'updated_at'>;
 
 export type ResultsCacheTable = Knex.CompositeTableType<
     DbResultsCache,
-    DbResultsCache,
+    DbResultsCacheIn,
     DbResultsCacheUpdate
 >;
 

--- a/packages/backend/src/database/migrations/20250411110948_add_updated_at_column_to_results_cache.ts
+++ b/packages/backend/src/database/migrations/20250411110948_add_updated_at_column_to_results_cache.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const RESULTS_CACHE_TABLE = 'results_cache';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(RESULTS_CACHE_TABLE, (table) => {
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(RESULTS_CACHE_TABLE, (table) => {
+        table.dropColumn('updated_at');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10375,7 +10375,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10385,7 +10385,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10395,7 +10395,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10408,7 +10408,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -14310,6 +14310,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                cacheMetadata: { ref: 'CacheMetadata', required: true },
                 appliedDashboardFilters: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3844,6 +3844,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 cacheHit: { dataType: 'boolean', required: true },
+                cacheExpiresAt: { dataType: 'datetime' },
                 cacheUpdatedTime: { dataType: 'datetime' },
             },
             validators: {},

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11157,22 +11157,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15124,6 +15124,9 @@
             },
             "ApiExecuteAsyncQueryResults": {
                 "properties": {
+                    "cacheMetadata": {
+                        "$ref": "#/components/schemas/CacheMetadata"
+                    },
                     "appliedDashboardFilters": {
                         "allOf": [
                             {
@@ -15136,7 +15139,11 @@
                         "type": "string"
                     }
                 },
-                "required": ["appliedDashboardFilters", "queryUuid"],
+                "required": [
+                    "cacheMetadata",
+                    "appliedDashboardFilters",
+                    "queryUuid"
+                ],
                 "type": "object"
             },
             "ApiExecuteAsyncQueryResponse": {
@@ -15793,7 +15800,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1567.6",
+        "version": "0.1568.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4281,6 +4281,10 @@
                     "cacheHit": {
                         "type": "boolean"
                     },
+                    "cacheExpiresAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
                     "cacheUpdatedTime": {
                         "type": "string",
                         "format": "date-time"

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
@@ -138,6 +138,7 @@ describe('ResultsCacheModel', () => {
                 totalRowCount: 100,
                 createdAt: futureDateCreatedAt,
                 updatedAt: futureDateCreatedAt,
+                expiresAt: futureDate,
             });
             expect(tracker.history.select).toHaveLength(1);
             expect(mockStorageClient.createUploadStream).not.toHaveBeenCalled();
@@ -146,9 +147,14 @@ describe('ResultsCacheModel', () => {
         test('should create new cache when no existing cache exists', async () => {
             tracker.on.select('results_cache').response([]);
 
-            tracker.on
-                .insert('results_cache')
-                .response([{ cache_key: cacheKey }]);
+            tracker.on.insert('results_cache').response([
+                {
+                    cache_key: cacheKey,
+                    expires_at: futureDate,
+                    created_at: futureDateCreatedAt,
+                    updated_at: futureDateCreatedAt,
+                },
+            ]);
 
             const result = await model.createOrGetExistingCache(
                 projectUuid,
@@ -163,6 +169,9 @@ describe('ResultsCacheModel', () => {
                 write: expect.any(Function),
                 close: expect.any(Function),
                 totalRowCount: null,
+                createdAt: futureDateCreatedAt,
+                updatedAt: futureDateCreatedAt,
+                expiresAt: futureDate,
             });
             expect(tracker.history.select).toHaveLength(1);
             expect(tracker.history.insert).toHaveLength(1);
@@ -201,10 +210,12 @@ describe('ResultsCacheModel', () => {
                 totalRowCount: null,
                 createdAt: pastDateCreatedAt,
                 updatedAt: expect.any(Date),
+                expiresAt: expect.any(Date),
             });
             expect(result.updatedAt.getTime()).toBeGreaterThan(
                 pastDateCreatedAt.getTime(),
             );
+            expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
             expect(tracker.history.select).toHaveLength(1);
             expect(tracker.history.update).toHaveLength(1);
             expect(tracker.history.update[0].bindings).toEqual([
@@ -248,10 +259,12 @@ describe('ResultsCacheModel', () => {
                 totalRowCount: null,
                 createdAt: futureDateCreatedAt,
                 updatedAt: expect.any(Date),
+                expiresAt: expect.any(Date),
             });
             expect(result.updatedAt.getTime()).toBeGreaterThan(
                 futureDateCreatedAt.getTime(),
             );
+            expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
             expect(tracker.history.select).toHaveLength(1);
             expect(tracker.history.update).toHaveLength(1);
             expect(tracker.history.update[0].bindings).toEqual([

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
@@ -80,6 +80,7 @@ export class ResultsCacheModel {
                 cacheKey: existingCache.cache_key,
                 createdAt: existingCache.created_at,
                 updatedAt: existingCache.updated_at,
+                expiresAt: existingCache.expires_at,
                 cacheHit: true,
                 write: undefined,
                 close: undefined,
@@ -108,6 +109,7 @@ export class ResultsCacheModel {
                 cacheKey: existingCache.cache_key,
                 createdAt: existingCache.created_at,
                 updatedAt: now,
+                expiresAt: newExpiresAt,
                 cacheHit: false,
                 write,
                 close,
@@ -123,7 +125,7 @@ export class ResultsCacheModel {
                 expires_at: newExpiresAt,
                 total_row_count: null,
             })
-            .returning(['cache_key', 'created_at', 'updated_at']);
+            .returning(['cache_key', 'created_at', 'updated_at', 'expires_at']);
 
         if (!createdCache) {
             await close();
@@ -134,6 +136,7 @@ export class ResultsCacheModel {
             cacheKey: createdCache.cache_key,
             createdAt: createdCache.created_at,
             updatedAt: createdCache.updated_at,
+            expiresAt: createdCache.expires_at,
             write,
             close,
             cacheHit: false,

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
@@ -45,9 +45,9 @@ export class ResultsCacheModel {
         return crypto.createHash('sha256').update(queryHashKey).digest('hex');
     }
 
-    private getCacheExpiresAt() {
+    private getCacheUpdatedAt(baseDate: Date) {
         return new Date(
-            Date.now() +
+            baseDate.getTime() +
                 this.lightdashConfig.resultsCache.cacheStateTimeSeconds * 1000,
         );
     }
@@ -78,6 +78,8 @@ export class ResultsCacheModel {
         ) {
             return {
                 cacheKey: existingCache.cache_key,
+                createdAt: existingCache.created_at,
+                updatedAt: existingCache.updated_at,
                 cacheHit: true,
                 write: undefined,
                 close: undefined,
@@ -91,15 +93,21 @@ export class ResultsCacheModel {
             DEFAULT_RESULTS_PAGE_SIZE,
         );
 
+        const now = new Date();
+        const newExpiresAt = this.getCacheUpdatedAt(now);
+
         // Case 2: Cache exists but is invalid or being invalidated
         if (existingCache) {
             // Update expiration time
             await this.update(existingCache.cache_key, projectUuid, {
-                expires_at: this.getCacheExpiresAt(),
+                expires_at: newExpiresAt,
+                updated_at: now,
             });
 
             return {
                 cacheKey: existingCache.cache_key,
+                createdAt: existingCache.created_at,
+                updatedAt: now,
                 cacheHit: false,
                 write,
                 close,
@@ -112,10 +120,10 @@ export class ResultsCacheModel {
             .insert({
                 cache_key: cacheKey,
                 project_uuid: projectUuid,
-                expires_at: this.getCacheExpiresAt(),
+                expires_at: newExpiresAt,
                 total_row_count: null,
             })
-            .returning('cache_key');
+            .returning(['cache_key', 'created_at', 'updated_at']);
 
         if (!createdCache) {
             await close();
@@ -124,6 +132,8 @@ export class ResultsCacheModel {
 
         return {
             cacheKey: createdCache.cache_key,
+            createdAt: createdCache.created_at,
+            updatedAt: createdCache.updated_at,
             write,
             close,
             cacheHit: false,

--- a/packages/backend/src/models/ResultsCacheModel/types.ts
+++ b/packages/backend/src/models/ResultsCacheModel/types.ts
@@ -4,6 +4,8 @@ export type CacheHitCacheResult = {
     close: undefined;
     cacheHit: true;
     totalRowCount: number;
+    createdAt: Date;
+    updatedAt: Date;
 };
 
 export type MissCacheResult = {
@@ -12,6 +14,8 @@ export type MissCacheResult = {
     close: () => Promise<void>;
     cacheHit: false;
     totalRowCount: null;
+    createdAt: Date;
+    updatedAt: Date;
 };
 
 export type CreateCacheResult = CacheHitCacheResult | MissCacheResult;

--- a/packages/backend/src/models/ResultsCacheModel/types.ts
+++ b/packages/backend/src/models/ResultsCacheModel/types.ts
@@ -6,6 +6,7 @@ export type CacheHitCacheResult = {
     totalRowCount: number;
     createdAt: Date;
     updatedAt: Date;
+    expiresAt: Date;
 };
 
 export type MissCacheResult = {
@@ -16,6 +17,7 @@ export type MissCacheResult = {
     totalRowCount: null;
     createdAt: Date;
     updatedAt: Date;
+    expiresAt: Date;
 };
 
 export type CreateCacheResult = CacheHitCacheResult | MissCacheResult;

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -500,12 +500,16 @@ describe('ProjectService', () => {
                 // Mock the resultsCacheModel to return a cache hit
                 const createdAt = new Date();
                 const updatedAt = new Date();
+                const expiresAt = new Date(
+                    createdAt.getTime() + 1000 * 60 * 60 * 24,
+                );
                 const mockCacheResult: CacheHitCacheResult = {
                     cacheHit: true,
                     cacheKey: 'test-cache-key',
                     totalRowCount: 10,
                     createdAt,
                     updatedAt,
+                    expiresAt,
                     write: undefined,
                     close: undefined,
                 };
@@ -549,6 +553,7 @@ describe('ProjectService', () => {
                     cacheMetadata: {
                         cacheHit: true,
                         cacheUpdatedTime: updatedAt,
+                        cacheExpiresAt: expiresAt,
                     },
                 } satisfies ExecuteAsyncQueryReturn);
 
@@ -577,6 +582,9 @@ describe('ProjectService', () => {
                 // Mock the resultsCacheModel to return a cache miss
                 const createdAt = new Date();
                 const updatedAt = new Date();
+                const expiresAt = new Date(
+                    createdAt.getTime() + 1000 * 60 * 60 * 24,
+                );
                 const mockCacheResult: MissCacheResult = {
                     cacheHit: false,
                     cacheKey: 'test-cache-key',
@@ -584,6 +592,7 @@ describe('ProjectService', () => {
                     close,
                     createdAt,
                     updatedAt,
+                    expiresAt,
                     totalRowCount: null,
                 };
 
@@ -626,6 +635,7 @@ describe('ProjectService', () => {
                     cacheMetadata: {
                         cacheHit: false,
                         cacheUpdatedTime: updatedAt,
+                        cacheExpiresAt: expiresAt,
                     },
                 } satisfies ExecuteAsyncQueryReturn);
 
@@ -787,6 +797,7 @@ describe('ProjectService', () => {
                     cacheMetadata: {
                         cacheHit: false,
                         cacheUpdatedTime: undefined,
+                        cacheExpiresAt: undefined,
                     },
                 } satisfies ExecuteAsyncQueryReturn);
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -33,6 +33,10 @@ import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel';
 import type { ResultsCacheModel } from '../../models/ResultsCacheModel/ResultsCacheModel';
+import type {
+    CacheHitCacheResult,
+    MissCacheResult,
+} from '../../models/ResultsCacheModel/types';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SshKeyPairModel } from '../../models/SshKeyPairModel';
@@ -70,6 +74,7 @@ import {
     user,
     validExplore,
 } from './ProjectService.mock';
+import type { ExecuteAsyncQueryReturn } from './types';
 
 jest.mock('@lightdash/warehouses', () => ({
     SshTunnel: jest.fn(() => ({
@@ -493,10 +498,16 @@ describe('ProjectService', () => {
 
             test('should return queryUuid when cache is hit', async () => {
                 // Mock the resultsCacheModel to return a cache hit
-                const mockCacheResult = {
+                const createdAt = new Date();
+                const updatedAt = new Date();
+                const mockCacheResult: CacheHitCacheResult = {
                     cacheHit: true,
                     cacheKey: 'test-cache-key',
                     totalRowCount: 10,
+                    createdAt,
+                    updatedAt,
+                    write: undefined,
+                    close: undefined,
                 };
 
                 (
@@ -535,7 +546,11 @@ describe('ProjectService', () => {
 
                 expect(result).toEqual({
                     queryUuid: 'test-query-uuid',
-                });
+                    cacheMetadata: {
+                        cacheHit: true,
+                        cacheUpdatedTime: updatedAt,
+                    },
+                } satisfies ExecuteAsyncQueryReturn);
 
                 // Verify that the query history was updated with READY status
                 expect(
@@ -560,11 +575,16 @@ describe('ProjectService', () => {
 
             test('should trigger background query when cache is not hit', async () => {
                 // Mock the resultsCacheModel to return a cache miss
-                const mockCacheResult = {
+                const createdAt = new Date();
+                const updatedAt = new Date();
+                const mockCacheResult: MissCacheResult = {
                     cacheHit: false,
                     cacheKey: 'test-cache-key',
                     write,
                     close,
+                    createdAt,
+                    updatedAt,
+                    totalRowCount: null,
                 };
 
                 (
@@ -603,7 +623,11 @@ describe('ProjectService', () => {
 
                 expect(result).toEqual({
                     queryUuid: 'test-query-uuid',
-                });
+                    cacheMetadata: {
+                        cacheHit: false,
+                        cacheUpdatedTime: updatedAt,
+                    },
+                } satisfies ExecuteAsyncQueryReturn);
 
                 // Verify that the query history was not updated with READY status
                 expect(
@@ -760,7 +784,11 @@ describe('ProjectService', () => {
 
                 expect(result).toEqual({
                     queryUuid: 'test-query-uuid',
-                });
+                    cacheMetadata: {
+                        cacheHit: false,
+                        cacheUpdatedTime: undefined,
+                    },
+                } satisfies ExecuteAsyncQueryReturn);
 
                 // Verify that resultsCacheModel.createOrGetExistingCache was not called
                 expect(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2544,6 +2544,7 @@ export class ProjectService extends BaseService {
                             cacheMetadata: {
                                 cacheHit: resultsCache.cacheHit,
                                 cacheUpdatedTime: resultsCache.updatedAt,
+                                cacheExpiresAt: resultsCache.expiresAt,
                             },
                         } satisfies ExecuteAsyncQueryReturn;
                     }
@@ -2567,6 +2568,7 @@ export class ProjectService extends BaseService {
                         cacheMetadata: {
                             cacheHit: resultsCache?.cacheHit || false,
                             cacheUpdatedTime: resultsCache?.updatedAt,
+                            cacheExpiresAt: resultsCache?.expiresAt,
                         },
                     } satisfies ExecuteAsyncQueryReturn;
                 } catch (e) {

--- a/packages/backend/src/services/ProjectService/types.ts
+++ b/packages/backend/src/services/ProjectService/types.ts
@@ -1,5 +1,6 @@
 import {
     MetricQuery,
+    type CacheMetadata,
     type DashboardFilters,
     type DateGranularity,
     type Filters,
@@ -46,4 +47,9 @@ export type ExecuteAsyncUnderlyingDataQueryArgs = CommonAsyncQueryArgs & {
     underlyingDataSourceQueryUuid: string;
     filters: Filters;
     underlyingDataItemId?: string;
+};
+
+export type ExecuteAsyncQueryReturn = {
+    queryUuid: string;
+    cacheMetadata: CacheMetadata;
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -475,6 +475,7 @@ export type ApiQueryResults = {
 export type ApiExecuteAsyncQueryResults = {
     queryUuid: string;
     appliedDashboardFilters: DashboardFilters | null;
+    cacheMetadata: CacheMetadata;
 };
 
 export type ReadyQueryResultsPage = ResultsPaginationMetadata<ResultRow> & {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -462,6 +462,7 @@ export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 
 export type CacheMetadata = {
     cacheUpdatedTime?: Date;
+    cacheExpiresAt?: Date;
     cacheHit: boolean;
 };
 

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -47,12 +47,13 @@ export const getQueryPaginatedResults = async (
         appliedDashboardFilters: DashboardFilters | null;
     }
 > => {
-    const firstPage = await lightdashApi<ApiExecuteAsyncQueryResults>({
-        url: `/projects/${projectUuid}/query`,
-        version: 'v2',
-        method: 'POST',
-        body: JSON.stringify(data),
-    });
+    const executeQueryResponse =
+        await lightdashApi<ApiExecuteAsyncQueryResults>({
+            url: `/projects/${projectUuid}/query`,
+            version: 'v2',
+            method: 'POST',
+            body: JSON.stringify(data),
+        });
 
     // Get all page rows in sequence
     let allRows: ResultRow[] = [];
@@ -80,9 +81,9 @@ export const getQueryPaginatedResults = async (
 
         const urlQueryParams = searchParams.toString();
         currentPage = await lightdashApi<ApiGetAsyncQueryResults>({
-            url: `/projects/${projectUuid}/query/${firstPage.queryUuid}${
-                urlQueryParams ? `?${urlQueryParams}` : ''
-            }`,
+            url: `/projects/${projectUuid}/query/${
+                executeQueryResponse.queryUuid
+            }${urlQueryParams ? `?${urlQueryParams}` : ''}`,
             version: 'v2',
             method: 'GET',
             body: undefined,
@@ -129,13 +130,10 @@ export const getQueryPaginatedResults = async (
     return {
         queryUuid: currentPage.queryUuid,
         metricQuery: currentPage.metricQuery,
-        cacheMetadata: {
-            // todo: to be replaced once we have save query metadata in the DB
-            cacheHit: false,
-        },
+        cacheMetadata: executeQueryResponse.cacheMetadata,
         rows: allRows,
         fields: currentPage.fields,
-        appliedDashboardFilters: firstPage.appliedDashboardFilters,
+        appliedDashboardFilters: executeQueryResponse.appliedDashboardFilters,
     };
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14375](https://github.com/lightdash/lightdash/issues/14375)

### Description:

- Adds `updated_at` column to `results_cache` table
- Returns cache metadata in `executeAsyncQuery`


https://github.com/user-attachments/assets/e4381746-28ef-4eb8-aa08-c81de300faa9



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
