### PR TITLE
chore(repl): script to fix duplicate dashboard slugs

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -74,7 +74,7 @@ export type DashboardTable = Knex.CompositeTableType<
     Partial<
         Pick<
             DbDashboard,
-            'name' | 'description' | 'views_count' | 'first_viewed_at'
+            'name' | 'description' | 'views_count' | 'first_viewed_at' | 'slug'
         >
     >
 >;

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
@@ -198,7 +198,7 @@ export function getFixDuplicateSlugsScripts(database: Knex) {
             }
 
             if (dryRun) {
-                // Rollback the transaction if it's a dry run, this is because slugs depend on updated charts
+                // Rollback the transaction if it's a dry run, this is because slugs depend on updated dashboards
                 await trx.rollback();
             }
 

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
@@ -187,7 +187,7 @@ export function getFixDuplicateSlugsScripts(database: Knex) {
                             );
 
                         console.info(
-                            `Updating slug from "${dashboard.slug}" to "${uniqueSlug}" for chart "${dashboard.name}" (${dashboard.dashboard_uuid}) in project ${projectUuid}${dryRunMessage}`,
+                            `Updating slug from "${dashboard.slug}" to "${uniqueSlug}" for dashboard "${dashboard.name}" (${dashboard.dashboard_uuid}) in project ${projectUuid}${dryRunMessage}`,
                         );
 
                         await trx(DashboardsTableName)

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -71,7 +71,6 @@ export const generateUniqueSlugScopedToProject = async (
                 .where(`${SavedChartsTableName}.slug`, 'like', `${baseSlug}%`)
                 .pluck(`${SavedChartsTableName}.slug`);
             break;
-        case 'saved_sql':
         case 'dashboards':
             matchingSlugs = await trx(DashboardsTableName)
                 .innerJoin(
@@ -89,6 +88,7 @@ export const generateUniqueSlugScopedToProject = async (
                 .where(`${DashboardsTableName}.slug`, 'like', `${baseSlug}%`)
                 .pluck(`${DashboardsTableName}.slug`);
             break;
+        case 'saved_sql':
         case 'spaces':
         case 'saved_semantic_viewer_charts':
             throw new Error('Not implemented');

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -73,6 +73,22 @@ export const generateUniqueSlugScopedToProject = async (
             break;
         case 'saved_sql':
         case 'dashboards':
+            matchingSlugs = await trx(DashboardsTableName)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_id`,
+                    `${DashboardsTableName}.space_id`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${SpaceTableName}.project_id`,
+                    `${ProjectTableName}.project_id`,
+                )
+                .where('project_uuid', projectUuid)
+                .select(`${DashboardsTableName}.slug`)
+                .where(`${DashboardsTableName}.slug`, 'like', `${baseSlug}%`)
+                .pluck(`${DashboardsTableName}.slug`);
+            break;
         case 'spaces':
         case 'saved_semantic_viewer_charts':
             throw new Error('Not implemented');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [#14584](https://github.com/lightdash/lightdash/issues/14584)<!-- reference the related issue e.g. #150 -->
Execution plan:

- add REPL scripts that fix chart&dashboards slug uniqueness across all projects
- test scripts in production, with dryRun:true option
- move the script's logic to a migration + enforce unique index
- delete REPL scripts
- 
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Add script to fix duplicate dashboard slugs across all projects. 90% copy paste from chart script

<img width="1220" alt="Screenshot 2025-05-01 at 15 28 28" src="https://github.com/user-attachments/assets/19c76197-7751-424d-bec5-672b7512e49b" />


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
