### PR TITLE
chore: add a frontend event for query performance

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1429,6 +1429,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     // State used to only track event on initial load. Excluding lazy load updates for table charts.
     const hasTrackedLoadEvent = useRef(false);
     useEffect(() => {
+<<<<<<< HEAD
         if (readyQuery.data?.executeQueryResponse?.queryUuid) {
             // Reset the tracking flag when queryUuid changes
             hasTrackedLoadEvent.current = false;

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1429,7 +1429,6 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     // State used to only track event on initial load. Excluding lazy load updates for table charts.
     const hasTrackedLoadEvent = useRef(false);
     useEffect(() => {
-<<<<<<< HEAD
         if (readyQuery.data?.executeQueryResponse?.queryUuid) {
             // Reset the tracking flag when queryUuid changes
             hasTrackedLoadEvent.current = false;

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1415,7 +1415,7 @@ export const GenericDashboardChartTile: FC<
 const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     const { user } = useApp();
     const { track } = useTracking();
-    const { dashboardUuid } = useParams<{ dashboardUuid: string; }>();
+    const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
     const readyQuery = useDashboardChartReadyQuery(
         props.tile.uuid,
         props.tile.properties?.savedChartUuid,
@@ -1436,7 +1436,13 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     }, [readyQuery.data?.executeQueryResponse?.queryUuid]);
     // Track chart loading time
     useEffect(() => {
-        if (!hasTrackedLoadEvent.current && !resultsData.isInitialLoading && readyQuery.data && user.data && dashboardUuid) {
+        if (
+            !hasTrackedLoadEvent.current &&
+            !resultsData.isInitialLoading &&
+            readyQuery.data &&
+            user.data &&
+            dashboardUuid
+        ) {
             track({
                 name: EventName.DASHBOARD_CHART_LOADED,
                 properties: {
@@ -1446,8 +1452,9 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
                     dashboardId: dashboardUuid,
                     chartId: readyQuery.data.chart.uuid,
                     queryId: readyQuery.data.executeQueryResponse.queryUuid,
-                    warehouseExecutionTimeMs: readyQuery.data.firstPage.initialQueryExecutionMs || null,
-                    totalTimeMs: resultsData.totalClientFetchTimeMs || null,
+                    warehouseExecutionTimeMs:
+                        readyQuery.data.firstPage.initialQueryExecutionMs,
+                    totalTimeMs: resultsData.totalClientFetchTimeMs,
                     totalResults: resultsData.totalResults || 0,
                     loadedRows: resultsData.rows.length,
                 },
@@ -1455,7 +1462,14 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
             // track only once
             hasTrackedLoadEvent.current = true;
         }
-    }, [hasTrackedLoadEvent, dashboardUuid, readyQuery, resultsData, track, user.data]);
+    }, [
+        hasTrackedLoadEvent,
+        dashboardUuid,
+        readyQuery,
+        resultsData,
+        track,
+        user.data,
+    ]);
 
     return (
         <GenericDashboardChartTile

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1,4 +1,4 @@
-import { type CacheMetadata, type SearchItemType, type TimeFrames } from '@lightdash/common';
+import { type SearchItemType, type TimeFrames } from '@lightdash/common';
 import { type FormState } from 'react-hook-form';
 import type * as rudderSDK from 'rudder-sdk-js';
 import {
@@ -392,8 +392,8 @@ type DashboardChartLoadedEvent = {
         dashboardId: string;
         chartId: string;
         queryId: string;
-        warehouseExecutionTimeMs: number | null;
-        totalTimeMs: number | null;
+        warehouseExecutionTimeMs: number | undefined;
+        totalTimeMs: number | undefined;
         totalResults: number;
         loadedRows: number;
         // cacheMetadata: CacheMetadata;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1,4 +1,4 @@
-import { type SearchItemType, type TimeFrames } from '@lightdash/common';
+import { type CacheMetadata, type SearchItemType, type TimeFrames } from '@lightdash/common';
 import { type FormState } from 'react-hook-form';
 import type * as rudderSDK from 'rudder-sdk-js';
 import {
@@ -383,6 +383,23 @@ type CustomMetricReplacementEvent = {
     };
 };
 
+type DashboardChartLoadedEvent = {
+    name: EventName.DASHBOARD_CHART_LOADED;
+    properties: {
+        userId: string;
+        organizationId: string;
+        projectId: string;
+        dashboardId: string;
+        chartId: string;
+        queryId: string;
+        warehouseExecutionTimeMs: number | null;
+        totalTimeMs: number | null;
+        totalResults: number;
+        loadedRows: number;
+        // cacheMetadata: CacheMetadata;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | FormClickedEvent
@@ -415,6 +432,7 @@ export type EventData =
     | MetricsCatalogTreesEdgeRemovedEvent
     | MetricsCatalogTreesCanvasModeClickedEvent
     | WriteBackEvent
+    | DashboardChartLoadedEvent
     | CustomMetricReplacementEvent;
 
 export type IdentifyData = {

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -148,4 +148,6 @@ export enum EventName {
     WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED = 'write_back_from_custom_dimension.clicked',
     WRITE_BACK_FROM_CUSTOM_DIMENSION_HEADER_CLICKED = 'write_back_from_custom_dimension_header.clicked',
     CUSTOM_FIELDS_REPLACEMENT_APPLIED = 'custom_fields_replacement.applied',
+
+    DASHBOARD_CHART_LOADED = 'dashboard_chart.loaded',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add an event to track dashboard query return time in the frontend. 

To test:
- Check that one `track` is sent per dashboard chart containing the load time

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
