### PR TITLE
feat: handle quarter filter with new picker

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -176,31 +176,31 @@ export const renderDateFilterSql = (
     };
 
     switch (filter.operator) {
-        case 'equals':
+        case FilterOperator.EQUALS:
             return `(${dimensionSql}) = ${castValue(
                 dateFormatter(filter.values?.[0]),
             )}`;
-        case 'notEquals':
+        case FilterOperator.NOT_EQUALS:
             return `((${dimensionSql}) != ${castValue(
                 dateFormatter(filter.values?.[0]),
             )} OR (${dimensionSql}) IS NULL)`;
-        case 'isNull':
+        case FilterOperator.NULL:
             return `(${dimensionSql}) IS NULL`;
-        case 'notNull':
+        case FilterOperator.NOT_NULL:
             return `(${dimensionSql}) IS NOT NULL`;
-        case 'greaterThan':
+        case FilterOperator.GREATER_THAN:
             return `(${dimensionSql}) > ${castValue(
                 dateFormatter(filter.values?.[0]),
             )}`;
-        case 'greaterThanOrEqual':
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
             return `(${dimensionSql}) >= ${castValue(
                 dateFormatter(filter.values?.[0]),
             )}`;
-        case 'lessThan':
+        case FilterOperator.LESS_THAN:
             return `(${dimensionSql}) < ${castValue(
                 dateFormatter(filter.values?.[0]),
             )}`;
-        case 'lessThanOrEqual':
+        case FilterOperator.LESS_THAN_OR_EQUAL:
             return `(${dimensionSql}) <= ${castValue(
                 dateFormatter(filter.values?.[0]),
             )}`;

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -257,6 +257,9 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                         [TimeFrames.WEEK]: moment(
                             valueIsDate ? value : undefined,
                         ).startOf('week'),
+                        [TimeFrames.QUARTER]: moment(
+                            valueIsDate ? value : undefined,
+                        ).startOf('quarter'),
                         [TimeFrames.MONTH]: moment(
                             valueIsDate ? value : undefined,
                         ).startOf('month'),
@@ -280,7 +283,10 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                         ? formatDate(
                               // Treat the date as UTC, then remove its timezone information before formatting
                               moment.utc(value).format('YYYY-MM-DD'),
-                              fieldTimeInterval, // Use the field's time interval if it has one
+                              // For QUARTER, we don't want to use the field's time interval(YYYY-[Q]Q) because the date is already in the correct format when generating the SQL
+                              fieldTimeInterval === TimeFrames.QUARTER
+                                  ? undefined
+                                  : fieldTimeInterval, // Use the field's time interval if it has one
                               false,
                           )
                         : formatDate(defaultDate, undefined, false);

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -23,6 +23,7 @@ import FilterDateRangePicker from './FilterDateRangePicker';
 import FilterDateTimePicker from './FilterDateTimePicker';
 import FilterDateTimeRangePicker from './FilterDateTimeRangePicker';
 import FilterMonthAndYearPicker from './FilterMonthAndYearPicker';
+import FilterQuarterPicker from './FilterQuarterPicker';
 import FilterUnitOfTimeAutoComplete from './FilterUnitOfTimeAutoComplete';
 import FilterWeekPicker from './FilterWeekPicker';
 import FilterYearPicker from './FilterYearPicker';
@@ -130,6 +131,28 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
                                         ...rule,
                                         values: [
                                             formatDate(value, TimeFrames.MONTH),
+                                        ],
+                                    });
+                                }}
+                            />
+                        );
+                    case TimeFrames.QUARTER:
+                        const ruleValue = rule.values?.[0];
+                        const parsedValue = ruleValue
+                            ? parseDate(ruleValue, TimeFrames.DAY)
+                            : null;
+                        return (
+                            <FilterQuarterPicker
+                                disabled={disabled}
+                                placeholder={placeholder}
+                                autoFocus={true}
+                                popoverProps={popoverProps}
+                                value={parsedValue}
+                                onChange={(newDate: Date) => {
+                                    onChange({
+                                        ...rule,
+                                        values: [
+                                            formatDate(newDate, TimeFrames.DAY),
                                         ],
                                     });
                                 }}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -1,0 +1,174 @@
+import { TimeFrames, formatDate } from '@lightdash/common';
+import {
+    type MantineTheme,
+    Popover,
+    Stack,
+    type Sx,
+    Text,
+    TextInput,
+} from '@mantine/core';
+import { MonthPicker, type MonthPickerProps } from '@mantine/dates';
+import { useDisclosure } from '@mantine/hooks';
+import dayjs from 'dayjs';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+import { type FC, useCallback, useState } from 'react';
+
+dayjs.extend(quarterOfYear);
+
+type Props = Pick<MonthPickerProps, 'value' | 'onChange'> & {
+    placeholder?: string;
+    disabled?: boolean;
+    popoverProps?: any;
+    autoFocus?: boolean;
+};
+
+const QUARTERS = [
+    { value: '1', months: [0, 1, 2], label: 'Q1', range: 'Jan - Mar' },
+    { value: '2', months: [3, 4, 5], label: 'Q2', range: 'Apr - Jun' },
+    { value: '3', months: [6, 7, 8], label: 'Q3', range: 'Jul - Sep' },
+    { value: '4', months: [9, 10, 11], label: 'Q4', range: 'Oct - Dec' },
+];
+
+const FilterQuarterPicker: FC<Props> = ({
+    value,
+    onChange,
+    placeholder = 'Select Quarter',
+    disabled,
+    popoverProps,
+}) => {
+    const [opened, { open, close }] = useDisclosure(false);
+
+    // Parse date value - it may be an ISO string like "2025-01-01T00:00:00.000Z"
+    const parsedDate = value ? dayjs(value) : null;
+    const yearValue = parsedDate ? parsedDate.year() : new Date().getFullYear();
+
+    // Determine the quarter based on the month of the date
+    const monthValue = parsedDate ? parsedDate.month() : 0;
+    const getQuarterFromMonth = useCallback((month: number): string => {
+        const quarter = QUARTERS.find((q) => q.months.includes(month));
+        return quarter ? quarter.value : '1';
+    }, []);
+
+    const [selectedYear, setSelectedYear] = useState<number>(yearValue);
+    const [hoveredMonth, setHoveredMonth] = useState<number | null>(null);
+
+    // Get quarter's first and last month based on a month
+    const getQuarterMonths = (month: number): number[] => {
+        const quarter = QUARTERS.find((q) => q.months.includes(month));
+        return quarter ? quarter.months : [0, 1, 2];
+    };
+
+    const handleMonthSelect = (date: Date | null) => {
+        if (!date) return;
+
+        // Use dayjs for date handling
+        const dateObj = dayjs(date);
+        const year = dateObj.year();
+        setSelectedYear(year);
+
+        const quarterDate = dateObj.startOf('quarter');
+
+        onChange?.(quarterDate.toDate());
+        close();
+    };
+
+    const getMonthControlProps = useCallback(
+        (
+            date: Date,
+        ): {
+            sx?: Sx;
+            onMouseEnter: () => void;
+            onMouseLeave?: () => void;
+        } => {
+            const month = date.getMonth();
+            const year = date.getFullYear();
+
+            // If this is the selected quarter's months, highlight them
+            if (
+                parsedDate &&
+                year === yearValue &&
+                getQuarterMonths(monthValue).includes(month)
+            ) {
+                return {
+                    sx: (theme: MantineTheme) => ({
+                        backgroundColor: theme.colors.blue[2],
+                        '&:hover': {
+                            backgroundColor: theme.colors.blue[2],
+                        },
+                    }),
+                    onMouseEnter: () => setHoveredMonth(month),
+                };
+            }
+
+            // If this is the hovered month's quarter, highlight all months in quarter
+            if (
+                hoveredMonth !== null &&
+                getQuarterMonths(hoveredMonth).includes(month)
+            ) {
+                return {
+                    sx: (theme: MantineTheme) => ({
+                        backgroundColor: theme.colors.blue[1],
+                        '&:hover': {
+                            backgroundColor: theme.colors.blue[1],
+                        },
+                    }),
+                    onMouseEnter: () => setHoveredMonth(month),
+                };
+            }
+
+            return {
+                onMouseEnter: () => setHoveredMonth(month),
+                onMouseLeave: () => setHoveredMonth(null),
+            };
+        },
+        [hoveredMonth, monthValue, parsedDate, yearValue],
+    );
+
+    return (
+        <Popover
+            opened={opened}
+            onClose={close}
+            position="bottom"
+            shadow="md"
+            withinPortal
+            {...popoverProps}
+        >
+            <Popover.Target>
+                <TextInput
+                    size="xs"
+                    onClick={disabled ? undefined : open}
+                    placeholder={placeholder}
+                    value={
+                        value
+                            ? formatDate(value, TimeFrames.QUARTER)
+                            : undefined
+                    }
+                    readOnly
+                    styles={{
+                        input: {
+                            cursor: 'pointer',
+                        },
+                    }}
+                />
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Stack spacing="xs">
+                    <MonthPicker
+                        defaultDate={new Date(selectedYear, 0)}
+                        value={null}
+                        onChange={handleMonthSelect}
+                        getMonthControlProps={getMonthControlProps}
+                        onMouseLeave={() => setHoveredMonth(null)}
+                    />
+                    {hoveredMonth !== null && (
+                        <Text size="xs" align="center">
+                            {selectedYear}-Q{getQuarterFromMonth(hoveredMonth)}
+                        </Text>
+                    )}
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default FilterQuarterPicker;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14176 

### Description:

- Created a new `FilterQuarterPicker` component that allows users to select quarters (Q1, Q2, Q3, Q4) for a given year
- Updated date filter handling to properly format and process quarterly date selections (see filters.ts)
- Added quarter support to the date filter rendering logic
- Replaced string literals with `FilterOperator` enum constants in the date filter SQL renderer

This change enables users to filter data by quarters, rather than using specific dates. Dates are stored in the same format as DAY as the truncation will work this way. 



https://github.com/user-attachments/assets/c3cfb15f-9da2-4b7b-94ef-6d504b2f0c38


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging