### PR TITLE
fix: show reset filters if url overrides dashboard filters

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -130,7 +130,11 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     const setHaveFiltersChanged = useDashboardContext(
         (c) => c.setHaveFiltersChanged,
     );
-    const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
+    const haveFiltersChanged = useDashboardContext(
+        (c) =>
+            c.haveFiltersChanged ||
+            c.dashboardTemporaryFilters.dimensions.length > 0,
+    );
 
     const mouseSensor = useSensor(MouseSensor, {
         activationConstraint: { distance: 10 },

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -203,12 +203,13 @@ const DashboardProvider: React.FC<
                             overridesForSavedDashboardFilters,
                         ),
                     };
+                    setHaveFiltersChanged(true);
                 } else {
                     updatedDashboardFilters = dashboard.filters;
+                    setHaveFiltersChanged(false);
                 }
 
                 setDashboardFilters(updatedDashboardFilters);
-                setHaveFiltersChanged(false);
             }
 
             setOriginalDashboardFilters(dashboard.filters);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/14353

### Description:

<img width="963" alt="image" src="https://github.com/user-attachments/assets/eb76046a-b893-4794-a9ab-26f42b19e236" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
