### PR TITLE
feat: support --defer dbt on CLi preview

### DIFF
--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -29,6 +29,7 @@ export type DbtCompileOptions = {
     skipDbtCompile: boolean | undefined;
     skipWarehouseCatalog: boolean | undefined;
     useDbtList: boolean | undefined;
+    defer: boolean | undefined;
 };
 
 const dbtCompileArgs = [
@@ -45,6 +46,7 @@ const dbtCompileArgs = [
     'selector',
     'state',
     'fullRefresh',
+    'defer',
 ];
 
 const camelToSnakeCase = (str: string) =>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -254,8 +254,16 @@ ${styles.bold('Examples:')}
     .option('--no-version-check')
     .option('-s, --select, <select> [selects...]')
     .option('--state <state>')
-    .option('--defer')
-    .option('--no-defer')
+    .option(
+        '--defer',
+        'dbt property. Resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
+    .option(
+        '--no-defer',
+        'dbt property. Do not resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
     .option('--full-refresh')
     .option(
         '--exclude-meta',
@@ -338,6 +346,16 @@ program
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
     .option('--vars <vars>')
+    .option(
+        '--defer',
+        'dbt property. Resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
+    .option(
+        '--no-defer',
+        'dbt property. Do not resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
     .option('--threads <number>')
     .option('--no-version-check')
     .option(
@@ -401,6 +419,16 @@ program
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
     .option('--vars <vars>')
+    .option(
+        '--defer',
+        'dbt property. Resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
+    .option(
+        '--no-defer',
+        'dbt property. Do not resolve unselected nodes by deferring to the manifest within the --state directory.',
+        undefined,
+    )
     .option('--threads <number>')
     .option('--no-version-check')
     .option(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14464

### Description:
Added support for the `--defer` flag in dbt commands. This allows users to resolve unselected nodes by deferring to the manifest within the `--state` directory.

The changes include:
- Added `defer` option to `DbtCompileOptions` type
- Added `defer` to the list of dbt compile arguments
- Added proper CLI options with descriptions for `--defer` and `--no-defer` flags in multiple commands


Before


![Screenshot from 2025-04-30 08-37-45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DiYMOADSFXKcNbL9606j/d64161bb-bfeb-4281-aafb-b449ccdfad0d.png)

After



![Screenshot from 2025-04-30 08-41-29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DiYMOADSFXKcNbL9606j/78e5da76-5883-4971-ad01-e2177edb2752.png)

![Screenshot from 2025-04-30 08-41-37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DiYMOADSFXKcNbL9606j/022f4cc9-f22e-4b26-b311-0e868e840854.png)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging