### PR TITLE
fix: subtotal calculation when table calculation references missing …

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -87,7 +87,7 @@ export class ValidationService extends BaseService {
         this.schedulerClient = schedulerClient;
     }
 
-    private static getTableCalculationFieldIds(
+    static getTableCalculationFieldIds(
         tableCalculations: TableCalculation[],
     ): string[] {
         const parseTableField = (field: string) =>


### PR DESCRIPTION
…dimension

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14187](https://github.com/lightdash/lightdash/issues/14187)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Example table calculation that references a dimension:
```
CASE
 WHEN ${events.event_tier} = 'High' THEN
 1
 ELSE
 0
 END
```


Before: no subtotals

<img width="1442" alt="Screenshot 2025-04-14 at 13 55 06" src="https://github.com/user-attachments/assets/be9ab8be-ddac-41d8-9b0b-a39eca74a1da" />

After: 

<img width="1443" alt="Screenshot 2025-04-14 at 13 54 43" src="https://github.com/user-attachments/assets/79cf402a-14c9-4953-9079-c1bb889b7d7c" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
