### PR TITLE
chore(repl): update script to fix chart slugs across all projects

### DIFF
--- a/packages/backend/src/ee/repl/index.ts
+++ b/packages/backend/src/ee/repl/index.ts
@@ -32,8 +32,8 @@ import { getListProjectsScripts } from './scripts/listProjects';
         models,
         database,
         scripts: {
-            fixDuplicateSlugs: getFixDuplicateSlugsScripts(database),
-            listProjects: getListProjectsScripts(database),
+            ...getFixDuplicateSlugsScripts(database),
+            ...getListProjectsScripts(database),
         },
     });
 })();

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.test.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.test.ts
@@ -23,16 +23,14 @@ describe('fixDuplicateSlugs', () => {
         jest.clearAllMocks();
     });
 
-    describe('fixDuplicateChartSlugsForProject', () => {
+    describe('fixDuplicateChartSlugs', () => {
         const projectUuid = 'test-project-uuid';
 
         test('should not update anything when no duplicate slugs exist', async () => {
             // Mock the query that finds duplicate slugs
-            tracker.on
-                .select(queryMatcher(SavedChartsTableName, [projectUuid]))
-                .response([]);
+            tracker.on.select(queryMatcher(SavedChartsTableName)).response([]);
 
-            await scripts.fixDuplicateChartSlugsForProject(projectUuid, {
+            await scripts.fixDuplicateChartSlugs({
                 dryRun: false,
             });
 
@@ -46,15 +44,15 @@ describe('fixDuplicateSlugs', () => {
 
             // Mock finding duplicate slugs
             tracker.on
-                .select(queryMatcher(SavedChartsTableName, [projectUuid]))
-                .responseOnce([{ slug: duplicateSlug }]);
+                .select(queryMatcher(SavedChartsTableName))
+                .responseOnce([{ slug: duplicateSlug, projectUuid }]);
 
             // Mock finding charts with the duplicate slug
             tracker.on
                 .select(
                     queryMatcher(SavedChartsTableName, [
-                        projectUuid,
                         duplicateSlug,
+                        projectUuid,
                     ]),
                 )
                 .responseOnce([
@@ -87,7 +85,7 @@ describe('fixDuplicateSlugs', () => {
                 )
                 .response([1]);
 
-            await scripts.fixDuplicateChartSlugsForProject(projectUuid, {
+            await scripts.fixDuplicateChartSlugs({
                 dryRun: false,
             });
 
@@ -110,15 +108,15 @@ describe('fixDuplicateSlugs', () => {
 
             // Mock finding duplicate slugs
             tracker.on
-                .select(queryMatcher(SavedChartsTableName, [projectUuid]))
-                .responseOnce([{ slug: duplicateSlug }]);
+                .select(queryMatcher(SavedChartsTableName))
+                .responseOnce([{ slug: duplicateSlug, projectUuid }]);
 
             // Mock finding charts with the duplicate slug
             tracker.on
                 .select(
                     queryMatcher(SavedChartsTableName, [
-                        projectUuid,
                         duplicateSlug,
+                        projectUuid,
                     ]),
                 )
                 .responseOnce([
@@ -151,7 +149,7 @@ describe('fixDuplicateSlugs', () => {
                 )
                 .response([1]);
 
-            await scripts.fixDuplicateChartSlugsForProject(projectUuid, {
+            await scripts.fixDuplicateChartSlugs({
                 dryRun: true,
             });
 
@@ -165,15 +163,15 @@ describe('fixDuplicateSlugs', () => {
 
             // Mock finding duplicate slugs
             tracker.on
-                .select(queryMatcher(SavedChartsTableName, [projectUuid]))
-                .responseOnce([{ slug: duplicateSlug }]);
+                .select(queryMatcher(SavedChartsTableName))
+                .responseOnce([{ slug: duplicateSlug, projectUuid }]);
 
             // Mock finding charts with the duplicate slug
             tracker.on
                 .select(
                     queryMatcher(SavedChartsTableName, [
-                        projectUuid,
                         duplicateSlug,
+                        projectUuid,
                     ]),
                 )
                 .responseOnce([
@@ -221,7 +219,7 @@ describe('fixDuplicateSlugs', () => {
                 )
                 .response([1]);
 
-            await scripts.fixDuplicateChartSlugsForProject(projectUuid, {
+            await scripts.fixDuplicateChartSlugs({
                 dryRun: false,
             });
 
@@ -247,7 +245,7 @@ describe('fixDuplicateSlugs', () => {
         test('should throw an error when dryRun is not provided', async () => {
             await expect(
                 // @ts-expect-error - we are testing the error case because the repl runs in JS not TS
-                scripts.fixDuplicateChartSlugsForProject(projectUuid),
+                scripts.fixDuplicateChartSlugs(),
             ).rejects.toThrow('Missing dryRun option!!');
         });
     });

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
@@ -77,6 +77,10 @@ export function getFixDuplicateSlugsScripts(database: Knex) {
                 if (chartsWithSlug.length > 1) {
                     const [firstChart, ...restCharts] = chartsWithSlug;
 
+                    console.info(
+                        `Keeping original slug "${firstChart.slug}" for chart "${firstChart.name}" (${firstChart.saved_query_uuid}) in project ${projectUuid}${dryRunMessage}`,
+                    );
+
                     for await (const chart of restCharts) {
                         const uniqueSlug =
                             await generateUniqueSlugScopedToProject(
@@ -87,7 +91,7 @@ export function getFixDuplicateSlugsScripts(database: Knex) {
                             );
 
                         console.info(
-                            `Updating chart "${chart.name}"(${chart.saved_query_uuid}) having slug "${chart.slug}" to "${uniqueSlug}" in project ${projectUuid}${dryRunMessage}`,
+                            `Updating slug from "${chart.slug}" to "${uniqueSlug}" for chart "${chart.name}" (${chart.saved_query_uuid}) in project ${projectUuid}${dryRunMessage}`,
                         );
 
                         await trx(SavedChartsTableName)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#14584](https://github.com/lightdash/lightdash/issues/14584)<!-- reference the related issue e.g. #150 -->

Execution plan:

- add REPL scripts that fix chart&dashboards slug uniqueness across all projects
- test scripts in production, with dryRun:true option
- move the script's logic to a migration + enforce unique index
- delete REPL scripts


### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Update script to work across all projects.
<img width="1336" alt="Screenshot 2025-05-01 at 14 56 37" src="https://github.com/user-attachments/assets/4489e528-9852-4ebb-b3ef-40ace278464e" />



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
