### PR TITLE
fix: ltree path generation for slugs with emojis

### DIFF
--- a/packages/common/src/utils/slug.test.ts
+++ b/packages/common/src/utils/slug.test.ts
@@ -173,5 +173,19 @@ describe('Slug', () => {
         test('should handle empty slug', () => {
             expect(getLtreePathFromSlug('')).toEqual('');
         });
+
+        test('should not trim hyphens from slug', () => {
+            expect(
+                getLtreePathFromSlug('-my-space-name-with-hyphens-'),
+            ).toEqual('_my_space_name_with_hyphens_');
+        });
+
+        test('should not trim hyphens from deeply nested slug', () => {
+            expect(
+                getLtreePathFromSlug(
+                    'grandparent-space-/-parent-space/child-space-',
+                ),
+            ).toEqual('grandparent_space_._parent_space.child_space_');
+        });
     });
 });

--- a/packages/common/src/utils/slugs.ts
+++ b/packages/common/src/utils/slugs.ts
@@ -1,12 +1,16 @@
-const sanitizeSlug = (slug: string) =>
-    slug
+const sanitizeSlug = (slug: string, trimHyphens = true) => {
+    let sanitizedSlug = slug
         .toLowerCase()
         // Then replace remaining non-alphanumeric characters with hyphens
-        .replace(/[^a-z0-9]+/g, '-')
-        // Replace multiple hyphens with a single hyphen
-        .replace(/-+/g, '-')
+        .replace(/[^a-z0-9]+/g, '-');
+
+    if (trimHyphens) {
         // Trim leading and trailing hyphens
-        .replace(/^-+|-+$/g, '');
+        sanitizedSlug = sanitizedSlug.replace(/^-+|-+$/g, '');
+    }
+
+    return sanitizedSlug;
+};
 
 export const generateSlug = (name: string) => {
     const sanitizedSlug = sanitizeSlug(name);
@@ -58,7 +62,7 @@ export const getLabelFromSlug = (slug: string) => slug.split('/').pop() ?? slug;
  */
 export const getLtreePathFromSlug = (slug: string) => {
     const slugs = slug.split('/');
-    const sanitizedSlugs = slugs.map(sanitizeSlug);
+    const sanitizedSlugs = slugs.map((s) => sanitizeSlug(s, false));
 
     return sanitizedSlugs.join('.').replace(/-/g, '_');
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/14559

### Description:

for space slugs that still contain leading and trailing hyphens, ignore the trimming of them when creating a nested space. 
This is related to #[this PR](https://github.com/lightdash/lightdash/pull/9875) where sanitization when generating removed leading and trailing but the migration did not account for that

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
