### PR TITLE
fix: add query execution time to total time

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -358,13 +358,18 @@ export const useInfiniteQueryResults = (
             return undefined;
         }
 
-        return fetchAll
+        const totalPagesFetchTime = fetchAll
             ? Math.round(
                   fetchedPages.reduce((acc, page) => {
                       return acc + page.clientFetchTimeMs;
                   }, 0),
               )
             : Math.round(fetchedPages[0]?.clientFetchTimeMs ?? 0); // If we're not fetching all pages, only return the time for the first page (enough to render the viz)
+
+        return (
+            totalPagesFetchTime +
+            (fetchedPages[0]?.initialQueryExecutionMs ?? 0) // Add the time it took to execute the initial query
+        );
     }, [fetchAll, fetchedPages]);
 
     const isInitialLoading = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Takes into account `warehouseExecutionTime` when calculating total fetch time

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
