### PR TITLE
fix: remove active field custom dim instead of deleting

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -75,10 +75,6 @@ const ContextMenu: FC<ContextMenuProps> = ({
         (context) => context.actions.toggleCustomDimensionModal,
     );
 
-    const removeCustomDimension = useExplorerContext(
-        (context) => context.actions.removeCustomDimension,
-    );
-
     if (item && isField(item)) {
         const itemFieldId = getItemId(item);
         return (
@@ -202,7 +198,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     icon={<MantineIcon icon={IconTrash} />}
                     color="red"
                     onClick={() => {
-                        removeCustomDimension(getItemId(item));
+                        removeActiveField(getItemId(item));
                     }}
                 >
                     Remove


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14345

### Description:

Clicking "Remove" from the results table should remove the field from the active fields, not actually "deleting" it from the explore. 

[bug-custom-dimension.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/246bf392-2a6b-469e-8eba-ac3afaccb340.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/246bf392-2a6b-469e-8eba-ac3afaccb340.mov)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
