### PR TITLE
fix: google trace metadata field

### DIFF
--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -36,7 +36,7 @@ const addSentryTraceId = winston.format(
             sentryTraceId: traceId,
             ...(gcpProjectId &&
                 traceId && {
-                    trace: `projects/${gcpProjectId}/traces/${traceId}`,
+                    'logging.googleapis.com/trace': `projects/${gcpProjectId}/traces/${traceId}`,
                 }),
         };
     },


### PR DESCRIPTION
Logging to `trace` ends up nesting the trace field in `.jsonPayload.trace` (this is where GCP puts all fields by default)

If we want `trace` to actually appear at the root of a GCP log object, we need to use the special metadata field: https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_field