### PR TITLE
chore: add pivot option to sql endpoint

### DIFF
--- a/packages/backend/src/controllers/v2/ProjectController.ts
+++ b/packages/backend/src/controllers/v2/ProjectController.ts
@@ -170,6 +170,7 @@ export class V2ProjectController extends BaseController {
                 invalidateCache: body.invalidateCache ?? false,
                 sql: body.sql,
                 context: context ?? QueryExecutionContext.SQL_RUNNER,
+                pivotConfiguration: body.pivotConfiguration,
             });
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5709,6 +5709,29 @@ const models: TsoaRoute.Models = {
         enums: ['sum', 'count', 'avg', 'min', 'max', 'any'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ValuesColumn: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                aggregation: { ref: 'VizAggregationOptions', required: true },
+                reference: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GroupByColumn: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                reference: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SortByDirection: {
         dataType: 'refEnum',
         enums: ['ASC', 'DESC'],
@@ -5748,13 +5771,8 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'array',
                             array: {
-                                dataType: 'nestedObjectLiteral',
-                                nestedProperties: {
-                                    reference: {
-                                        dataType: 'string',
-                                        required: true,
-                                    },
-                                },
+                                dataType: 'refAlias',
+                                ref: 'GroupByColumn',
                             },
                         },
                         { dataType: 'undefined' },
@@ -5763,16 +5781,7 @@ const models: TsoaRoute.Models = {
                 },
                 valuesColumns: {
                     dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            aggregation: {
-                                ref: 'VizAggregationOptions',
-                                required: true,
-                            },
-                            reference: { dataType: 'string', required: true },
-                        },
-                    },
+                    array: { dataType: 'refAlias', ref: 'ValuesColumn' },
                     required: true,
                 },
                 indexColumn: { ref: 'PivotIndexColum', required: true },
@@ -14814,6 +14823,15 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SortBy: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'array',
+            array: { dataType: 'refAlias', ref: 'VizSortBy' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExecuteAsyncSqlQueryRequestParams: {
         dataType: 'refAlias',
         type: {
@@ -14823,6 +14841,45 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        pivotConfiguration: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                sortBy: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'SortBy' },
+                                        { dataType: 'undefined' },
+                                    ],
+                                    required: true,
+                                },
+                                groupByColumns: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            dataType: 'array',
+                                            array: {
+                                                dataType: 'refAlias',
+                                                ref: 'GroupByColumn',
+                                            },
+                                        },
+                                        { dataType: 'undefined' },
+                                    ],
+                                    required: true,
+                                },
+                                valuesColumns: {
+                                    dataType: 'array',
+                                    array: {
+                                        dataType: 'refAlias',
+                                        ref: 'ValuesColumn',
+                                    },
+                                    required: true,
+                                },
+                                indexColumn: {
+                                    ref: 'PivotIndexColum',
+                                    required: true,
+                                },
+                            },
+                        },
                         sql: { dataType: 'string', required: true },
                     },
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6456,6 +6456,27 @@
                 "enum": ["sum", "count", "avg", "min", "max", "any"],
                 "type": "string"
             },
