### PR TITLE
feat: add dashboard-sql-chart endpoint that just uses pivoted results

### DIFF
--- a/packages/backend/src/controllers/v2/ProjectController.ts
+++ b/packages/backend/src/controllers/v2/ProjectController.ts
@@ -3,9 +3,11 @@ import {
     ApiGetAsyncQueryResults,
     ApiSuccessEmpty,
     ExecuteAsyncSqlQueryRequestParams,
+    isExecuteAsyncDashboardSqlChartByUuidParams,
     QueryExecutionContext,
     type ApiExecuteAsyncQueryResults,
     type ExecuteAsyncDashboardChartRequestParams,
+    type ExecuteAsyncDashboardSqlChartRequestParams,
     type ExecuteAsyncMetricQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
     type ExecuteAsyncUnderlyingDataRequestParams,
@@ -151,37 +153,6 @@ export class V2ProjectController extends BaseController {
     @Hidden()
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Post('{projectUuid}/query/sql')
-    @OperationId('executeAsyncSqlQuery')
-    async executeAsyncSqlQuery(
-        @Body()
-        body: ExecuteAsyncSqlQueryRequestParams,
-        @Path() projectUuid: string,
-        @Request() req: express.Request,
-    ): Promise<ApiExecuteAsyncQueryResponse> {
-        this.setStatus(200);
-        const context = body.context ?? getContextFromHeader(req);
-
-        const results = await this.services
-            .getAsyncQueryService()
-            .executeAsyncSqlQuery({
-                user: req.user!,
-                projectUuid,
-                invalidateCache: body.invalidateCache ?? false,
-                sql: body.sql,
-                context: context ?? QueryExecutionContext.SQL_RUNNER,
-                pivotConfiguration: body.pivotConfiguration,
-            });
-
-        return {
-            status: 'ok',
-            results,
-        };
-    }
-
-    @Hidden()
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
     @Post('{projectUuid}/query/chart')
     @OperationId('executeAsyncSavedChartQuery')
     async executeAsyncSavedChartQuery(
@@ -273,6 +244,72 @@ export class V2ProjectController extends BaseController {
                 underlyingDataItemId: body.underlyingDataItemId,
                 context: context ?? QueryExecutionContext.API,
                 dateZoom: body.dateZoom,
+            });
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    @Hidden()
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/query/sql')
+    @OperationId('executeAsyncSqlQuery')
+    async executeAsyncSqlQuery(
+        @Body()
+        body: ExecuteAsyncSqlQueryRequestParams,
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiExecuteAsyncQueryResponse> {
+        this.setStatus(200);
+        const context = body.context ?? getContextFromHeader(req);
+
+        const results = await this.services
+            .getAsyncQueryService()
+            .executeAsyncSqlQuery({
+                user: req.user!,
+                projectUuid,
+                invalidateCache: body.invalidateCache ?? false,
+                sql: body.sql,
+                context: context ?? QueryExecutionContext.SQL_RUNNER,
+                pivotConfiguration: body.pivotConfiguration,
+            });
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    @Hidden()
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/query/dashboard-sql-chart')
+    @OperationId('executeAsyncDashboardSqlChartQuery')
+    async executeAsyncDashboardSqlChartQuery(
+        @Body()
+        body: ExecuteAsyncDashboardSqlChartRequestParams,
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiExecuteAsyncQueryResponse> {
+        this.setStatus(200);
+        const context = body.context ?? getContextFromHeader(req);
+
+        const results = await this.services
+            .getAsyncQueryService()
+            .executeAsyncDashboardSqlChartQuery({
+                user: req.user!,
+                projectUuid,
+                invalidateCache: body.invalidateCache ?? false,
+                dashboardUuid: body.dashboardUuid,
+                dashboardFilters: body.dashboardFilters,
+                dashboardSorts: body.dashboardSorts,
+                context: context ?? QueryExecutionContext.SQL_RUNNER,
+                ...(isExecuteAsyncDashboardSqlChartByUuidParams(body)
+                    ? { savedSqlUuid: body.savedSqlUuid }
+                    : { slug: body.slug }),
             });
 
         return {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -206,6 +206,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     userModel: models.getUserModel(),
                     queryHistoryModel: models.getQueryHistoryModel(),
                     cacheService: repository.getCacheService(),
+                    savedSqlModel: models.getSavedSqlModel(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14940,6 +14940,78 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExecuteAsyncDashboardSqlChartCommonParams: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CommonPaginatedQueryRequestParams' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardSorts: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'SortField' },
+                            required: true,
+                        },
+                        dashboardFilters: {
+                            ref: 'DashboardFilters',
+                            required: true,
+                        },
+                        dashboardUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExecuteAsyncDashboardSqlChartByUuidRequestParams: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ExecuteAsyncDashboardSqlChartCommonParams' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        savedSqlUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExecuteAsyncDashboardSqlChartBySlugRequestParams: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ExecuteAsyncDashboardSqlChartCommonParams' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        slug: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExecuteAsyncDashboardSqlChartRequestParams: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ExecuteAsyncDashboardSqlChartByUuidRequestParams' },
+                { ref: 'ExecuteAsyncDashboardSqlChartBySlugRequestParams' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FeatureFlag: {
         dataType: 'refAlias',
         type: {
@@ -30776,6 +30848,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'executeAsyncUnderlyingDataQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsV2ProjectController_executeAsyncDashboardSqlChartQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ExecuteAsyncDashboardSqlChartRequestParams',
+        },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v2/projects/:projectUuid/query/dashboard-sql-chart',
+        ...fetchMiddlewares<RequestHandler>(V2ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            V2ProjectController.prototype.executeAsyncDashboardSqlChartQuery,
+        ),
+
+        async function V2ProjectController_executeAsyncDashboardSqlChartQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsV2ProjectController_executeAsyncDashboardSqlChartQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<V2ProjectController>(
+                        V2ProjectController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'executeAsyncDashboardSqlChartQuery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15774,6 +15774,77 @@
                     }
                 ]
             },
+            "ExecuteAsyncDashboardSqlChartCommonParams": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CommonPaginatedQueryRequestParams"
+                    },
+                    {
+                        "properties": {
+                            "dashboardSorts": {
+                                "items": {
+                                    "$ref": "#/components/schemas/SortField"
+                                },
+                                "type": "array"
+                            },
+                            "dashboardFilters": {
+                                "$ref": "#/components/schemas/DashboardFilters"
+                            },
+                            "dashboardUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "dashboardSorts",
+                            "dashboardFilters",
+                            "dashboardUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ExecuteAsyncDashboardSqlChartByUuidRequestParams": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ExecuteAsyncDashboardSqlChartCommonParams"
+                    },
+                    {
+                        "properties": {
+                            "savedSqlUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["savedSqlUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ExecuteAsyncDashboardSqlChartBySlugRequestParams": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ExecuteAsyncDashboardSqlChartCommonParams"
+                    },
+                    {
+                        "properties": {
+                            "slug": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["slug"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ExecuteAsyncDashboardSqlChartRequestParams": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ExecuteAsyncDashboardSqlChartByUuidRequestParams"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ExecuteAsyncDashboardSqlChartBySlugRequestParams"
+                    }
+                ]
+            },
             "FeatureFlag": {
                 "properties": {
                     "enabled": {
@@ -16344,7 +16415,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1610.0",
+        "version": "0.1611.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3,9 +3,11 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
     WarehouseQueryError,
+    type CreateWarehouseCredentials,
     type ExecuteAsyncQueryRequestParams,
     type QueryHistory,
 } from '@lightdash/common';
+import type { SshTunnel } from '@lightdash/warehouses';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import { S3Client } from '../../clients/Aws/S3Client';
@@ -25,6 +27,7 @@ import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { projectUuid } from '../../models/ProjectModel/ProjectModel.mock';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel';
 import type { SavedChartModel } from '../../models/SavedChartModel';
+import type { SavedSqlModel } from '../../models/SavedSqlModel';
 import type { SpaceModel } from '../../models/SpaceModel';
 import type { SshKeyPairModel } from '../../models/SshKeyPairModel';
 import type { TagsModel } from '../../models/TagsModel';
@@ -58,11 +61,13 @@ import {
 import { AsyncQueryService } from './AsyncQueryService';
 import type { ExecuteAsyncQueryReturn } from './types';
 
+const mockSshTunnel = {
+    connect: jest.fn(() => warehouseClientMock.credentials),
+    disconnect: jest.fn(),
+} as unknown as SshTunnel<CreateWarehouseCredentials>;
+
 jest.mock('@lightdash/warehouses', () => ({
-    SshTunnel: jest.fn(() => ({
-        connect: jest.fn(() => warehouseClientMock.credentials),
-        disconnect: jest.fn(),
-    })),
+    SshTunnel: jest.fn(() => mockSshTunnel),
 }));
 
 const projectModel = {
@@ -142,6 +147,7 @@ const getMockedAsyncQueryService = (lightdashConfig: LightdashConfig) =>
             update: jest.fn(),
         } as unknown as QueryHistoryModel,
         userModel: {} as UserModel,
+        savedSqlModel: {} as SavedSqlModel,
     });
 
 describe('AsyncQueryService', () => {
@@ -227,6 +233,10 @@ describe('AsyncQueryService', () => {
                         invalidateCache: false,
                     },
                     { query: metricQueryMock },
+                    {
+                        warehouseClient: warehouseClientMock,
+                        sshTunnel: mockSshTunnel,
+                    },
                 );
 
                 expect(result).toEqual({
@@ -309,6 +319,10 @@ describe('AsyncQueryService', () => {
                         invalidateCache: false,
                     },
                     { query: metricQueryMock },
+                    {
+                        warehouseClient: warehouseClientMock,
+                        sshTunnel: mockSshTunnel,
+                    },
                 );
 
                 expect(result).toEqual({
@@ -389,6 +403,10 @@ describe('AsyncQueryService', () => {
                         invalidateCache: true,
                     },
                     { query: metricQueryMock },
+                    {
+                        warehouseClient: warehouseClientMock,
+                        sshTunnel: mockSshTunnel,
+                    },
                 );
 
                 // Verify that createOrGetExistingCache was called with invalidateCache: true
@@ -463,6 +481,10 @@ describe('AsyncQueryService', () => {
                         invalidateCache: false,
                     },
                     { query: metricQueryMock },
+                    {
+                        warehouseClient: warehouseClientMock,
+                        sshTunnel: mockSshTunnel,
+                    },
                 );
 
                 expect(result).toEqual({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -34,20 +34,26 @@ import {
     isField,
     isMetric,
     isUserWithOrg,
+    isVizTableConfig,
     ItemsMap,
     MetricQuery,
+    type Organization,
     PivotIndexColum,
     prefixPivotConfigurationReferences,
+    type Project,
     QueryHistoryStatus,
     type RunQueryTags,
     SessionUser,
     SortBy,
+    type SpaceShare,
+    type SpaceSummary,
     ValuesColumn,
     WarehouseClient,
 } from '@lightdash/common';
 import { SshTunnel } from '@lightdash/warehouses';
 import { measureTime } from '../../logging/measureTime';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel';
+import type { SavedSqlModel } from '../../models/SavedSqlModel';
 import { applyLimitToSqlQuery } from '../../queryBuilder';
 import { wrapSentryTransaction } from '../../utils';
 import type { ICacheService } from '../CacheService/ICacheService';
@@ -66,18 +72,21 @@ import {
 } from '../ProjectService/resultsPagination';
 import {
     type ExecuteAsyncDashboardChartQueryArgs,
+    type ExecuteAsyncDashboardSqlChartArgs,
     type ExecuteAsyncMetricQueryArgs,
     type ExecuteAsyncQueryReturn,
     type ExecuteAsyncSavedChartQueryArgs,
     ExecuteAsyncSqlQueryArgs,
     type ExecuteAsyncUnderlyingDataQueryArgs,
     type GetAsyncQueryResultsArgs,
+    isExecuteAsyncDashboardSqlChartByUuid,
 } from './types';
 
 type AsyncQueryServiceArguments<ResultsCacheStorageClient = unknown> =
     ProjectServiceArguments & {
         queryHistoryModel: QueryHistoryModel;
         cacheService?: ICacheService<ResultsCacheStorageClient>;
+        savedSqlModel: SavedSqlModel;
     };
 
 export class AsyncQueryService<
@@ -87,14 +96,67 @@ export class AsyncQueryService<
 
     cacheService?: ICacheService<ResultsCacheStorageClient>;
 
+    savedSqlModel: SavedSqlModel;
+
     constructor({
         queryHistoryModel,
         cacheService,
+        savedSqlModel,
         ...projectServiceArgs
     }: AsyncQueryServiceArguments<ResultsCacheStorageClient>) {
         super(projectServiceArgs);
         this.queryHistoryModel = queryHistoryModel;
         this.cacheService = cacheService;
+        this.savedSqlModel = savedSqlModel;
+    }
+
+    // ! Duplicate of SavedSqlService.hasAccess
+    private async hasAccess(
+        user: SessionUser,
+        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        {
+            spaceUuid,
+            projectUuid,
+            organizationUuid,
+        }: { spaceUuid: string; projectUuid: string; organizationUuid: string },
+    ): Promise<{ hasAccess: boolean; userAccess: SpaceShare | undefined }> {
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        const access = await this.spaceModel.getUserSpaceAccess(
+            user.userUuid,
+            spaceUuid,
+        );
+
+        const hasPermission = user.ability.can(
+            action,
+            subject('SavedChart', {
+                organizationUuid,
+                projectUuid,
+                isPrivate: space.isPrivate,
+                access,
+            }),
+        );
+
+        return {
+            hasAccess: hasPermission,
+            userAccess: access[0],
+        };
+    }
+
+    // ! Duplicate of SavedSqlService.hasSavedChartAccess
+    private async hasSavedChartAccess(
+        user: SessionUser,
+        action: 'view' | 'create' | 'update' | 'delete' | 'manage',
+        savedChart: {
+            project: Pick<Project, 'projectUuid'>;
+            organization: Pick<Organization, 'organizationUuid'>;
+            space: Pick<SpaceSummary, 'uuid'>;
+        },
+    ) {
+        return this.hasAccess(user, action, {
+            spaceUuid: savedChart.space.uuid,
+            projectUuid: savedChart.project.projectUuid,
+            organizationUuid: savedChart.organization.organizationUuid,
+        });
     }
 
     async cancelAsyncQuery({
@@ -332,11 +394,18 @@ export class AsyncQueryService<
                 status,
             };
         } else {
-            const explore = await this.getExplore(
-                user,
-                projectUuid,
-                metricQuery.exploreName,
-            );
+            let explore: Explore | undefined;
+
+            try {
+                explore = await this.getExplore(
+                    user,
+                    projectUuid,
+                    metricQuery.exploreName,
+                );
+            } catch (e) {
+                // No-op, if we don't find an explore that's fine as we're only using it to get warehouse overrides for the client
+                // SQL Runner queries don't have an explore, they use a virtual view which is not saved in the database
+            }
 
             const { warehouseClient, sshTunnel } =
                 await this._getWarehouseClient(
@@ -346,8 +415,8 @@ export class AsyncQueryService<
                         user.userUuid,
                     ),
                     {
-                        snowflakeVirtualWarehouse: explore.warehouse,
-                        databricksCompute: explore.databricksCompute,
+                        snowflakeVirtualWarehouse: explore?.warehouse,
+                        databricksCompute: explore?.databricksCompute,
                     },
                 );
 
@@ -623,6 +692,13 @@ export class AsyncQueryService<
             explore: Explore;
         },
         requestParameters: ExecuteAsyncQueryRequestParams,
+        {
+            warehouseClient,
+            sshTunnel,
+        }: {
+            warehouseClient: WarehouseClient;
+            sshTunnel: SshTunnel<CreateWarehouseCredentials>;
+        },
         pivotConfiguration?: {
             indexColumn: PivotIndexColum;
             valuesColumns: ValuesColumn[];
@@ -664,19 +740,6 @@ export class AsyncQueryService<
                     ) {
                         throw new ForbiddenError();
                     }
-
-                    const { warehouseClient, sshTunnel } =
-                        await this._getWarehouseClient(
-                            projectUuid,
-                            await this.getWarehouseCredentials(
-                                projectUuid,
-                                user.userUuid,
-                            ),
-                            {
-                                snowflakeVirtualWarehouse: explore.warehouse,
-                                databricksCompute: explore.databricksCompute,
-                            },
-                        );
 
                     span.setAttribute('lightdash.projectUuid', projectUuid);
                     span.setAttribute(
@@ -963,6 +1026,15 @@ export class AsyncQueryService<
             organizationUuid,
         );
 
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+            {
+                snowflakeVirtualWarehouse: explore.warehouse,
+                databricksCompute: explore.databricksCompute,
+            },
+        );
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 user,
@@ -975,122 +1047,7 @@ export class AsyncQueryService<
                 invalidateCache,
             },
             requestParameters,
-        );
-
-        return {
-            queryUuid,
-            cacheMetadata,
-            appliedDashboardFilters: null,
-        };
-    }
-
-    async executeAsyncSqlQuery({
-        user,
-        projectUuid,
-        sql,
-        context,
-        invalidateCache,
-        pivotConfiguration,
-    }: ExecuteAsyncSqlQueryArgs): Promise<ApiExecuteAsyncQueryResults> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User does not belong to an organization');
-        }
-
-        const { organizationUuid } = await this.projectModel.getSummary(
-            projectUuid,
-        );
-
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('SqlRunner', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
-        const { warehouseClient } = await this._getWarehouseClient(
-            projectUuid,
-            await this.getWarehouseCredentials(projectUuid, user.userUuid),
-        );
-
-        const queryTags: RunQueryTags = {
-            organization_uuid: organizationUuid,
-            user_uuid: user.userUuid,
-            query_context: context,
-        };
-
-        // Get one row to get the column definitions
-        const columns: { name: string; type: DimensionType }[] = [];
-        await warehouseClient.streamQuery(
-            applyLimitToSqlQuery({ sqlQuery: sql, limit: 1 }),
-            (row) => {
-                if (row.fields) {
-                    Object.keys(row.fields).forEach((key) => {
-                        columns.push({
-                            name: key,
-                            type: row.fields[key].type,
-                        });
-                    });
-                }
-            },
-            {
-                tags: queryTags,
-            },
-        );
-
-        const vizColumns = columns.map((col) => ({
-            reference: col.name,
-            type: col.type,
-        }));
-
-        const virtualView = createVirtualViewObject(
-            'virtual_view',
-            sql,
-            vizColumns,
-            warehouseClient,
-        );
-
-        const dimensions = Object.values(
-            virtualView.tables[virtualView.baseTable].dimensions,
-        ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
-
-        const prefixedPivotConfiguration = pivotConfiguration
-            ? prefixPivotConfigurationReferences(
-                  pivotConfiguration,
-                  `${virtualView.name}`,
-              )
-            : undefined;
-
-        const query: MetricQuery = {
-            exploreName: virtualView.name,
-            dimensions,
-            metrics: [],
-            filters: {},
-            tableCalculations: [],
-            sorts: [],
-            customDimensions: [],
-            additionalMetrics: [],
-            limit: 500,
-        };
-
-        const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
-            {
-                user,
-                projectUuid,
-                explore: virtualView,
-                queryTags,
-                metricQuery: query,
-                context,
-            },
-            {
-                query,
-                invalidateCache,
-            },
-            prefixedPivotConfiguration,
+            warehouseConnection,
         );
 
         return {
@@ -1184,6 +1141,15 @@ export class AsyncQueryService<
             savedChartOrganizationUuid,
         );
 
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+            {
+                snowflakeVirtualWarehouse: explore.warehouse,
+                databricksCompute: explore.databricksCompute,
+            },
+        );
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 user,
@@ -1195,6 +1161,7 @@ export class AsyncQueryService<
                 metricQuery,
             },
             requestParameters,
+            warehouseConnection,
         );
 
         return {
@@ -1346,6 +1313,15 @@ export class AsyncQueryService<
             query_context: context,
         };
 
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+            {
+                snowflakeVirtualWarehouse: explore.warehouse,
+                databricksCompute: explore.databricksCompute,
+            },
+        );
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 user,
@@ -1358,6 +1334,7 @@ export class AsyncQueryService<
                 dateZoom,
             },
             requestParameters,
+            warehouseConnection,
         );
 
         return {
@@ -1490,6 +1467,15 @@ export class AsyncQueryService<
             additionalMetrics: [],
         };
 
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+            {
+                snowflakeVirtualWarehouse: explore.warehouse,
+                databricksCompute: explore.databricksCompute,
+            },
+        );
+
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =
             await this.executeAsyncQuery(
                 {
@@ -1503,12 +1489,287 @@ export class AsyncQueryService<
                     dateZoom,
                 },
                 requestParameters,
+                warehouseConnection,
             );
 
         return {
             queryUuid: underlyingDataQueryUuid,
             appliedDashboardFilters: null,
             cacheMetadata,
+        };
+    }
+
+    async executeAsyncSqlQuery({
+        user,
+        projectUuid,
+        sql,
+        context,
+        invalidateCache,
+        pivotConfiguration,
+    }: ExecuteAsyncSqlQueryArgs): Promise<ApiExecuteAsyncQueryResults> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User does not belong to an organization');
+        }
+
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
+
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('SqlRunner', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+        );
+
+        const queryTags: RunQueryTags = {
+            organization_uuid: organizationUuid,
+            user_uuid: user.userUuid,
+            query_context: context,
+        };
+
+        // Get one row to get the column definitions
+        const columns: { name: string; type: DimensionType }[] = [];
+        await warehouseConnection.warehouseClient.streamQuery(
+            applyLimitToSqlQuery({ sqlQuery: sql, limit: 1 }),
+            (row) => {
+                if (row.fields) {
+                    Object.keys(row.fields).forEach((key) => {
+                        columns.push({
+                            name: key,
+                            type: row.fields[key].type,
+                        });
+                    });
+                }
+            },
+            {
+                tags: queryTags,
+            },
+        );
+
+        const vizColumns = columns.map((col) => ({
+            reference: col.name,
+            type: col.type,
+        }));
+
+        const virtualView = createVirtualViewObject(
+            'virtual_view',
+            sql,
+            vizColumns,
+            warehouseConnection.warehouseClient,
+        );
+
+        const dimensions = Object.values(
+            virtualView.tables[virtualView.baseTable].dimensions,
+        ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
+
+        const prefixedPivotConfiguration = pivotConfiguration
+            ? prefixPivotConfigurationReferences(
+                  pivotConfiguration,
+                  `${virtualView.name}`,
+              )
+            : undefined;
+
+        const query: MetricQuery = {
+            exploreName: virtualView.name,
+            dimensions,
+            metrics: [],
+            filters: {},
+            tableCalculations: [],
+            sorts: [],
+            customDimensions: [],
+            additionalMetrics: [],
+            limit: 500,
+        };
+
+        const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
+            {
+                user,
+                projectUuid,
+                explore: virtualView,
+                queryTags,
+                metricQuery: query,
+                context,
+            },
+            {
+                query,
+                invalidateCache,
+            },
+            warehouseConnection,
+            prefixedPivotConfiguration,
+        );
+
+        return {
+            queryUuid,
+            cacheMetadata,
+            appliedDashboardFilters: null,
+        };
+    }
+
+    async executeAsyncDashboardSqlChartQuery(
+        args: ExecuteAsyncDashboardSqlChartArgs,
+    ): Promise<ApiExecuteAsyncQueryResults> {
+        const savedChart = isExecuteAsyncDashboardSqlChartByUuid(args)
+            ? await this.savedSqlModel.getByUuid(args.savedSqlUuid, {
+                  projectUuid: args.projectUuid,
+              })
+            : await this.savedSqlModel.getBySlug(args.projectUuid, args.slug);
+
+        if (!savedChart) {
+            throw new Error('Either chartUuid or slug must be provided');
+        }
+
+        const {
+            user,
+            projectUuid,
+            context,
+            invalidateCache,
+            dashboardFilters,
+            dashboardSorts,
+        } = args;
+
+        const { hasAccess: hasViewAccess } = await this.hasSavedChartAccess(
+            user,
+            'view',
+            savedChart,
+        );
+
+        if (!hasViewAccess) {
+            throw new ForbiddenError("You don't have access to this chart");
+        }
+
+        const warehouseConnection = await this._getWarehouseClient(
+            projectUuid,
+            await this.getWarehouseCredentials(projectUuid, user.userUuid),
+        );
+
+        const queryTags: RunQueryTags = {
+            organization_uuid: savedChart.organization.organizationUuid,
+            user_uuid: user.userUuid,
+            query_context: context,
+        };
+
+        // Get one row to get the column definitions
+        const columns: { name: string; type: DimensionType }[] = [];
+        await warehouseConnection.warehouseClient.streamQuery(
+            applyLimitToSqlQuery({ sqlQuery: savedChart.sql, limit: 1 }),
+            (row) => {
+                if (row.fields) {
+                    Object.keys(row.fields).forEach((key) => {
+                        columns.push({
+                            name: key,
+                            type: row.fields[key].type,
+                        });
+                    });
+                }
+            },
+            {
+                tags: queryTags,
+            },
+        );
+
+        const vizColumns = columns.map((col) => ({
+            reference: col.name,
+            type: col.type,
+        }));
+
+        const virtualView = createVirtualViewObject(
+            'virtual_view',
+            savedChart.sql,
+            vizColumns,
+            warehouseConnection.warehouseClient,
+        );
+
+        const dimensions = Object.values(
+            virtualView.tables[virtualView.baseTable].dimensions,
+        ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
+
+        const prefixedPivotConfiguration =
+            !isVizTableConfig(savedChart.config) &&
+            savedChart.config.fieldConfig
+                ? prefixPivotConfigurationReferences(
+                      {
+                          indexColumn: savedChart.config.fieldConfig.x,
+                          valuesColumns: savedChart.config.fieldConfig.y,
+                          groupByColumns: savedChart.config.fieldConfig.groupBy,
+                          sortBy: savedChart.config.fieldConfig.sortBy,
+                      },
+                      `${virtualView.name}`,
+                  )
+                : undefined;
+
+        const tables = Object.keys(virtualView.tables);
+        const appliedDashboardFilters: DashboardFilters = {
+            dimensions: getDashboardFilterRulesForTables(
+                tables,
+                dashboardFilters.dimensions,
+            ),
+            metrics: getDashboardFilterRulesForTables(
+                tables,
+                dashboardFilters.metrics,
+            ),
+            tableCalculations: getDashboardFilterRulesForTables(
+                tables,
+                dashboardFilters.tableCalculations,
+            ),
+        };
+
+        const query: MetricQuery = {
+            exploreName: virtualView.name,
+            dimensions,
+            metrics: [],
+            filters: {},
+            tableCalculations: [],
+            sorts: [],
+            customDimensions: [],
+            additionalMetrics: [],
+            limit: 500,
+        };
+
+        // This override isn't used for anything at the moment since sql charts don't support filters, but it's here for future use
+        const metricQueryWithDashboardOverrides: MetricQuery = {
+            ...addDashboardFiltersToMetricQuery(
+                query,
+                appliedDashboardFilters,
+                virtualView,
+            ),
+            sorts:
+                dashboardSorts && dashboardSorts.length > 0
+                    ? dashboardSorts
+                    : [],
+        };
+
+        const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
+            {
+                user,
+                projectUuid,
+                explore: virtualView,
+                queryTags,
+                metricQuery: metricQueryWithDashboardOverrides,
+                context,
+            },
+            {
+                query,
+                invalidateCache,
+            },
+            warehouseConnection,
+            prefixedPivotConfiguration,
+        );
+
+        return {
+            queryUuid,
+            cacheMetadata,
+            appliedDashboardFilters,
         };
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -35,16 +35,6 @@ export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     dateZoom?: DateZoom;
 };
 
-export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
-    sql: string;
-    pivotConfiguration?: {
-        indexColumn: PivotIndexColum;
-        valuesColumns: ValuesColumn[];
-        groupByColumns: GroupByColumn[] | undefined;
-        sortBy: SortBy | undefined;
-    };
-};
-
 export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {
     chartUuid: string;
     versionUuid?: string;
@@ -69,3 +59,37 @@ export type ExecuteAsyncQueryReturn = {
     queryUuid: string;
     cacheMetadata: CacheMetadata;
 };
+
+export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
+    sql: string;
+    pivotConfiguration?: {
+        indexColumn: PivotIndexColum;
+        valuesColumns: ValuesColumn[];
+        groupByColumns: GroupByColumn[] | undefined;
+        sortBy: SortBy | undefined;
+    };
+};
+
+export type ExecuteAsyncDashboardSqlChartCommonArgs = CommonAsyncQueryArgs & {
+    dashboardUuid: string;
+    dashboardFilters: DashboardFilters;
+    dashboardSorts: SortField[];
+};
+
+export type ExecuteAsyncDashboardSqlChartByUuidArgs =
+    ExecuteAsyncDashboardSqlChartCommonArgs & {
+        savedSqlUuid: string;
+    };
+
+export type ExecuteAsyncDashboardSqlChartBySlugArgs =
+    ExecuteAsyncDashboardSqlChartCommonArgs & {
+        slug: string;
+    };
+
+export type ExecuteAsyncDashboardSqlChartArgs =
+    | ExecuteAsyncDashboardSqlChartByUuidArgs
+    | ExecuteAsyncDashboardSqlChartBySlugArgs;
+
+export const isExecuteAsyncDashboardSqlChartByUuid = (
+    args: ExecuteAsyncDashboardSqlChartArgs,
+): args is ExecuteAsyncDashboardSqlChartByUuidArgs => 'savedSqlUuid' in args;

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -505,6 +505,7 @@ export class ServiceRepository
                     encryptionUtil: this.utils.getEncryptionUtil(),
                     userModel: this.models.getUserModel(),
                     queryHistoryModel: this.models.getQueryHistoryModel(),
+                    savedSqlModel: this.models.getSavedSqlModel(),
                 }),
         );
     }

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -59,9 +59,36 @@ export type ExecuteAsyncUnderlyingDataRequestParams =
         dateZoom?: DateZoom;
     };
 
