### PR TITLE
fix: loading state on dashboard charts refresh

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -297,7 +297,7 @@ describe('Dashboard', () => {
         cy.wait(2000);
 
         // get the fourth button with class  mantine-ActionIcon-root
-        cy.get('.mantine-ActionIcon-root').eq(5).click();
+        cy.get('[data-testid="dashboard-header-menu"]').click();
         cy.contains('Export dashboard').click();
         cy.findByText('Generate preview').click();
 

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -273,7 +273,7 @@ describe('Dashboard', () => {
         // create dashboard with title small
         cy.contains('Create dashboard').click();
         cy.findByLabelText('Name your dashboard *').type('Small');
-        cy.findByText('Create').click();
+        cy.findByTestId('dashboard-create-modal-create-button').click();
 
         // Create chart within dashboard
         cy.findAllByText('Add tile').click({ multiple: true });

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1427,7 +1427,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
             {...props}
             isLoading={
                 (resultsData.fetchAll && !resultsData.hasFetchedAllRows) ||
-                readyQuery.isInitialLoading
+                readyQuery.isFetching
             }
             resultsData={resultsData}
             dashboardChartReadyQuery={readyQuery.data}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -416,6 +416,7 @@ const DashboardHeader = ({
 
                     {!isFullscreen && (
                         <Menu
+                            data-testid="dashboard-header-menu"
                             position="bottom"
                             withArrow
                             withinPortal

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -299,6 +299,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                             disabled={!form.isValid}
                             loading={isCreatingDashboard || isCreatingSpace}
                             type="submit"
+                            data-testid="dashboard-create-modal-create-button"
                         >
                             Create
                         </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Fixes dashboard charts loading state which wasn't showing loading while doing the post to execute query + get first page other than on the initial load

**Before**

https://github.com/user-attachments/assets/0e109f93-fe4b-463d-a875-f85ebea107a3

**After**

https://github.com/user-attachments/assets/88a00b86-b290-4d71-8f19-beda95625e86



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
