### PR TITLE
fix: dashboard double fetch on first refresh

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
@@ -5,39 +5,70 @@ import {
 } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
-const QUERIES_TO_REFRESH = [
-    'dashboard_chart_ready_query',
+const DASHBOARD_RELATED_QUERIES = [
     'saved_query',
     'saved_dashboard_query',
     'dashboards',
 ];
 
-const queryPredicate = (query: Query) => {
-    return QUERIES_TO_REFRESH.some((key) => {
-        const firstQueryKey =
-            typeof query.queryKey === 'string'
-                ? query.queryKey
-                : query.queryKey?.[0];
-        return firstQueryKey === key;
-    });
+const DASHBOARD_RESULTS_QUERIES = ['dashboard_chart_ready_query'];
+
+const getPredicateFunction = (keyArray: string[]) => {
+    return (query: Query) => {
+        return keyArray.some((key) => {
+            const firstQueryKey =
+                typeof query.queryKey === 'string'
+                    ? query.queryKey
+                    : query.queryKey?.[0];
+            return firstQueryKey === key;
+        });
+    };
 };
+
+const dashboardRelatedQueryPredicate = getPredicateFunction(
+    DASHBOARD_RELATED_QUERIES,
+);
+
+const dashboardResultsQueryPredicate = getPredicateFunction(
+    DASHBOARD_RESULTS_QUERIES,
+);
 
 export const useDashboardRefresh = () => {
     const queryClient = useQueryClient();
 
-    const isFetching = useIsFetching({ predicate: queryPredicate });
+    const isFetchingDashboardRelatedQueries = useIsFetching({
+        predicate: dashboardRelatedQueryPredicate,
+    });
+
+    const isFetchingDashboardResultsQueries = useIsFetching({
+        predicate: dashboardResultsQueryPredicate,
+    });
 
     const invalidateDashboardRelatedQueries = useCallback(() => {
         return queryClient.invalidateQueries({
-            predicate: queryPredicate,
+            predicate: dashboardRelatedQueryPredicate,
+        });
+    }, [queryClient]);
+
+    const invalidateDashboardResultsQueries = useCallback(() => {
+        return queryClient.invalidateQueries({
+            predicate: dashboardResultsQueryPredicate,
         });
     }, [queryClient]);
 
     return useMemo(
         () => ({
             invalidateDashboardRelatedQueries,
-            isFetching,
+            invalidateDashboardResultsQueries,
+            isFetching:
+                isFetchingDashboardRelatedQueries +
+                isFetchingDashboardResultsQueries,
         }),
-        [invalidateDashboardRelatedQueries, isFetching],
+        [
+            invalidateDashboardRelatedQueries,
+            invalidateDashboardResultsQueries,
+            isFetchingDashboardRelatedQueries,
+            isFetchingDashboardResultsQueries,
+        ],
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14659](https://github.com/lightdash/lightdash/issues/14659)

### Description:

- We were updating `invalidateQueries` state + invalidating manually the query. This caused double fetch on first refresh because `invalidateQueries` went from `false` to `true` which invalidates the query itself, but then it was also getting invalidated by the refresh button.

- This PR fixes this by splitting queries into invalidate between related queries (which always get fetched and are not dependent on `invalidateCache`) and results queries (dependent on `invalidateCache`). Then we only manually invalidate the results manually when `invalidateCache` is true and the button is clicked, otherwise the `invalidateCache` state change invalidates the query by itself

**Before**

https://github.com/user-attachments/assets/60b684d1-c168-4714-993a-1c6e34d3b2c6

**After**

https://github.com/user-attachments/assets/f3371697-a31e-48ff-9def-75da8a1cd6b5



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
