### PR TITLE
feat: enable underlying data for charts with sql custom dimensions

### DIFF
--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -144,8 +144,11 @@ export const countCustomDimensionsInMetricQuery = (
         ).length || 0,
 });
 
-export const hasCustomDimension = (metricQuery: MetricQuery | undefined) =>
-    metricQuery?.customDimensions && metricQuery.customDimensions.length > 0;
+export const hasCustomBinDimension = (metricQuery: MetricQuery | undefined) =>
+    metricQuery?.customDimensions &&
+    metricQuery.customDimensions.some((dimension) =>
+        isCustomBinDimension(dimension),
+    );
 
 export type MetricQueryRequest = {
     // tsoa doesn't support complex types like MetricQuery, so we simplified it

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -13,7 +13,7 @@ import {
     getItemMap,
     getPivotConfig,
     getVisibleFields,
-    hasCustomDimension,
+    hasCustomBinDimension,
     isCartesianChartConfig,
     isCompleteLayout,
     isDashboardChartTileType,
@@ -1175,7 +1175,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                     projectUuid: projectUuid,
                                 })}
                             >
-                                {!hasCustomDimension(metricQuery) && (
+                                {!hasCustomBinDimension(metricQuery) && (
                                     <Menu.Item
                                         icon={<MantineIcon icon={IconStack} />}
                                         onClick={handleViewUnderlyingData}

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import {
-    hasCustomDimension,
+    hasCustomBinDimension,
     isCustomDimension,
     isDimension,
     isDimensionValueInvalidDate,
@@ -148,7 +148,7 @@ const CellContextMenu: FC<
             {item &&
                 !isDimension(item) &&
                 !isCustomDimension(item) &&
-                !hasCustomDimension(metricQuery) && (
+                !hasCustomBinDimension(metricQuery) && (
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { getItemMap, hasCustomDimension } from '@lightdash/common';
+import { getItemMap, hasCustomBinDimension } from '@lightdash/common';
 import { Menu, Portal } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
@@ -167,7 +167,7 @@ export const SeriesContextMenu: FC<{
                         projectUuid: projectUuid,
                     })}
                 >
-                    {!hasCustomDimension(metricQuery) && (
+                    {!hasCustomBinDimension(metricQuery) && (
                         <Menu.Item
                             icon={<MantineIcon icon={IconStack} />}
                             onClick={handleViewUnderlyingData}

--- a/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
+++ b/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import {
-    hasCustomDimension,
+    hasCustomBinDimension,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
@@ -131,7 +131,8 @@ const FunnelChartContextMenu: FC<FunnelChartContextMenuProps> = ({
                     Copy value
                 </Menu.Item>
 
-                {canViewUnderlyingData && !hasCustomDimension(metricQuery) ? (
+                {canViewUnderlyingData &&
+                !hasCustomBinDimension(metricQuery) ? (
                     <Menu.Item
                         icon={<MantineIcon icon={IconStack} />}
                         onClick={handleOpenUnderlyingDataModal}

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -7,6 +7,7 @@ import {
     getFields,
     getFiltersFromGroup,
     getItemId,
+    isCustomBinDimension,
     isDimension,
     isField,
     isMetric,
@@ -58,13 +59,28 @@ const UnderlyingDataModalContent: FC<Props> = () => {
         [underlyingDataConfig?.item],
     );
 
-    const allFields = useMemo(
-        () => (explore ? getFields(explore) : []),
-        [explore],
+    const nonBinCustomDimensions = useMemo(
+        () =>
+            metricQuery?.customDimensions?.filter(
+                (dimension) => !isCustomBinDimension(dimension),
+            ) || [],
+        [metricQuery?.customDimensions],
     );
+
+    const allFields = useMemo(
+        () => [
+            ...nonBinCustomDimensions,
+            ...(explore ? getFields(explore) : []),
+        ],
+        [explore, nonBinCustomDimensions],
+    );
+
     const allDimensions = useMemo(
-        () => (explore ? getDimensions(explore) : []),
-        [explore],
+        () => [
+            ...nonBinCustomDimensions,
+            ...(explore ? getDimensions(explore) : []),
+        ],
+        [explore, nonBinCustomDimensions],
     );
 
     const joinedTables = useMemo(

--- a/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
+++ b/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     createDashboardFilterRuleFromField,
-    hasCustomDimension,
+    hasCustomBinDimension,
     isDimension,
     isFilterableDimension,
     type FilterDashboardToRule,
@@ -191,7 +191,8 @@ const PieChartContextMenu: FC<PieChartContextMenuProps> = ({
                     Copy value
                 </Menu.Item>
 
-                {canViewUnderlyingData && !hasCustomDimension(metricQuery) ? (
+                {canViewUnderlyingData &&
+                !hasCustomBinDimension(metricQuery) ? (
                     <Menu.Item
                         icon={<MantineIcon icon={IconStack} />}
                         onClick={handleOpenUnderlyingDataModal}

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { hasCustomDimension, type ResultValue } from '@lightdash/common';
+import { hasCustomBinDimension, type ResultValue } from '@lightdash/common';
 import { Menu, Text } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconArrowBarToDown, IconCopy, IconStack } from '@tabler/icons-react';
@@ -139,7 +139,7 @@ const BigNumberContextMenu: FC<React.PropsWithChildren<{}>> = ({
                     </Menu.Item>
                 )}
 
-                {item && !hasCustomDimension(metricQuery) && (
+                {item && !hasCustomBinDimension(metricQuery) && (
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import {
-    hasCustomDimension,
+    hasCustomBinDimension,
     isCustomDimension,
     isDimension,
     isField,
@@ -92,7 +92,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
             {item &&
                 !isDimension(item) &&
                 !isCustomDimension(item) &&
-                !hasCustomDimension(metricQuery) && (
+                !hasCustomBinDimension(metricQuery) && (
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     createDashboardFilterRuleFromField,
-    hasCustomDimension,
+    hasCustomBinDimension,
     isDimension,
     isDimensionValueInvalidDate,
     isField,
@@ -149,22 +149,24 @@ const DashboardCellContextMenu: FC<
                 Copy value
             </Menu.Item>
 
-            {item && !isDimension(item) && !hasCustomDimension(metricQuery) && (
-                <Can
-                    I="view"
-                    this={subject('UnderlyingData', {
-                        organizationUuid: user.data?.organizationUuid,
-                        projectUuid: projectUuid,
-                    })}
-                >
-                    <Menu.Item
-                        icon={<MantineIcon icon={IconStack} />}
-                        onClick={handleViewUnderlyingData}
+            {item &&
+                !isDimension(item) &&
+                !hasCustomBinDimension(metricQuery) && (
+                    <Can
+                        I="view"
+                        this={subject('UnderlyingData', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid: projectUuid,
+                        })}
                     >
-                        View underlying data
-                    </Menu.Item>
-                </Can>
-            )}
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconStack} />}
+                            onClick={handleViewUnderlyingData}
+                        >
+                            View underlying data
+                        </Menu.Item>
+                    </Can>
+                )}
 
             <Can
                 I="manage"

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     createDashboardFilterRuleFromField,
-    hasCustomDimension,
+    hasCustomBinDimension,
     isDimension,
     isDimensionValueInvalidDate,
     type ItemsMap,
@@ -196,7 +196,7 @@ const ValueCellMenu: FC<React.PropsWithChildren<ValueCellMenuProps>> = ({
 
                 {item &&
                 (canViewUnderlyingData || canViewDrillInto) &&
-                !hasCustomDimension(metricQuery) ? (
+                !hasCustomBinDimension(metricQuery) ? (
                     <>
                         {canViewUnderlyingData ? (
                             <Menu.Item


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10023 

### Description:

**Before**
- Underlying data option didn't show for any metric

**After**

https://github.com/user-attachments/assets/d5772ab7-49ca-4b1b-ac36-3a91776f13ac

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
