### PR TITLE
fix: default time intervals for date

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -553,7 +553,13 @@ export const getDefaultTimeFrames = (type: DimensionType) =>
               TimeFrames.QUARTER,
               TimeFrames.YEAR,
           ]
-        : [TimeFrames.DAY, TimeFrames.WEEK, TimeFrames.MONTH, TimeFrames.YEAR];
+        : [
+              TimeFrames.DAY,
+              TimeFrames.WEEK,
+              TimeFrames.MONTH,
+              TimeFrames.QUARTER,
+              TimeFrames.YEAR,
+          ];
 
 export const isTimeInterval = (value: string): value is TimeFrames =>
     Object.keys(timeFrameConfigs).includes(value);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14534

### Description:

- Updates `time_intervals` defaults for `date` types to match docs

docs: https://docs.lightdash.com/references/dimensions#by-default-the-time-intervals-we-use-are

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NymtOECmPxzpCcYh2n9e/b6b2b78b-1807-4987-a76b-11dc8c2f9fc7.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NymtOECmPxzpCcYh2n9e/ad956b53-e56f-415f-aa73-adc9b04ad115.png)

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
