### PR TITLE
fix: conditional formatting for small numbers and smooth color range

### DIFF
--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -13,7 +13,6 @@ export type ConditionalFormattingMinMax<T = number> = {
 export type ConditionalFormattingColorRange = {
     start: string;
     end: string;
-    steps: number;
 };
 
 export type ConditionalFormattingWithValues<T = number | string> =
@@ -59,9 +58,7 @@ export type ConditionalFormattingConfigWithColorRange = {
 export const isConditionalFormattingConfigWithColorRange = (
     config: ConditionalFormattingConfig,
 ): config is ConditionalFormattingConfigWithColorRange =>
-    'color' in config &&
-    typeof config.color === 'object' &&
-    'steps' in config.color;
+    'color' in config && typeof config.color === 'object';
 
 export type ConditionalFormattingConfig =
     | ConditionalFormattingConfigWithSingleColor

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -74,7 +74,6 @@ export const createConditionalFormattingConfigWithColorRange = (
     color: {
         start: '#ffffff',
         end: defaultColor,
-        steps: 5,
     },
     rule: {
         min: 0,

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -14,9 +14,7 @@ export const readableColor = (backgroundColor: string) => {
     return onWhite > onBlack ? 'white' : 'black';
 };
 
-const getColorRange = (
-    colorConfig: ConditionalFormattingColorRange,
-): string[] | undefined => {
+const getColorRange = (colorConfig: ConditionalFormattingColorRange) => {
     if (
         !isHexCodeColor(colorConfig.start) ||
         !isHexCodeColor(colorConfig.end)
@@ -24,16 +22,13 @@ const getColorRange = (
         return undefined;
     }
 
-    const colors = Color.steps(
+    return Color.range(
         new Color(colorConfig.start),
         new Color(colorConfig.end),
         {
-            steps: colorConfig.steps,
             space: 'srgb',
         },
     );
-
-    return colors.map((c) => new Color(c).toString({ format: 'hex' }));
 };
 
 export const getColorFromRange = (
@@ -41,14 +36,27 @@ export const getColorFromRange = (
     colorRange: ConditionalFormattingColorRange,
     minMaxRange: ConditionalFormattingMinMax,
 ): string | undefined => {
-    const colors = getColorRange(colorRange);
-    if (!colors) return undefined;
+    const interpolateColor = getColorRange(colorRange);
+
+    if (!interpolateColor) return undefined;
 
     const min = minMaxRange.min;
-    const inclusiveMax = minMaxRange.max + 1;
+    const max = minMaxRange.max;
 
-    const step = (inclusiveMax - min) / colorRange.steps;
-    const index = Math.floor((value - min) / step);
+    if (min > max || value < min || value > max) {
+        console.error(
+            new Error(
+                `invalid minMaxRange: [${min},${max}] or value: ${value}`,
+            ),
+        );
+        return undefined;
+    }
 
-    return colors[index];
+    if (min === max) {
+        return interpolateColor(1).toString({ format: 'hex' });
+    }
+
+    const percentage = (value - min) / (max - min);
+
+    return interpolateColor(percentage).toString({ format: 'hex' });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12557 and fixes bug with small (close to 1) numbers

### Description:
Instead of using discrete fixed number of steps, smoothly interpolate numbers

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/dea14c16-8b7e-4f15-9ff0-c62dadf6e67f.png)

![CleanShot 2025-04-23 at 16.35.32@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/c622abff-a761-452d-ad89-27c5978bbb9d.png)

<!-- Even better add a screenshot / gif / loom -->

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
