### PR TITLE
fix: add loading states/overlays when moving

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -150,7 +150,8 @@ const SavedChartsHeader: FC = () => {
 
     const { user, health } = useApp();
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
-    const { mutate: moveChartToSpace } = useMoveChartMutation();
+    const { mutateAsync: moveChartToSpace, isLoading: isMovingChartToSpace } =
+        useMoveChartMutation();
     const updateSavedChart = useUpdateMutation(
         dashboardUuid ? dashboardUuid : undefined,
         savedChart?.uuid,
@@ -784,10 +785,11 @@ const SavedChartsHeader: FC = () => {
                     opened={isTransferToSpaceModalOpen}
                     items={[savedChart]}
                     spaces={spaces}
+                    isLoading={isMovingChart || isMovingChartToSpace}
                     onClose={transferToSpaceModalHandlers.close}
-                    onConfirm={(newSpaceUuid) => {
+                    onConfirm={async (newSpaceUuid) => {
                         if (savedChart) {
-                            moveChartToSpace({
+                            await moveChartToSpace({
                                 uuid: savedChart.uuid,
                                 spaceUuid: newSpaceUuid,
                             });

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -78,6 +78,7 @@ type DashboardHeaderProps = {
     oldestCacheTime?: Date;
     activeTabUuid?: string;
     dashboardTabs?: Dashboard['tabs'];
+    isMovingDashboardToSpace: boolean;
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
     onCancel: () => void;
     onSaveDashboard: () => void;
@@ -98,6 +99,7 @@ const DashboardHeader = ({
     hasNewSemanticLayerChart,
     isEditMode,
     isSaving,
+    isMovingDashboardToSpace,
     isFullScreenFeatureEnabled,
     isFullscreen,
     oldestCacheTime,
@@ -307,8 +309,9 @@ const DashboardHeader = ({
                         onClose={transferToSpaceModalHandlers.close}
                         items={[dashboard]}
                         spaces={spaces}
-                        onConfirm={(spaceUuid) => {
-                            onMoveToSpace(spaceUuid);
+                        isLoading={isMovingDashboardToSpace}
+                        onConfirm={async (spaceUuid) => {
+                            await onMoveToSpace(spaceUuid);
                             transferToSpaceModalHandlers.close();
                         }}
                     />

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -49,14 +49,17 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: spaces } = useSpaceSummaries(projectUuid, true, {});
 
-    const { mutate: moveChart } = useMoveChartMutation();
-    const { mutate: updateSqlChart } = useUpdateSqlChartMutation(
-        projectUuid,
-        '',
-        '', // TODO: get slug or savedSqlUuid to invalidate the query if necessary
-    );
+    const { mutateAsync: moveChart, isLoading: isMovingChart } =
+        useMoveChartMutation();
+    const { mutateAsync: updateSqlChart, isLoading: isUpdatingSqlChart } =
+        useUpdateSqlChartMutation(
+            projectUuid,
+            '',
+            '', // TODO: get slug or savedSqlUuid to invalidate the query if necessary
+        );
 
-    const { mutate: moveDashboard } = useMoveDashboardMutation();
+    const { mutateAsync: moveDashboard, isLoading: isMovingDashboard } =
+        useMoveDashboardMutation();
     const { mutate: pinChart } = useChartPinningMutation();
     const { mutate: pinDashboard } = useDashboardPinningMutation();
     const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
@@ -103,11 +106,11 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     );
 
     const handleCreateSpace = useCallback(
-        (space: Space | null) => {
+        async (space: Space | null) => {
             if (!space) return;
             if (action.type !== ResourceViewItemAction.CREATE_SPACE) return;
 
-            moveToSpace(action.item, space.uuid);
+            await moveToSpace(action.item, space.uuid);
         },
         [action, moveToSpace],
     );
@@ -298,8 +301,11 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                     onClose={handleReset}
                     items={[action.item]}
                     spaces={spaces ?? []}
-                    onConfirm={(spaceUuid) => {
-                        moveToSpace(action.item, spaceUuid);
+                    isLoading={
+                        isMovingChart || isMovingDashboard || isUpdatingSqlChart
+                    }
+                    onConfirm={async (spaceUuid) => {
+                        await moveToSpace(action.item, spaceUuid);
                         handleReset();
                     }}
                 />

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -1,5 +1,5 @@
 import { type SpaceSummary } from '@lightdash/common';
-import { Alert, Box, Button, Group, Text } from '@mantine/core';
+import { Alert, Box, Button, Group, LoadingOverlay, Text } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
@@ -13,6 +13,7 @@ type Props<T, U> = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     projectUuid: string;
     items: T;
     spaces: U;
+    isLoading: boolean;
     onConfirm: (spaceUuid: string) => void;
 };
 
@@ -26,6 +27,7 @@ const TransferItemsModal = <
     items,
     spaces,
     onConfirm,
+    isLoading,
 }: Props<T, U>) => {
     const {
         selectedSpaceUuid,
@@ -112,6 +114,9 @@ const TransferItemsModal = <
                 </>
             }
         >
+            <LoadingOverlay
+                visible={createSpaceMutation.isLoading || isLoading}
+            />
             {isCreatingNewSpace ? (
                 <SpaceCreationForm
                     spaceName={newSpaceName}

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -3,6 +3,7 @@ import { type Dashboard, type Space } from '@lightdash/common';
 import {
     Button,
     Group,
+    LoadingOverlay,
     MantineProvider,
     Stack,
     TextInput,
@@ -235,6 +236,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                     </Group>
                 }
             >
+                <LoadingOverlay visible={isLoading} />
                 <form
                     id="dashboard-create-modal"
                     title="Create Dashboard"

--- a/packages/frontend/src/features/semanticViewer/components/Modals/SaveSemanticViewerChartModal.tsx
+++ b/packages/frontend/src/features/semanticViewer/components/Modals/SaveSemanticViewerChartModal.tsx
@@ -216,6 +216,11 @@ const SaveSemanticViewerChartModal: FC<Props> = ({ onSave }) => {
         ],
     );
 
+    const isLoading =
+        isSaving ||
+        spacesQuery.isLoading ||
+        spaceManagement.createSpaceMutation.isLoading;
+
     return (
         <Modal
             opened={opened}
@@ -291,14 +296,6 @@ const SaveSemanticViewerChartModal: FC<Props> = ({ onSave }) => {
                         </Button>
                     )}
 
-                    <Button
-                        onClick={handleClose}
-                        variant="outline"
-                        disabled={isSaving}
-                    >
-                        Cancel
-                    </Button>
-
                     {modalSteps.currentStep === ModalStep.InitialInfo ? (
                         <Button
                             onClick={handleNextStep}
@@ -314,7 +311,7 @@ const SaveSemanticViewerChartModal: FC<Props> = ({ onSave }) => {
                             <Button
                                 type="submit"
                                 disabled={!isFormReadyToSave}
-                                loading={isSaving}
+                                loading={isLoading}
                             >
                                 Save
                             </Button>

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -200,6 +200,11 @@ const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
         ],
     );
 
+    const isLoading =
+        isLoadingSpace ||
+        isCreatingSavedSqlChart ||
+        spaceManagement.createSpaceMutation.isLoading;
+
     return (
         <form onSubmit={form.onSubmit(handleOnSubmit)}>
             {modalSteps.currentStep === ModalStep.InitialInfo && (
@@ -258,14 +263,6 @@ const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
                     </Button>
                 )}
 
-                <Button
-                    onClick={onClose}
-                    variant="outline"
-                    disabled={isCreatingSavedSqlChart}
-                >
-                    Cancel
-                </Button>
-
                 {hasUnrunChanges && (
                     <Button
                         leftIcon={<MantineIcon icon={IconArrowBack} />}
@@ -291,7 +288,7 @@ const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
                         <Button
                             type="submit"
                             disabled={!isFormReadyToSave}
-                            loading={isCreatingSavedSqlChart}
+                            loading={isLoading}
                         >
                             Save
                         </Button>

--- a/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/UpdateSqlChartModal.tsx
@@ -156,7 +156,11 @@ export const UpdateSqlChartModal = ({
         ],
     );
 
-    const isLoading = isSavingChart || isChartLoading || isSpacesLoading;
+    const isLoading =
+        isSavingChart ||
+        isChartLoading ||
+        isSpacesLoading ||
+        spaceManagement.createSpaceMutation.isLoading;
 
     return (
         <Modal
@@ -230,14 +234,6 @@ export const UpdateSqlChartModal = ({
                             New Space
                         </Button>
                     )}
-
-                    <Button
-                        onClick={onClose}
-                        variant="outline"
-                        disabled={isLoading}
-                    >
-                        Cancel
-                    </Button>
 
                     {modalSteps.currentStep === ModalStep.InitialInfo ? (
                         <Button

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -117,7 +117,10 @@ const Dashboard: FC = () => {
         reset,
         isLoading: isSaving,
     } = useUpdateDashboard(dashboardUuid);
-    const { mutate: moveDashboardToSpace } = useMoveDashboardMutation();
+    const {
+        mutateAsync: moveDashboardToSpace,
+        isLoading: isMovingDashboardToSpace,
+    } = useMoveDashboardMutation();
 
     const [isDeleteModalOpen, deleteModalHandlers] = useDisclosure();
     const [isDuplicateModalOpen, duplicateModalHandlers] = useDisclosure();
@@ -441,10 +444,10 @@ const Dashboard: FC = () => {
     ]);
 
     const handleMoveDashboardToSpace = useCallback(
-        (spaceUuid: string) => {
+        async (spaceUuid: string) => {
             if (!dashboard) return;
 
-            moveDashboardToSpace({
+            await moveDashboardToSpace({
                 uuid: dashboard.uuid,
                 name: dashboard.name,
                 spaceUuid,
@@ -630,6 +633,7 @@ const Dashboard: FC = () => {
                         }}
                         onCancel={handleCancel}
                         onMoveToSpace={handleMoveDashboardToSpace}
+                        isMovingDashboardToSpace={isMovingDashboardToSpace}
                         onDuplicate={duplicateModalHandlers.open}
                         onDelete={deleteModalHandlers.open}
                         onExport={exportDashboardModalHandlers.open}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: n/A

### Description:

Improves loading states with loading overlays/loading states when

saving sql runner chart
[state loadin sql runner.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/951c3dbf-ba46-45ae-b59f-2445921098c4.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/951c3dbf-ba46-45ae-b59f-2445921098c4.mov)

transferring dashboard
[saved-dashboard-tranfer.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/2c87eb58-ad87-4182-aa49-1324f4f37bcc.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/2c87eb58-ad87-4182-aa49-1324f4f37bcc.mov)

transferring through resource-action menu
[resource-action.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/c4cdbcaf-c425-4173-ac33-156f7d99cfac.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/c4cdbcaf-c425-4173-ac33-156f7d99cfac.mov)

transferring chart
[loading-chart-transfer.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/c278549d-4c89-4e43-89f2-047bbe554998.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/c278549d-4c89-4e43-89f2-047bbe554998.mov)

saving chart

[uploading savinghcart.mov...]

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
