### PR TITLE
fix: remove invalidate cache from query key

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -109,7 +109,6 @@ export const useDashboardChartReadyQuery = (
             sortKey,
             context,
             autoRefresh,
-            invalidateCache,
             hasADateDimension ? granularity : null,
         ],
         [
@@ -121,7 +120,6 @@ export const useDashboardChartReadyQuery = (
             sortKey,
             context,
             autoRefresh,
-            invalidateCache,
             hasADateDimension,
             granularity,
         ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Invalidate cache in query key was causing the first refresh of a dashboard to trigger 2 queries

### Description:

**Before**

https://github.com/user-attachments/assets/f40fb113-4426-4be3-b6aa-cf65b5d1fce1

**After**

https://github.com/user-attachments/assets/719cd176-4b63-420f-a524-fb27e7d78385


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
