### PR TITLE
fix: neighbor spaces when promoting

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -898,19 +898,6 @@ export class CoderService extends BaseService {
                 parentPath = `${parentPath}.${currentPath}`;
             }
 
-            console.log(
-                {
-                    isPrivate: closestAncestorSpace?.isPrivate ?? true,
-                    name: friendlyName(currentPath),
-                    parentSpaceUuid,
-                },
-                {
-                    projectUuid,
-                    userId: user.userId,
-                    path: parentPath,
-                },
-            );
-
             const newSpace = await this.spaceModel.createSpace(
                 {
                     isPrivate: closestAncestorSpace?.isPrivate ?? true,

--- a/packages/common/src/utils/slug.test.ts
+++ b/packages/common/src/utils/slug.test.ts
@@ -1,6 +1,7 @@
 import {
     generateSlug,
     getContentAsCodePathFromLtreePath,
+    getDeepestPaths,
     getLtreePathFromContentAsCodePath,
     getLtreePathFromSlug,
 } from './slugs';
@@ -170,5 +171,50 @@ describe('getContentAsCodePathFromLtreePath + getLtreePathFromContentAsCodePath'
                 getContentAsCodePathFromLtreePath('__my_space_.foo.bar'),
             ),
         ).toEqual('__my_space_.foo.bar');
+    });
+});
+
+describe('getDeepestPaths', () => {
+    test('should return the deepest paths', () => {
+        expect(
+            getDeepestPaths([
+                'dash',
+                'charts',
+                'charts2',
+                'charts2.charts2_child',
+            ]),
+        ).toEqual(['dash', 'charts', 'charts2.charts2_child']);
+
+        expect(
+            getDeepestPaths([
+                'jaffle_shop.dashboards.dashboards_marketing',
+                'jaffle_shop.sub_charts_2.sub_charts_2_child',
+                'jaffle_shop.dashboards',
+                'jaffle_shop.sub_charts',
+                'jaffle_shop.sub_charts_2',
+            ]),
+        ).toEqual([
+            'jaffle_shop.dashboards.dashboards_marketing',
+            'jaffle_shop.sub_charts_2.sub_charts_2_child',
+            'jaffle_shop.sub_charts',
+        ]);
+
+        expect(
+            getDeepestPaths([
+                'a.b.c.d',
+                'a.b.c',
+                'a.b.c.d.e',
+                'a.b.c.d.e.f',
+                'a.b.c.d.e.f.g',
+                'a.b.c.d.e.f.g.h',
+                'a.b.c.d.e.f.g.h.i',
+                'foo',
+                'bar',
+            ]),
+        ).toEqual(['a.b.c.d.e.f.g.h.i', 'foo', 'bar']);
+
+        expect(getDeepestPaths(['a'])).toEqual(['a']);
+
+        expect(getDeepestPaths(['a', 'b'])).toEqual(['a', 'b']);
     });
 });

--- a/packages/common/src/utils/slugs.ts
+++ b/packages/common/src/utils/slugs.ts
@@ -37,3 +37,33 @@ export const getLtreePathFromContentAsCodePath = (path: string) =>
 
 export const getContentAsCodePathFromLtreePath = (path: string) =>
     path.replace(/_/g, '-').replace(/\./g, '/');
+
+export const getDeepestPaths = (paths: string[]): string[] => {
+    const uniquePaths = Array.from(new Set(paths));
+    const result: string[] = [];
+
+    for (const path of uniquePaths) {
+        const pathSegments = path.split('.');
+
+        const isPrefix = uniquePaths.some((otherPath) => {
+            if (path === otherPath) return false;
+
+            const otherSegments = otherPath.split('.');
+
+            if (pathSegments.length < otherSegments.length) {
+                const potentialPrefix = otherSegments
+                    .slice(0, pathSegments.length)
+                    .join('.');
+                return potentialPrefix === path;
+            }
+
+            return false;
+        });
+
+        if (!isPrefix) {
+            result.push(path);
+        }
+    }
+
+    return result;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
This PR improves space creation during promotion by:

1. Removing debug console.log statements from CoderService
2. Enhancing the PromoteService to handle multiple space hierarchies correctly:
   - Added a `getDeepestPaths` utility function to identify leaf nodes in space hierarchies
   - Modified space creation logic to process each hierarchy independently
   - Prevented duplicate space creation by tracking created spaces in a Map
3. Added comprehensive tests for the new `getDeepestPaths` utility function

This change ensures that when promoting content with complex space hierarchies, all spaces are created correctly and efficiently.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging