### PR TITLE
fix: add user_id index to project_memberships table

### DIFF
--- a/packages/backend/src/database/migrations/20250411142258_add_user_id_index_to_project_memberships.ts
+++ b/packages/backend/src/database/migrations/20250411142258_add_user_id_index_to_project_memberships.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('project_memberships', (table) => {
+        table.index(['user_id']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('project_memberships', (table) => {
+        table.dropIndex(['user_id']);
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/14373

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

When getting the session user, we fetch all the projects roles.
```
SELECT
  *
FROM
  "project_memberships"
LEFT JOIN
  "projects"
ON
  "project_memberships"."project_id" = "projects"."project_id"
WHERE
  "user_id" = $1
```

Since project_memberships doesn't have an index for `user_id` it does a seq scan:

<img width="399" alt="Screenshot 2025-04-11 at 15 24 20" src="https://github.com/user-attachments/assets/d303b24d-0635-4625-874c-e92d5f4770ad" />

Explain plan: ( now uses index scan )
```
Nested Loop Left Join  (cost=0.26..17.06 rows=1 width=2820) (actual time=0.036..0.038 rows=1 loops=1)
  ->  Index Scan using project_memberships_project_id_index on project_memberships  (cost=0.12..8.14 rows=1 width=48) (actual time=0.022..0.024 rows=1 loops=1)
        Filter: (user_id = 1)
  ->  Index Scan using projects_pkey on projects  (cost=0.14..8.15 rows=1 width=2772) (actual time=0.010..0.011 rows=1 loops=1)
        Index Cond: (project_id = project_memberships.project_id)
Planning Time: 0.210 ms
Execution Time: 0.069 ms
```

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
