### PR TITLE
fix: only fetch explore once

### DIFF
--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import useQueryError from './useQueryError';
 
-export const getExplore = async (projectUuid: string, exploreId: string) =>
+const getExplore = async (projectUuid: string, exploreId: string) =>
     lightdashApi<ApiExploreResults>({
         url: `/projects/${projectUuid}/explores/${exploreId}`,
         method: 'GET',

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -73,7 +73,7 @@ const updateSavedQuery = async (
     });
 };
 
-export const getSavedQuery = async (id: string): Promise<SavedChart> =>
+const getSavedQuery = async (id: string): Promise<SavedChart> =>
     lightdashApi<SavedChart>({
         url: `/saved/${id}`,
         method: 'GET',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/14299, https://github.com/lightdash/lightdash/issues/14373, 

### Description:

- Improves `useDashboardChart` hook so it doesn't request for the same explore multiple times by using the hooks

**Before**

- dashboard containing multiple duplicate charts ((uses same explore)
![image](https://github.com/user-attachments/assets/4c22bcb6-f4c7-468b-be86-c1c00046f9d6)

**After**
- dashboard containing multiple duplicate charts (uses same explore)
![image](https://github.com/user-attachments/assets/ba9104c0-6802-4d20-926b-7ab0d46d9c34)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
