### PR TITLE
fix: get dashboards from allowed private space when embedding

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -1,5 +1,6 @@
 import { type ApiError, type DecodedEmbed } from '@lightdash/common';
 import {
+    Anchor,
     Button,
     Flex,
     Paper,
@@ -98,8 +99,11 @@ const useEmbedConfigUpdateMutation = (projectUuid: string) => {
 const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { health } = useApp();
     const { isLoading, data: embedConfig, error } = useEmbedConfig(projectUuid);
-    const { isLoading: isLoadingDashboards, data: dashboards } =
-        useDashboards(projectUuid);
+    const { isLoading: isLoadingDashboards, data: dashboards } = useDashboards(
+        projectUuid,
+        undefined,
+        true,
+    );
     const { mutate: createEmbedConfig, isLoading: isCreating } =
         useEmbedConfigCreateMutation(projectUuid);
     const { mutate: updateEmbedConfig, isLoading: isUpdating } =
@@ -172,13 +176,12 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         The secret is used to generate embed tokens for
                         embedding dashboards.
                     </Text>
-                    {/* Uncomment once we have a docs page */}
-                    {/*<Text color="dimmed">*/}
-                    {/*    Read more about using embed secret in our{' '}*/}
-                    {/*    <Anchor href="https://docs.lightdash.com/guides/embed">*/}
-                    {/*        docs guide*/}
-                    {/*    </Anchor>*/}
-                    {/*</Text>*/}
+                    <Text color="dimmed" fz="xs">
+                        Read more about using embed secret in our{' '}
+                        <Anchor href="https://docs.lightdash.com/references/embedding">
+                            docs guide
+                        </Anchor>
+                    </Text>
                 </Stack>
                 <Stack>
                     <PasswordInput


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14385

### Description:

Gets dashboards from private spaces **if** the user has ability to see them **or** has direct access to them. A similar PR was done here: https://github.com/lightdash/lightdash/pull/14409/files

To test

create public and private space and insert a dashboard in each
for another user, create a private space and add a dashboard

you should see all dashboards as an admin on the embed configuration 
<img width="475" alt="image" src="https://github.com/user-attachments/assets/e78795dc-b166-4b91-8e63-2e69a7eb9a27" />


<img width="304" alt="image" src="https://github.com/user-attachments/assets/52f14844-2225-4f96-a845-b6a92500f4a7" />

Also test the dashboards-as-code
1. download a dashboard (as another user)
2. and upload it to a private space with a different slug/filename to test it out
3. you should see that one as well in the embed configuration



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
