### PR TITLE
fix: don't trigger unfurl timeout when there are 0 expected responses

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -138,6 +138,10 @@ export class UnfurlService extends BaseService {
         expectedResponses: number,
         timeout: number,
     ) {
+        if (expectedResponses === 0) {
+            return undefined;
+        }
+
         let responseCount = 0;
 
         this.logger.info(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14462

### Description:

- Timeout to wait for charts was still running even when expected responses was 0

**Steps to reproduce:**
1. Create dashboard with just markdown tiles ( don't add any saved charts )
2. Trigger `Generate preview`

**Before**
![image](https://github.com/user-attachments/assets/17d134e5-a94b-444c-8aff-a6d187e97c13)

**After**
![image](https://github.com/user-attachments/assets/b13e5349-acfc-4e32-a6ad-b48bf78e77e9)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
