### PR TITLE
feat: cancel explore query

### DIFF
--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -216,26 +216,30 @@ describe('Date tests', () => {
         cy.findByTestId('Chart-card-expand').click(); // Close chart
 
         // Filter by year
-        cy.get('tbody > :nth-child(1) > :nth-child(5)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(5)',
+        ).click();
         cy.contains('Filter by 2018').click();
         cy.get('.mantine-YearPickerInput-input').contains('2018');
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('YEAR', "orders".order_date)) = ('2018-01-01')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by month
-        cy.get('tbody > :nth-child(1) > :nth-child(4)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(4)',
+        ).click();
         cy.contains('Filter by 2018-04').click();
 
         cy.get('.mantine-MonthPickerInput-input').contains('April 2018');
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('MONTH', "orders".order_date)) = ('2018-04-01')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by week
-        cy.get('tbody > :nth-child(1) > :nth-child(3)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(3)',
+        ).click();
         cy.contains('Filter by 2018-04-09').click();
         cy.get('.mantine-DateInput-input').should(
             'have.value',
@@ -244,10 +248,11 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('WEEK', "orders".order_date)) = ('2018-04-09')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by day
-        cy.get('tbody > :nth-child(1) > :nth-child(2)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(2)',
+        ).click();
         cy.contains('Filter by 2018-04-09').click();
         cy.get('.mantine-DateInput-input').should(
             'have.value',
@@ -256,7 +261,6 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('DAY', "orders".order_date)) = ('2018-04-09')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
     });
 
     it('Should filter by datetimes on results table', () => {
@@ -272,7 +276,9 @@ describe('Date tests', () => {
         cy.findByTestId('Chart-card-expand').click(); // Close chart
 
         // Filter by raw
-        cy.get('tbody > :nth-child(1) > :nth-child(2)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(2)',
+        ).click();
         cy.contains('Filter by 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
@@ -281,10 +287,11 @@ describe('Date tests', () => {
             `("events".timestamp_tz) = ('2020-08-11 23:44:00')`,
         );
 
-        cy.get('.tabler-icon-x').click({ multiple: true, force: true });
         // Filter by Milisecond
         // FIXME: selecting a different cell is not working
-        cy.get('tbody > :nth-child(1) > :nth-child(3)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(3)',
+        ).click();
         cy.contains('Filter by 2020-08-11, 23:44:00:000 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
@@ -292,10 +299,11 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('MILLISECOND', "events".timestamp_tz)) = ('2020-08-11 23:44:00')`, // Known Milisecond limitation
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by Second
-        cy.get('tbody > :nth-child(1) > :nth-child(4)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(4)',
+        ).click();
         cy.contains('Filter by 2020-08-11, 23:44:00 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
@@ -303,9 +311,11 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('SECOND', "events".timestamp_tz)) = ('2020-08-11 23:44:00')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+
         // Filter by Minute
-        cy.get('tbody > :nth-child(1) > :nth-child(5)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(5)',
+        ).click();
         cy.contains('Filter by 2020-08-11, 23:44 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:44:00'), // Timezone sensitive
@@ -313,10 +323,11 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('MINUTE', "events".timestamp_tz)) = ('2020-08-11 23:44:00')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by Hour
-        cy.get('tbody > :nth-child(1) > :nth-child(6)').click();
+        cy.get(
+            '.mantine-Card-root tbody > :nth-child(1) > :nth-child(6)',
+        ).click();
         cy.contains('Filter by 2020-08-11, 23 (+00:00)').click(); // Server Timezone sensitive
         cy.get('.mantine-DateTimePicker-input').contains(
             getLocalTime('2020-08-11 23:00:00'), // Timezone sensitive
@@ -324,7 +335,6 @@ describe('Date tests', () => {
         cy.get('.mantine-Prism-code').contains(
             `(DATE_TRUNC('HOUR', "events".timestamp_tz)) = ('2020-08-11 23:00:00')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
     });
 
     it('Should change dates on filters', () => {

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -53,6 +53,7 @@ type LightdashApiProps = {
     body: BodyInit | null | undefined;
     headers?: Record<string, string> | undefined;
     version?: 'v1' | 'v2';
+    signal?: AbortSignal;
 };
 
 const MAX_NETWORK_HISTORY = 10;
@@ -64,6 +65,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     body,
     headers,
     version = 'v1',
+    signal,
 }: LightdashApiProps): Promise<T> => {
     const baseUrl = sessionStorage.getItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
@@ -97,6 +99,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             ...(sentryTrace ? { 'sentry-trace': sentryTrace } : {}),
         },
         body,
+        signal,
     })
         .then((r) => {
             if (!r.ok) {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -39,11 +39,7 @@ export const ExplorerResults = memo(() => {
     const totalRows = useExplorerContext(
         (context) => context.queryResults.totalResults,
     );
-    const isInitialLoading = useExplorerContext((context) => {
-        const isCreatingQuery = context.query.isFetching;
-        const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
-        return isCreatingQuery || isFetchingFirstPage;
-    });
+
     const isFetchingRows = useExplorerContext(
         (context) => context.queryResults.isFetchingRows,
     );
@@ -51,8 +47,10 @@ export const ExplorerResults = memo(() => {
         (context) => context.queryResults.fetchMoreRows,
     );
     const status = useExplorerContext((context) => {
+        const isCreatingQuery = context.query.isFetching;
+        const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
         // Don't return context.queryResults.status because we changed from mutation to query so 'loading' as a different meaning
-        if (context.query.isFetching) {
+        if (isCreatingQuery || isFetchingFirstPage) {
             return 'loading';
         } else if (context.query.status === 'loading') {
             return 'idle';
@@ -63,9 +61,10 @@ export const ExplorerResults = memo(() => {
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );
-    const { data: exploreData } = useExplore(activeTableName, {
-        refetchOnMount: false,
-    });
+    const { data: exploreData, isInitialLoading: isExploreLoading } =
+        useExplore(activeTableName, {
+            refetchOnMount: false,
+        });
     const tableCalculations = useExplorerContext(
         (context) =>
             context.state.unsavedChartVersion.metricQuery.tableCalculations,
@@ -160,7 +159,7 @@ export const ExplorerResults = memo(() => {
 
     if (columns.length === 0) return <EmptyStateNoColumns />;
 
-    if (isInitialLoading) return <EmptyStateExploreLoading />;
+    if (isExploreLoading) return <EmptyStateExploreLoading />;
     return (
         <TrackSection name={SectionName.RESULTS_TABLE}>
             <Box px="xs" py="lg">

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,3 +1,4 @@
+import { QueryHistoryStatus } from '@lightdash/common';
 import {
     Button,
     Group,
@@ -8,7 +9,7 @@ import {
     type MantineSize,
 } from '@mantine/core';
 import { useHotkeys, useOs } from '@mantine/hooks';
-import { IconPlayerPlay } from '@tabler/icons-react';
+import { IconPlayerPlay, IconX } from '@tabler/icons-react';
 import { memo, useCallback, type FC } from 'react';
 import useHealth from '../hooks/health/useHealth';
 import useExplorerContext from '../providers/Explorer/useExplorerContext';
@@ -36,8 +37,14 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
             context.query.isFetching ||
             context.queryResults.isFetchingFirstPage,
     );
+    const queryStatus = useExplorerContext(
+        (context) => context.queryResults.queryStatus,
+    );
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,
+    );
+    const cancelQuery = useExplorerContext(
+        (context) => context.actions.cancelQuery,
     );
 
     const canRunQuery = isValidQuery;
@@ -93,13 +100,27 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                 </Button>
             </Tooltip>
 
-            <LimitButton
-                disabled={!isValidQuery}
-                size={size}
-                maxLimit={maxLimit}
-                limit={limit}
-                onLimitChange={setRowLimit}
-            />
+            {isLoading &&
+            (!queryStatus || queryStatus === QueryHistoryStatus.PENDING) ? (
+                <Tooltip
+                    label={'Cancel query'}
+                    position="bottom"
+                    withArrow
+                    withinPortal
+                >
+                    <Button size={size} p="xs" onClick={cancelQuery}>
+                        <MantineIcon icon={IconX} size="sm" />
+                    </Button>
+                </Tooltip>
+            ) : (
+                <LimitButton
+                    disabled={!isValidQuery}
+                    size={size}
+                    maxLimit={maxLimit}
+                    limit={limit}
+                    onLimitChange={setRowLimit}
+                />
+            )}
         </Button.Group>
     );
 });

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -35,9 +35,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const isLoading = useExplorerContext((context) => {
         const isCreatingQuery = context.query.isFetching;
         const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
-        const isFetchingAllRows =
-            context.queryResults.fetchAll &&
-            !context.queryResults.hasFetchedAllRows;
+        const isFetchingAllRows = context.queryResults.isFetchingAllPages;
         return isCreatingQuery || isFetchingFirstPage || isFetchingAllRows;
     });
     const fetchResults = useExplorerContext(

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -92,6 +92,7 @@ const EmbedDashboardChartTile: FC<Props> = ({
                 totalResults: translatedChartData?.rows.length,
                 initialQueryExecutionMs: 0,
                 isFetchingRows: false,
+                isFetchingAllPages: false,
                 fetchMoreRows: () => undefined,
                 setFetchAll: () => undefined,
                 fetchAll: true,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -189,12 +189,14 @@ export type ReadyQueryResultsPageWithClientFetchTimeMs =
 export const executeQuery = async (
     projectUuid: string,
     data: ExecuteAsyncQueryRequestParams,
+    options: { signal?: AbortSignal } = {},
 ): Promise<ApiExecuteAsyncQueryResults> =>
     lightdashApi<ApiExecuteAsyncQueryResults>({
         url: `/projects/${projectUuid}/query`,
         version: 'v2',
         method: 'POST',
         body: JSON.stringify(data),
+        signal: options.signal,
     });
 
 export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
@@ -206,30 +208,42 @@ export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
     const result = useQuery<ApiExecuteAsyncQueryResults, ApiError>({
         enabled: !!data,
         queryKey: ['create-query', data],
-        queryFn: () => {
+        queryFn: ({ signal }) => {
             if (data?.chartUuid && data?.chartVersionUuid) {
-                return executeQuery(data.projectUuid, {
-                    context: QueryExecutionContext.CHART_HISTORY,
-                    chartUuid: data.chartUuid,
-                    versionUuid: data.chartVersionUuid,
-                });
-            } else if (data?.chartUuid) {
-                return executeQuery(data.projectUuid, {
-                    context: QueryExecutionContext.CHART,
-                    chartUuid: data.chartUuid,
-                });
-            } else if (data?.query) {
-                return executeQuery(data.projectUuid, {
-                    context: QueryExecutionContext.EXPLORE,
-                    query: {
-                        ...data.query,
-                        filters: convertDateFilters(data.query.filters),
-                        timezone: data.query.timezone ?? undefined,
-                        exploreName: data.tableId,
-                        granularity: data.dateZoomGranularity,
+                return executeQuery(
+                    data.projectUuid,
+                    {
+                        context: QueryExecutionContext.CHART_HISTORY,
+                        chartUuid: data.chartUuid,
+                        versionUuid: data.chartVersionUuid,
                     },
-                    invalidateCache: true, // Note: do not cache explore queries
-                });
+                    { signal },
+                );
+            } else if (data?.chartUuid) {
+                return executeQuery(
+                    data.projectUuid,
+                    {
+                        context: QueryExecutionContext.CHART,
+                        chartUuid: data.chartUuid,
+                    },
+                    { signal },
+                );
+            } else if (data?.query) {
+                return executeQuery(
+                    data.projectUuid,
+                    {
+                        context: QueryExecutionContext.EXPLORE,
+                        query: {
+                            ...data.query,
+                            filters: convertDateFilters(data.query.filters),
+                            timezone: data.query.timezone ?? undefined,
+                            exploreName: data.tableId,
+                            granularity: data.dateZoomGranularity,
+                        },
+                        invalidateCache: true, // Note: do not cache explore queries
+                    },
+                    { signal },
+                );
             }
             return Promise.reject(
                 new ParameterError('Missing QueryResultsProps'),
@@ -286,6 +300,7 @@ export type InfiniteQueryResults = Partial<
     >
 > & {
     projectUuid?: string;
+    queryStatus?: QueryHistoryStatus;
     rows: ResultRow[];
     isInitialLoading: boolean;
     isFetchingFirstPage: boolean;
@@ -493,6 +508,7 @@ export const useInfiniteQueryResults = (
         () => ({
             projectUuid,
             queryUuid,
+            queryStatus: nextPageData?.status, // show latest status
             metricQuery: fetchedPages[0]?.metricQuery,
             fields: fetchedPages[0]?.fields,
             totalResults: fetchedPages[0]?.totalResults,
@@ -522,6 +538,7 @@ export const useInfiniteQueryResults = (
             totalClientFetchTimeMs,
             isInitialLoading,
             fetchAll,
+            nextPageData,
         ],
     );
 };

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -305,6 +305,7 @@ export type InfiniteQueryResults = Partial<
     isInitialLoading: boolean;
     isFetchingFirstPage: boolean;
     isFetchingRows: boolean;
+    isFetchingAllPages: boolean;
     fetchMoreRows: () => void;
     setFetchAll: (value: boolean) => void;
     fetchAll: boolean;
@@ -525,6 +526,7 @@ export const useInfiniteQueryResults = (
                 (fetchedPages[0]?.totalResults === undefined ||
                     (fetchedPages[0]?.totalResults > 0 &&
                         fetchedRows.length === 0)),
+            isFetchingAllPages: !!queryUuid && fetchAll && !hasFetchedAllRows,
             fetchAll,
         }),
         [

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1562,15 +1562,22 @@ const ExplorerProvider: FC<
         dispatch({ type: ActionType.SET_FETCH_RESULTS_FALSE });
     }, [runQuery, state.shouldFetchResults]);
 
+    const queryClient = useQueryClient();
     const clearExplore = useCallback(async () => {
         resetCachedChartConfig();
-
+        // cancel query creation
+        void queryClient.cancelQueries({
+            queryKey: ['create-query'],
+            exact: false,
+        });
+        // reset query history
+        setQueryUuidHistory([]);
         dispatch({
             type: ActionType.RESET,
             payload: defaultStateWithConfig,
         });
         resetQueryResults();
-    }, [resetQueryResults, defaultStateWithConfig]);
+    }, [queryClient, resetQueryResults, defaultStateWithConfig]);
 
     const navigate = useNavigate();
     const clearQuery = useCallback(async () => {
@@ -1617,7 +1624,6 @@ const ExplorerProvider: FC<
         runQuery,
     ]);
 
-    const queryClient = useQueryClient();
     const cancelQuery = useCallback(() => {
         // cancel query creation
         void queryClient.cancelQueries({

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -12,7 +12,6 @@ import {
     toggleArrayValue,
     updateFieldIdInFilters,
     type AdditionalMetric,
-    type ApiExecuteAsyncQueryResults,
     type ChartConfig,
     type CustomDimension,
     type CustomFormat,
@@ -1620,19 +1619,20 @@ const ExplorerProvider: FC<
 
     const queryClient = useQueryClient();
     const cancelQuery = useCallback(() => {
-        const queryKey = ['create-query', validQueryArgs];
         // cancel query creation
-        void queryClient.cancelQueries({ queryKey });
+        void queryClient.cancelQueries({
+            queryKey: ['create-query', validQueryArgs],
+        });
 
-        const data =
-            queryClient.getQueryData<ApiExecuteAsyncQueryResults>(queryKey);
         // remove current queryUuid from setQueryUuidHistory
-        if (data?.queryUuid) {
+        if (query.data?.queryUuid) {
             setQueryUuidHistory((prev) => {
-                return prev.filter((queryUuid) => queryUuid !== data.queryUuid);
+                return prev.filter(
+                    (queryUuid) => queryUuid !== query.data.queryUuid,
+                );
             });
         }
-    }, [queryClient, validQueryArgs]);
+    }, [queryClient, validQueryArgs, query.data]);
 
     const actions = useMemo(
         () => ({

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -319,6 +319,7 @@ export interface ExplorerContextType {
         setChartType: (chartType: ChartType) => void;
         setChartConfig: (chartConfig: ChartConfig) => void;
         fetchResults: () => void;
+        cancelQuery: () => void;
         toggleExpandedSection: (section: ExplorerSection) => void;
         addCustomDimension: (customDimension: CustomDimension) => void;
         editCustomDimension: (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1406 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Note this only cancels the query in the frontend. 
A separate PR is necessary to cancel the query in the warehouse.

Changes:
- support signal in fetch calls and query execution hook
- show cancel button when query is being created or pending
- on cancel, cancel query creation and set the previous queryUuid. (loads cached pages)

![cancel query.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/CIQVnVTkiLq0ysfP4597/8c2507b5-977c-4631-b8dc-b20012e427c6.gif)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
