### PR TITLE
fix: sort series for fallback colors

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -153,12 +153,14 @@ const VisualizationProvider: FC<React.PropsWithChildren<Props>> = ({
             computedSeries && computedSeries.length > 0
                 ? computedSeries
                 : chartConfig.config.eChartsConfig.series;
+
+        const sortedSeriesIdentifiers = (allSeries ?? [])
+            .map((series) => calculateSeriesLikeIdentifier(series).join('|'))
+            .sort((a, b) => b.localeCompare(a));
+
         return Object.fromEntries(
-            (allSeries ?? []).map((series, i) => {
-                return [
-                    calculateSeriesLikeIdentifier(series).join('|'),
-                    colorPalette[i % colorPalette.length],
-                ];
+            sortedSeriesIdentifiers.map((identifier, i) => {
+                return [identifier, colorPalette[i % colorPalette.length]];
             }),
         );
     }, [chartConfig, colorPalette, computedSeries]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14468

This happens when calculated series colors is disabled. Calculated series colors introduces other issues related to chart render order, but fixes this.

This approach will sort the `fallback` colors so that colors always match if 2 charts contain the same series and are using fallback colors

Related PR: https://github.com/lightdash/lightdash/pull/13923 

### Description:

**Before**
![image](https://github.com/user-attachments/assets/2fe1eadb-7a65-4e91-b672-83a65613f643)

**After**
![image](https://github.com/user-attachments/assets/aead050f-c6f7-4a7f-8b15-00a707965671)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
