### PR TITLE
fix: allow clicking on space row in InfiniteResourceTable

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -460,9 +460,7 @@ const InfiniteResourceTable = ({
         },
         mantineTableBodyRowProps: ({ row }) => ({
             sx: {
-                cursor: isResourceViewSpaceItem(row.original)
-                    ? undefined
-                    : 'pointer',
+                cursor: 'pointer',
                 'td:first-of-type > div > .explore-button-container': {
                     visibility: 'hidden',
                     opacity: 0,
@@ -481,10 +479,6 @@ const InfiniteResourceTable = ({
                 },
             },
             onClick: () => {
-                if (isResourceViewSpaceItem(row.original)) {
-                    return;
-                }
-
                 void navigate(
                     getResourceUrl(filters.projectUuid, row.original),
                 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14486


### Description:

Allows clicking on a space row besides its name

![Screenshot 2025-04-24 at 10.04.06.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/12b8b30c-2da1-428f-9650-ebf376a9be3a.png)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
