### PR TITLE
feat: show tile query execution timing

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -56,6 +56,11 @@ export enum FeatureFlags {
      * Enable a new API endpoint that requests results page by page.
      */
     QueryPagination = 'query-pagination',
+
+    /**
+     * Enable the ability to show the warehouse execution time and total time in the chart tile.
+     */
+    ShowExecutionTime = 'show-execution-time',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1302,6 +1302,7 @@ export const GenericDashboardChartTile: FC<
             | (ApiChartAndResults & {
                   queryUuid?: string;
                   warehouseExecutionTimeMs?: number;
+                  totalTimeMs?: number;
               })
             | undefined;
         error: ApiError | null;

--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -190,7 +190,14 @@ const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
         return prev;
     });
 
-    return useQuery<ApiChartAndResults & { queryUuid?: string }, ApiError>({
+    return useQuery<
+        ApiChartAndResults & {
+            queryUuid?: string;
+            warehouseExecutionTimeMs?: number;
+            totalTimeMs?: number;
+        },
+        ApiError
+    >({
         queryKey:
             hasADateDimension && granularity
                 ? queryKey.concat([granularity])

--- a/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChart.ts
@@ -111,7 +111,13 @@ const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
         !!apiChartAndResults?.metricQuery?.metadata?.hasADateDimension;
 
     const fetchChartAndResults = useCallback<
-        () => Promise<ApiChartAndResults & { queryUuid?: string }>
+        () => Promise<
+            ApiChartAndResults & {
+                queryUuid?: string;
+                warehouseExecutionTimeMs?: number;
+                totalTimeMs?: number;
+            }
+        >
     >(async () => {
         if (queryPaginationEnabled?.enabled) {
             const chart = await getSavedQuery(chartUuid!);
@@ -147,6 +153,8 @@ const useDashboardChart = (tileUuid: string, chartUuid: string | null) => {
                 rows: results.rows,
                 fields: results.fields,
                 queryUuid: results.queryUuid,
+                warehouseExecutionTimeMs: results.warehouseExecutionTimeMs,
+                totalTimeMs: results.totalTimeMs,
             };
         }
         return getChartAndResults({

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -45,8 +45,12 @@ export const getQueryPaginatedResults = async (
     ApiQueryResults & {
         queryUuid: string;
         appliedDashboardFilters: DashboardFilters | null;
+        warehouseExecutionTimeMs?: number;
+        totalTimeMs?: number;
     }
 > => {
+    const startTime = new Date();
+
     const firstPage = await lightdashApi<ApiExecuteAsyncQueryResults>({
         url: `/projects/${projectUuid}/query`,
         version: 'v2',
@@ -126,6 +130,9 @@ export const getQueryPaginatedResults = async (
         }
     }
 
+    const endTime = new Date();
+    const totalTime = endTime.getTime() - startTime.getTime();
+
     return {
         queryUuid: currentPage.queryUuid,
         metricQuery: currentPage.metricQuery,
@@ -136,6 +143,11 @@ export const getQueryPaginatedResults = async (
         rows: allRows,
         fields: currentPage.fields,
         appliedDashboardFilters: firstPage.appliedDashboardFilters,
+        warehouseExecutionTimeMs:
+            currentPage.status === QueryHistoryStatus.READY
+                ? currentPage.initialQueryExecutionMs
+                : undefined,
+        totalTimeMs: totalTime,
     };
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14349 
### Description:

Shows the warehouse execution time and total time for tiles on dashboards. 

Feature flag is created and enabled for dev and analytics
<img width="841" alt="Screenshot 2025-04-11 at 15 46 47" src="https://github.com/user-attachments/assets/200df708-706a-4956-8cff-c1bbb94df77a" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
