### PR TITLE
fix: duplicate use query client

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1625,7 +1625,6 @@ const ExplorerProvider: FC<
         runQuery,
     ]);
 
-    const queryClient = useQueryClient();
     const { mutate: cancelQueryMutation } = useCancelQuery(
         projectUuid,
         query.data?.queryUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removes duplicate declaration of `queryClient`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