+            "ValuesColumn": {
+                "properties": {
+                    "aggregation": {
+                        "$ref": "#/components/schemas/VizAggregationOptions"
+                    },
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": ["aggregation", "reference"],
+                "type": "object"
+            },
+            "GroupByColumn": {
+                "properties": {
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": ["reference"],
+                "type": "object"
+            },
             "SortByDirection": {
                 "enum": ["ASC", "DESC"],
                 "type": "string"
@@ -6482,28 +6503,13 @@
                     },
                     "groupByColumns": {
                         "items": {
-                            "properties": {
-                                "reference": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["reference"],
-                            "type": "object"
+                            "$ref": "#/components/schemas/GroupByColumn"
                         },
                         "type": "array"
                     },
                     "valuesColumns": {
                         "items": {
-                            "properties": {
-                                "aggregation": {
-                                    "$ref": "#/components/schemas/VizAggregationOptions"
-                                },
-                                "reference": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["aggregation", "reference"],
-                            "type": "object"
+                            "$ref": "#/components/schemas/ValuesColumn"
                         },
                         "type": "array"
                     },
@@ -15670,6 +15676,12 @@
                     }
                 ]
             },
+            "SortBy": {
+                "items": {
+                    "$ref": "#/components/schemas/VizSortBy"
+                },
+                "type": "array"
+            },
             "ExecuteAsyncSqlQueryRequestParams": {
                 "allOf": [
                     {
@@ -15677,6 +15689,30 @@
                     },
                     {
                         "properties": {
+                            "pivotConfiguration": {
+                                "properties": {
+                                    "sortBy": {
+                                        "$ref": "#/components/schemas/SortBy"
+                                    },
+                                    "groupByColumns": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/GroupByColumn"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "valuesColumns": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/ValuesColumn"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "indexColumn": {
+                                        "$ref": "#/components/schemas/PivotIndexColum"
+                                    }
+                                },
+                                "required": ["valuesColumns", "indexColumn"],
+                                "type": "object"
+                            },
                             "sql": {
                                 "type": "string"
                             }
@@ -16336,7 +16372,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1604.2",
+        "version": "0.1606.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4067,7 +4067,7 @@ export class ProjectService<
             ),
         ];
 
-        const orderBy: string = sortBy
+        const orderBy: string = sortBy?.length
             ? `ORDER BY ${sortBy
                   .map((s) => `${q}${s.reference}${q} ${s.direction}`)
                   .join(', ')}`

--- a/packages/backend/src/services/ProjectService/types.ts
+++ b/packages/backend/src/services/ProjectService/types.ts
@@ -1,9 +1,13 @@
 import {
+    GroupByColumn,
     MetricQuery,
+    SortBy,
+    ValuesColumn,
     type CacheMetadata,
     type DashboardFilters,
     type DateGranularity,
     type Filters,
+    type PivotIndexColum,
     type QueryExecutionContext,
     type ResultsPaginationArgs,
     type SessionUser,
@@ -32,6 +36,12 @@ export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
 
 export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
     sql: string;
+    pivotConfiguration?: {
+        indexColumn: PivotIndexColum;
+        valuesColumns: ValuesColumn[];
+        groupByColumns: GroupByColumn[] | undefined;
+        sortBy: SortBy | undefined;
+    };
 };
 
 export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -1,3 +1,9 @@
+import {
+    type GroupByColumn,
+    type PivotIndexColum,
+    type SortBy,
+    type ValuesColumn,
+} from '../..';
 import type { QueryExecutionContext } from '../analytics';
 import type { DashboardFilters, Filters } from '../filter';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
@@ -31,6 +37,12 @@ export type ExecuteAsyncDashboardChartRequestParams =
 export type ExecuteAsyncSqlQueryRequestParams =
     CommonPaginatedQueryRequestParams & {
         sql: string;
+        pivotConfiguration?: {
+            indexColumn: PivotIndexColum;
+            valuesColumns: ValuesColumn[];
+            groupByColumns: GroupByColumn[] | undefined;
+            sortBy: SortBy | undefined;
+        };
     };
 
 export type ExecuteAsyncUnderlyingDataRequestParams =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14627 

### Description:

Add an optional pivot config to the paginated SQL endpoint. 

`POST /api/v2/projects/:projectId/query/sql`

The POST body I've been using for initial tests looks like

```
{
    "context": "dashboardView",
    "invalidateCache": false,
    "sql": "SELECT * FROM \"postgres\".\"jaffle\".\"customers\" ",
    "pivotConfiguration": {
        "indexColumn": {
            "reference": "created",
            "type": "time"
        },
        "valuesColumns": [
            {
                "reference": "customer_id",
                "aggregation": "sum"
            }
        ],
        "groupByColumns": [],
        "sortBy": [
            {
                "direction": "ASC",
                "reference": "created"
            }
        ]
    }
}
```

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
