### PR TITLE
chore: add analytics events to nested spaces' feature

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -694,6 +694,7 @@ type SpaceEvent = BaseTrack & {
         projectId: string;
         isPrivate: boolean;
         userAccessCount: number;
+        isNested: boolean;
     };
 };
 
@@ -705,6 +706,7 @@ type SpaceDeleted = BaseTrack & {
         name: string;
         spaceId: string;
         projectId: string;
+        isNested: boolean;
     };
 };
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -203,6 +203,7 @@ export class SpaceService extends BaseService {
                 projectId: projectUuid,
                 isPrivate: newSpace.isPrivate,
                 userAccessCount: space.access?.length ?? 0,
+                isNested: !!space.parentSpaceUuid,
             },
         });
         return newSpace;
@@ -248,6 +249,7 @@ export class SpaceService extends BaseService {
                 projectId: space.projectUuid,
                 isPrivate: space.isPrivate,
                 userAccessCount: space.access.length,
+                isNested,
             },
         });
         return updatedSpace;
@@ -279,6 +281,7 @@ export class SpaceService extends BaseService {
                 name: space.name,
                 spaceId: spaceUuid,
                 projectId: space.projectUuid,
+                isNested: !!space.parentSpaceUuid,
             },
         });
     }

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -32,6 +32,8 @@ import { useFeatureFlagEnabled } from '../hooks/useFeatureFlagEnabled';
 import { useSpace } from '../hooks/useSpaces';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 
 const Space: FC = () => {
     const { projectUuid, spaceUuid } = useParams<{
@@ -49,6 +51,7 @@ const Space: FC = () => {
 
     const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
     const { user, health } = useApp();
+    const { track } = useTracking();
 
     const areNestedSpacesEnabled = useFeatureFlagEnabled(
         FeatureFlags.NestedSpaces,
@@ -143,6 +146,22 @@ const Space: FC = () => {
                                     index ===
                                     (space.breadcrumbs?.length ?? 0) - 1,
                                 to: `/projects/${projectUuid}/spaces/${breadcrumb.uuid}`,
+                                onClick: () => {
+                                    if (
+                                        user.data?.userUuid &&
+                                        user.data?.organizationUuid
+                                    ) {
+                                        track({
+                                            name: EventName.SPACE_BREADCRUMB_CLICKED,
+                                            properties: {
+                                                userId: user.data?.userUuid,
+                                                organizationId:
+                                                    user.data?.organizationUuid,
+                                                projectId: projectUuid,
+                                            },
+                                        });
+                                    }
+                                },
                             })) ?? []),
                         ]}
                     />

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -400,6 +400,15 @@ type DashboardChartLoadedEvent = {
     };
 };
 
+type SpaceBreadcrumbClickedEvent = {
+    name: EventName.SPACE_BREADCRUMB_CLICKED;
+    properties: {
+        userId: string;
+        organizationId: string;
+        projectId: string;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | FormClickedEvent
@@ -433,7 +442,8 @@ export type EventData =
     | MetricsCatalogTreesCanvasModeClickedEvent
     | WriteBackEvent
     | DashboardChartLoadedEvent
-    | CustomMetricReplacementEvent;
+    | CustomMetricReplacementEvent
+    | SpaceBreadcrumbClickedEvent;
 
 export type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -150,4 +150,7 @@ export enum EventName {
     CUSTOM_FIELDS_REPLACEMENT_APPLIED = 'custom_fields_replacement.applied',
 
     DASHBOARD_CHART_LOADED = 'dashboard_chart.loaded',
+
+    // Spaces
+    SPACE_BREADCRUMB_CLICKED = 'space_breadcrumb.clicked',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14396

### Description:

**server events - create/update/delete**

<img width="1890" alt="Screenshot 2025-04-22 at 10 58 01" src="https://github.com/user-attachments/assets/aa7ac4c7-1fd5-46dc-9e52-47b6c93e2383" />
<img width="1856" alt="Screenshot 2025-04-22 at 10 58 33" src="https://github.com/user-attachments/assets/61e9fa0f-7cb7-490c-9081-ad5dcab720e0" />
<img width="1848" alt="Screenshot 2025-04-22 at 10 58 37" src="https://github.com/user-attachments/assets/ad2aa1af-aa04-49b3-9b62-05a4e6c392bd" />

**UI - click on space breadcrumb**

<img width="1899" alt="Screenshot 2025-04-22 at 10 59 04" src="https://github.com/user-attachments/assets/1a2b448a-5126-418a-92e7-bd37c15f86db" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
