### PR TITLE
fix: error when cacheMetadata is undefined

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -538,8 +538,12 @@ const DashboardProvider: React.FC<
         [removeSavedFilterOverride],
     );
 
-    const addResultsCacheTime = useCallback((cacheMetadata: CacheMetadata) => {
-        if (cacheMetadata.cacheHit && cacheMetadata.cacheUpdatedTime) {
+    const addResultsCacheTime = useCallback((cacheMetadata?: CacheMetadata) => {
+        if (
+            cacheMetadata &&
+            cacheMetadata.cacheHit &&
+            cacheMetadata.cacheUpdatedTime
+        ) {
             setResultsCacheTimes((old) =>
                 cacheMetadata.cacheUpdatedTime
                     ? [...old, cacheMetadata.cacheUpdatedTime]


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds a guard for accessing cacheMetadata. There is a crash report in sentry from this. 

https://lightdash.sentry.io/issues/6536834014/events/dbfc780c5d104c93a5e6a584930a8515?environment=cloud_beta&project=4507168845529088

I don't know how this can get undefined. I'm looking into that and we need to clean up the types here, but this should be safe and avoid the crash. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
