### PR TITLE
fix: only set default space if form not initialised

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -175,11 +175,14 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
     const { setFieldValue } = form;
 
     useEffect(
+        // If default space is set, set the spaceUuid to the default space
+        // This happens when the user creates a chart from a space view, so that space is selected by default
         function setSpaceWhenUserReachesSelectionStep() {
             if (
                 currentStep === ModalStep.SelectDestination &&
                 saveDestination === SaveDestination.Space &&
-                form.values.spaceUuid === null
+                form.values.spaceUuid === null &&
+                !form.initialized
             ) {
                 const isValidDefaultSpaceUuid = spaces?.some(
                     (space) => space.uuid === defaultSpaceUuid,
@@ -208,6 +211,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             spaceManagement,
             form.values.spaceUuid,
             isNestedSpacesEnabled,
+            form.initialized,
         ],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Fix max update depth issue when de-selecting a _default space_ - this happens when creating a chart when in the space detail view

before

[before-max.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/53ff3834-c1c5-4ea1-852a-e3b9b4902dc3.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/53ff3834-c1c5-4ea1-852a-e3b9b4902dc3.mov)

after

[fixed-max.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/d1223c51-ca3d-4972-b882-e4d952aa83ea.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/d1223c51-ca3d-4972-b882-e4d952aa83ea.mov)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
