### PR TITLE
feat: add double legend click handlers

### DIFF
--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -8,6 +8,7 @@ import { memo, useCallback, useEffect, useState, type FC } from 'react';
 import useEchartsFunnelConfig, {
     type FunnelSeriesDataPoint,
 } from '../../hooks/echarts/useEchartsFunnelConfig';
+import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
 import useApp from '../../providers/App/useApp';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -46,8 +47,13 @@ const EchartOptions: Opts = { renderer: 'svg' };
 
 const FunnelChart: FC<FunnelChartProps> = memo((props) => {
     const { chartRef, isLoading, resultsData } = useVisualizationContext();
+    const { selectedLegends, onLegendChange } = useLegendDoubleClickSelection();
 
-    const funnelChartOptions = useEchartsFunnelConfig(props.isInDashboard);
+    const funnelChartOptions = useEchartsFunnelConfig(
+        selectedLegends,
+        props.isInDashboard,
+    );
+
     const { user } = useApp();
 
     const [isOpen, { open, close }] = useDisclosure();
@@ -122,6 +128,7 @@ const FunnelChart: FC<FunnelChartProps> = memo((props) => {
                 onEvents={{
                     click: handleOpenContextMenu,
                     oncontextmenu: handleOpenContextMenu,
+                    legendselectchanged: onLegendChange,
                 }}
             />
 

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -2,18 +2,12 @@ import { type PivotReference } from '@lightdash/common';
 import { IconChartBarOff } from '@tabler/icons-react';
 import EChartsReact from 'echarts-for-react';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
-import {
-    memo,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState,
-    type FC,
-} from 'react';
+import { memo, useCallback, useEffect, useMemo, type FC } from 'react';
 import useEchartsCartesianConfig, {
     getFormattedValue,
     isLineSeriesOption,
 } from '../../hooks/echarts/useEchartsCartesianConfig';
+import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
@@ -55,12 +49,6 @@ export type EchartSeriesClickEvent = EchartBaseClickEvent & {
 
 type EchartClickEvent = EchartSeriesClickEvent | EchartBaseClickEvent;
 
-type LegendClickEvent = {
-    selected: {
-        [name: string]: boolean;
-    };
-};
-
 export const EmptyChart = () => (
     <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
         <SuboptimalState
@@ -95,19 +83,9 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
     const { chartRef, isLoading, onSeriesContextMenu, itemsMap, resultsData } =
         useVisualizationContext();
 
-    const [selectedLegends, setSelectedLegends] = useState({});
-    const [selectedLegendsUpdated, setSelectedLegendsUpdated] = useState({});
-
-    const onLegendChange = useCallback((params: LegendClickEvent) => {
-        setSelectedLegends(params.selected);
-    }, []);
-
-    useEffect(() => {
-        setSelectedLegendsUpdated(selectedLegends);
-    }, [selectedLegends]);
-
+    const { selectedLegends, onLegendChange } = useLegendDoubleClickSelection();
     const eChartsOptions = useEchartsCartesianConfig(
-        selectedLegendsUpdated,
+        selectedLegends,
         props.isInDashboard,
     );
 

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -7,6 +7,7 @@ import { memo, useCallback, useEffect, useState, type FC } from 'react';
 import useEchartsPieConfig, {
     type PieSeriesDataPoint,
 } from '../../hooks/echarts/useEchartsPieConfig';
+import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
 import useApp from '../../providers/App/useApp';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -45,8 +46,12 @@ const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
     const { chartRef, isLoading, resultsData } = useVisualizationContext();
+    const { selectedLegends, onLegendChange } = useLegendDoubleClickSelection();
 
-    const pieChartOptions = useEchartsPieConfig(props.isInDashboard);
+    const pieChartOptions = useEchartsPieConfig(
+        selectedLegends,
+        props.isInDashboard,
+    );
     const { user } = useApp();
 
     const [isOpen, { open, close }] = useDisclosure();
@@ -120,6 +125,7 @@ const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
                 onEvents={{
                     click: handleOpenContextMenu,
                     oncontextmenu: handleOpenContextMenu,
+                    legendselectchanged: onLegendChange,
                 }}
             />
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -61,6 +61,7 @@ import {
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
 import getPlottedData from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
+import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 // NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
 type TooltipFormatterParams = DefaultLabelFormatterCallbackParams & {
@@ -2023,6 +2024,26 @@ const useEchartsCartesianConfig = (
         };
     }, [validCartesianConfig?.eChartsConfig.grid]);
 
+    const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
+
+    const legendConfigWithInstructionsTooltip = useMemo(() => {
+        const mergedLegendConfig = mergeLegendSettings(
+            validCartesianConfig?.eChartsConfig.legend,
+            validCartesianConfigLegend,
+            series,
+        );
+
+        return {
+            ...mergedLegendConfig,
+            tooltip: legendDoubleClickTooltip,
+        };
+    }, [
+        legendDoubleClickTooltip,
+        validCartesianConfig?.eChartsConfig.legend,
+        validCartesianConfigLegend,
+        series,
+    ]);
+
     const eChartsOptions = useMemo(
         () => ({
             xAxis: axes.xAxis,
@@ -2030,11 +2051,7 @@ const useEchartsCartesianConfig = (
             useUTC: true,
             series: stackedSeriesWithColorAssignments,
             animation: !(isInDashboard || minimal),
-            legend: mergeLegendSettings(
-                validCartesianConfig?.eChartsConfig.legend,
-                validCartesianConfigLegend,
-                series,
-            ),
+            legend: legendConfigWithInstructionsTooltip,
             dataset: {
                 id: 'lightdashResults',
                 source: sortedResultsByTotals,
@@ -2053,9 +2070,7 @@ const useEchartsCartesianConfig = (
             stackedSeriesWithColorAssignments,
             isInDashboard,
             minimal,
-            validCartesianConfig?.eChartsConfig.legend,
-            validCartesianConfigLegend,
-            series,
+            legendConfigWithInstructionsTooltip,
             sortedResultsByTotals,
             tooltip,
             theme?.other.chartFont,

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -13,6 +13,7 @@ import { round } from 'lodash';
 import { useMemo } from 'react';
 import { isFunnelVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
+import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 export type FunnelSeriesDataPoint = NonNullable<
     FunnelSeriesOption['data']
@@ -40,7 +41,10 @@ const getValueAndPercentage = ({
     return { formattedValue, percentOfMax };
 };
 
-const useEchartsFunnelConfig = (isInDashboard: boolean) => {
+const useEchartsFunnelConfig = (
+    selectedLegends?: Record<string, boolean>,
+    isInDashboard?: boolean,
+) => {
     const { visualizationConfig, itemsMap, colorPalette } =
         useVisualizationContext();
 
@@ -148,6 +152,8 @@ const useEchartsFunnelConfig = (isInDashboard: boolean) => {
         };
     }, [chartConfig, colorPalette, seriesData]);
 
+    const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
+
     const eChartsOptions: EChartsOption | undefined = useMemo(() => {
         if (!chartConfig || !funnelSeriesOptions || !seriesData) return;
 
@@ -179,6 +185,8 @@ const useEchartsFunnelConfig = (isInDashboard: boolean) => {
                           top: 'top',
                           align: 'auto',
                       }),
+                selected: selectedLegends,
+                tooltip: legendDoubleClickTooltip,
             },
         };
     }, [
@@ -186,7 +194,9 @@ const useEchartsFunnelConfig = (isInDashboard: boolean) => {
         funnelSeriesOptions,
         seriesData,
         isInDashboard,
-        theme?.other?.chartFont,
+        theme,
+        legendDoubleClickTooltip,
+        selectedLegends,
     ]);
 
     if (!itemsMap) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -10,6 +10,7 @@ import { type EChartsOption, type PieSeriesOption } from 'echarts';
 import { useMemo } from 'react';
 import { isPieVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
+import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 export type PieSeriesDataPoint = NonNullable<
     PieSeriesOption['data']
 >[number] & {
@@ -19,7 +20,10 @@ export type PieSeriesDataPoint = NonNullable<
     };
 };
 
-const useEchartsPieConfig = (isInDashboard: boolean) => {
+const useEchartsPieConfig = (
+    selectedLegends?: Record<string, boolean>,
+    isInDashboard?: boolean,
+) => {
     const { visualizationConfig, itemsMap, getGroupColor, minimal } =
         useVisualizationContext();
 
@@ -155,6 +159,8 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
         };
     }, [chartConfig, seriesData]);
 
+    const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
+
     const eChartsOption: EChartsOption | undefined = useMemo(() => {
         if (!chartConfig || !pieSeriesOption) return;
 
@@ -181,10 +187,8 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
                           )}...`
                         : name;
                 },
-                tooltip: {
-                    show: true, // show tooltip for truncated legend items
-                    trigger: 'item',
-                },
+                tooltip: legendDoubleClickTooltip,
+                selected: selectedLegends,
                 ...(legendPosition === 'vertical'
                     ? {
                           left: 'left',
@@ -204,11 +208,13 @@ const useEchartsPieConfig = (isInDashboard: boolean) => {
             animation: !(isInDashboard || minimal),
         };
     }, [
+        legendDoubleClickTooltip,
+        selectedLegends,
         chartConfig,
         isInDashboard,
         minimal,
         pieSeriesOption,
-        theme?.other?.chartFont,
+        theme,
     ]);
 
     if (!itemsMap) return;

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickSelection.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type LegendClickEvent = {
+    name: string;
+    selected: Record<string, boolean>;
+};
+
+const DOUBLE_CLICK_DELAY = 300;
+
+export const useLegendDoubleClickSelection = () => {
+    const [selectedLegends, setSelectedLegends] = useState<
+        Record<string, boolean>
+    >({});
+    const legendClicksRef = useRef<
+        Record<
+            string,
+            {
+                singleClickTimeout: NodeJS.Timeout | undefined;
+                lastClick: number;
+            }
+        >
+    >({});
+
+    const overrideSelectAllLegends = useCallback((params: LegendClickEvent) => {
+        setSelectedLegends(
+            Object.fromEntries(
+                Object.keys(params.selected).map((key) => [key, true]),
+            ),
+        );
+    }, []);
+
+    const overrideSelectSingleLegend = useCallback(
+        (params: LegendClickEvent) => {
+            setSelectedLegends(
+                Object.fromEntries(
+                    Object.keys(params.selected).map((key) => [
+                        key,
+                        key === params.name,
+                    ]),
+                ),
+            );
+        },
+        [],
+    );
+
+    const onLegendChange = useCallback(
+        (params: LegendClickEvent) => {
+            const now = Date.now();
+            const { lastClick, singleClickTimeout } = legendClicksRef.current[
+                params.name
+            ] ?? {
+                lastClick: 0,
+                singleClickTimeout: undefined,
+            };
+            const isDoubleClick = now - lastClick <= DOUBLE_CLICK_DELAY;
+            if (isDoubleClick) {
+                clearTimeout(singleClickTimeout);
+                delete legendClicksRef.current[params.name];
+                if (
+                    Object.entries(params.selected).every(([key, value]) => {
+                        if (key !== params.name) {
+                            return value === false;
+                        }
+                        return true;
+                    })
+                ) {
+                    overrideSelectAllLegends(params);
+                } else {
+                    overrideSelectSingleLegend(params);
+                }
+            } else {
+                const timeoutId = setTimeout(() => {
+                    delete legendClicksRef.current[params.name];
+                    setSelectedLegends(params.selected);
+                }, DOUBLE_CLICK_DELAY + 50);
+                legendClicksRef.current[params.name] = {
+                    singleClickTimeout: timeoutId,
+                    lastClick: now,
+                };
+            }
+        },
+        [overrideSelectAllLegends, overrideSelectSingleLegend],
+    );
+
+    return { selectedLegends, onLegendChange };
+};

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
@@ -1,0 +1,23 @@
+import { px, useMantineTheme } from '@mantine/core';
+
+export const useLegendDoubleClickTooltip = () => {
+    const theme = useMantineTheme();
+
+    return {
+        tooltip: {
+            show: true,
+            borderColor: theme.colors.gray[2],
+            borderWidth: 1,
+            textStyle: {
+                color: theme.colors.gray[6],
+                fontSize: 12,
+                fontWeight: 400,
+            },
+            padding: [px(theme.spacing.two), px(theme.spacing.xxs)],
+            extraCssText: `box-shadow: ${theme.shadows.subtle};`,
+            formatter: () => {
+                return `Click to toggle visibility. Double click to isolate`;
+            },
+        },
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#13780](https://github.com/lightdash/lightdash/issues/13780)

### Description:

- Use double click to select series, echarts doesn't provide a way to handle right clicks: https://github.com/apache/echarts/issues/20288


**Cartesian charts**

https://github.com/user-attachments/assets/04c50a38-1511-49a4-8167-bb049130ad04

**Pie charts**


https://github.com/user-attachments/assets/f02ad7b3-b4bf-4e59-af1b-cee6acd9d4b5

**Funnel charts**


https://github.com/user-attachments/assets/fdb4e5a9-577d-496b-a8f1-3eab30f84e73




### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
