### PR TITLE
chore: add analytics events for results cache

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2,6 +2,7 @@
 import { Type } from '@aws-sdk/client-s3';
 import {
     AnyType,
+    CacheMetadata,
     CartesianSeriesType,
     ChartKind,
     ChartType,
@@ -256,6 +257,7 @@ type QueryExecutionEvent = BaseTrack & {
         context: QueryExecutionContext;
         organizationId: string;
         projectId: string;
+        cacheMetadata?: CacheMetadata;
     } & (
         | PaginatedMetricQueryExecutionProperties
         | MetricQueryExecutionProperties
@@ -290,7 +292,7 @@ type QueryPageEvent = BaseTrack & {
     properties: {
         queryId: string;
         projectId: string;
-        warehouseType: WarehouseTypes;
+        warehouseType: WarehouseTypes | null;
         page: number;
         columnsCount: number;
         totalRowCount: number;
@@ -298,6 +300,50 @@ type QueryPageEvent = BaseTrack & {
         resultsPageSize: number;
         resultsPageExecutionMs: number;
         status: QueryHistoryStatus;
+        cacheMetadata: CacheMetadata | null;
+    };
+};
+
+type ResultsCacheCreateEvent = BaseTrack & {
+    event: 'results_cache.create';
+    properties: {
+        projectId: string;
+        cacheKey: string;
+        totalRowCount: number | null;
+        createdAt: Date;
+        expiresAt: Date;
+    };
+};
+
+type ResultsCacheWriteEvent = BaseTrack & {
+    event: 'results_cache.write';
+    properties: {
+        queryId: string;
+        projectId: string;
+        cacheKey: string;
+        totalRowCount: number | null;
+    };
+};
+
+type ResultsCacheReadEvent = BaseTrack & {
+    event: 'results_cache.read';
+    properties: {
+        queryId: string;
+        projectId: string;
+        cacheKey: string;
+        page: number;
+        requestedPageSize: number;
+        rowCount: number;
+        resultsPageExecutionMs: number;
+    };
+};
+
+type ResultsCacheDeleteEvent = BaseTrack & {
+    event: 'results_cache.delete';
+    properties: {
+        queryId: string;
+        projectId: string;
+        cacheKey: string;
     };
 };
 
@@ -1262,6 +1308,10 @@ type TypedEvent =
     | QueryReadyEvent
     | QueryErrorEvent
     | QueryPageEvent
+    | ResultsCacheCreateEvent
+    | ResultsCacheWriteEvent
+    | ResultsCacheReadEvent
+    | ResultsCacheDeleteEvent
     | ModeDashboardChartEvent
     | UpdateSavedChartEvent
     | DeleteSavedChartEvent

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -300,7 +300,7 @@ type QueryPageEvent = BaseTrack & {
         resultsPageSize: number;
         resultsPageExecutionMs: number;
         status: QueryHistoryStatus;
-        cacheMetadata: CacheMetadata | null;
+        cacheMetadata: Omit<CacheMetadata, 'cacheHit'> | null;
     };
 };
 

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
@@ -452,6 +452,7 @@ describe('ResultsCacheModel', () => {
                     { value: 'test4' },
                 ],
                 totalRowCount: 100,
+                expiresAt: futureDate,
             });
 
             expect(mockStorageClient.getDowloadStream).toHaveBeenCalledWith(
@@ -487,6 +488,7 @@ describe('ResultsCacheModel', () => {
             expect(result).toEqual({
                 rows: [],
                 totalRowCount: 0,
+                expiresAt: futureDate,
             });
         });
 
@@ -560,6 +562,7 @@ describe('ResultsCacheModel', () => {
             expect(result).toEqual({
                 rows: [{ value: 'test3' }, { value: 'test4' }],
                 totalRowCount: 100,
+                expiresAt: futureDate,
             });
 
             expect(mockStorageClient.getDowloadStream).toHaveBeenCalledWith(
@@ -615,6 +618,7 @@ describe('ResultsCacheModel', () => {
                     { value: 'test3' },
                 ],
                 totalRowCount: 100,
+                expiresAt: futureDate,
             });
         });
     });

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
@@ -222,6 +222,7 @@ export class ResultsCacheModel {
         return {
             rows,
             totalRowCount: cache.total_row_count ?? 0,
+            expiresAt: cache.expires_at,
         };
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2088,7 +2088,6 @@ export class ProjectService extends BaseService {
                     resultsPageExecutionMs: roundedDurationMs,
                     status,
                     cacheMetadata: {
-                        cacheHit: true,
                         cacheExpiresAt: expiresAt,
                         cacheKey,
                     },

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -481,7 +481,7 @@ export type CacheMetadata = {
     cacheUpdatedTime?: Date;
     cacheExpiresAt?: Date;
     cacheKey?: string;
-    cacheHit: boolean;
+    cacheHit?: boolean;
 };
 
 export type ApiQueryResults = {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -480,6 +480,7 @@ export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 export type CacheMetadata = {
     cacheUpdatedTime?: Date;
     cacheExpiresAt?: Date;
+    cacheKey?: string;
     cacheHit: boolean;
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -481,7 +481,7 @@ export type CacheMetadata = {
     cacheUpdatedTime?: Date;
     cacheExpiresAt?: Date;
     cacheKey?: string;
-    cacheHit?: boolean;
+    cacheHit: boolean;
 };
 
 export type ApiQueryResults = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add analytics events for caching.

Adds events for
- results_cache.create
- results_cache.write
- results_cache.read
- results_cache.delete

And adds cache metadata these events when available
- query.executed
- query_page.fetched

Note: I wasn't sure about tracking 2 events in sequence, but this code does that sometimes. For example, it sends a `results_cache.read`, then a `query_page.fetched` one after the other when a page is fetched. It seems like it will be useful to have these types separated for when actually doing analytics, but if there is a reason not to do this, we can adjust it. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
