### PR TITLE
fix: don't reload page on early submit from chart save

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -334,6 +334,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
         <form
             onSubmit={(e) => {
                 if (currentStep === ModalStep.InitialInfo) {
+                    e.preventDefault();
                     return;
                 }
                 form.onSubmit((values) => handleOnSubmit(values))(e);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Hitting "Enter" when saving a chart caused the page to reload (form submit), loosing any progress on the chart. This prevents the reload in the case of early submission of the form. 

Before:
![Kapture 2025-05-05 at 15 51 09](https://github.com/user-attachments/assets/3fc25231-0c66-468e-86ce-e4b1015c1981)

To test:
- Make a chart
- Click "Save Chart"
- Git it a name
- Hit Enter 
- Before: page reload
- With this fix: nothing happens

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