+type ExecuteAsyncDashboardSqlChartCommonParams =
+    CommonPaginatedQueryRequestParams & {
+        dashboardUuid: string;
+        dashboardFilters: DashboardFilters;
+        dashboardSorts: SortField[];
+    };
+
+export type ExecuteAsyncDashboardSqlChartByUuidRequestParams =
+    ExecuteAsyncDashboardSqlChartCommonParams & {
+        savedSqlUuid: string;
+    };
+
+export type ExecuteAsyncDashboardSqlChartBySlugRequestParams =
+    ExecuteAsyncDashboardSqlChartCommonParams & {
+        slug: string;
+    };
+
+export type ExecuteAsyncDashboardSqlChartRequestParams =
+    | ExecuteAsyncDashboardSqlChartByUuidRequestParams
+    | ExecuteAsyncDashboardSqlChartBySlugRequestParams;
+
+export const isExecuteAsyncDashboardSqlChartByUuidParams = (
+    params: ExecuteAsyncDashboardSqlChartRequestParams,
+): params is ExecuteAsyncDashboardSqlChartByUuidRequestParams =>
+    'savedSqlUuid' in params;
+
 export type ExecuteAsyncQueryRequestParams =
     | ExecuteAsyncMetricQueryRequestParams
     | ExecuteAsyncSqlQueryRequestParams
     | ExecuteAsyncSavedChartRequestParams
     | ExecuteAsyncDashboardChartRequestParams
-    | ExecuteAsyncUnderlyingDataRequestParams;
+    | ExecuteAsyncUnderlyingDataRequestParams
+    | ExecuteAsyncDashboardSqlChartRequestParams;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14626 

### Description:

- Adds `POST /api/v2/projects/{projectUuid}/query/dashboard-sql-chart` endpoint that returns just the pivoted results of a sql chart (when not table viz)

**Example body**
```json
{
    "context": "dashboardView",
    "invalidateCache": false,
    "savedSqlUuid": "d0cda854-6b6c-41e7-b3d2-dc5cd46ebe42",
    "dashboardUuid": "e9d95a07-e5c8-4ea9-8365-e45bc4b47898",
    "dashboardFilters": {
        "dimensions": [],
        "metrics": [],
        "tableCalculations": []
    },
    "dashboardSorts": []
}
```


https://github.com/user-attachments/assets/af826c10-fa93-45ae-b0b7-e712e02be466

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
