### PR TITLE
fix: use networkMode always for tanstack queries and mutations

### DIFF
--- a/packages/frontend/src/features/queryRunner/BaseResultsRunner.ts
+++ b/packages/frontend/src/features/queryRunner/BaseResultsRunner.ts
@@ -16,7 +16,8 @@ import {
     type VizIndexLayoutOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { QueryClient } from '@tanstack/react-query';
+import { type QueryClient } from '@tanstack/react-query';
+import { createQueryClient } from '../../providers/ReactQuery/createQueryClient';
 
 export function getDimensionTypeFromSemanticLayerFieldType(
     type: SemanticLayerFieldType,
@@ -92,7 +93,7 @@ export class BaseResultsRunner implements IResultsRunner {
             (field) => field.kind === FieldType.METRIC,
         );
 
-        this.queryClient = new QueryClient();
+        this.queryClient = createQueryClient();
     }
 
     async getPivotedVisualizationData(

--- a/packages/frontend/src/providers/ReactQuery/createQueryClient.ts
+++ b/packages/frontend/src/providers/ReactQuery/createQueryClient.ts
@@ -14,9 +14,11 @@ export const createQueryClient = (options?: DefaultOptions) => {
                         await queryClient.invalidateQueries(['health']);
                     }
                 },
+                networkMode: 'always',
                 ...options?.queries,
             },
             mutations: {
+                networkMode: 'always',
                 ...options?.mutations,
             },
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Related issues: https://github.com/lightdash/lightdash/issues/13292#issuecomment-2701083940, https://github.com/TanStack/query/discussions/4753#discussioncomment-4592410

Docs: https://tanstack.com/query/v4/docs/framework/react/guides/network-mode

**How to test**
1. Turn off your wifi
2. Try to run lightdash locally, without this change you will see an infinite loading spinner in the login page

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
