### PR TITLE
chore: prometheus metrics for database

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -241,6 +241,7 @@ export default class App {
 
     async start() {
         this.prometheusMetrics.start();
+        this.prometheusMetrics.monitorDatabase(this.database);
         // @ts-ignore
         // eslint-disable-next-line no-extend-native, func-names
         BigInt.prototype.toJSON = function () {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -86,6 +86,8 @@ export default class SchedulerApp {
 
     private readonly models: ModelRepository;
 
+    private readonly database: Knex;
+
     private readonly schedulerWorkerFactory: typeof schedulerWorkerFactory;
 
     constructor(args: SchedulerAppArguments) {
@@ -105,7 +107,7 @@ export default class SchedulerApp {
             },
         });
 
-        const database = knex(
+        this.database = knex(
             this.environment === 'production'
                 ? args.knexConfig.production
                 : args.knexConfig.development,
@@ -118,7 +120,7 @@ export default class SchedulerApp {
         this.models = new ModelRepository({
             modelProviders: args.modelProviders,
             lightdashConfig: this.lightdashConfig,
-            database,
+            database: this.database,
             utils,
         });
 
@@ -152,6 +154,7 @@ export default class SchedulerApp {
 
     public async start() {
         this.prometheusMetrics.start();
+        this.prometheusMetrics.monitorDatabase(this.database);
         // @ts-ignore
         // eslint-disable-next-line no-extend-native, func-names
         BigInt.prototype.toJSON = function () {

--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -1,5 +1,7 @@
+import { AnyType } from '@lightdash/common';
 import express from 'express';
 import http from 'http';
+import { Knex } from 'knex';
 import { performance } from 'perf_hooks';
 import prometheus from 'prom-client';
 import { LightdashConfig } from './config/parseConfig';
@@ -47,6 +49,145 @@ export default class PrometheusMetrics {
             } catch (e) {
                 Logger.error('Error starting prometheus metrics', e);
             }
+        }
+    }
+
+    public monitorDatabase(knex: Knex) {
+        const { enabled, ...rest } = this.config;
+        if (!enabled) {
+            return;
+        }
+
+        // Initialize database metrics
+        const pgPoolMaxSize = new prometheus.Gauge({
+            name: 'pg_pool_max_size',
+            help: 'Max size of the PG pool',
+            ...rest,
+        });
+
+        const pgPoolSize = new prometheus.Gauge({
+            name: 'pg_pool_size',
+            help: 'Current size of the PG pool',
+            ...rest,
+        });
+
+        const pgActiveConnections = new prometheus.Gauge({
+            name: 'pg_active_connections',
+            help: 'Number of active connections in the PG pool',
+            ...rest,
+        });
+
+        const pgIdleConnections = new prometheus.Gauge({
+            name: 'pg_idle_connections',
+            help: 'Number of idle connections in the PG pool',
+            ...rest,
+        });
+
+        const pgQueuedQueries = new prometheus.Gauge({
+            name: 'pg_queued_queries',
+            help: 'Number of queries waiting in the PG pool queue',
+            ...rest,
+        });
+
+        const pgConnectionAcquireTime = new prometheus.Histogram({
+            name: 'pg_connection_acquire_time',
+            help: 'Time to acquire a connection from the PG pool (ms)',
+            buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000],
+            ...rest,
+        });
+
+        const pgQueryDurationHistogram = new prometheus.Histogram({
+            name: 'pg_query_duration',
+            help: 'Histogram of PG query execution time (ms)',
+            buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000],
+            ...rest,
+        });
+
+        // Update metrics on pool events
+        function updatePoolMetrics(pool: AnyType): void {
+            try {
+                if (pool) {
+                    pgPoolMaxSize.set(pool.max);
+                    pgPoolSize.set(pool.numUsed() + pool.numFree());
+                    pgIdleConnections.set(pool.numFree());
+                    pgActiveConnections.set(pool.numUsed());
+                    pgQueuedQueries.set(pool.numPendingAcquires());
+                }
+            } catch (e) {
+                console.warn(`Error updating PG prometheus metrics`, e);
+            }
+        }
+
+        // Create a Map to store query start times
+        const queryTimings = new Map<string, number>();
+
+        knex.on('query', (query) => {
+            // Store starting time to query so we can calculate duration in 'query-response' event
+            if (query.__knexQueryUid) {
+                queryTimings.set(query.__knexQueryUid, Date.now());
+            }
+        });
+
+        // Calculate query duration and cleanup
+        knex.on(
+            'query-response',
+            (_response, query, queryBuilder: Knex.QueryBuilder) => {
+                try {
+                    if (query.__knexQueryUid) {
+                        const startTime = queryTimings.get(
+                            query.__knexQueryUid,
+                        );
+                        if (startTime) {
+                            pgQueryDurationHistogram.observe(
+                                Date.now() - startTime,
+                            );
+                            // Clean up the timing entry
+                            queryTimings.delete(query.__knexQueryUid);
+                        }
+                    }
+
+                    updatePoolMetrics(queryBuilder.client.pool);
+                } catch (e) {
+                    console.warn(
+                        `Error on PG event listener 'query-response'`,
+                        e,
+                    );
+                }
+            },
+        );
+
+        // Clean up on query-error
+        knex.on('query-error', (_error, query) => {
+            if (query.__knexQueryUid) {
+                queryTimings.delete(query.__knexQueryUid);
+            }
+        });
+
+        // Create a Map to store acquire start times
+        const poolWaitTimes = new Map<number, number>();
+        const pool = knex.client.pool as AnyType;
+        if (pool) {
+            pool.on('connect', () => {
+                updatePoolMetrics(pool);
+            });
+            pool.on('release', () => {
+                updatePoolMetrics(pool);
+            });
+            pool.on('acquireRequest', (eventId: number) => {
+                poolWaitTimes.set(eventId, Date.now());
+                updatePoolMetrics(pool);
+            });
+            pool.on('acquireSuccess', (eventId: number) => {
+                const startTime = poolWaitTimes.get(eventId);
+                if (startTime) {
+                    pgConnectionAcquireTime.observe(Date.now() - startTime);
+                    poolWaitTimes.delete(eventId); // Clean up
+                }
+                updatePoolMetrics(pool);
+            });
+            pool.on('acquireFail', (eventId: number) => {
+                poolWaitTimes.delete(eventId);
+            });
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [#14373](https://github.com/lightdash/lightdash/issues/14373)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add prometheus metrics for database. Helps track if there is a bottleneck in the database connections.

Metrics example:
```
# HELP pg_pool_max_size Max size of the PG pool
# TYPE pg_pool_max_size gauge
pg_pool_max_size 10

# HELP pg_pool_size Current size of the PG pool
# TYPE pg_pool_size gauge
pg_pool_size 10

# HELP pg_active_connections Number of active connections in the PG pool
# TYPE pg_active_connections gauge
pg_active_connections 1

# HELP pg_idle_connections Number of idle connections in the PG pool
# TYPE pg_idle_connections gauge
pg_idle_connections 9

# HELP pg_queued_queries Number of queries waiting in the PG pool queue
# TYPE pg_queued_queries gauge
pg_queued_queries 0

# HELP pg_connection_acquire_time Time to acquire a connection from the PG pool (ms)
# TYPE pg_connection_acquire_time histogram
pg_connection_acquire_time_bucket{le="1"} 552
pg_connection_acquire_time_bucket{le="5"} 621
pg_connection_acquire_time_bucket{le="10"} 631
pg_connection_acquire_time_bucket{le="25"} 634
pg_connection_acquire_time_bucket{le="50"} 634
pg_connection_acquire_time_bucket{le="100"} 635
pg_connection_acquire_time_bucket{le="250"} 635
pg_connection_acquire_time_bucket{le="500"} 635
pg_connection_acquire_time_bucket{le="1000"} 635
pg_connection_acquire_time_bucket{le="2500"} 635
pg_connection_acquire_time_bucket{le="5000"} 635
pg_connection_acquire_time_bucket{le="+Inf"} 635
pg_connection_acquire_time_sum 475
pg_connection_acquire_time_count 635

# HELP pg_query_duration Histogram of PG query execution time (ms)
# TYPE pg_query_duration histogram
pg_query_duration_bucket{le="1"} 235
pg_query_duration_bucket{le="5"} 573
pg_query_duration_bucket{le="10"} 626
pg_query_duration_bucket{le="25"} 641
pg_query_duration_bucket{le="50"} 642
pg_query_duration_bucket{le="100"} 642
pg_query_duration_bucket{le="250"} 642
pg_query_duration_bucket{le="500"} 642
pg_query_duration_bucket{le="1000"} 642
pg_query_duration_bucket{le="2500"} 642
pg_query_duration_bucket{le="5000"} 642
pg_query_duration_bucket{le="+Inf"} 642
pg_query_duration_sum 1817
pg_query_duration_count 642
```


Example number of pending queries and time spend in queue:
<img width="571" alt="Screenshot 2025-04-11 at 13 51 44" src="https://github.com/user-attachments/assets/bfde26e6-dc49-41b7-84c1-4c3ef612446e" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
