### PR TITLE
fix: no new sessions in trx blocks

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -131,7 +131,7 @@ export class AnalyticsModel {
         userUuid: string,
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
-            await this.database(AnalyticsDashboardViewsTableName).insert({
+            await trx(AnalyticsDashboardViewsTableName).insert({
                 dashboard_uuid: dashboardUuid,
                 user_uuid: userUuid,
             });

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -146,8 +146,7 @@ export class CatalogModel {
                                         ),
                                         BATCH_SIZE,
                                     )
-                                    .returning('*')
-                                    .transacting(trx);
+                                    .returning('*');
 
                                 // Create project yaml tag insert objects depending on the ID of the catalog insert
                                 const yamlTagInserts: DbCatalogTagIn[] =
@@ -172,8 +171,7 @@ export class CatalogModel {
                                 if (yamlTagInserts.length > 0) {
                                     await trx(CatalogTagsTableName)
                                         .insert(yamlTagInserts)
-                                        .returning('*')
-                                        .transacting(trx);
+                                        .returning('*');
                                 }
 
                                 return results;

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1135,7 +1135,7 @@ export class DashboardModel {
                         ? {
                               space_id: (
                                   await SpaceModel.getSpaceIdAndName(
-                                      this.database,
+                                      trx,
                                       dashboard.spaceUuid,
                                   )
                               )?.spaceId,

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -159,10 +159,11 @@ export class OpenIdIdentityModel {
 
     async deleteIdentity(userId: number, issuer: string, email: string) {
         await this.database.transaction(async (trx) => {
-            const identities = await this.database(
-                OpenIdIdentitiesTableName,
-            ).where('openid_identities.user_id', userId);
-            const passwords = await this.database(PasswordLoginTableName).where(
+            const identities = await trx(OpenIdIdentitiesTableName).where(
+                'openid_identities.user_id',
+                userId,
+            );
+            const passwords = await trx(PasswordLoginTableName).where(
                 'user_id',
                 userId,
             );

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1811,8 +1811,7 @@ export class ProjectModel {
                         }),
                         batchSize,
                     )
-                    .returning('*')
-                    .transacting(trx);
+                    .returning('*');
 
                 return newContent;
             };

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -981,12 +981,12 @@ export class UserModel {
 
             const projectMemberships = Object.entries(projects || {}).map(
                 async ([projectUuid, projectRole]) => {
-                    const [project] = await this.database('projects')
+                    const [project] = await trx('projects')
                         .select('project_id')
                         .where('project_uuid', projectUuid);
 
                     if (project) {
-                        await this.database('project_memberships').insert({
+                        await trx('project_memberships').insert({
                             project_id: project.project_id,
                             role: projectRole,
                             user_id: user.user_id,

--- a/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
+++ b/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
@@ -108,9 +108,7 @@ export class WarehouseAvailableTablesModel {
                 .del();
 
             if (rows.length !== 0) {
-                await this.database
-                    .batchInsert(WarehouseAvailableTablesTableName, rows)
-                    .transacting(trx);
+                await trx.batchInsert(WarehouseAvailableTablesTableName, rows);
             }
         });
     }
@@ -138,9 +136,7 @@ export class WarehouseAvailableTablesModel {
                 )
                 .del();
             if (rows.length !== 0) {
-                await this.database
-                    .batchInsert(WarehouseAvailableTablesTableName, rows)
-                    .transacting(trx);
+                await trx.batchInsert(WarehouseAvailableTablesTableName, rows);
             }
         });
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

   - Reduce number of connections checked out from knex by properly using transaction objects (`trx`) in database queries instead of the main database connection (in other words these were checking out one connection for trx and _another_ connection for each this.database use)
   - Removed redundant `.transacting(trx)` calls when the transaction is already being used (no biggy but just cleaning)