### PR TITLE
feat(frontend): Move space to another space

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -807,6 +807,10 @@ const SavedChartsHeader: FC = () => {
                     isLoading={isMovingChart || isMovingChartToSpace}
                     onClose={transferToSpaceModalHandlers.close}
                     onConfirm={async (newSpaceUuid) => {
+                        if (!newSpaceUuid) {
+                            throw new Error('No space uuid provided');
+                        }
+
                         if (savedChart) {
                             await moveChartToSpace({
                                 uuid: savedChart.uuid,

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -1,6 +1,12 @@
 import { subject } from '@casl/ability';
 import { ActionIcon, Box, Menu } from '@mantine/core';
-import { IconEdit, IconPin, IconPinned, IconTrash } from '@tabler/icons-react';
+import {
+    IconEdit,
+    IconFolderSymlink,
+    IconPin,
+    IconPinned,
+    IconTrash,
+} from '@tabler/icons-react';
 import React from 'react';
 import { useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
@@ -71,6 +77,22 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
                         {isPinned ? 'Unpin from homepage' : 'Pin to homepage'}
                     </Menu.Item>
                 )}
+
+                <Menu.Divider />
+
+                <Menu.Item
+                    component="button"
+                    role="menuitem"
+                    icon={<IconFolderSymlink size={18} />}
+                    onClick={() => {
+                        // onAction({
+                        //     type: ResourceViewItemAction.TRANSFER_TO_SPACE,
+                        //     item,
+                        // });
+                    }}
+                >
+                    Transfer to space
+                </Menu.Item>
 
                 <Menu.Item
                     component="button"

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -17,6 +17,7 @@ interface Props {
     onRename: () => void;
     onDelete: () => void;
     onTogglePin: () => void;
+    onTransferToSpace: () => void;
 }
 
 export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
@@ -24,6 +25,7 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
     onRename,
     onDelete,
     onTogglePin,
+    onTransferToSpace,
     children,
 }) => {
     const { user } = useApp();
@@ -85,14 +87,13 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
                     role="menuitem"
                     icon={<IconFolderSymlink size={18} />}
                     onClick={() => {
-                        // onAction({
-                        //     type: ResourceViewItemAction.TRANSFER_TO_SPACE,
-                        //     item,
-                        // });
+                        onTransferToSpace();
                     }}
                 >
                     Transfer to space
                 </Menu.Item>
+
+                <Menu.Divider />
 
                 <Menu.Item
                     component="button"

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -317,6 +317,11 @@ const DashboardHeader = ({
                         spaces={spaces}
                         isLoading={isMovingDashboardToSpace}
                         onConfirm={async (spaceUuid) => {
+                            if (!spaceUuid) {
+                                throw new Error(
+                                    'Space UUID is required to move a dashboard',
+                                );
+                            }
                             await onMoveToSpace(spaceUuid);
                             transferToSpaceModalHandlers.close();
                         }}

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -319,28 +319,21 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         </Menu.Item>
                     ) : null}
 
-                    {item.type === ResourceViewItemType.CHART ||
-                    item.type === ResourceViewItemType.DASHBOARD ? (
-                        <>
-                            <Menu.Divider
-                                display={isSqlChart ? 'none' : 'block'}
-                            />
+                    <Menu.Divider display={isSqlChart ? 'none' : 'block'} />
 
-                            <Menu.Item
-                                component="button"
-                                role="menuitem"
-                                icon={<IconFolderSymlink size={18} />}
-                                onClick={() => {
-                                    onAction({
-                                        type: ResourceViewItemAction.TRANSFER_TO_SPACE,
-                                        item,
-                                    });
-                                }}
-                            >
-                                Transfer to space
-                            </Menu.Item>
-                        </>
-                    ) : null}
+                    <Menu.Item
+                        component="button"
+                        role="menuitem"
+                        icon={<IconFolderSymlink size={18} />}
+                        onClick={() => {
+                            onAction({
+                                type: ResourceViewItemAction.TRANSFER_TO_SPACE,
+                                item,
+                            });
+                        }}
+                    >
+                        Transfer to space
+                    </Menu.Item>
 
                     {allowDelete && (
                         <>

--- a/packages/frontend/src/components/common/ResourceView/types.ts
+++ b/packages/frontend/src/components/common/ResourceView/types.ts
@@ -2,6 +2,7 @@ import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
     type ResourceViewItem,
+    type ResourceViewSpaceItem,
 } from '@lightdash/common';
 import { type ReactNode } from 'react';
 
@@ -56,7 +57,10 @@ export type ResourceViewItemActionState =
       }
     | {
           type: ResourceViewItemAction.TRANSFER_TO_SPACE;
-          item: ResourceViewChartItem | ResourceViewDashboardItem; // TODO: implement spaces
+          item:
+              | ResourceViewChartItem
+              | ResourceViewDashboardItem
+              | ResourceViewSpaceItem;
       };
 
 type TabType = {

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -103,9 +103,7 @@ const SpaceSelector = ({
             >
                 <Tree
                     // top level item can only be selected for a single space
-                    withTopLevelSelectable={
-                        itemType === ResourceViewItemType.SPACE
-                    }
+                    withRootSelectable={itemType === ResourceViewItemType.SPACE}
                     data={fuzzyFilteredSpaces ?? filteredSpaces}
                     value={selectedSpaceUuid}
                     onChange={onSelectSpace}

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { assertUnreachable, type SpaceSummary } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ResourceViewItemType,
+    type SpaceSummary,
+} from '@lightdash/common';
 import { Paper, ScrollArea, Stack, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useMemo, useState } from 'react';
@@ -17,6 +21,7 @@ type SpaceSelectorProps = {
         | Array<Pick<SpaceSummary, 'isPrivate' | 'access'> & NestableItem>
         | undefined;
     isLoading?: boolean;
+    itemType: ResourceViewItemType | undefined;
     onSelectSpace: (spaceUuid: string | null) => void;
 };
 
@@ -25,6 +30,7 @@ const SpaceSelector = ({
     selectedSpaceUuid,
     spaces = [],
     isLoading: _isLoading, // TODO: implement loading state for the tree.
+    itemType,
     onSelectSpace,
     children,
 }: React.PropsWithChildren<SpaceSelectorProps>) => {
@@ -96,6 +102,10 @@ const SpaceSelector = ({
                 withBorder
             >
                 <Tree
+                    // top level item can only be selected for a single space
+                    withTopLevelSelectable={
+                        itemType === ResourceViewItemType.SPACE
+                    }
                     data={fuzzyFilteredSpaces ?? filteredSpaces}
                     value={selectedSpaceUuid}
                     onChange={onSelectSpace}

--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -20,7 +20,7 @@ import classes from './Tree.module.css';
 type Data<T> = T | FuzzyFilteredItem<T> | FuzzyFilteredItem<FuzzyMatches<T>>;
 
 type Props = {
-    withTopLevelSelectable?: boolean;
+    withRootSelectable?: boolean;
     topLevelLabel: string;
     isExpanded: boolean;
     data: Data<NestableItem>[];
@@ -29,7 +29,7 @@ type Props = {
 };
 
 const Tree: React.FC<Props> = ({
-    withTopLevelSelectable = true,
+    withRootSelectable = true,
     topLevelLabel,
     isExpanded,
     value,
@@ -98,16 +98,16 @@ const Tree: React.FC<Props> = ({
     }, [tree.selectedState, onChange, data, value]);
 
     const handleSelectTopLevel = useCallback(() => {
-        if (withTopLevelSelectable) {
+        if (withRootSelectable) {
             tree.clearSelected();
         }
-    }, [withTopLevelSelectable, tree]);
+    }, [withRootSelectable, tree]);
 
     return (
         <MantineProvider>
             <Box px="sm" py="xs">
                 <TreeItem
-                    withSelectable={withTopLevelSelectable}
+                    withRootSelectable={withRootSelectable}
                     selected={!value}
                     label={topLevelLabel}
                     isRoot={true}

--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -20,6 +20,7 @@ import classes from './Tree.module.css';
 type Data<T> = T | FuzzyFilteredItem<T> | FuzzyFilteredItem<FuzzyMatches<T>>;
 
 type Props = {
+    withTopLevelSelectable?: boolean;
     topLevelLabel: string;
     isExpanded: boolean;
     data: Data<NestableItem>[];
@@ -28,6 +29,7 @@ type Props = {
 };
 
 const Tree: React.FC<Props> = ({
+    withTopLevelSelectable = true,
     topLevelLabel,
     isExpanded,
     value,
@@ -95,13 +97,21 @@ const Tree: React.FC<Props> = ({
         }
     }, [tree.selectedState, onChange, data, value]);
 
+    const handleSelectTopLevel = useCallback(() => {
+        if (withTopLevelSelectable) {
+            tree.clearSelected();
+        }
+    }, [withTopLevelSelectable, tree]);
+
     return (
         <MantineProvider>
             <Box px="sm" py="xs">
                 <TreeItem
+                    withSelectable={withTopLevelSelectable}
                     selected={!value}
                     label={topLevelLabel}
                     isRoot={true}
+                    onClick={handleSelectTopLevel}
                 />
 
                 <Box ml={rem(6)} pl={rem(13.5)}>
@@ -140,10 +150,10 @@ const Tree: React.FC<Props> = ({
                                         label={node.label}
                                         matchHighlights={highlights}
                                         hasChildren={hasChildren}
-                                        onToggleSelect={() =>
+                                        onClick={() =>
                                             nTree.toggleSelected(node.value)
                                         }
-                                        onToggleExpand={() =>
+                                        onClickExpand={() =>
                                             nTree.toggleExpanded(node.value)
                                         }
                                     />

--- a/packages/frontend/src/components/common/Tree/TreeItem.module.css
+++ b/packages/frontend/src/components/common/Tree/TreeItem.module.css
@@ -2,14 +2,16 @@
     overflow: hidden;
     background-color: transparent;
 
-    &:where([data-is-root='false']) {
+    &:where([data-is-selectable='true']) {
+        cursor: pointer;
+
         &:hover {
             background-color: var(--mantine-color-gray-0);
         }
-    }
 
-    &:is([data-selected='true']) {
-        background-color: var(--mantine-color-blue-0);
+        &:is([data-selected='true']) {
+            background-color: var(--mantine-color-blue-0);
+        }
     }
 }
 

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -15,6 +15,7 @@ import React, { useMemo } from 'react';
 
 import MantineIcon from '../MantineIcon';
 
+import { clsx } from '@mantine/core';
 import classes from './TreeItem.module.css';
 
 type Props = {
@@ -23,10 +24,12 @@ type Props = {
     expanded?: boolean;
     selected?: boolean;
     hasChildren?: boolean;
-    withPadding?: boolean;
     isRoot?: boolean;
-    onToggleSelect?: () => void;
-    onToggleExpand?: () => void;
+    className?: string;
+    withPadding?: boolean;
+    withSelectable?: boolean;
+    onClick?: () => void;
+    onClickExpand?: () => void;
 };
 
 const TreeItem: React.FC<Props> = ({
@@ -36,9 +39,11 @@ const TreeItem: React.FC<Props> = ({
     selected = false,
     hasChildren = false,
     withPadding = true,
+    className,
+    withSelectable: _withSelectable = true,
     isRoot = false,
-    onToggleSelect,
-    onToggleExpand,
+    onClick,
+    onClickExpand,
 }) => {
     const stringLabel = useMemo(() => {
         if (typeof label === 'string') {
@@ -54,7 +59,7 @@ const TreeItem: React.FC<Props> = ({
             component={Group}
             data-selected={selected}
             data-is-root={isRoot}
-            className={classes.paper}
+            className={clsx(classes.paper, className)}
             miw={rem(200)}
             w="100%"
             gap={rem(4)}
@@ -67,7 +72,7 @@ const TreeItem: React.FC<Props> = ({
             pr={withPadding ? 'xs' : undefined}
             radius="sm"
             wrap="nowrap"
-            onClick={onToggleSelect}
+            onClick={onClick}
         >
             {isRoot ? null : (
                 <ActionIcon
@@ -75,7 +80,7 @@ const TreeItem: React.FC<Props> = ({
                     className={classes.actionIcon}
                     onClick={(e) => {
                         e.stopPropagation();
-                        onToggleExpand?.();
+                        onClickExpand?.();
                     }}
                     size="xs"
                     variant="transparent"

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -27,7 +27,7 @@ type Props = {
     isRoot?: boolean;
     className?: string;
     withPadding?: boolean;
-    withSelectable?: boolean;
+    withRootSelectable?: boolean;
     onClick?: () => void;
     onClickExpand?: () => void;
 };
@@ -39,9 +39,9 @@ const TreeItem: React.FC<Props> = ({
     selected = false,
     hasChildren = false,
     withPadding = true,
-    className,
-    withSelectable: _withSelectable = true,
+    withRootSelectable = true,
     isRoot = false,
+    className,
     onClick,
     onClickExpand,
 }) => {
@@ -58,7 +58,7 @@ const TreeItem: React.FC<Props> = ({
         <Paper
             component={Group}
             data-selected={selected}
-            data-is-root={isRoot}
+            data-is-selectable={!isRoot || withRootSelectable}
             className={clsx(classes.paper, className)}
             miw={rem(200)}
             w="100%"

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceForm.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceForm.tsx
@@ -1,4 +1,4 @@
-import { type SpaceSummary } from '@lightdash/common';
+import { ResourceViewItemType, type SpaceSummary } from '@lightdash/common';
 import { type UseFormReturnType } from '@mantine/form';
 import { type useSpaceManagement } from '../../../../hooks/useSpaceManagement';
 import SpaceCreationForm from '../../SpaceSelector/SpaceCreationForm';
@@ -54,6 +54,7 @@ const SaveToSpaceForm = <T extends SaveToSpaceFormType>({
     return (
         <SpaceSelector
             projectUuid={projectUuid}
+            itemType={ResourceViewItemType.CHART}
             spaces={spaces}
             selectedSpaceUuid={selectedSpaceUuid}
             onSelectSpace={(spaceUuid: string | null) => {

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -1,16 +1,19 @@
 import {
     type ApiError,
+    type ApiSuccessEmpty,
     type CreateSpace,
     type Space,
     type SpaceSummary,
     type UpdateSpace,
 } from '@lightdash/common';
+import { IconArrowRight } from '@tabler/icons-react';
 import {
     useMutation,
     useQuery,
     useQueryClient,
     type UseQueryOptions,
 } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
 import useUser from './user/useUser';
@@ -392,6 +395,79 @@ export const useDeleteSpaceGroupAccessMutation = (
                 showToastError({
                     title: `Failed to update space group access`,
                     subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};
+
+const postMoveSpace = async (
+    projectUuid: string,
+    spaceUuid: string,
+    parentSpaceUuid: string | null,
+) => {
+    return lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/projects/${projectUuid}/spaces/${spaceUuid}/move`,
+        method: 'POST',
+        body: JSON.stringify({ parentSpaceUuid }),
+    });
+};
+
+export const useMoveSpaceMutation = (projectUuid: string | undefined) => {
+    const navigate = useNavigate();
+
+    const queryClient = useQueryClient();
+
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        {
+            spaceUuid: string;
+            parentSpaceUuid: string | null;
+        }
+    >(
+        ({ spaceUuid, parentSpaceUuid }) => {
+            if (!projectUuid) {
+                throw new Error(
+                    'Project UUID is required to use useMoveSpaceMutation',
+                );
+            }
+
+            return postMoveSpace(projectUuid, spaceUuid, parentSpaceUuid);
+        },
+        {
+            mutationKey: ['space_move'],
+            onSuccess: async (_data, { parentSpaceUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries([
+                        'projects',
+                        projectUuid,
+                        'spaces',
+                    ]),
+                    queryClient.invalidateQueries(['pinned_items']),
+                    queryClient.invalidateQueries(['content']),
+                ]);
+
+                showToastSuccess({
+                    title: `Space has been moved`,
+                    action: {
+                        children: 'Go to space',
+                        icon: IconArrowRight,
+                        onClick: () =>
+                            navigate(
+                                parentSpaceUuid
+                                    ? `/projects/${projectUuid}/spaces/${parentSpaceUuid}`
+                                    : `/projects/${projectUuid}/spaces`,
+                            ),
+                    },
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: `Failed to move Space`,
+                    apiError: error,
                 });
             },
         },

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -448,6 +448,7 @@ export const useMoveSpaceMutation = (projectUuid: string | undefined) => {
                     ]),
                     queryClient.invalidateQueries(['pinned_items']),
                     queryClient.invalidateQueries(['content']),
+                    queryClient.invalidateQueries(['space', projectUuid]),
                 ]);
 
                 showToastSuccess({

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -1,6 +1,12 @@
 import { subject } from '@casl/ability';
-import { ContentType, LightdashMode } from '@lightdash/common';
+import {
+    ContentType,
+    LightdashMode,
+    ResourceViewItemType,
+    type ResourceViewSpaceItem,
+} from '@lightdash/common';
 import { ActionIcon, Box, Button, Group, Menu, Stack } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import {
     IconDots,
     IconFolderCog,
@@ -26,9 +32,14 @@ import ShareSpaceModal from '../components/common/ShareSpaceModal';
 import SpaceActionModal from '../components/common/SpaceActionModal';
 import { ActionType } from '../components/common/SpaceActionModal/types';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import TransferItemsModal from '../components/common/TransferItemsModal/TransferItemsModal';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
-import { useSpace } from '../hooks/useSpaces';
+import {
+    useMoveSpaceMutation,
+    useSpace,
+    useSpaceSummaries,
+} from '../hooks/useSpaces';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
@@ -70,12 +81,20 @@ const Space: FC = () => {
 
     const [updateSpace, setUpdateSpace] = useState<boolean>(false);
     const [deleteSpace, setDeleteSpace] = useState<boolean>(false);
+    const [
+        isTransferToSpaceOpen,
+        { open: openTransferToSpace, close: closeTransferToSpace },
+    ] = useDisclosure(false);
     const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
         useState<boolean>(false);
     const [isCreateNestedSpaceOpen, setIsCreateNestedSpaceOpen] =
         useState<boolean>(false);
     const [addToSpace, setAddToSpace] = useState<AddToSpaceResources>();
     const [createToSpace, setCreateToSpace] = useState<AddToSpaceResources>();
+
+    const { data: spaces } = useSpaceSummaries(projectUuid, true, {});
+    const { mutateAsync: moveSpace, isLoading: isMovingSpace } =
+        useMoveSpaceMutation(projectUuid);
 
     const handlePinToggleSpace = useCallback(
         (spaceId: string) => pinSpace(spaceId),
@@ -256,6 +275,9 @@ const Space: FC = () => {
                                 onTogglePin={() =>
                                     handlePinToggleSpace(space?.uuid)
                                 }
+                                onTransferToSpace={() => {
+                                    openTransferToSpace();
+                                }}
                                 isPinned={!!space?.pinnedListUuid}
                             >
                                 <ActionIcon variant="default" size={36}>
@@ -360,6 +382,36 @@ const Space: FC = () => {
                             setIsCreateNestedSpaceOpen(false);
                         }}
                         shouldRedirect={false}
+                    />
+                )}
+
+                {isTransferToSpaceOpen && (
+                    <TransferItemsModal
+                        projectUuid={projectUuid}
+                        opened
+                        items={[
+                            {
+                                data: {
+                                    ...space,
+                                    access: [],
+                                    accessListLength: 0,
+                                    dashboardCount: 0,
+                                    chartCount: 0,
+                                },
+                                type: ResourceViewItemType.SPACE,
+                            } satisfies ResourceViewSpaceItem,
+                        ]}
+                        spaces={spaces ?? []}
+                        isLoading={isMovingSpace}
+                        onClose={closeTransferToSpace}
+                        onConfirm={async (newSpaceUuid) => {
+                            await moveSpace({
+                                spaceUuid: space.uuid,
+                                parentSpaceUuid: newSpaceUuid,
+                            });
+
+                            closeTransferToSpace();
+                        }}
                     />
                 )}
             </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14326

### Description:
Adds the ability to transfer spaces to other spaces, allowing users to organize their space hierarchy. This feature enables moving spaces between parent spaces or to the root level.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging