### PR TITLE
fix: filter date zoom when viewing underlying data

### DIFF
--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -175,7 +175,7 @@ export class RunViewChartQueryController extends BaseController {
                 projectUuid,
                 exploreId,
                 body.csvLimit,
-                body.granularity,
+                body.dateZoom,
                 context,
             );
         this.setStatus(200);

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -9,6 +9,7 @@ import {
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
     DateGranularity,
+    DateZoom,
     QueryExecutionContext,
     SortField,
 } from '@lightdash/common';
@@ -112,7 +113,7 @@ export class SavedChartController extends BaseController {
             invalidateCache?: boolean;
             dashboardSorts: SortField[];
             dashboardUuid: string;
-            granularity?: DateGranularity;
+            dateZoom?: DateZoom;
             autoRefresh?: boolean;
         },
         @Path() chartUuid: string,
@@ -129,7 +130,7 @@ export class SavedChartController extends BaseController {
                     dashboardFilters: body.dashboardFilters,
                     invalidateCache: body.invalidateCache,
                     dashboardSorts: body.dashboardSorts,
-                    granularity: body.granularity,
+                    dateZoom: body.dateZoom,
                     dashboardUuid: body.dashboardUuid,
                     autoRefresh: body.autoRefresh,
                     context: getContextFromQueryOrHeader(req),

--- a/packages/backend/src/controllers/v2/ProjectController.ts
+++ b/packages/backend/src/controllers/v2/ProjectController.ts
@@ -139,7 +139,7 @@ export class V2ProjectController extends BaseController {
                 invalidateCache: body.invalidateCache,
                 metricQuery,
                 context: context ?? QueryExecutionContext.API,
-                granularity: body.query.granularity,
+                dateZoom: body.dateZoom,
             });
 
         return {
@@ -236,7 +236,7 @@ export class V2ProjectController extends BaseController {
                 dashboardUuid: body.dashboardUuid,
                 dashboardFilters: body.dashboardFilters,
                 dashboardSorts: body.dashboardSorts,
-                granularity: body.granularity,
+                dateZoom: body.dateZoom,
                 context: context ?? QueryExecutionContext.API,
             });
 
@@ -272,6 +272,7 @@ export class V2ProjectController extends BaseController {
                 filters: body.filters,
                 underlyingDataItemId: body.underlyingDataItemId,
                 context: context ?? QueryExecutionContext.API,
+                dateZoom: body.dateZoom,
             });
 
         return {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -701,7 +701,11 @@ export class EmbedService extends BaseService {
             intrinsicUserAttributes,
             userAttributes,
             this.lightdashConfig.query.timezone || 'UTC',
-            dateZoomGranularity,
+            dateZoomGranularity
+                ? {
+                      granularity: dateZoomGranularity,
+                  }
+                : undefined,
         );
 
         const results =

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2184,13 +2184,14 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CompiledDimension.label-or-name_': {
+    'Pick_CompiledDimension.label-or-name-or-table_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 name: { dataType: 'string', required: true },
                 label: { dataType: 'string', required: true },
+                table: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -2205,7 +2206,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         hasADateDimension: {
-                            ref: 'Pick_CompiledDimension.label-or-name_',
+                            ref: 'Pick_CompiledDimension.label-or-name-or-table_',
                             required: true,
                         },
                     },
@@ -3332,6 +3333,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                table: { dataType: 'string', required: true },
                 hidden: {
                     dataType: 'union',
                     subSchemas: [
@@ -3339,7 +3341,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                table: { dataType: 'string', required: true },
                 sqlOn: { dataType: 'string', required: true },
                 always: {
                     dataType: 'union',
@@ -3815,7 +3816,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         hasADateDimension: {
-                            ref: 'Pick_CompiledDimension.label-or-name_',
+                            ref: 'Pick_CompiledDimension.label-or-name-or-table_',
                             required: true,
                         },
                     },
@@ -7876,6 +7877,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DateZoom: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                xAxisFieldId: { dataType: 'string' },
+                granularity: { ref: 'DateGranularity' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetricQueryRequest: {
         dataType: 'refAlias',
         type: {
@@ -7887,12 +7900,12 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         hasADateDimension: {
-                            ref: 'Pick_CompiledDimension.label-or-name_',
+                            ref: 'Pick_CompiledDimension.label-or-name-or-table_',
                             required: true,
                         },
                     },
                 },
-                granularity: { ref: 'DateGranularity' },
+                dateZoom: { ref: 'DateZoom' },
                 customDimensions: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'CustomDimension' },
@@ -10664,7 +10677,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10674,7 +10687,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -10684,7 +10697,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -10697,7 +10710,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -14652,7 +14665,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CompiledDimension.name-or-label_': {
+    'Pick_CompiledDimension.name-or-label-or-table_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -14690,13 +14703,6 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'TableCalculation' },
                     required: true,
                 },
-                granularity: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DateGranularity' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 exploreName: { dataType: 'string', required: true },
                 sorts: {
                     dataType: 'array',
@@ -14730,6 +14736,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                dateZoom: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DateZoom' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 metadata: {
                     dataType: 'union',
                     subSchemas: [
@@ -14737,7 +14750,7 @@ const models: TsoaRoute.Models = {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
                                 hasADateDimension: {
-                                    ref: 'Pick_CompiledDimension.name-or-label_',
+                                    ref: 'Pick_CompiledDimension.name-or-label-or-table_',
                                     required: true,
                                 },
                             },
@@ -14781,6 +14794,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dateZoom: { ref: 'DateZoom' },
                         query: {
                             ref: 'Omit_MetricQueryRequest.csvLimit_',
                             required: true,
@@ -14884,7 +14898,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        granularity: { ref: 'DateGranularity' },
+                        dateZoom: { ref: 'DateZoom' },
                         dashboardSorts: {
                             dataType: 'array',
                             array: { dataType: 'refAlias', ref: 'SortField' },
@@ -14912,6 +14926,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        dateZoom: { ref: 'DateZoom' },
                         filters: { ref: 'Filters', required: true },
                         underlyingDataItemId: { dataType: 'string' },
                         underlyingDataSourceQueryUuid: {
@@ -22004,7 +22019,7 @@ export function RegisterRoutes(app: Router) {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 autoRefresh: { dataType: 'boolean' },
-                granularity: { ref: 'DateGranularity' },
+                dateZoom: { ref: 'DateZoom' },
                 dashboardUuid: { dataType: 'string', required: true },
                 dashboardSorts: {
                     dataType: 'array',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2399,16 +2399,19 @@
                 },
                 "type": "object"
             },
-            "Pick_CompiledDimension.label-or-name_": {
+            "Pick_CompiledDimension.label-or-name-or-table_": {
                 "properties": {
                     "name": {
                         "type": "string"
                     },
                     "label": {
                         "type": "string"
+                    },
+                    "table": {
+                        "type": "string"
                     }
                 },
-                "required": ["name", "label"],
+                "required": ["name", "label", "table"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -2417,7 +2420,7 @@
                     "metadata": {
                         "properties": {
                             "hasADateDimension": {
-                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
+                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name-or-table_"
                             }
                         },
                         "required": ["hasADateDimension"],
@@ -3593,11 +3596,11 @@
                     "type": {
                         "$ref": "#/components/schemas/DbtModelJoinType"
                     },
-                    "hidden": {
-                        "type": "boolean"
-                    },
                     "table": {
                         "type": "string"
+                    },
+                    "hidden": {
+                        "type": "boolean"
                     },
                     "sqlOn": {
                         "type": "string"
@@ -4227,7 +4230,7 @@
                     "metadata": {
                         "properties": {
                             "hasADateDimension": {
-                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
+                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name-or-table_"
                             }
                         },
                         "required": ["hasADateDimension"],
@@ -8746,6 +8749,17 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "DateZoom": {
+                "properties": {
+                    "xAxisFieldId": {
+                        "type": "string"
+                    },
+                    "granularity": {
+                        "$ref": "#/components/schemas/DateGranularity"
+                    }
+                },
+                "type": "object"
+            },
             "MetricQueryRequest": {
                 "properties": {
                     "metricOverrides": {
@@ -8757,14 +8771,14 @@
                     "metadata": {
                         "properties": {
                             "hasADateDimension": {
-                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name_"
+                                "$ref": "#/components/schemas/Pick_CompiledDimension.label-or-name-or-table_"
                             }
                         },
                         "required": ["hasADateDimension"],
                         "type": "object"
                     },
-                    "granularity": {
-                        "$ref": "#/components/schemas/DateGranularity"
+                    "dateZoom": {
+                        "$ref": "#/components/schemas/DateZoom"
                     },
                     "customDimensions": {
                         "items": {
@@ -11490,22 +11504,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -15519,7 +15533,7 @@
                 },
                 "type": "object"
             },
-            "Pick_CompiledDimension.name-or-label_": {
+            "Pick_CompiledDimension.name-or-label-or-table_": {
                 "properties": {},
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -15552,9 +15566,6 @@
                         },
                         "type": "array"
                     },
-                    "granularity": {
-                        "$ref": "#/components/schemas/DateGranularity"
-                    },
                     "exploreName": {
                         "type": "string"
                     },
@@ -15580,10 +15591,13 @@
                         },
                         "type": "array"
                     },
+                    "dateZoom": {
+                        "$ref": "#/components/schemas/DateZoom"
+                    },
                     "metadata": {
                         "properties": {
                             "hasADateDimension": {
-                                "$ref": "#/components/schemas/Pick_CompiledDimension.name-or-label_"
+                                "$ref": "#/components/schemas/Pick_CompiledDimension.name-or-label-or-table_"
                             }
                         },
                         "required": ["hasADateDimension"],
@@ -15619,6 +15633,9 @@
                     },
                     {
                         "properties": {
+                            "dateZoom": {
+                                "$ref": "#/components/schemas/DateZoom"
+                            },
                             "query": {
                                 "$ref": "#/components/schemas/Omit_MetricQueryRequest.csvLimit_"
                             }
@@ -15700,8 +15717,8 @@
                     },
                     {
                         "properties": {
-                            "granularity": {
-                                "$ref": "#/components/schemas/DateGranularity"
+                            "dateZoom": {
+                                "$ref": "#/components/schemas/DateZoom"
                             },
                             "dashboardSorts": {
                                 "items": {
@@ -15736,6 +15753,9 @@
                     },
                     {
                         "properties": {
+                            "dateZoom": {
+                                "$ref": "#/components/schemas/DateZoom"
+                            },
                             "filters": {
                                 "$ref": "#/components/schemas/Filters"
                             },
@@ -18905,8 +18925,8 @@
                                     "autoRefresh": {
                                         "type": "boolean"
                                     },
-                                    "granularity": {
-                                        "$ref": "#/components/schemas/DateGranularity"
+                                    "dateZoom": {
+                                        "$ref": "#/components/schemas/DateZoom"
                                     },
                                     "dashboardUuid": {
                                         "type": "string"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -219,7 +219,7 @@ describe('AsyncQueryService', () => {
                         projectUuid,
                         metricQuery: metricQueryMock,
                         context: QueryExecutionContext.EXPLORE,
-                        granularity: undefined,
+                        dateZoom: undefined,
                         queryTags: {
                             query_context: QueryExecutionContext.EXPLORE,
                         },
@@ -301,7 +301,7 @@ describe('AsyncQueryService', () => {
                         projectUuid,
                         metricQuery: metricQueryMock,
                         context: QueryExecutionContext.EXPLORE,
-                        granularity: undefined,
+                        dateZoom: undefined,
                         queryTags: {
                             query_context: QueryExecutionContext.EXPLORE,
                         },
@@ -381,7 +381,7 @@ describe('AsyncQueryService', () => {
                         projectUuid,
                         metricQuery: metricQueryMock,
                         context: QueryExecutionContext.EXPLORE,
-                        granularity: undefined,
+                        dateZoom: undefined,
                         queryTags: {
                             query_context: QueryExecutionContext.EXPLORE,
                         },
@@ -455,7 +455,7 @@ describe('AsyncQueryService', () => {
                         projectUuid,
                         metricQuery: metricQueryMock,
                         context: QueryExecutionContext.EXPLORE,
-                        granularity: undefined,
+                        dateZoom: undefined,
                         queryTags: {
                             query_context: QueryExecutionContext.EXPLORE,
                         },

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -6,6 +6,7 @@ import {
     type CacheMetadata,
     type DashboardFilters,
     type DateGranularity,
+    type DateZoom,
     type Filters,
     type PivotIndexColum,
     type QueryExecutionContext,
@@ -31,7 +32,7 @@ export type GetAsyncQueryResultsArgs = Omit<
 
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     metricQuery: MetricQuery;
-    granularity?: DateGranularity;
+    dateZoom?: DateZoom;
 };
 
 export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
@@ -54,13 +55,14 @@ export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {
     dashboardUuid: string;
     dashboardFilters: DashboardFilters;
     dashboardSorts: SortField[];
-    granularity?: DateGranularity;
+    dateZoom?: DateZoom;
 };
 
 export type ExecuteAsyncUnderlyingDataQueryArgs = CommonAsyncQueryArgs & {
     underlyingDataSourceQueryUuid: string;
     filters: Filters;
     underlyingDataItemId?: string;
+    dateZoom?: DateZoom;
 };
 
 export type ExecuteAsyncQueryReturn = {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -594,7 +594,9 @@ This method can be memory intensive
             exploreName: exploreId,
             csvLimit: getSchedulerCsvLimit(options),
             context: QueryExecutionContext.CSV,
-            granularity: dateZoomGranularity,
+            dateZoom: {
+                granularity: dateZoomGranularity,
+            },
             chartUuid,
             queryTags,
         });

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -14,9 +14,15 @@ type CommonPaginatedQueryRequestParams = {
     invalidateCache?: boolean;
 };
 
+export type DateZoom = {
+    granularity?: DateGranularity;
+    xAxisFieldId?: string;
+};
+
 export type ExecuteAsyncMetricQueryRequestParams =
     CommonPaginatedQueryRequestParams & {
         query: Omit<MetricQueryRequest, 'csvLimit'>;
+        dateZoom?: DateZoom;
     };
 
 export type ExecuteAsyncSavedChartRequestParams =
@@ -31,7 +37,7 @@ export type ExecuteAsyncDashboardChartRequestParams =
         dashboardUuid: string;
         dashboardFilters: DashboardFilters;
         dashboardSorts: SortField[];
-        granularity?: DateGranularity;
+        dateZoom?: DateZoom;
     };
 
 export type ExecuteAsyncSqlQueryRequestParams =
@@ -50,6 +56,7 @@ export type ExecuteAsyncUnderlyingDataRequestParams =
         underlyingDataSourceQueryUuid: string;
         underlyingDataItemId?: string;
         filters: Filters;
+        dateZoom?: DateZoom;
     };
 
 export type ExecuteAsyncQueryRequestParams =

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -1,4 +1,5 @@
 import { type AnyType } from './any';
+import { type DateZoom } from './api/paginatedQuery';
 import {
     BinType,
     friendlyName,
@@ -19,7 +20,6 @@ import {
     type TableCalculation,
 } from './field';
 import { type Filters, type MetricFilterRule } from './filter';
-import { type DateGranularity } from './timeFrames';
 
 export interface AdditionalMetric {
     label?: string;
@@ -71,7 +71,7 @@ export type MetricQuery = {
     metricOverrides?: MetricOverrides; // Override format options for fields in "metrics"
     timezone?: string; // Local timezone to use for the query
     metadata?: {
-        hasADateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+        hasADateDimension: Pick<CompiledDimension, 'label' | 'name' | 'table'>;
     };
 };
 export type CompiledMetricQuery = Omit<MetricQuery, 'customDimensions'> & {
@@ -113,7 +113,7 @@ export type MetricQueryResponse = {
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     customDimensions?: CustomDimension[];
     metadata?: {
-        hasADateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+        hasADateDimension: Pick<CompiledDimension, 'label' | 'name' | 'table'>;
     };
 };
 
@@ -166,7 +166,7 @@ export type MetricQueryRequest = {
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     csvLimit?: number;
     customDimensions?: CustomDimension[];
-    granularity?: DateGranularity;
+    dateZoom?: DateZoom;
     metadata?: MetricQuery['metadata'];
     timezone?: string;
     metricOverrides?: MetricOverrides;

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -519,6 +519,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         }),
     );
 
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const chartsWithDateZoomApplied = useDashboardContext(
+        (c) => c.chartsWithDateZoomApplied,
+    );
     const { openUnderlyingDataModal } = useMetricQueryDataContext();
 
     const [viewUnderlyingDataOptions, setViewUnderlyingDataOptions] = useState<{
@@ -533,9 +539,22 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const handleViewUnderlyingData = useCallback(() => {
         if (!viewUnderlyingDataOptions) return;
 
+        const applyDateZoom =
+            metricQuery?.metadata?.hasADateDimension &&
+            savedChartUuid &&
+            dateZoomGranularity &&
+            chartsWithDateZoomApplied?.has(savedChartUuid);
+
         openUnderlyingDataModal({
             ...viewUnderlyingDataOptions,
+            ...(applyDateZoom && {
+                dateZoom: {
+                    granularity: dateZoomGranularity,
+                    xAxisFieldId: `${metricQuery?.metadata?.hasADateDimension.table}_${metricQuery?.metadata?.hasADateDimension.name}`,
+                },
+            }),
         });
+
         track({
             name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
             properties: {
@@ -545,11 +564,16 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
             },
         });
     }, [
-        track,
-        user,
-        projectUuid,
-        openUnderlyingDataModal,
         viewUnderlyingDataOptions,
+        dateZoomGranularity,
+        openUnderlyingDataModal,
+        track,
+        user?.data?.organizationUuid,
+        user?.data?.userUuid,
+        projectUuid,
+        metricQuery?.metadata?.hasADateDimension,
+        savedChartUuid,
+        chartsWithDateZoomApplied,
     ]);
 
     const handleCopyToClipboard = useCallback(() => {
@@ -779,13 +803,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 />
             ),
         [showComments, isCommentsMenuOpen, tileUuid],
-    );
-
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
-    );
-    const chartsWithDateZoomApplied = useDashboardContext(
-        (c) => c.chartsWithDateZoomApplied,
     );
 
     const editButtonTooltipLabel = useMemo(() => {

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModalContent.tsx
@@ -223,7 +223,12 @@ const UnderlyingDataModalContent: FC<Props> = () => {
         error,
         data: resultsData,
         isInitialLoading,
-    } = useUnderlyingDataResults(filters, queryUuid, underlyingDataItemId);
+    } = useUnderlyingDataResults(
+        filters,
+        queryUuid,
+        underlyingDataItemId,
+        underlyingDataConfig?.dateZoom,
+    );
 
     const exploreFromHereUrl = useMemo(() => {
         if (!resultsData) {

--- a/packages/frontend/src/components/MetricQueryData/types.ts
+++ b/packages/frontend/src/components/MetricQueryData/types.ts
@@ -1,4 +1,5 @@
 import {
+    type DateZoom,
     type ItemsMap,
     type PivotReference,
     type ResultValue,
@@ -10,6 +11,7 @@ export type UnderlyingDataConfig = {
     fieldValues: Record<string, ResultValue>;
     dimensions?: string[];
     pivotReference?: PivotReference;
+    dateZoom?: DateZoom;
 };
 
 export type DrillDownConfig = {

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -144,7 +144,9 @@ export const useDashboardChartReadyQuery = (
                     dashboardUuid: dashboardUuid!,
                     dashboardFilters: timezoneFixFilters,
                     dashboardSorts,
-                    granularity,
+                    dateZoom: {
+                        granularity,
+                    },
                     invalidateCache,
                 },
             );

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -107,7 +107,11 @@ export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
                             filters: convertDateFilters(data.query.filters),
                             timezone: data.query.timezone ?? undefined,
                             exploreName: data.tableId,
-                            granularity: data.dateZoomGranularity,
+                            dateZoom: data.dateZoomGranularity
+                                ? {
+                                      granularity: data.dateZoomGranularity,
+                                  }
+                                : undefined,
                         },
                         invalidateCache: true, // Note: do not cache explore queries
                     },

--- a/packages/frontend/src/hooks/useUnderlyingDataResults.ts
+++ b/packages/frontend/src/hooks/useUnderlyingDataResults.ts
@@ -6,6 +6,7 @@ import {
     assertUnreachable,
     type DashboardFilters,
     type DateGranularity,
+    type DateZoom,
     type ExecuteAsyncUnderlyingDataRequestParams,
     type MetricQuery,
     QueryExecutionContext,
@@ -148,6 +149,7 @@ export const useUnderlyingDataResults = (
     filters: MetricQuery['filters'],
     underlyingDataSourceQueryUuid?: string,
     underlyingDataItemId?: string,
+    dateZoom?: DateZoom,
 ) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
@@ -158,6 +160,7 @@ export const useUnderlyingDataResults = (
             underlyingDataSourceQueryUuid,
             underlyingDataItemId,
             filters,
+            dateZoom,
         ],
         enabled: Boolean(projectUuid) && Boolean(underlyingDataSourceQueryUuid),
         queryFn: () => {
@@ -166,6 +169,7 @@ export const useUnderlyingDataResults = (
                 underlyingDataSourceQueryUuid: underlyingDataSourceQueryUuid!,
                 underlyingDataItemId,
                 filters: convertDateFilters(filters),
+                dateZoom,
             });
         },
         retry: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14615


### Description:

Gets x axis field from cartesian configs, otherwise, the first date dim from metric query

Overrides correct x axis ID

Passes `DateZoom` to underlying data query

Also renames `granularity` to a `dateZoom` property with a few properties



[datezoomwithunderlyingdata.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/77b318af-aade-4003-bf2b-3bdf30c67e48.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/77b318af-aade-4003-bf2b-3bdf30c67e48.mov)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging

