### PR TITLE
fix: race condition cache being written while another execute query was called

### DIFF
--- a/packages/backend/src/database/entities/resultsCache.ts
+++ b/packages/backend/src/database/entities/resultsCache.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import type { ResultsCacheStatus } from '../../models/ResultsCacheModel/types';
 
 export type DbResultsCache = {
     cache_key: string;
@@ -7,6 +8,7 @@ export type DbResultsCache = {
     updated_at: Date;
     expires_at: Date;
     total_row_count: number | null;
+    status: ResultsCacheStatus;
 };
 
 export type DbResultsCacheIn = Omit<
@@ -14,9 +16,12 @@ export type DbResultsCacheIn = Omit<
     'created_at' | 'updated_at'
 >;
 
-export type DbResultsCacheUpdate =
-    | Pick<DbResultsCache, 'total_row_count'>
-    | Pick<DbResultsCache, 'expires_at' | 'updated_at'>;
+export type DbResultsCacheUpdate = Partial<
+    Pick<
+        DbResultsCache,
+        'total_row_count' | 'status' | 'expires_at' | 'updated_at'
+    >
+>;
 
 export type ResultsCacheTable = Knex.CompositeTableType<
     DbResultsCache,

--- a/packages/backend/src/database/migrations/20250501102249_add_status_column_to_results_cache.ts
+++ b/packages/backend/src/database/migrations/20250501102249_add_status_column_to_results_cache.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+import { ResultsCacheStatus } from '../../models/ResultsCacheModel/types';
+
+const RESULTS_CACHE_TABLE = 'results_cache';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(RESULTS_CACHE_TABLE, (table) => {
+        table
+            .string('status')
+            .notNullable()
+            .defaultTo(ResultsCacheStatus.PENDING);
+    });
+
+    // Set all existing cache entries to READY
+    await knex(RESULTS_CACHE_TABLE).update({
+        status: ResultsCacheStatus.READY,
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(RESULTS_CACHE_TABLE, (table) => {
+        table.dropColumn('status');
+    });
+}

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.test.ts
@@ -9,6 +9,7 @@ import {
     type DbResultsCache,
 } from '../../database/entities/resultsCache';
 import { ResultsCacheModel } from './ResultsCacheModel';
+import { ResultsCacheStatus } from './types';
 
 // Mock storage client
 const mockStorageClient = {
@@ -119,6 +120,7 @@ describe('ResultsCacheModel', () => {
                 created_at: futureDateCreatedAt,
                 updated_at: futureDateCreatedAt,
                 total_row_count: 100,
+                status: ResultsCacheStatus.READY,
             };
 
             tracker.on.select('results_cache').response([existingCache]);
@@ -139,6 +141,7 @@ describe('ResultsCacheModel', () => {
                 createdAt: futureDateCreatedAt,
                 updatedAt: futureDateCreatedAt,
                 expiresAt: futureDate,
+                status: ResultsCacheStatus.READY,
             });
             expect(tracker.history.select).toHaveLength(1);
             expect(mockStorageClient.createUploadStream).not.toHaveBeenCalled();
@@ -189,6 +192,7 @@ describe('ResultsCacheModel', () => {
                 created_at: pastDateCreatedAt,
                 updated_at: pastDateCreatedAt,
                 total_row_count: 100,
+                status: ResultsCacheStatus.READY,
             };
 
             tracker.on.select('results_cache').response([expiredCache]);
@@ -238,6 +242,7 @@ describe('ResultsCacheModel', () => {
                 total_row_count: 100,
                 created_at: futureDateCreatedAt,
                 updated_at: futureDateCreatedAt,
+                status: ResultsCacheStatus.READY,
             };
 
             tracker.on.select('results_cache').response([existingCache]);

--- a/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
+++ b/packages/backend/src/models/ResultsCacheModel/ResultsCacheModel.ts
@@ -13,7 +13,7 @@ import {
     ResultsCacheTableName,
     type DbResultsCacheUpdate,
 } from '../../database/entities/resultsCache';
-import type { CreateCacheResult } from './types';
+import { CreateCacheResult, ResultsCacheStatus } from './types';
 
 export class ResultsCacheModel {
     readonly database: Knex;
@@ -85,6 +85,7 @@ export class ResultsCacheModel {
                 write: undefined,
                 close: undefined,
                 totalRowCount: existingCache.total_row_count ?? 0, // TODO cache: db types need to match the union
+                status: existingCache.status,
             };
         }
 
@@ -124,6 +125,7 @@ export class ResultsCacheModel {
                 project_uuid: projectUuid,
                 expires_at: newExpiresAt,
                 total_row_count: null,
+                status: ResultsCacheStatus.PENDING,
             })
             .returning(['cache_key', 'created_at', 'updated_at', 'expires_at']);
 

--- a/packages/backend/src/models/ResultsCacheModel/types.ts
+++ b/packages/backend/src/models/ResultsCacheModel/types.ts
@@ -1,9 +1,15 @@
+export enum ResultsCacheStatus {
+    PENDING = 'pending',
+    READY = 'ready',
+}
+
 export type CacheHitCacheResult = {
     cacheKey: string;
     write: undefined;
     close: undefined;
     cacheHit: true;
     totalRowCount: number;
+    status: ResultsCacheStatus;
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -33,9 +33,10 @@ import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel';
 import type { ResultsCacheModel } from '../../models/ResultsCacheModel/ResultsCacheModel';
-import type {
-    CacheHitCacheResult,
-    MissCacheResult,
+import {
+    ResultsCacheStatus,
+    type CacheHitCacheResult,
+    type MissCacheResult,
 } from '../../models/ResultsCacheModel/types';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -510,6 +511,7 @@ describe('ProjectService', () => {
                     createdAt,
                     updatedAt,
                     expiresAt,
+                    status: ResultsCacheStatus.READY,
                     write: undefined,
                     close: undefined,
                 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14620 

### Description:

- Fixes race condition where if 2 charts were loaded at the same time (with caching enabled) the first one would still be writing to cache while the second would render a cache hit and try to request the results from the file while it was still being written
- Adding column to `results_cache` table which tracks whether the cache is `READY` or `PENDING`
- Sets the `queryHistory` status depending on this when it is a cache hit
- On get results, updates the `queryHistory` status to `READY`

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
