### PR TITLE
feat: add audit logging for casl checks

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -188,13 +188,13 @@ export const getPemFileContent = (certValue: string | undefined) =>
         decodeUnlessStartsWith: '-----BEGIN ', // -----BEGIN CERTIFICATE | -----BEGIN PRIVATE KEY
     });
 
-type LoggingLevel = 'error' | 'warn' | 'info' | 'http' | 'debug';
+type LoggingLevel = 'error' | 'warn' | 'info' | 'http' | 'debug' | 'audit';
 const assertIsLoggingLevel = (x: string): x is LoggingLevel =>
-    ['error', 'warn', 'info', 'http', 'debug'].includes(x);
+    ['error', 'warn', 'info', 'http', 'debug', 'audit'].includes(x);
 const parseLoggingLevel = (raw: string): LoggingLevel => {
     if (!assertIsLoggingLevel(raw)) {
         throw new ParseError(
-            `Cannot parse environment variable "LIGHTDASH_LOG_LEVEL". Value must be one of "error", "warn", "info", "debug" but LIGHTDASH_LOG_LEVEL=${raw}`,
+            `Cannot parse environment variable "LIGHTDASH_LOG_LEVEL". Value must be one of "error", "warn", "info", "debug", "audit" but LIGHTDASH_LOG_LEVEL=${raw}`,
         );
     }
     return raw;

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -1,0 +1,72 @@
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+
+export type AuditStatusType = 'allowed' | 'denied';
+
+export const AuditStatusSchema = z.enum(['allowed', 'denied']);
+
+export const AuditActorSchema = z.object({
+    uuid: z.string(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    email: z.string().optional(),
+    organizationUuid: z.string(),
+    organizationRole: z.string(),
+    groupMemberships: z.array(z.string()).optional(),
+});
+
+export type AuditActor = z.infer<typeof AuditActorSchema>;
+
+export const AuditResourceSchema = z.object({
+    type: z.string(),
+    uuid: z.string().optional(),
+    name: z.string().optional(),
+    organizationUuid: z.string(),
+    projectUuid: z.string().optional(),
+});
+
+export type AuditResource = z.infer<typeof AuditResourceSchema>;
+
+export const AuditContextSchema = z.object({
+    ip: z.string().optional(),
+    userAgent: z.string().optional(),
+    requestId: z.string().optional(),
+});
+
+export type AuditContext = z.infer<typeof AuditContextSchema>;
+
+export const AuditLogEventSchema = z.object({
+    id: z.string().default(() => uuidv4()),
+    timestamp: z.string().default(() => new Date().toISOString()),
+    actor: AuditActorSchema,
+    action: z.string(),
+    resource: AuditResourceSchema,
+    context: AuditContextSchema,
+    status: AuditStatusSchema,
+    reason: z.string().optional(),
+    ruleConditions: z.string().optional(),
+});
+
+export type AuditLogEvent = z.infer<typeof AuditLogEventSchema>;
+
+export const validateAuditLogEvent = (event: unknown): AuditLogEvent =>
+    AuditLogEventSchema.parse(event);
+
+export const createAuditLogEvent = (
+    actor: AuditActor,
+    action: string,
+    resource: AuditResource,
+    context: AuditContext,
+    status: AuditStatusType,
+    reason?: string,
+    ruleConditions?: string,
+): AuditLogEvent =>
+    validateAuditLogEvent({
+        actor,
+        action,
+        resource,
+        context,
+        status,
+        reason,
+        ruleConditions,
+    });

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -1,0 +1,327 @@
+import { defineAbility, subject } from '@casl/ability';
+import { ForcedSubject, type AnyObject } from '@casl/ability/dist/types/types';
+import { CaslSubjectNames, OrganizationMemberRole } from '@lightdash/common';
+import { type AuditLogEvent } from './auditLog';
+import {
+    CaslAuditWrapper,
+    type AuditLogger,
+    type AuditableUser,
+} from './caslAuditWrapper';
+
+// Test subjects
+const createDashboard = (uuid: string, attributes: AnyObject = {}) =>
+    subject('Dashboard', {
+        uuid,
+        organizationUuid: 'test-org-uuid',
+        ...attributes,
+    });
+
+const createSavedChart = (uuid: string, attributes: AnyObject = {}) =>
+    subject('SavedChart', {
+        uuid,
+        organizationUuid: 'test-org-uuid',
+        ...attributes,
+    });
+
+describe('CaslAuditWrapper', () => {
+    // Create a user with only the required fields for AuditableUser
+    const mockUser: AuditableUser = {
+        userUuid: 'test-user-uuid',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        organizationUuid: 'test-org-uuid',
+        role: OrganizationMemberRole.MEMBER,
+    };
+
+    // Use function to create fresh instances for each test
+    const createMockLogger = (): jest.Mock<void, [AuditLogEvent]> =>
+        jest.fn<void, [AuditLogEvent]>();
+
+    // Tests run with a simple set of mock abilities - this does not test the real abilities/permissions in Lightdash
+    const createTestAbility = () =>
+        defineAbility((can, cannot) => {
+            // Simple rule
+            can('read', 'Dashboard');
+
+            // Rule with conditions
+            can('update', 'Dashboard', { authorId: mockUser.userUuid });
+
+            // Rule with reason
+            can('delete', 'Dashboard', { authorId: mockUser.userUuid }).because(
+                'User is the author',
+            );
+
+            // Forbidden rule with conditions
+            cannot('read', 'Dashboard', { isPrivate: true }).because(
+                'Private dashboards are not readable',
+            );
+
+            // Rule with multiple conditions
+            can('manage', 'SavedChart', {
+                authorId: mockUser.userUuid,
+                status: 'published',
+            });
+        });
+
+    // Create a new wrapper for each test - cast ability to avoid complex type issues
+    const createWrapper = (mockLogger: jest.Mock<void, [AuditLogEvent]>) =>
+        new CaslAuditWrapper(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            createTestAbility() as any,
+            mockUser,
+            {
+                ip: '127.0.0.1',
+                userAgent: 'test-agent',
+                requestId: 'test-request-id',
+                auditLogger: mockLogger as AuditLogger,
+            },
+        );
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('can method', () => {
+        it('should return the same result as the original ability', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const ability = createTestAbility();
+
+            const publicDashboard = createDashboard('1', {
+                authorId: 'someone-else',
+            });
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+            const privateDashboard = createDashboard('3', { isPrivate: true });
+
+            // Test various scenarios
+            expect(wrapper.can('read', publicDashboard)).toBe(
+                ability.can('read', publicDashboard),
+            );
+            expect(wrapper.can('update', userDashboard)).toBe(
+                ability.can('update', userDashboard),
+            );
+            expect(wrapper.can('update', publicDashboard)).toBe(
+                ability.can('update', publicDashboard),
+            );
+            expect(wrapper.can('read', privateDashboard)).toBe(
+                ability.can('read', privateDashboard),
+            );
+        });
+
+        it('should log the audit event with allowed status when permission is granted', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+
+            // Act
+            wrapper.can('update', userDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
+            expect(loggedEvent.action).toBe('update');
+            expect(loggedEvent.resource.type).toBe('Dashboard');
+            expect(loggedEvent.resource.uuid).toBe('2');
+            expect(loggedEvent.status).toBe('allowed');
+            expect(loggedEvent.context.ip).toBe('127.0.0.1');
+            expect(loggedEvent.context.userAgent).toBe('test-agent');
+            expect(loggedEvent.context.requestId).toBe('test-request-id');
+        });
+
+        it('should log the audit event with denied status when permission is denied', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const privateDashboard = createDashboard('3', { isPrivate: true });
+
+            // Act
+            wrapper.can('read', privateDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
+            expect(loggedEvent.action).toBe('read');
+            expect(loggedEvent.resource.type).toBe('Dashboard');
+            expect(loggedEvent.resource.uuid).toBe('3');
+            expect(loggedEvent.status).toBe('denied');
+        });
+
+        it('should include the reason when provided by a rule', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+
+            // Act
+            wrapper.can('delete', userDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.reason).toBe('User is the author');
+        });
+
+        it('should include properly formatted rule conditions', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+
+            // Act
+            wrapper.can('update', userDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.ruleConditions).toBe(
+                JSON.stringify({ authorId: mockUser.userUuid }),
+            );
+        });
+
+        it('should include complex rule conditions correctly', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const userSavedChart = createSavedChart('1', {
+                authorId: mockUser.userUuid,
+                status: 'published',
+            });
+
+            // Act
+            wrapper.can('manage', userSavedChart);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.ruleConditions).toBe(
+                JSON.stringify({
+                    authorId: mockUser.userUuid,
+                    status: 'published',
+                }),
+            );
+        });
+    });
+
+    describe('cannot method', () => {
+        it('should return the same result as the original ability', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const ability = createTestAbility();
+
+            const publicDashboard = createDashboard('1', {
+                authorId: 'someone-else',
+            });
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+            const privateDashboard = createDashboard('3', { isPrivate: true });
+
+            // Test various scenarios
+            expect(wrapper.cannot('read', publicDashboard)).toBe(
+                ability.cannot('read', publicDashboard),
+            );
+            expect(wrapper.cannot('update', userDashboard)).toBe(
+                ability.cannot('update', userDashboard),
+            );
+            expect(wrapper.cannot('update', publicDashboard)).toBe(
+                ability.cannot('update', publicDashboard),
+            );
+            expect(wrapper.cannot('read', privateDashboard)).toBe(
+                ability.cannot('read', privateDashboard),
+            );
+        });
+
+        it('should log the audit event with denied status when permission is denied', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const privateDashboard = createDashboard('3', { isPrivate: true });
+
+            // Act
+            wrapper.cannot('read', privateDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
+            expect(loggedEvent.action).toBe('read');
+            expect(loggedEvent.resource.type).toBe('Dashboard');
+            expect(loggedEvent.resource.uuid).toBe('3');
+            expect(loggedEvent.status).toBe('denied');
+        });
+
+        it('should log the audit event with allowed status when permission is granted', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const publicDashboard = createDashboard('1');
+
+            // Act
+            wrapper.cannot('read', publicDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.status).toBe('allowed');
+        });
+
+        it('should include the reason from cannot rules', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const privateDashboard = createDashboard('3', { isPrivate: true });
+
+            // Act
+            wrapper.cannot('read', privateDashboard);
+
+            // Assert
+            expect(mockLogger).toHaveBeenCalledTimes(1);
+
+            const loggedEvent = mockLogger.mock.calls[0][0];
+            expect(loggedEvent.reason).toBe(
+                'Private dashboards are not readable',
+            );
+        });
+    });
+
+    describe('rules property', () => {
+        it('should expose the original ability rules', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+            const ability = createTestAbility();
+
+            expect(wrapper.rules).toEqual(ability.rules);
+        });
+    });
+
+    describe('default logger', () => {
+        it('should not throw if no logger is provided', () => {
+            // Use type assertion to satisfy the compiler
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ability = createTestAbility() as any;
+            const wrapperWithoutLogger = new CaslAuditWrapper(
+                ability,
+                mockUser,
+            );
+            const userDashboard = createDashboard('2', {
+                authorId: mockUser.userUuid,
+            });
+
+            // Act & Assert - should not throw
+            expect(() =>
+                wrapperWithoutLogger.can('update', userDashboard),
+            ).not.toThrow();
+        });
+    });
+});

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -1,0 +1,199 @@
+import { type Ability } from '@casl/ability';
+import type { Rule as CaslRule } from '@casl/ability/dist/types/Rule';
+import { Abilities, ForcedSubject } from '@casl/ability/dist/types/types';
+import { CaslSubjectNames, type SessionUser } from '@lightdash/common';
+import {
+    AuditActor,
+    AuditContext,
+    AuditResource,
+    AuditStatusType,
+    createAuditLogEvent,
+    type AuditLogEvent,
+} from './auditLog';
+
+export type AuditLogger = (event: AuditLogEvent) => void;
+
+export type AuditableUser = Pick<
+    SessionUser,
+    | 'userUuid'
+    | 'email'
+    | 'firstName'
+    | 'lastName'
+    | 'organizationUuid'
+    | 'role'
+>;
+
+// Todo: can we remove the & { properties } by improving typing of CaslSubjectNames?
+type AuditableCaslSubject = ForcedSubject<CaslSubjectNames> & {
+    organizationUuid: string;
+    uuid: string;
+    name?: string;
+    projectUuid?: string;
+};
+
+type AuditHelperArgs = {
+    user: AuditableUser;
+    action: string;
+    subject: AuditableCaslSubject;
+    ip?: string;
+    userAgent?: string;
+    requestId?: string;
+    ruleConditions?: string;
+};
+
+/**
+ * Creates an audit actor from a user
+ */
+const createActorFromUser = (user: AuditableUser): AuditActor => ({
+    uuid: user.userUuid,
+    email: user.email || '',
+    firstName: user.firstName || '',
+    lastName: user.lastName || '',
+    organizationUuid: user.organizationUuid || '',
+    organizationRole: user.role || 'unknown',
+    // TODO: Add group memberships
+    groupMemberships: [],
+});
+
+const createResourceFromSubject = (
+    subject: AuditableCaslSubject,
+): AuditResource => ({
+    type: subject.__caslSubjectType__ || 'unknown',
+    uuid: subject.uuid,
+    name: subject.name,
+    organizationUuid: subject.organizationUuid,
+    projectUuid: subject.projectUuid,
+});
+
+const createContextFromArgs = (args: AuditHelperArgs): AuditContext => ({
+    ip: args.ip,
+    userAgent: args.userAgent,
+    requestId: args.requestId,
+});
+
+// Helper function to extract conditions from a CASL Rule
+const extractRuleConditions = <A extends Abilities, C>(
+    rule: CaslRule<A, C> | null,
+): string | undefined => {
+    if (!rule) return undefined;
+
+    try {
+        // Get conditions directly from Rule object's conditions property
+        const { conditions } = rule;
+
+        if (conditions && typeof conditions === 'object') {
+            return JSON.stringify(conditions);
+        }
+
+        return undefined;
+    } catch (e) {
+        return undefined;
+    }
+};
+
+export class CaslAuditWrapper<T extends Ability> {
+    private wrappedAbility: T;
+
+    private user: AuditableUser;
+
+    private ip?: string;
+
+    private userAgent?: string;
+
+    private requestId?: string;
+
+    private auditLogger: AuditLogger;
+
+    constructor(
+        ability: T,
+        user: AuditableUser,
+        options?: {
+            ip?: string;
+            userAgent?: string;
+            requestId?: string;
+            auditLogger?: AuditLogger;
+        },
+    ) {
+        this.wrappedAbility = ability;
+        this.user = user;
+        this.ip = options?.ip;
+        this.userAgent = options?.userAgent;
+        this.requestId = options?.requestId;
+        this.auditLogger = options?.auditLogger || ((_event) => {});
+    }
+
+    private logAbilityCheck(
+        args: AuditHelperArgs,
+        status: AuditStatusType,
+        reason?: string,
+    ): void {
+        const actor = createActorFromUser(args.user);
+        const resource = createResourceFromSubject(args.subject);
+        const context = createContextFromArgs(args);
+
+        const event = createAuditLogEvent(
+            actor,
+            args.action,
+            resource,
+            context,
+            status,
+            reason,
+            args.ruleConditions,
+        );
+
+        this.auditLogger(event);
+    }
+
+    can(action: string, subject: AuditableCaslSubject): boolean {
+        const result = this.wrappedAbility.can(action, subject);
+
+        // Extract the relevant rule that allowed this permission
+        const rule = this.wrappedAbility.relevantRuleFor(action, subject);
+        const ruleConditions = extractRuleConditions(rule);
+
+        const reason = rule?.reason;
+
+        this.logAbilityCheck(
+            {
+                user: this.user,
+                action,
+                subject,
+                ip: this.ip,
+                userAgent: this.userAgent,
+                requestId: this.requestId,
+                ruleConditions,
+            },
+            result ? 'allowed' : 'denied',
+            reason,
+        );
+        return result;
+    }
+
+    cannot(action: string, subject: AuditableCaslSubject): boolean {
+        const result = this.wrappedAbility.cannot(action, subject);
+
+        const rule = this.wrappedAbility.relevantRuleFor(action, subject);
+        const ruleConditions = extractRuleConditions(rule);
+        const reason = rule?.reason;
+
+        this.logAbilityCheck(
+            {
+                user: this.user,
+                action,
+                subject,
+                ip: this.ip,
+                userAgent: this.userAgent,
+                requestId: this.requestId,
+                ruleConditions,
+            },
+            result ? 'denied' : 'allowed',
+            reason,
+        );
+        return result;
+    }
+
+    // Forward any property access to the wrapped ability
+    get rules() {
+        return this.wrappedAbility.rules;
+    }
+}

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -5,13 +5,15 @@ import * as expressWinston from 'express-winston';
 import ExecutionContext from 'node-execution-context';
 import * as winston from 'winston';
 import { lightdashConfig } from '../config/lightdashConfig';
