### PR TITLE
fix: initialize form values only when editing a space

### DIFF
--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -96,7 +96,7 @@ const SpaceModal: FC<ActionModalProps> = ({
     const [modalStep, setModalStep] = useState(CreateModalStep.SET_NAME);
 
     const form = useForm<Space>({
-        initialValues: data,
+        initialValues: actionType === ActionType.CREATE ? undefined : data,
         validate: zodResolver(validate),
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14673

### Description:
Fix form initialization in SpaceActionModal to only use provided data when editing an existing space. When creating a new space, the form should start with undefined values rather than potentially using stale data.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging