### PR TITLE
fix: stop waiting for first results page

### DIFF
--- a/packages/backend/src/controllers/v2/ProjectController.ts
+++ b/packages/backend/src/controllers/v2/ProjectController.ts
@@ -63,11 +63,6 @@ export class V2ProjectController extends BaseController {
     ): Promise<ApiGetAsyncQueryResultsResponse> {
         this.setStatus(200);
 
-        // sleep 500ms
-        await new Promise((resolve) => {
-            setTimeout(resolve, 5000);
-        });
-
         const results = await this.services
             .getProjectService()
             .getAsyncQueryResults({

--- a/packages/backend/src/controllers/v2/ProjectController.ts
+++ b/packages/backend/src/controllers/v2/ProjectController.ts
@@ -63,6 +63,11 @@ export class V2ProjectController extends BaseController {
     ): Promise<ApiGetAsyncQueryResultsResponse> {
         this.setStatus(200);
 
+        // sleep 500ms
+        await new Promise((resolve) => {
+            setTimeout(resolve, 5000);
+        });
+
         const results = await this.services
             .getProjectService()
             .getAsyncQueryResults({

--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -91,7 +91,6 @@ describe('Table calculations', () => {
         cy.contains('Add "rank_1"').click();
         cy.get('button').contains('Run query').click();
 
-        cy.contains('Loading results'); // wait for results to load
         // Check valid results
         cy.contains('rank_1');
         cy.contains('rank_2').should('not.exist');
@@ -134,7 +133,6 @@ describe('Table calculations', () => {
         cy.findByPlaceholderText('Enter value(s)').clear().type('250');
         cy.get('button').contains('Run query').click();
 
-        cy.contains('Loading results'); // wait for results to load
         // Check valid results
         cy.contains('300');
         cy.contains('100').should('not.exist');

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1471,13 +1471,26 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
         readyQuery.data?.executeQueryResponse.queryUuid,
     );
 
+    const isLoading = useMemo(() => {
+        const isCreatingQuery = readyQuery.isFetching;
+        const isFetchingFirstPage =
+            resultsData.totalResults === undefined ||
+            (resultsData.totalResults > 0 && resultsData.rows.length === 0);
+        const isFetchingAllRows =
+            resultsData.fetchAll && !resultsData.hasFetchedAllRows;
+        return isCreatingQuery || isFetchingFirstPage || isFetchingAllRows;
+    }, [
+        readyQuery.isFetching,
+        resultsData.fetchAll,
+        resultsData.hasFetchedAllRows,
+        resultsData.rows.length,
+        resultsData.totalResults,
+    ]);
+
     return (
         <GenericDashboardChartTile
             {...props}
-            isLoading={
-                (resultsData.fetchAll && !resultsData.hasFetchedAllRows) ||
-                readyQuery.isFetching
-            }
+            isLoading={isLoading}
             resultsData={resultsData}
             dashboardChartReadyQuery={readyQuery.data}
             error={readyQuery.error}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1473,9 +1473,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
 
     const isLoading = useMemo(() => {
         const isCreatingQuery = readyQuery.isFetching;
-        const isFetchingFirstPage =
-            resultsData.totalResults === undefined ||
-            (resultsData.totalResults > 0 && resultsData.rows.length === 0);
+        const isFetchingFirstPage = resultsData.isFetchingFirstPage;
         const isFetchingAllRows =
             resultsData.fetchAll && !resultsData.hasFetchedAllRows;
         return isCreatingQuery || isFetchingFirstPage || isFetchingAllRows;
@@ -1483,8 +1481,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
         readyQuery.isFetching,
         resultsData.fetchAll,
         resultsData.hasFetchedAllRows,
-        resultsData.rows.length,
-        resultsData.totalResults,
+        resultsData.isFetchingFirstPage,
     ]);
 
     return (

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -418,12 +418,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
 
     const {
         executeQueryResponse: { appliedDashboardFilters },
-        firstPage: { initialQueryExecutionMs },
         chart,
         explore,
     } = dashboardChartReadyQuery;
 
-    const { metricQuery, rows } = resultsData;
+    const { metricQuery, rows, initialQueryExecutionMs } = resultsData;
 
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid: string;
@@ -473,8 +472,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     queryId:
                         dashboardChartReadyQuery.executeQueryResponse.queryUuid,
                     warehouseExecutionTimeMs:
-                        dashboardChartReadyQuery.firstPage
-                            .initialQueryExecutionMs,
+                        resultsData.initialQueryExecutionMs,
                     totalTimeMs: resultsData.totalClientFetchTimeMs,
                     totalResults: resultsData.totalResults || 0,
                     loadedRows: resultsData.rows.length,

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -28,8 +28,8 @@ const ExplorerHeader: FC = memo(() => {
     );
     const showLimitWarning = useExplorerContext(
         (context) =>
-            context.query.data &&
-            context.query.data.firstPage.totalResults >=
+            context.queryResults.totalResults &&
+            context.queryResults.totalResults >=
                 context.state.unsavedChartVersion.metricQuery.limit,
     );
     const limit = useExplorerContext(

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -40,7 +40,7 @@ export const ExplorerResults = memo(() => {
         (context) => context.queryResults.totalResults,
     );
     const isInitialLoading = useExplorerContext((context) => {
-        const isCreatingQuery = context.query.isInitialLoading;
+        const isCreatingQuery = context.query.isFetching;
         const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
         return isCreatingQuery || isFetchingFirstPage;
     });
@@ -158,9 +158,9 @@ export const ExplorerResults = memo(() => {
 
     if (!activeTableName) return <NoTableSelected />;
 
-    if (isInitialLoading) return <EmptyStateExploreLoading />;
-
     if (columns.length === 0) return <EmptyStateNoColumns />;
+
+    if (isInitialLoading) return <EmptyStateExploreLoading />;
     return (
         <TrackSection name={SectionName.RESULTS_TABLE}>
             <Box px="xs" py="lg">

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -39,11 +39,11 @@ export const ExplorerResults = memo(() => {
     const totalRows = useExplorerContext(
         (context) => context.queryResults.totalResults,
     );
-    const isInitialLoading = useExplorerContext(
-        (context) =>
-            context.query.isInitialLoading ||
-            context.queryResults.isInitialLoading,
-    );
+    const isInitialLoading = useExplorerContext((context) => {
+        const isCreatingQuery = context.query.isInitialLoading;
+        const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
+        return isCreatingQuery || isFetchingFirstPage;
+    });
     const isFetchingRows = useExplorerContext(
         (context) => context.queryResults.isFetchingRows,
     );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -39,6 +39,11 @@ export const ExplorerResults = memo(() => {
     const totalRows = useExplorerContext(
         (context) => context.queryResults.totalResults,
     );
+    const isInitialLoading = useExplorerContext(
+        (context) =>
+            context.query.isInitialLoading ||
+            context.queryResults.isInitialLoading,
+    );
     const isFetchingRows = useExplorerContext(
         (context) => context.queryResults.isFetchingRows,
     );
@@ -58,10 +63,9 @@ export const ExplorerResults = memo(() => {
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );
-    const { isInitialLoading, data: exploreData } = useExplore(
-        activeTableName,
-        { refetchOnMount: false },
-    );
+    const { data: exploreData } = useExplore(activeTableName, {
+        refetchOnMount: false,
+    });
     const tableCalculations = useExplorerContext(
         (context) =>
             context.state.unsavedChartVersion.metricQuery.tableCalculations,

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -139,7 +139,7 @@ const SavedChartsHeader: FC = () => {
     const reset = useExplorerContext((context) => context.actions.reset);
 
     const itemsMap = useExplorerContext(
-        (context) => context.query.data?.firstPage.fields,
+        (context) => context.queryResults.fields,
     );
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -32,7 +32,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const { projectUuid } = useParams<{ projectUuid: string }>();
 
         const queryUuid = useExplorerContext(
-            (context) => context.query?.data?.executeQueryResponse.queryUuid,
+            (context) => context.query?.data?.queryUuid,
         );
 
         const { data: projects } = useProjects({ refetchOnMount: false });

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -31,7 +31,10 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const isValidQuery = useExplorerContext(
         (context) => context.state.isValidQuery,
     );
-    const isLoading = useExplorerContext((context) => context.query.isFetching);
+    const isLoading = useExplorerContext(
+        (context) =>
+            context.query.isFetching || context.queryResults.isInitialLoading,
+    );
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,
     );

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -33,7 +33,8 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     );
     const isLoading = useExplorerContext(
         (context) =>
-            context.query.isFetching || context.queryResults.isInitialLoading,
+            context.query.isFetching ||
+            context.queryResults.isFetchingFirstPage,
     );
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -98,6 +98,7 @@ const EmbedDashboardChartTile: FC<Props> = ({
                 hasFetchedAllRows: true,
                 totalClientFetchTimeMs: 0,
                 isInitialLoading: false,
+                isFetchingFirstPage: false,
                 projectUuid: translatedChartData?.chart.projectUuid,
             } satisfies InfiniteQueryResults),
         [translatedChartData],

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -1,4 +1,4 @@
-import { mergeExisting, QueryHistoryStatus } from '@lightdash/common';
+import { mergeExisting } from '@lightdash/common';
 import { Box } from '@mantine/core';
 import { produce } from 'immer';
 import { useMemo, type ComponentProps, type FC } from 'react';
@@ -77,22 +77,6 @@ const EmbedDashboardChartTile: FC<Props> = ({
                     translatedChartData.appliedDashboardFilters ?? null,
                 cacheMetadata: translatedChartData.cacheMetadata,
             },
-            firstPage: {
-                queryUuid: '', // Does not use paginated query therefore there's no queryUuid
-                fields: translatedChartData.fields,
-                metricQuery: translatedChartData.metricQuery,
-                rows: translatedChartData.rows,
-                status: QueryHistoryStatus.READY,
-                initialQueryExecutionMs: 0,
-                resultsPageExecutionMs: 0,
-                totalResults: translatedChartData.rows.length,
-                pageSize: translatedChartData.rows.length,
-                page: 1,
-                totalPageCount: 1,
-                nextPage: undefined,
-                previousPage: undefined,
-                clientFetchTimeMs: 0,
-            },
             chart: translatedChartData.chart,
             explore: translatedChartData.explore,
         } satisfies DashboardChartReadyQuery;
@@ -106,6 +90,7 @@ const EmbedDashboardChartTile: FC<Props> = ({
                 fields: translatedChartData?.fields,
                 rows: translatedChartData?.rows ?? [],
                 totalResults: translatedChartData?.rows.length,
+                initialQueryExecutionMs: 0,
                 isFetchingRows: false,
                 fetchMoreRows: () => undefined,
                 setFetchAll: () => undefined,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -84,10 +84,10 @@ export const useColumns = (): TableColumn[] => {
         (context) => context.state.unsavedChartVersion.metricQuery.sorts,
     );
     const resultsMetricQuery = useExplorerContext(
-        (context) => context.query.data?.firstPage.metricQuery,
+        (context) => context.queryResults.metricQuery,
     );
     const resultsFields = useExplorerContext(
-        (context) => context.query.data?.firstPage.fields,
+        (context) => context.queryResults.fields,
     );
 
     const { data: exploreData } = useExplore(tableName, {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -288,6 +288,7 @@ export type InfiniteQueryResults = Partial<
     projectUuid?: string;
     rows: ResultRow[];
     isInitialLoading: boolean;
+    isFetchingFirstPage: boolean;
     isFetchingRows: boolean;
     fetchMoreRows: () => void;
     setFetchAll: (value: boolean) => void;
@@ -503,6 +504,9 @@ export const useInfiniteQueryResults = (
             setFetchAll,
             totalClientFetchTimeMs,
             isInitialLoading,
+            isFetchingFirstPage:
+                fetchedPages[0]?.totalResults === undefined ||
+                (fetchedPages[0]?.totalResults > 0 && fetchedRows.length === 0),
             fetchAll,
         }),
         [

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -505,8 +505,10 @@ export const useInfiniteQueryResults = (
             totalClientFetchTimeMs,
             isInitialLoading,
             isFetchingFirstPage:
-                fetchedPages[0]?.totalResults === undefined ||
-                (fetchedPages[0]?.totalResults > 0 && fetchedRows.length === 0),
+                !!queryUuid &&
+                (fetchedPages[0]?.totalResults === undefined ||
+                    (fetchedPages[0]?.totalResults > 0 &&
+                        fetchedRows.length === 0)),
             fetchAll,
         }),
         [

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1499,7 +1499,7 @@ const ExplorerProvider: FC<
     const query = useGetReadyQueryResults(validQueryArgs);
     const queryResults = useInfiniteQueryResults(
         validQueryArgs?.projectUuid,
-        query.data?.executeQueryResponse.queryUuid,
+        query.data?.queryUuid,
     );
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { remove: clearQueryResults } = query;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#1406](https://github.com/lightdash/lightdash/issues/1406)<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Stop loading the first page of results on query creation. 
This will allow us to cancel a query while it's pending.

Changes:
- update dashboard hook to not fetch first page
- update infinite results hook to refetct query while in pending state
- update loading states condition
- refactor firstPage usage to use resultsData
### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