+import { AuditLogEvent } from './auditLog';
 
 const levels = {
     error: 0,
     warn: 1,
     info: 2,
     http: 3,
-    debug: 4,
+    audit: 4,
+    debug: 5,
 };
 
 const colors = {
@@ -19,6 +21,7 @@ const colors = {
     warn: 'yellow',
     info: 'green',
     http: 'magenta',
+    audit: 'cyan',
     debug: 'white',
 };
 winston.addColors(colors);
@@ -129,6 +132,18 @@ export const winstonLogger = winston.createLogger({
     levels,
     transports,
 });
+
+export const logAuditEvent = (event: AuditLogEvent): void => {
+    winstonLogger.log({
+        level: 'audit',
+        message: `${event.action} ${event.resource.type}${
+            event.resource.uuid ? ` ${event.resource.uuid}` : ''
+        } by ${event.actor.uuid} (${event.status})${
+            event.reason ? ` - ${event.reason}` : ''
+        }`,
+        ...event,
+    });
+};
 
 declare global {
     namespace Express {

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -18,10 +18,7 @@ interface Organization {
     organizationUuid: string;
 }
 
-type Subject =
-    | Project
-    | Organization
-    | OrganizationMemberProfile
+export type CaslSubjectNames =
     | 'Project'
     | 'Organization'
     | 'OrganizationMemberProfile'
@@ -50,7 +47,13 @@ type Subject =
     | 'PersonalAccessToken'
     | 'MetricsTree'
     | 'SpotlightTableConfig'
-    | 'ContentAsCode'
+    | 'ContentAsCode';
+
+export type Subject =
+    | CaslSubjectNames
+    | Project
+    | Organization
+    | OrganizationMemberProfile
     | 'all';
 
 export type PossibleAbilities = [


### PR DESCRIPTION
Logs out permission checks for auditing. This doesn't actually enable the wrapper yet.

- Adds CASL wrapper to enable logging
- Adds winston log levels for auditing
- Adds tests for CASL formatting

Example check from the dashboard (not included in this PR)

```
{
  "action": "view",
  "actor": {
    "email": "demo@lightdash.com",
    "firstName": "David",
    "groupMemberships": [],
    "lastName": "Attenborough",
    "organizationRole": "admin",
    "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
    "uuid": "b264d83a-9000-426a-85ec-3f9c20f368ce"
  },
  "context": {},
  "id": "fbd1f07a-df3f-4d40-8005-62e48339c34b",
  "level": "audit",
  "message": "view Dashboard 747c7e64-cffb-4e72-b92c-9b035c8e17d5 by b264d83a-9000-426a-85ec-3f9c20f368ce (allowed)",
  "resource": {
    "name": "Jaffle dashboard",
    "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
    "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3",
    "type": "Dashboard",
    "uuid": "747c7e64-cffb-4e72-b92c-9b035c8e17d5"
  },
  "ruleConditions": "{\"organizationUuid\":\"172a2270-000f-42be-9c68-c4752c23ae51\"}",
  "sentryTraceId": "f68d4089573a4d59a1cec855114fa8ad",
  "status": "allowed",
  "timestamp": "2025-04-16 12:13:17",
  "trace": "projects/lightdash-cloud-beta/traces/f68d4089573a4d59a1cec855114fa8ad"
}
```