### PR TITLE
feat: admins can allow all dashboards to be embedded

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -21,6 +21,7 @@ import {
     MetricQueryResponse,
     SavedChart,
     SavedChartsInfoForDashboardAvailableFilters,
+    UpdateEmbed,
 } from '@lightdash/common';
 import {
     Body,
@@ -135,13 +136,13 @@ export class EmbedController extends BaseController {
     async updateEmbeddedDashboards(
         @Request() req: express.Request,
         @Path() projectUuid: string,
-        @Body() body: { dashboardUuids: string[] },
+        @Body() body: UpdateEmbed,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
         await this.getEmbedService().updateDashboards(
             req.user!,
             projectUuid,
-            body.dashboardUuids,
+            body,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/database/migrations/20250424123216_add_allow_all_dashboards_column_to_embeddings.ts
+++ b/packages/backend/src/ee/database/migrations/20250424123216_add_allow_all_dashboards_column_to_embeddings.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+const EMBEDDING_TABLE_NAME = 'embedding';
+export async function up(knex: Knex): Promise<void> {
+    if (
+        !(await knex.schema.hasColumn(
+            EMBEDDING_TABLE_NAME,
+            'allow_all_dashboards',
+        ))
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.boolean('allow_all_dashboards').defaultTo(false);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (
+        await knex.schema.hasColumn(
+            EMBEDDING_TABLE_NAME,
+            'allow_all_dashboards',
+        )
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.dropColumn('allow_all_dashboards');
+        });
+    }
+}

--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -1,4 +1,4 @@
-import { Embed, NotFoundError } from '@lightdash/common';
+import { Embed, NotFoundError, UpdateEmbed } from '@lightdash/common';
 import { Knex } from 'knex';
 
 type Dependencies = {
@@ -42,6 +42,7 @@ export class EmbedModel {
             projectUuid: embed.project_uuid,
             encodedSecret: embed.encoded_secret,
             dashboardUuids: validDashboardUuids,
+            allowAllDashboards: embed.allow_all_dashboards,
             createdAt: embed.created_at,
             user: {
                 userUuid: embed.user_uuid,
@@ -70,10 +71,13 @@ export class EmbedModel {
 
     async updateDashboards(
         projectUuid: string,
-        dashboardUuids: string[],
+        { dashboardUuids, allowAllDashboards }: UpdateEmbed,
     ): Promise<void> {
         await this.database('embedding')
-            .update('dashboard_uuids', dashboardUuids)
+            .update({
+                dashboard_uuids: dashboardUuids,
+                allow_all_dashboards: allowAllDashboards,
+            })
             .where('project_uuid', projectUuid);
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -628,6 +628,7 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
+                allowAllDashboards: { dataType: 'boolean', required: true },
                 createdAt: { dataType: 'string', required: true },
                 user: {
                     ref: 'Pick_LightdashUser.userUuid-or-firstName-or-lastName_',
@@ -701,6 +702,22 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: { dataType: 'undefined', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateEmbed: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                allowAllDashboards: { dataType: 'boolean', required: true },
+                dashboardUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
             },
             validators: {},
         },
@@ -16576,19 +16593,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                dashboardUuids: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-            },
-        },
+        body: { in: 'body', name: 'body', required: true, ref: 'UpdateEmbed' },
     };
     app.patch(
         '/api/v1/embed/:projectUuid/config/dashboards',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -609,6 +609,9 @@
                         },
                         "type": "array"
                     },
+                    "allowAllDashboards": {
+                        "type": "boolean"
+                    },
                     "createdAt": {
                         "type": "string"
                     },
@@ -619,6 +622,7 @@
                 "required": [
                     "projectUuid",
                     "dashboardUuids",
+                    "allowAllDashboards",
                     "createdAt",
                     "user"
                 ],
@@ -682,6 +686,21 @@
                     }
                 },
                 "required": ["status"],
+                "type": "object"
+            },
+            "UpdateEmbed": {
+                "properties": {
+                    "allowAllDashboards": {
+                        "type": "boolean"
+                    },
+                    "dashboardUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["allowAllDashboards", "dashboardUuids"],
                 "type": "object"
             },
             "EmbedUrl": {
@@ -16303,7 +16322,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1597.0",
+        "version": "0.1600.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -6,6 +6,7 @@ export type Embed = {
     projectUuid: string;
     encodedSecret: string;
     dashboardUuids: string[];
+    allowAllDashboards: boolean;
     createdAt: string;
     user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
 };
@@ -17,6 +18,11 @@ export type DecodedEmbed = Omit<Embed, 'encodedSecret'> & {
 
 export type CreateEmbed = {
     dashboardUuids: string[];
+};
+
+export type UpdateEmbed = {
+    dashboardUuids: string[];
+    allowAllDashboards: boolean;
 };
 
 export enum FilterInteractivityValues {

--- a/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
@@ -31,6 +31,7 @@ const updateEmbedConfigDashboards = (
         method: 'PATCH',
         body: {
             dashboardUuids,
+            allowAllDashboards: false,
         },
         ...requestOptions,
     });

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
@@ -1,47 +1,67 @@
-import { type DashboardBasicDetails } from '@lightdash/common';
-import { Button, Flex, MultiSelect, Stack } from '@mantine/core';
+import {
+    type DashboardBasicDetails,
+    type DecodedEmbed,
+    type UpdateEmbed,
+} from '@lightdash/common';
+import { Button, Flex, MultiSelect, Stack, Switch } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import React, { type FC } from 'react';
 
 const EmbedDashboardsForm: FC<{
     disabled: boolean;
-    selectedDashboardsUuids: string[];
+    embedConfig: DecodedEmbed;
     dashboards: DashboardBasicDetails[];
-    onSave: (dashboardUuids: string[]) => void;
-}> = ({ disabled, selectedDashboardsUuids, dashboards, onSave }) => {
+    onSave: (values: UpdateEmbed) => void;
+}> = ({ disabled, embedConfig, dashboards, onSave }) => {
     const form = useForm({
         initialValues: {
-            dashboardUuids: selectedDashboardsUuids,
+            allowAllDashboards: embedConfig.allowAllDashboards,
+            dashboardUuids: embedConfig.dashboardUuids,
         },
     });
 
     const handleSubmit = form.onSubmit((values) => {
-        if (values.dashboardUuids.length > 0) {
-            onSave(values.dashboardUuids);
-        }
+        onSave({
+            dashboardUuids: values.dashboardUuids,
+            allowAllDashboards: values.allowAllDashboards,
+        });
     });
 
     return (
         <form id="add-dashboard-to-embed-config" onSubmit={handleSubmit}>
             <Stack>
-                <MultiSelect
-                    required
-                    label={'Dashboards'}
-                    data={dashboards.map((dashboard) => ({
-                        value: dashboard.uuid,
-                        label: dashboard.name,
-                    }))}
-                    disabled={disabled || dashboards.length === 0}
-                    defaultValue={[]}
-                    placeholder={
-                        dashboards.length === 0
-                            ? 'No dashboards available to embed'
-                            : 'Select a dashboard...'
-                    }
-                    searchable
-                    withinPortal
-                    {...form.getInputProps('dashboardUuids')}
+                <Switch
+                    name="allowAllDashboards"
+                    label="Allow all dashboards"
+                    {...form.getInputProps('allowAllDashboards', {
+                        type: 'checkbox',
+                    })}
                 />
+                {!form.values.allowAllDashboards && (
+                    <MultiSelect
+                        required={!form.values.allowAllDashboards}
+                        label={'Dashboards'}
+                        data={dashboards.map((dashboard) => ({
+                            value: dashboard.uuid,
+                            label: dashboard.name,
+                        }))}
+                        disabled={
+                            disabled ||
+                            dashboards.length === 0 ||
+                            form.values.allowAllDashboards
+                        }
+                        defaultValue={[]}
+                        placeholder={
+                            dashboards.length === 0
+                                ? 'No dashboards available to embed'
+                                : 'Select a dashboard...'
+                        }
+                        searchable
+                        withinPortal
+                        description="Only these dashboards will be allowed to be embedded."
+                        {...form.getInputProps('dashboardUuids')}
+                    />
+                )}
                 <Flex justify="flex-end" gap="sm">
                     <Button
                         type="submit"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14361

### Description:
Added a new "Allow all dashboards" option to the embed settings, which allows users to embed any dashboard without having to explicitly select each one.

The changes include:
- Added a new `allow_all_dashboards` column to the `embedding` table
- Updated the embed model, service, and controller to support the new option
- Added a switch in the UI to toggle between allowing all dashboards or selecting specific ones
- Updated permission checks to respect the new setting

Demo: https://cln.sh/DL4qwBxr

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging