### PR TITLE
feat: allow saving content to any space (tree view)

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -80,6 +80,7 @@ describe('Dashboard', () => {
         cy.get('[data-testid="ExploreMenu/NewDashboardButton"]').click();
 
         cy.findByLabelText('Name your dashboard *').type('Title');
+        cy.findByText('Next').click();
         cy.findByText('Create').click();
 
         // Check url has no filters
@@ -94,6 +95,7 @@ describe('Dashboard', () => {
         cy.contains('Create dashboard').click();
         cy.findByLabelText('Name your dashboard *').type('Title');
         cy.findByLabelText('Dashboard description').type('Description');
+        cy.findByText('Next').click();
         cy.findByText('Create').click();
 
         // Add Saved Chart

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -53,10 +53,9 @@ describe('Explore', () => {
         cy.findByTestId('Chart-card-expand').click();
 
         cy.findByText('Save chart').click();
-        cy.findByText('Select a space to save the chart directly to').should(
-            'exist',
-        );
+
         cy.findByTestId('ChartCreateModal/NameInput').type('My chart');
+        cy.contains('Next').click();
         cy.findByText('Save').click();
         cy.findByText('Success! Chart was saved.');
 

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -52,6 +52,7 @@ describe('Pivot Tables', () => {
         cy.get('[data-testid="ChartCreateModal/NameInput"]').type(
             'My Pivot Table Chart',
         );
+        cy.findByText('Next').click();
         cy.findByText('Save').click();
         cy.contains('Chart was saved');
         cy.contains('My Pivot Table Chart');

--- a/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
@@ -20,6 +20,7 @@ describe('Dashboard List', () => {
 
         cy.findByLabelText('Name your dashboard *').type('Untitled dashboard');
         cy.findByLabelText('Dashboard description').type('Description');
+        cy.findByText('Next').click();
         cy.findByText('Create').click();
 
         cy.url().should(

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -54,7 +54,8 @@ describe('Space', () => {
         cy.findByPlaceholderText('eg. KPI Dashboard').type(
             `Private dashboard ${timestamp}`,
         );
-        cy.get('.mantine-Modal-body').find('button').contains('Create').click();
+        cy.findByText('Next').click();
+        cy.findByText('Create').click();
         // At this point the dashboard is created, but empty
         // TODO add private chart to dashboard ?
 

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -27,12 +27,16 @@ describe('Space', () => {
         cy.contains('Chart name');
 
         cy.get('.mantine-Modal-body').find('button').should('be.disabled');
-        cy.contains('Select a space to save the chart directly to'); // Wait until it finishes loading, otherwise the input will be cleared
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 
-        // Saves to space by default
+        // Saves to space by default - FIX ME - note OWRKING
+        cy.get('.mantine-Modal-body')
+            .find('button')
+            .should('not.be.disabled')
+            .contains('Next')
+            .click();
         cy.get('.mantine-Modal-body')
             .find('button')
             .should('not.be.disabled')

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -31,7 +31,7 @@ describe('Space', () => {
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 
-        // Saves to space by default - FIX ME - note OWRKING
+        // Saves to space by default
         cy.get('.mantine-Modal-body')
             .find('button')
             .should('not.be.disabled')
@@ -42,6 +42,8 @@ describe('Space', () => {
             .should('not.be.disabled')
             .contains('Save')
             .click();
+
+        cy.contains('Success! Chart was saved.').should('exist');
 
         // Go back to space using breadcrumbs
         cy.contains('Private space').click();

--- a/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
@@ -209,6 +209,7 @@ describe('SQL Runner (new)', () => {
         cy.get(
             'input[placeholder="eg. How many weekly active users do we have?"]',
         ).type('Customers table SQL chart');
+        cy.findByText('Next').click();
         cy.get('section[role="dialog"]')
             .find('button')
             .contains('Save')

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
@@ -1,0 +1,67 @@
+import { Alert, Box, Button, Stack, Text, TextInput } from '@mantine/core';
+import { IconArrowLeft, IconInfoCircle } from '@tabler/icons-react';
+import MantineIcon from '../MantineIcon';
+
+type SpaceCreationFormProps = {
+    spaceName: string;
+    onSpaceNameChange: (name: string) => void;
+    onCancel: () => void;
+    isLoading?: boolean;
+    parentSpaceName?: string;
+};
+
+const SpaceCreationForm = ({
+    spaceName,
+    onSpaceNameChange,
+    onCancel,
+    isLoading,
+    parentSpaceName,
+}: SpaceCreationFormProps) => {
+    return (
+        <Stack spacing="xs">
+            <Box>
+                <Button
+                    variant="subtle"
+                    leftIcon={<MantineIcon icon={IconArrowLeft} />}
+                    onClick={onCancel}
+                    disabled={isLoading}
+                    size="xs"
+                    compact
+                >
+                    Back
+                </Button>
+            </Box>
+
+            {parentSpaceName && (
+                <Text fz="sm" fw={500}>
+                    You are creating a new space in{' '}
+                    <Text span fw={600}>
+                        '{parentSpaceName}'
+                    </Text>
+                </Text>
+            )}
+
+            <TextInput
+                label="Name"
+                placeholder="Space name"
+                required
+                disabled={isLoading}
+                value={spaceName}
+                onChange={(e) => onSpaceNameChange(e.target.value)}
+            />
+
+            {parentSpaceName && (
+                <Alert color="blue" icon={<IconInfoCircle size={16} />}>
+                    <Text fw={500} color="blue">
+                        Permissions will be inherited from{' '}
+                        <Text span fw={600}>
+                            '{parentSpaceName}'
+                        </Text>
+                    </Text>
+                </Alert>
+            )}
+        </Stack>
+    );
+};
+
+export default SpaceCreationForm;

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -1,0 +1,46 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Paper, ScrollArea } from '@mantine/core';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import Tree from '../Tree/Tree';
+import { type NestableItem } from '../Tree/types';
+
+type SpaceSelectorProps = {
+    spaces: Array<NestableItem> | undefined;
+    selectedSpaceUuid: string | null;
+    onSelectSpace: (spaceUuid: string | null) => void;
+    isLoading?: boolean;
+};
+
+const SpaceSelector = ({
+    spaces = [],
+    selectedSpaceUuid,
+    onSelectSpace,
+}: SpaceSelectorProps) => {
+    const isNestedSpacesEnabled = useFeatureFlagEnabled(
+        FeatureFlags.NestedSpaces,
+    );
+
+    if (isNestedSpacesEnabled) {
+        return (
+            <Paper
+                component={ScrollArea}
+                w="100%"
+                h="200px"
+                withBorder
+                px="sm"
+                py="xs"
+            >
+                <Tree
+                    data={spaces}
+                    value={selectedSpaceUuid}
+                    onChange={onSelectSpace}
+                    topLevelLabel="Spaces"
+                />
+            </Paper>
+        );
+    }
+
+    return null;
+};
+
+export default SpaceSelector;

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -1,19 +1,11 @@
-import {
-    Alert,
-    Box,
-    Button,
-    Group,
-    Paper,
-    ScrollArea,
-    Text,
-    TextInput,
-} from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { IconArrowLeft, IconInfoCircle, IconPlus } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useCreateMutation } from '../../../hooks/useSpaces';
+import { Alert, Box, Button, Group, Text } from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+import { useCallback, useMemo } from 'react';
+import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
+import MantineIcon from '../MantineIcon';
 import MantineModal, { type MantineModalProps } from '../MantineModal';
-import Tree from '../Tree/Tree';
+import SpaceCreationForm from '../SpaceSelector/SpaceCreationForm';
+import SpaceSelector from '../SpaceSelector/SpaceSelector';
 import { type NestableItem } from '../Tree/types';
 
 type Props<T, U> = Pick<MantineModalProps, 'opened' | 'onClose'> & {
@@ -34,31 +26,41 @@ const TransferItemsModal = <
     spaces,
     onConfirm,
 }: Props<T, U>) => {
-    const [spaceUuid, setSpaceUuid] = useState<string | null>(null);
-    const [isCreateNewSpace, createNewSpaceHandlers] = useDisclosure(false);
-    const [newSpaceName, setNewSpaceName] = useState('');
-
-    const createSpaceMutation = useCreateMutation(projectUuid);
+    const {
+        selectedSpaceUuid,
+        setSelectedSpaceUuid,
+        isCreatingNewSpace,
+        newSpaceName,
+        setNewSpaceName,
+        createSpaceMutation,
+        handleCreateNewSpace,
+        openCreateSpaceForm,
+        closeCreateSpaceForm,
+    } = useSpaceManagement({ projectUuid });
 
     const selectedSpaceLabel = useMemo(() => {
-        if (!spaceUuid) return null;
-        return spaces.find((space) => space.uuid === spaceUuid)?.name;
-    }, [spaceUuid, spaces]);
+        if (!selectedSpaceUuid) return '';
+        return (
+            spaces.find((space) => space.uuid === selectedSpaceUuid)?.name || ''
+        );
+    }, [selectedSpaceUuid, spaces]);
 
-    const handleCreateNewSpace = useCallback(() => {
-        if (newSpaceName.length === 0) return;
-
-        createSpaceMutation.mutate({
-            name: newSpaceName,
-            parentSpaceUuid: spaceUuid ?? undefined,
-        });
-    }, [createSpaceMutation, newSpaceName, spaceUuid]);
-
-    useEffect(() => {
-        if (createSpaceMutation.isSuccess) {
-            onConfirm(createSpaceMutation.data.uuid);
+    const handleConfirm = useCallback(() => {
+        if (selectedSpaceUuid) {
+            onConfirm(selectedSpaceUuid);
         }
-    }, [createSpaceMutation.isSuccess, createSpaceMutation.data, onConfirm]);
+    }, [selectedSpaceUuid, onConfirm]);
+
+    const createSpace = useCallback(async () => {
+        try {
+            const result = await handleCreateNewSpace();
+            if (result?.uuid) {
+                onConfirm(result.uuid);
+            }
+        } catch (error) {
+            console.error('Failed to create space:', error);
+        }
+    }, [handleCreateNewSpace, onConfirm]);
 
     return (
         <MantineModal
@@ -67,12 +69,13 @@ const TransferItemsModal = <
             onClose={onClose}
             actions={
                 <>
-                    {!isCreateNewSpace ? (
+                    {!isCreatingNewSpace ? (
                         <Button
-                            disabled={!spaceUuid}
+                            disabled={!selectedSpaceUuid}
                             variant="subtle"
-                            leftIcon={<IconPlus size={14} />}
-                            onClick={createNewSpaceHandlers.open}
+                            size="xs"
+                            onClick={openCreateSpaceForm}
+                            leftIcon={<MantineIcon icon={IconPlus} />}
                         >
                             New Space
                         </Button>
@@ -89,22 +92,18 @@ const TransferItemsModal = <
                             Cancel
                         </Button>
 
-                        {isCreateNewSpace ? (
+                        {isCreatingNewSpace ? (
                             <Button
                                 loading={createSpaceMutation.isLoading}
                                 disabled={newSpaceName.length === 0}
-                                onClick={handleCreateNewSpace}
+                                onClick={createSpace}
                             >
                                 Create space & transfer
                             </Button>
                         ) : (
                             <Button
-                                disabled={!spaceUuid}
-                                onClick={() => {
-                                    if (spaceUuid) {
-                                        onConfirm(spaceUuid);
-                                    }
-                                }}
+                                disabled={!selectedSpaceUuid}
+                                onClick={handleConfirm}
                             >
                                 Confirm
                             </Button>
@@ -113,43 +112,14 @@ const TransferItemsModal = <
                 </>
             }
         >
-            {isCreateNewSpace ? (
-                <>
-                    <Box>
-                        <Button
-                            variant="subtle"
-                            leftIcon={<IconArrowLeft size={14} />}
-                            onClick={createNewSpaceHandlers.close}
-                        >
-                            Back
-                        </Button>
-                    </Box>
-
-                    <Text fz="sm" fw={500}>
-                        You are creating a new space in{' '}
-                        <Text span fw={600}>
-                            "{selectedSpaceLabel}".
-                        </Text>
-                    </Text>
-
-                    <Alert color="blue" icon={<IconInfoCircle size={16} />}>
-                        <Text fw={500} color="blue">
-                            Permissions will be inherited from{' '}
-                            <Text span fw={600}>
-                                "{selectedSpaceLabel}".
-                            </Text>
-                        </Text>
-                    </Alert>
-
-                    <TextInput
-                        label="Name"
-                        placeholder="Space name"
-                        required
-                        disabled={createSpaceMutation.isLoading}
-                        value={newSpaceName}
-                        onChange={(e) => setNewSpaceName(e.target.value)}
-                    />
-                </>
+            {isCreatingNewSpace ? (
+                <SpaceCreationForm
+                    spaceName={newSpaceName}
+                    onSpaceNameChange={setNewSpaceName}
+                    onCancel={closeCreateSpaceForm}
+                    isLoading={createSpaceMutation.isLoading}
+                    parentSpaceName={selectedSpaceLabel}
+                />
             ) : (
                 <>
                     <Text fz="sm" fw={500}>
@@ -157,21 +127,12 @@ const TransferItemsModal = <
                         {items.length > 1 ? 'items' : 'item'} to:
                     </Text>
 
-                    <Paper
-                        component={ScrollArea}
-                        w="100%"
-                        h="320px"
-                        withBorder
-                        px="sm"
-                        py="xs"
-                    >
-                        <Tree
-                            data={spaces}
-                            value={spaceUuid}
-                            onChange={setSpaceUuid}
-                            topLevelLabel="Spaces"
-                        />
-                    </Paper>
+                    <SpaceSelector
+                        spaces={spaces}
+                        selectedSpaceUuid={selectedSpaceUuid}
+                        onSelectSpace={setSelectedSpaceUuid}
+                        isLoading={createSpaceMutation.isLoading}
+                    />
                 </>
             )}
 
@@ -179,8 +140,12 @@ const TransferItemsModal = <
                 <Alert color="gray">
                     <Text fw={500}>
                         Transfer {items.length}{' '}
-                        {items.length > 1 ? 'items' : 'item'} to "
-                        {selectedSpaceLabel}".
+                        {items.length > 1 ? 'items' : 'item'}{' '}
+                        {!isCreatingNewSpace
+                            ? `"
+                        ${selectedSpaceLabel}"`
+                            : ''}{' '}
+                        .
                     </Text>
                 </Alert>
             ) : null}

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboardForm.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboardForm.tsx
@@ -21,10 +21,8 @@ const SaveToDashboardForm = <T extends SaveToDashboardFormType>({
 }: Props<T>) => {
     return (
         <Select
-            description="Select a dashboard to save the chart directly to"
             id="select-dashboard"
             label="Dashboard"
-            size="xs"
             data={dashboards.map((d) => ({
                 value: d.uuid,
                 label: d.name,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -179,7 +179,6 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             if (
                 currentStep === ModalStep.SelectDestination &&
                 saveDestination === SaveDestination.Space &&
-                !selectedSpaceUuid &&
                 form.values.spaceUuid === null
             ) {
                 const isValidDefaultSpaceUuid = spaces?.some(
@@ -237,8 +236,6 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
 
     const handleOnSubmit = useCallback(
         async (values: FormValues) => {
-            console.log('values', values);
-            // return;
             if (!isFormReadyToSave) {
                 return;
             }

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     DashboardTileTypes,
+    FeatureFlags,
     assertUnreachable,
     getDefaultChartTileSize,
     type CreateSavedChartVersion,
@@ -20,7 +21,8 @@ import {
     Textarea,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { IconPlus } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import { z } from 'zod';
 import {
@@ -29,12 +31,12 @@ import {
     useUpdateDashboard,
 } from '../../../../hooks/dashboard/useDashboard';
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
+import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
-import {
-    useCreateMutation as useSpaceCreateMutation,
-    useSpaceSummaries,
-} from '../../../../hooks/useSpaces';
+import { useSpaceManagement } from '../../../../hooks/useSpaceManagement';
+import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import useApp from '../../../../providers/App/useApp';
+import MantineIcon from '../../../common/MantineIcon';
 import SaveToDashboardForm from './SaveToDashboardForm';
 import SaveToSpaceForm from './SaveToSpaceForm';
 import { saveToDashboardSchema, saveToSpaceSchema } from './types';
@@ -42,6 +44,11 @@ import { saveToDashboardSchema, saveToSpaceSchema } from './types';
 enum SaveDestination {
     Dashboard = 'dashboard',
     Space = 'space',
+}
+
+enum ModalStep {
+    InitialInfo,
+    SelectDestination,
 }
 
 const saveToSpaceOrDashboardSchema = z
@@ -80,12 +87,25 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
 
     const { mutateAsync: createChart, isLoading: isSavingChart } =
         useCreateMutation();
-    const { mutateAsync: createSpace, isLoading: isSavingSpace } =
-        useSpaceCreateMutation(projectUuid);
 
     const [saveDestination, setSaveDestination] = useState<SaveDestination>(
         SaveDestination.Space,
     );
+    const [currentStep, setCurrentStep] = useState<ModalStep>(
+        ModalStep.InitialInfo,
+    );
+
+    const spaceManagement = useSpaceManagement({
+        projectUuid,
+        defaultSpaceUuid,
+    });
+
+    const {
+        selectedSpaceUuid,
+        isCreatingNewSpace,
+        openCreateSpaceForm,
+        handleCreateNewSpace,
+    } = spaceManagement;
 
     const form = useForm<FormValues>({
         validate: zodResolver(saveToSpaceOrDashboardSchema),
@@ -101,6 +121,10 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             staleTime: 0,
         },
         true,
+    );
+
+    const isNestedSpacesEnabled = useFeatureFlagEnabled(
+        FeatureFlags.NestedSpaces,
     );
 
     const {
@@ -122,37 +146,71 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
         staleTime: 0,
     });
 
-    useEffect(() => {
-        if (!isSpacesSuccess || !isDashboardsSuccess) return;
-        if (form.initialized) return;
+    const { initialize } = form;
 
-        const isValidDefaultSpaceUuid = spaces.some(
-            (space) => space.uuid === defaultSpaceUuid,
-        );
+    useEffect(
+        function initializeForm() {
+            if (!isSpacesSuccess || !isDashboardsSuccess) return;
+            if (form.initialized) return;
 
-        const initialSpaceUuid = isValidDefaultSpaceUuid
-            ? defaultSpaceUuid
-            : spaces[0].uuid;
+            const initialValues: FormValues = {
+                name: '',
+                description: null,
+                newSpaceName: null,
+                dashboardUuid: dashboardInfoFromSavedData.dashboardUuid,
+                spaceUuid: null,
+            };
 
-        const initialValues: FormValues = {
-            name: '',
-            description: null,
+            initialize(initialValues);
+        },
+        [
+            form.initialized,
+            initialize,
+            dashboardInfoFromSavedData.dashboardUuid,
+            isDashboardsSuccess,
+            isSpacesSuccess,
+        ],
+    );
 
-            newSpaceName: null,
+    const { setFieldValue } = form;
 
-            dashboardUuid: dashboardInfoFromSavedData.dashboardUuid,
-            spaceUuid: initialSpaceUuid ?? null,
-        };
+    useEffect(
+        function setSpaceWhenUserReachesSelectionStep() {
+            if (
+                currentStep === ModalStep.SelectDestination &&
+                saveDestination === SaveDestination.Space &&
+                !selectedSpaceUuid &&
+                form.values.spaceUuid === null
+            ) {
+                const isValidDefaultSpaceUuid = spaces?.some(
+                    (space) => space.uuid === defaultSpaceUuid,
+                );
 
-        form.initialize(initialValues);
-    }, [
-        form,
-        dashboardInfoFromSavedData.dashboardUuid,
-        defaultSpaceUuid,
-        isDashboardsSuccess,
-        isSpacesSuccess,
-        spaces,
-    ]);
+                const initialSpaceUuid = isValidDefaultSpaceUuid
+                    ? defaultSpaceUuid
+                    : spaces?.[0]?.uuid;
+
+                if (initialSpaceUuid) {
+                    if (isNestedSpacesEnabled) {
+                        spaceManagement.setSelectedSpaceUuid(initialSpaceUuid);
+                    }
+
+                    setFieldValue('spaceUuid', initialSpaceUuid);
+                }
+            }
+        },
+        [
+            currentStep,
+            saveDestination,
+            setFieldValue,
+            spaces,
+            defaultSpaceUuid,
+            selectedSpaceUuid,
+            spaceManagement,
+            form.values.spaceUuid,
+            isNestedSpacesEnabled,
+        ],
+    );
 
     const { mutateAsync: updateDashboard } = useUpdateDashboard(
         form.values.dashboardUuid ?? undefined,
@@ -161,8 +219,30 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
         form.values.dashboardUuid ?? undefined,
     );
 
+    const isFormReadyToSave = useMemo(() => {
+        if (currentStep === ModalStep.SelectDestination) {
+            if (saveDestination === SaveDestination.Space) {
+                return (
+                    form.values.newSpaceName ||
+                    (form.values.spaceUuid !== null &&
+                        form.values.spaceUuid !== undefined)
+                );
+            }
+            if (saveDestination === SaveDestination.Dashboard) {
+                return form.values.dashboardUuid;
+            }
+        }
+        return false;
+    }, [currentStep, form.values, saveDestination]);
+
     const handleOnSubmit = useCallback(
         async (values: FormValues) => {
+            console.log('values', values);
+            // return;
+            if (!isFormReadyToSave) {
+                return;
+            }
+
             let savedQuery: SavedChart | undefined;
             /**
              * Create chart
@@ -206,9 +286,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
              */
             if (saveDestination === SaveDestination.Space) {
                 let newSpace = values.newSpaceName
-                    ? await createSpace({
-                          name: values.newSpaceName,
-                          access: [],
+                    ? await handleCreateNewSpace({
                           isPrivate: true,
                       })
                     : undefined;
@@ -231,12 +309,13 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             }
         },
         [
+            isFormReadyToSave,
             saveDestination,
             selectedDashboard,
             createChart,
             savedData,
             updateDashboard,
-            createSpace,
+            handleCreateNewSpace,
             onConfirm,
         ],
     );
@@ -246,70 +325,105 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
         isLoadingDashboards ||
         isLoadingSpaces ||
         isSavingChart ||
-        isSavingSpace;
+        spaceManagement.createSpaceMutation.isLoading;
+
+    const handleBack = () => {
+        setCurrentStep(ModalStep.InitialInfo);
+    };
+
+    const handleNextStep = () => {
+        setCurrentStep(ModalStep.SelectDestination);
+    };
+
+    // Determine if we should show the "New Space" button
+    const shouldShowNewSpaceButton =
+        isNestedSpacesEnabled &&
+        currentStep === ModalStep.SelectDestination &&
+        saveDestination === SaveDestination.Space &&
+        !isCreatingNewSpace;
+
+    // Get the name of the selected space for display in SpaceCreationForm
+    const selectedSpaceName = useMemo(() => {
+        if (!selectedSpaceUuid) return undefined;
+        return spaces?.find((space) => space.uuid === selectedSpaceUuid)?.name;
+    }, [selectedSpaceUuid, spaces]);
 
     return (
-        <form onSubmit={form.onSubmit((values) => handleOnSubmit(values))}>
+        <form
+            onSubmit={(e) => {
+                if (currentStep === ModalStep.InitialInfo) {
+                    return;
+                }
+                form.onSubmit((values) => handleOnSubmit(values))(e);
+            }}
+        >
             <LoadingOverlay visible={isLoading} />
 
             <Box p="md">
-                <Stack spacing="xs">
-                    <TextInput
-                        label="Chart name"
-                        placeholder="eg. How many weekly active users do we have?"
-                        required
-                        {...form.getInputProps('name')}
-                        value={form.values.name ?? ''}
-                        data-testid="ChartCreateModal/NameInput"
-                    />
-                    <Textarea
-                        label="Chart description"
-                        placeholder="A few words to give your team some context"
-                        autosize
-                        maxRows={3}
-                        {...form.getInputProps('description')}
-                        value={form.values.description ?? ''}
-                    />
-                </Stack>
+                {currentStep === ModalStep.InitialInfo && (
+                    <Stack spacing="xs">
+                        <TextInput
+                            label="Chart name"
+                            placeholder="eg. How many weekly active users do we have?"
+                            required
+                            {...form.getInputProps('name')}
+                            value={form.values.name ?? ''}
+                            data-testid="ChartCreateModal/NameInput"
+                        />
+                        <Textarea
+                            label="Chart description"
+                            placeholder="A few words to give your team some context"
+                            autosize
+                            maxRows={3}
+                            {...form.getInputProps('description')}
+                            value={form.values.description ?? ''}
+                        />
 
-                <Stack spacing="sm" mt="sm">
-                    <Radio.Group
-                        size="xs"
-                        value={saveDestination}
-                        onChange={(value: SaveDestination) =>
-                            setSaveDestination(value)
-                        }
-                    >
-                        <Group spacing="xs" mb="xs">
+                        <Stack spacing="sm" mt="sm">
                             <Text fw={500}>Save to</Text>
 
-                            <Radio
-                                value={SaveDestination.Space}
-                                label="Space"
-                                styles={(theme) => ({
-                                    label: {
-                                        paddingLeft: theme.spacing.xs,
-                                    },
-                                })}
-                                disabled={!spaces || isLoadingSpaces}
-                            />
-                            <Radio
-                                value={SaveDestination.Dashboard}
-                                label="Dashboard"
-                                styles={(theme) => ({
-                                    label: {
-                                        paddingLeft: theme.spacing.xs,
-                                    },
-                                })}
-                            />
-                        </Group>
+                            <Radio.Group
+                                value={saveDestination}
+                                onChange={(value: SaveDestination) =>
+                                    setSaveDestination(value)
+                                }
+                            >
+                                <Stack spacing="xs">
+                                    <Radio
+                                        value={SaveDestination.Space}
+                                        label="Space"
+                                        styles={(theme) => ({
+                                            label: {
+                                                paddingLeft: theme.spacing.xs,
+                                            },
+                                        })}
+                                        disabled={!spaces || isLoadingSpaces}
+                                    />
+                                    <Radio
+                                        value={SaveDestination.Dashboard}
+                                        label="Dashboard"
+                                        styles={(theme) => ({
+                                            label: {
+                                                paddingLeft: theme.spacing.xs,
+                                            },
+                                        })}
+                                    />
+                                </Stack>
+                            </Radio.Group>
+                        </Stack>
+                    </Stack>
+                )}
 
+                {currentStep === ModalStep.SelectDestination && (
+                    <>
                         {saveDestination === SaveDestination.Space ? (
                             <SaveToSpaceForm
                                 form={form}
                                 isLoading={isLoadingSpaces}
                                 spaces={spaces}
                                 projectUuid={projectUuid}
+                                spaceManagement={spaceManagement}
+                                selectedSpaceName={selectedSpaceName}
                             />
                         ) : saveDestination === SaveDestination.Dashboard ? (
                             <SaveToDashboardForm
@@ -326,8 +440,8 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                                 `Unknown save destination ${saveDestination}`,
                             )
                         )}
-                    </Radio.Group>
-                </Stack>
+                    </>
+                )}
             </Box>
             <Group
                 position="right"
@@ -338,24 +452,53 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     padding: theme.spacing.md,
                 })}
             >
-                <Button onClick={onClose} variant="outline">
-                    Cancel
-                </Button>
+                {currentStep === ModalStep.InitialInfo ? (
+                    <>
+                        <Button onClick={onClose} variant="outline">
+                            Cancel
+                        </Button>
+                        <Button
+                            onClick={(
+                                e: React.MouseEvent<HTMLButtonElement>,
+                            ) => {
+                                e.preventDefault();
+                                handleNextStep();
+                            }}
+                            disabled={!form.values.name}
+                            type="button"
+                        >
+                            Next
+                        </Button>
+                    </>
+                ) : (
+                    <>
+                        {shouldShowNewSpaceButton && (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                onClick={openCreateSpaceForm}
+                                mr="auto"
+                            >
+                                New Space
+                            </Button>
+                        )}
 
-                <Button
-                    type="submit"
-                    loading={isSavingChart || isSavingSpace}
-                    disabled={
-                        !form.values.name ||
-                        (!form.values.newSpaceName &&
-                            saveDestination === SaveDestination.Space &&
-                            !form.values.spaceUuid) ||
-                        (!form.values.dashboardUuid &&
-                            saveDestination === SaveDestination.Dashboard)
-                    }
-                >
-                    Save
-                </Button>
+                        <Button onClick={handleBack} variant="outline">
+                            Back
+                        </Button>
+                        <Button
+                            type="submit"
+                            loading={
+                                isSavingChart ||
+                                spaceManagement.createSpaceMutation.isLoading
+                            }
+                            disabled={!isFormReadyToSave}
+                        >
+                            Save
+                        </Button>
+                    </>
+                )}
             </Group>
         </form>
     );

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -11,28 +11,26 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconArrowBack, IconChartBar } from '@tabler/icons-react';
-import {
-    useCallback,
-    useEffect,
-    useState,
-    type Dispatch,
-    type FC,
-    type SetStateAction,
-} from 'react';
+import { IconArrowBack, IconChartBar, IconPlus } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, type FC } from 'react';
 import { z } from 'zod';
 import { selectCompleteConfigByKind } from '../../../components/DataViz/store/selectors';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SaveToSpaceForm from '../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
 import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateModal/types';
-import {
-    useCreateMutation as useSpaceCreateMutation,
-    useSpaceSummaries,
-} from '../../../hooks/useSpaces';
+import { useModalSteps } from '../../../hooks/useModalSteps';
+import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { EditorTabs, updateName } from '../store/sqlRunnerSlice';
 import { SqlQueryBeforeSaveAlert } from './SqlQueryBeforeSaveAlert';
+
+enum ModalStep {
+    Warning = 'warning',
+    InitialInfo = 'initialInfo',
+    SelectDestination = 'selectDestination',
+}
 
 const saveChartFormSchema = z
     .object({
@@ -45,11 +43,7 @@ type FormValues = z.infer<typeof saveChartFormSchema>;
 
 type Props = Pick<ModalProps, 'opened' | 'onClose'>;
 
-const SaveChartForm: FC<
-    {
-        setShowWarning: Dispatch<SetStateAction<boolean>>;
-    } & Pick<Props, 'onClose'>
-> = ({ setShowWarning, onClose }) => {
+const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const hasUnrunChanges = useAppSelector(
@@ -79,6 +73,22 @@ const SaveChartForm: FC<
         ),
     );
 
+    const form = useForm<FormValues>({
+        initialValues: {
+            name: '',
+            description: null,
+            spaceUuid: null,
+            newSpaceName: null,
+        },
+        validate: zodResolver(saveChartFormSchema),
+    });
+
+    const modalSteps = useModalSteps<ModalStep>(ModalStep.InitialInfo, {
+        validators: {
+            [ModalStep.InitialInfo]: () => !!form.values.name,
+        },
+    });
+
     // TODO: this sometimes runs `/api/v1/projects//spaces` request
     // because initial `projectUuid` is set to '' (empty string)
     // we should handle this by creating an impossible state
@@ -89,19 +99,12 @@ const SaveChartForm: FC<
         isSuccess: isSuccessSpace,
     } = useSpaceSummaries(projectUuid, true);
 
-    const { mutateAsync: createSpace, isLoading: isCreatingSpace } =
-        useSpaceCreateMutation(projectUuid);
-
-    const form = useForm<FormValues>({
-        initialValues: {
-            name: '',
-            description: null,
-
-            spaceUuid: null,
-            newSpaceName: null,
-        },
-        validate: zodResolver(saveChartFormSchema),
+    const spaceManagement = useSpaceManagement({
+        projectUuid,
     });
+
+    const { handleCreateNewSpace, isCreatingNewSpace, openCreateSpaceForm } =
+        spaceManagement;
 
     useEffect(() => {
         if (isSuccessSpace && spaces) {
@@ -122,14 +125,13 @@ const SaveChartForm: FC<
         mutateAsync: createSavedSqlChart,
         isLoading: isCreatingSavedSqlChart,
     } = useCreateSqlChartMutation(projectUuid);
+
     const handleOnSubmit = useCallback(async () => {
         if (spaces.length === 0) {
             return;
         }
         let newSpace = form.values.newSpaceName
-            ? await createSpace({
-                  name: form.values.newSpaceName,
-                  access: [],
+            ? await handleCreateNewSpace({
                   isPrivate: true,
               })
             : undefined;
@@ -159,7 +161,7 @@ const SaveChartForm: FC<
         form.values.spaceUuid,
         form.values.name,
         form.values.description,
-        createSpace,
+        handleCreateNewSpace,
         currentVizConfig,
         sql,
         createSavedSqlChart,
@@ -168,33 +170,72 @@ const SaveChartForm: FC<
         onClose,
     ]);
 
+    const handleNextStep = () => {
+        modalSteps.goToStep(ModalStep.SelectDestination);
+    };
+
+    const handleBack = () => {
+        modalSteps.goToStep(ModalStep.InitialInfo);
+    };
+
+    const shouldShowNewSpaceButton = useMemo(
+        () =>
+            modalSteps.currentStep === ModalStep.SelectDestination &&
+            !isCreatingNewSpace,
+        [modalSteps.currentStep, isCreatingNewSpace],
+    );
+
+    const isFormReadyToSave = useMemo(
+        () =>
+            modalSteps.currentStep === ModalStep.SelectDestination &&
+            form.values.name &&
+            (form.values.newSpaceName || form.values.spaceUuid) &&
+            sql,
+        [
+            modalSteps.currentStep,
+            form.values.name,
+            form.values.newSpaceName,
+            form.values.spaceUuid,
+            sql,
+        ],
+    );
+
     return (
         <form onSubmit={form.onSubmit(handleOnSubmit)}>
-            <Stack p="md">
-                <Stack spacing="xs">
-                    <TextInput
-                        label="Chart name"
-                        placeholder="eg. How many weekly active users do we have?"
-                        required
-                        {...form.getInputProps('name')}
-                    />
-                    <Textarea
-                        label="Description"
-                        {...form.getInputProps('description')}
-                        value={form.values.description ?? ''}
+            {modalSteps.currentStep === ModalStep.InitialInfo && (
+                <Stack p="md">
+                    <Stack spacing="xs">
+                        <TextInput
+                            label="Chart name"
+                            placeholder="eg. How many weekly active users do we have?"
+                            required
+                            {...form.getInputProps('name')}
+                        />
+                        <Textarea
+                            label="Description"
+                            {...form.getInputProps('description')}
+                            value={form.values.description ?? ''}
+                        />
+                    </Stack>
+                </Stack>
+            )}
+
+            {modalSteps.currentStep === ModalStep.SelectDestination && (
+                <Stack p="md">
+                    <SaveToSpaceForm
+                        form={form}
+                        spaces={spaces}
+                        projectUuid={projectUuid}
+                        isLoading={isLoadingSpace || isCreatingSavedSqlChart}
+                        spaceManagement={spaceManagement}
+                        selectedSpaceName={
+                            spaces.find(
+                                (space) => space.uuid === form.values.spaceUuid,
+                            )?.name
+                        }
                     />
                 </Stack>
-                <SaveToSpaceForm
-                    form={form}
-                    spaces={spaces}
-                    projectUuid={projectUuid}
-                    isLoading={
-                        isLoadingSpace ||
-                        isCreatingSpace ||
-                        isCreatingSavedSqlChart
-                    }
-                />
-            </Stack>
+            )}
 
             <Group
                 position="right"
@@ -205,6 +246,18 @@ const SaveChartForm: FC<
                     padding: theme.spacing.md,
                 })}
             >
+                {shouldShowNewSpaceButton && (
+                    <Button
+                        variant="subtle"
+                        size="xs"
+                        leftIcon={<MantineIcon icon={IconPlus} />}
+                        onClick={openCreateSpaceForm}
+                        mr="auto"
+                    >
+                        New Space
+                    </Button>
+                )}
+
                 <Button
                     onClick={onClose}
                     variant="outline"
@@ -217,19 +270,33 @@ const SaveChartForm: FC<
                     <Button
                         leftIcon={<MantineIcon icon={IconArrowBack} />}
                         variant="outline"
-                        onClick={() => setShowWarning(true)}
+                        onClick={() => modalSteps.goToStep(ModalStep.Warning)}
                     >
                         Back
                     </Button>
                 )}
 
-                <Button
-                    type="submit"
-                    disabled={!form.values.name || !sql}
-                    loading={isCreatingSavedSqlChart}
-                >
-                    Save
-                </Button>
+                {modalSteps.currentStep === ModalStep.InitialInfo ? (
+                    <Button
+                        onClick={handleNextStep}
+                        disabled={!form.values.name}
+                    >
+                        Next
+                    </Button>
+                ) : (
+                    <>
+                        <Button onClick={handleBack} variant="outline">
+                            Back
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={!isFormReadyToSave}
+                            loading={isCreatingSavedSqlChart}
+                        >
+                            Save
+                        </Button>
+                    </>
+                )}
             </Group>
         </form>
     );
@@ -239,7 +306,11 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     const hasUnrunChanges = useAppSelector(
         (state) => state.sqlRunner.hasUnrunChanges,
     );
-    const [showWarning, setShowWarning] = useState(hasUnrunChanges);
+
+    const initialStep = hasUnrunChanges
+        ? ModalStep.Warning
+        : ModalStep.InitialInfo;
+    const modalSteps = useModalSteps<ModalStep>(initialStep);
 
     return (
         <Modal
@@ -257,7 +328,7 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
                 body: { padding: 0 },
             })}
         >
-            {showWarning ? (
+            {modalSteps.currentStep === ModalStep.Warning ? (
                 <Box>
                     <SqlQueryBeforeSaveAlert />
                     <Group
@@ -273,16 +344,17 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
                             Cancel
                         </Button>
 
-                        <Button onClick={() => setShowWarning(false)}>
+                        <Button
+                            onClick={() =>
+                                modalSteps.goToStep(ModalStep.InitialInfo)
+                            }
+                        >
                             Next
                         </Button>
                     </Group>
                 </Box>
             ) : (
-                <SaveChartForm
-                    setShowWarning={setShowWarning}
-                    onClose={onClose}
-                />
+                <SaveChartForm onClose={onClose} />
             )}
         </Modal>
     );

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -1,4 +1,4 @@
-import { ChartKind } from '@lightdash/common';
+import { ChartKind, FeatureFlags } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -18,6 +18,7 @@ import { selectCompleteConfigByKind } from '../../../components/DataViz/store/se
 import MantineIcon from '../../../components/common/MantineIcon';
 import SaveToSpaceForm from '../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
 import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateModal/types';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useModalSteps } from '../../../hooks/useModalSteps';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
@@ -44,6 +45,9 @@ type FormValues = z.infer<typeof saveChartFormSchema>;
 type Props = Pick<ModalProps, 'opened' | 'onClose'>;
 
 const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
+    const isNestedSpacesEnabled = useFeatureFlagEnabled(
+        FeatureFlags.NestedSpaces,
+    );
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const hasUnrunChanges = useAppSelector(
@@ -180,9 +184,10 @@ const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
 
     const shouldShowNewSpaceButton = useMemo(
         () =>
+            isNestedSpacesEnabled &&
             modalSteps.currentStep === ModalStep.SelectDestination &&
             !isCreatingNewSpace,
-        [modalSteps.currentStep, isCreatingNewSpace],
+        [isNestedSpacesEnabled, modalSteps.currentStep, isCreatingNewSpace],
     );
 
     const isFormReadyToSave = useMemo(

--- a/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
@@ -9,21 +9,24 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { IconChartBar } from '@tabler/icons-react';
-import { useEffect } from 'react';
+import { IconChartBar, IconPlus } from '@tabler/icons-react';
+import { useEffect, useMemo } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SaveToSpaceForm from '../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
 import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateModal/types';
-
-import {
-    useCreateMutation as useSpaceCreateMutation,
-    useSpaceSummaries,
-} from '../../../hooks/useSpaces';
+import { useModalSteps } from '../../../hooks/useModalSteps';
+import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import {
     useSavedSqlChart,
     useUpdateSqlChartMutation,
 } from '../hooks/useSavedSqlCharts';
+
+enum ModalStep {
+    InitialInfo = 'initialInfo',
+    SelectDestination = 'selectDestination',
+}
 
 const updateSqlChartSchema = z
     .object({
@@ -62,11 +65,13 @@ export const UpdateSqlChartModal = ({
         projectUuid,
         true,
     );
-    const { mutateAsync: createSpace, isLoading: isCreatingSpace } =
-        useSpaceCreateMutation(projectUuid);
 
-    const { mutateAsync: updateChart, isLoading: isSavingChart } =
-        useUpdateSqlChartMutation(projectUuid, savedSqlUuid, slug);
+    const spaceManagement = useSpaceManagement({
+        projectUuid,
+        defaultSpaceUuid: data?.space.uuid,
+    });
+
+    const { isCreatingNewSpace, openCreateSpaceForm } = spaceManagement;
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -77,6 +82,15 @@ export const UpdateSqlChartModal = ({
         },
         validate: zodResolver(updateSqlChartSchema),
     });
+
+    const modalSteps = useModalSteps<ModalStep>(ModalStep.InitialInfo, {
+        validators: {
+            [ModalStep.InitialInfo]: () => !!form.values.name,
+        },
+    });
+
+    const { mutateAsync: updateChart, isLoading: isSavingChart } =
+        useUpdateSqlChartMutation(projectUuid, savedSqlUuid, slug);
 
     useEffect(() => {
         if (isChartSuccess && data) {
@@ -97,9 +111,7 @@ export const UpdateSqlChartModal = ({
     const handleOnSubmit = form.onSubmit(
         async ({ name, description, spaceUuid, newSpaceName }) => {
             let newSpace = newSpaceName
-                ? await createSpace({
-                      name: newSpaceName,
-                      access: [],
+                ? await spaceManagement.handleCreateNewSpace({
                       isPrivate: true,
                   })
                 : undefined;
@@ -108,7 +120,7 @@ export const UpdateSqlChartModal = ({
                 unversionedData: {
                     name,
                     description: description ?? null,
-                    spaceUuid: newSpace?.uuid || spaceUuid || spaces[0].uuid,
+                    spaceUuid: newSpace?.uuid || spaceUuid || spaces[0]?.uuid,
                 },
             });
 
@@ -116,8 +128,35 @@ export const UpdateSqlChartModal = ({
         },
     );
 
-    const isLoading =
-        isSavingChart || isChartLoading || isSpacesLoading || isCreatingSpace;
+    const handleNextStep = () => {
+        modalSteps.goToStep(ModalStep.SelectDestination);
+    };
+
+    const handleBack = () => {
+        modalSteps.goToStep(ModalStep.InitialInfo);
+    };
+
+    const shouldShowNewSpaceButton = useMemo(
+        () =>
+            modalSteps.currentStep === ModalStep.SelectDestination &&
+            !isCreatingNewSpace,
+        [modalSteps.currentStep, isCreatingNewSpace],
+    );
+
+    const isFormReadyToSave = useMemo(
+        () =>
+            modalSteps.currentStep === ModalStep.SelectDestination &&
+            form.values.name &&
+            (form.values.newSpaceName || form.values.spaceUuid),
+        [
+            modalSteps.currentStep,
+            form.values.name,
+            form.values.newSpaceName,
+            form.values.spaceUuid,
+        ],
+    );
+
+    const isLoading = isSavingChart || isChartLoading || isSpacesLoading;
 
     return (
         <Modal
@@ -136,27 +175,40 @@ export const UpdateSqlChartModal = ({
             })}
         >
             <form onSubmit={handleOnSubmit}>
-                <Stack p="md">
-                    <Stack spacing="xs">
-                        <TextInput
-                            label="Chart name"
-                            placeholder="eg. How many weekly active users do we have?"
-                            required
-                            {...form.getInputProps('name')}
-                        />
-                        <Textarea
-                            label="Description"
-                            {...form.getInputProps('description')}
+                {modalSteps.currentStep === ModalStep.InitialInfo && (
+                    <Stack p="md">
+                        <Stack spacing="xs">
+                            <TextInput
+                                label="Chart name"
+                                placeholder="eg. How many weekly active users do we have?"
+                                required
+                                {...form.getInputProps('name')}
+                            />
+                            <Textarea
+                                label="Description"
+                                {...form.getInputProps('description')}
+                            />
+                        </Stack>
+                    </Stack>
+                )}
+
+                {modalSteps.currentStep === ModalStep.SelectDestination && (
+                    <Stack p="md">
+                        <SaveToSpaceForm
+                            form={form}
+                            spaces={spaces}
+                            projectUuid={projectUuid}
+                            isLoading={isLoading}
+                            spaceManagement={spaceManagement}
+                            selectedSpaceName={
+                                spaces.find(
+                                    (space) =>
+                                        space.uuid === form.values.spaceUuid,
+                                )?.name
+                            }
                         />
                     </Stack>
-
-                    <SaveToSpaceForm
-                        form={form}
-                        spaces={spaces}
-                        projectUuid={projectUuid}
-                        isLoading={isLoading}
-                    />
-                </Stack>
+                )}
 
                 <Group
                     position="right"
@@ -167,6 +219,18 @@ export const UpdateSqlChartModal = ({
                         padding: theme.spacing.md,
                     })}
                 >
+                    {shouldShowNewSpaceButton && (
+                        <Button
+                            variant="subtle"
+                            size="xs"
+                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            onClick={openCreateSpaceForm}
+                            mr="auto"
+                        >
+                            New Space
+                        </Button>
+                    )}
+
                     <Button
                         onClick={onClose}
                         variant="outline"
@@ -174,13 +238,28 @@ export const UpdateSqlChartModal = ({
                     >
                         Cancel
                     </Button>
-                    <Button
-                        type="submit"
-                        disabled={!form.values.name}
-                        loading={isLoading}
-                    >
-                        Save
-                    </Button>
+
+                    {modalSteps.currentStep === ModalStep.InitialInfo ? (
+                        <Button
+                            onClick={handleNextStep}
+                            disabled={!form.values.name}
+                        >
+                            Next
+                        </Button>
+                    ) : (
+                        <>
+                            <Button onClick={handleBack} variant="outline">
+                                Back
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={!isFormReadyToSave}
+                                loading={isLoading}
+                            >
+                                Save
+                            </Button>
+                        </>
+                    )}
                 </Group>
             </form>
         </Modal>

--- a/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import {
     Button,
     Group,
@@ -15,6 +16,7 @@ import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SaveToSpaceForm from '../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
 import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateModal/types';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useModalSteps } from '../../../hooks/useModalSteps';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
@@ -52,6 +54,9 @@ export const UpdateSqlChartModal = ({
     onClose,
     onSuccess,
 }: Props) => {
+    const isNestedSpacesEnabled = useFeatureFlagEnabled(
+        FeatureFlags.NestedSpaces,
+    );
     const {
         data,
         isLoading: isChartLoading,
@@ -138,9 +143,10 @@ export const UpdateSqlChartModal = ({
 
     const shouldShowNewSpaceButton = useMemo(
         () =>
+            isNestedSpacesEnabled &&
             modalSteps.currentStep === ModalStep.SelectDestination &&
             !isCreatingNewSpace,
-        [modalSteps.currentStep, isCreatingNewSpace],
+        [isNestedSpacesEnabled, modalSteps.currentStep, isCreatingNewSpace],
     );
 
     const isFormReadyToSave = useMemo(

--- a/packages/frontend/src/hooks/useModalSteps.ts
+++ b/packages/frontend/src/hooks/useModalSteps.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Hook for managing steps in a modal flow
+ * @param initialStep - The initial step to start with
+ */
+export function useModalSteps<T extends string | number>(
+    initialStep: T,
+    options?: {
+        /**
+         * Optional validation functions for each step
+         * Return true if the step is valid and can proceed
+         */
+        validators?: Partial<Record<T, () => boolean>>;
+    },
+) {
+    const [currentStep, setCurrentStep] = useState<T>(initialStep);
+
+    const goToStep = useCallback((step: T) => {
+        setCurrentStep(step);
+    }, []);
+
+    const goToNextStep = useCallback(
+        (nextStep: T) => {
+            const validator = options?.validators?.[currentStep];
+
+            if (validator && !validator()) {
+                return false;
+            }
+
+            setCurrentStep(nextStep);
+            return true;
+        },
+        [currentStep, options?.validators],
+    );
+
+    const goToPreviousStep = useCallback((previousStep: T) => {
+        setCurrentStep(previousStep);
+    }, []);
+
+    return {
+        currentStep,
+        goToStep,
+        goToNextStep,
+        goToPreviousStep,
+    };
+}

--- a/packages/frontend/src/hooks/useSpaceManagement.ts
+++ b/packages/frontend/src/hooks/useSpaceManagement.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+import { useCreateMutation } from './useSpaces';
+
+type UseSpaceManagementProps = {
+    projectUuid?: string;
+    defaultSpaceUuid?: string;
+};
+
+/**
+ * This hook is used to manage the space management UI.
+ * It is used to create a new space (nested or not) and to select a space.
+ */
+export const useSpaceManagement = ({
+    projectUuid,
+    defaultSpaceUuid,
+}: UseSpaceManagementProps = {}) => {
+    const [selectedSpaceUuid, setSelectedSpaceUuid] = useState<string | null>(
+        defaultSpaceUuid || null,
+    );
+    const [isCreatingNewSpace, setIsCreatingNewSpace] = useState(false);
+    const [newSpaceName, setNewSpaceName] = useState('');
+
+    const createSpaceMutation = useCreateMutation(projectUuid);
+
+    const handleCreateNewSpace = useCallback(
+        async ({ isPrivate }: { isPrivate?: boolean } = {}) => {
+            if (newSpaceName.length === 0) return null;
+
+            const result = await createSpaceMutation.mutateAsync({
+                name: newSpaceName,
+                parentSpaceUuid: selectedSpaceUuid || undefined,
+                ...(isPrivate && { isPrivate }),
+            });
+
+            // Reset form state after successful creation
+            setNewSpaceName('');
+            setIsCreatingNewSpace(false);
+
+            return result;
+        },
+        [createSpaceMutation, newSpaceName, selectedSpaceUuid],
+    );
+
+    const openCreateSpaceForm = useCallback(() => {
+        setIsCreatingNewSpace(true);
+    }, []);
+
+    const closeCreateSpaceForm = useCallback(() => {
+        setIsCreatingNewSpace(false);
+        setNewSpaceName('');
+    }, []);
+
+    return {
+        selectedSpaceUuid,
+        setSelectedSpaceUuid,
+        isCreatingNewSpace,
+        setIsCreatingNewSpace,
+        newSpaceName,
+        setNewSpaceName,
+        createSpaceMutation,
+        handleCreateNewSpace,
+        openCreateSpaceForm,
+        closeCreateSpaceForm,
+    };
+};

--- a/packages/frontend/src/hooks/useSpaceManagement.ts
+++ b/packages/frontend/src/hooks/useSpaceManagement.ts
@@ -24,7 +24,7 @@ export const useSpaceManagement = ({
 
     const handleCreateNewSpace = useCallback(
         async ({ isPrivate }: { isPrivate?: boolean } = {}) => {
-            if (newSpaceName.length === 0) return null;
+            if (newSpaceName.length === 0) return;
 
             const result = await createSpaceMutation.mutateAsync({
                 name: newSpaceName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #14329

### Description:

Adds multi-step modal when saving a chart

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/bf229734-1a3c-4416-a0f2-c2cac9fbe209.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/c4557fdd-d6b4-4624-b916-7e4235dc59b4.png)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
