### PR TITLE
fix: check dbt project directory exists before running commands

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -332,6 +332,18 @@ export class DbtCliClient implements DbtClient {
         }
     }
 
+    private async ensureDbtProjectDir(): Promise<void> {
+        try {
+            await fs.access(this.dbtProjectDirectory);
+        } catch (e) {
+            throw new DbtError(
+                `dbt project directory not found: /${path.basename(
+                    this.dbtProjectDirectory,
+                )}`,
+            );
+        }
+    }
+
     async test(): Promise<void> {
         return Sentry.startSpan(
             {
@@ -339,6 +351,7 @@ export class DbtCliClient implements DbtClient {
                 name: 'test',
             },
             async () => {
+                await this.ensureDbtProjectDir();
                 await this.installDeps();
                 await this._runDbtCommand('parse');
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Added a new `ensureDbtProjectDir` method to the `DbtCliClient` class that checks if the dbt project directory exists before running commands. This method is now called before installing dependencies in the `test` method, which will throw a more descriptive error when the project directory is missing.

[CleanShot 2025-04-25 at 16.58.14.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/SRLEqMEevAzoFwvhnfeq/83209ea3-05d8-4158-8421-5e54af834214.mp4" />](https://app.graphite.dev/media/video/SRLEqMEevAzoFwvhnfeq/83209ea3-05d8-4158-8421-5e54af834214.mp4)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging