### PR TITLE
fix: show error for visualizations on paginated query error

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1373,30 +1373,6 @@ export const GenericDashboardChartTile: FC<
             subject('SavedChart', dashboardChartReadyQuery.chart),
         );
 
-    if (isLoading || !dashboardChartReadyQuery || !resultsData) {
-        return (
-            <TileBase
-                isEditMode={isEditMode}
-                chartName={tile.properties.chartName ?? ''}
-                titleHref={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/`}
-                description={''}
-                belongsToDashboard={tile.properties.belongsToDashboard}
-                tile={tile}
-                isLoading
-                title={tile.properties.title || tile.properties.chartName || ''}
-                extraMenuItems={
-                    !minimal &&
-                    userCanManageChart &&
-                    tile.properties.savedChartUuid && (
-                        <EditChartMenuItem tile={tile} />
-                    )
-                }
-                minimal={minimal}
-                {...rest}
-            />
-        );
-    }
-
     if (error !== null) {
         return (
             <TileBase
@@ -1425,6 +1401,30 @@ export const GenericDashboardChartTile: FC<
                     title={error?.error?.message || 'No data available'}
                 ></SuboptimalState>
             </TileBase>
+        );
+    }
+
+    if (isLoading || !dashboardChartReadyQuery || !resultsData) {
+        return (
+            <TileBase
+                isEditMode={isEditMode}
+                chartName={tile.properties.chartName ?? ''}
+                titleHref={`/projects/${projectUuid}/saved/${tile.properties.savedChartUuid}/`}
+                description={''}
+                belongsToDashboard={tile.properties.belongsToDashboard}
+                tile={tile}
+                isLoading
+                title={tile.properties.title || tile.properties.chartName || ''}
+                extraMenuItems={
+                    !minimal &&
+                    userCanManageChart &&
+                    tile.properties.savedChartUuid && (
+                        <EditChartMenuItem tile={tile} />
+                    )
+                }
+                minimal={minimal}
+                {...rest}
+            />
         );
     }
 
@@ -1476,12 +1476,16 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
         const isFetchingFirstPage = resultsData.isFetchingFirstPage;
         const isFetchingAllRows =
             resultsData.fetchAll && !resultsData.hasFetchedAllRows;
-        return isCreatingQuery || isFetchingFirstPage || isFetchingAllRows;
+        return (
+            (isCreatingQuery || isFetchingFirstPage || isFetchingAllRows) &&
+            !resultsData.error
+        );
     }, [
         readyQuery.isFetching,
         resultsData.fetchAll,
         resultsData.hasFetchedAllRows,
         resultsData.isFetchingFirstPage,
+        resultsData.error,
     ]);
 
     return (
@@ -1490,7 +1494,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
             isLoading={isLoading}
             resultsData={resultsData}
             dashboardChartReadyQuery={readyQuery.data}
-            error={readyQuery.error}
+            error={readyQuery.error ?? resultsData.error}
         />
     );
 };

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -41,7 +41,8 @@ export const ExplorerResults = memo(() => {
     );
 
     const isFetchingRows = useExplorerContext(
-        (context) => context.queryResults.isFetchingRows,
+        (context) =>
+            context.queryResults.isFetchingRows && !context.queryResults.error,
     );
     const fetchMoreRows = useExplorerContext(
         (context) => context.queryResults.fetchMoreRows,
@@ -50,7 +51,9 @@ export const ExplorerResults = memo(() => {
         const isCreatingQuery = context.query.isFetching;
         const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
         // Don't return context.queryResults.status because we changed from mutation to query so 'loading' as a different meaning
-        if (isCreatingQuery || isFetchingFirstPage) {
+        if (context.queryResults.error) {
+            return 'error';
+        } else if (isCreatingQuery || isFetchingFirstPage) {
             return 'loading';
         } else if (context.query.status === 'loading') {
             return 'idle';

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -214,3 +214,10 @@ export const ExploreLoadingState = () => (
         <Loader color="gray" />
     </EmptyState>
 );
+
+export const ExploreErrorState = () => (
+    <EmptyState
+        title="Error loading results"
+        description="There was an error loading the results"
+    ></EmptyState>
+);

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -36,7 +36,11 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
         const isCreatingQuery = context.query.isFetching;
         const isFetchingFirstPage = context.queryResults.isFetchingFirstPage;
         const isFetchingAllRows = context.queryResults.isFetchingAllPages;
-        return isCreatingQuery || isFetchingFirstPage || isFetchingAllRows;
+        const isQueryError = context.queryResults.error;
+        return (
+            (isCreatingQuery || isFetchingFirstPage || isFetchingAllRows) &&
+            !isQueryError
+        );
     });
     const fetchResults = useExplorerContext(
         (context) => context.actions.fetchResults,

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -8,8 +8,8 @@ import useEchartsCartesianConfig, {
     isLineSeriesOption,
 } from '../../hooks/echarts/useEchartsCartesianConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
-import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 type EchartBaseClickEvent = {
     // The component name clicked,
@@ -231,6 +231,7 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
         }
     }, [chartRef, eChartsOptions?.tooltip]);
 
+    if (resultsData?.error) return <EmptyChart />;
     if (isLoading) return <LoadingChart />;
     if (!eChartsOptions) return <EmptyChart />;
 

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -2,6 +2,7 @@ import { useMantineTheme } from '@mantine/core';
 import { type ComponentProps, type FC } from 'react';
 import {
     ExploreEmptyQueryState,
+    ExploreErrorState,
     ExploreIdleState,
     ExploreLoadingState,
 } from '../../Explorer/ResultsCard/ExplorerResultsNonIdealStates';
@@ -61,6 +62,7 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
                     showSubtotals={showSubtotals}
                 />
 
+                {status === 'error' && <ExploreErrorState />}
                 {status === 'idle' && <IdleState />}
                 {status === 'success' && rest.data.length === 0 && (
                     <EmptyState />

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -101,8 +101,9 @@ const EmbedDashboardChartTile: FC<Props> = ({
                 isInitialLoading: false,
                 isFetchingFirstPage: false,
                 projectUuid: translatedChartData?.chart.projectUuid,
+                error: error,
             } satisfies InfiniteQueryResults),
-        [translatedChartData],
+        [translatedChartData, error],
     );
 
     if (locked) {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -271,6 +271,8 @@ export const useInfiniteQueryResults = (
 
             const { status } = results;
 
+            const clientFetchTimeMs = performance.now() - startTime;
+
             switch (status) {
                 case QueryHistoryStatus.ERROR: {
                     backoffRef.current = 250;
@@ -319,10 +321,13 @@ export const useInfiniteQueryResults = (
                         ...prevState,
                         {
                             ...results,
-                            clientFetchTimeMs: performance.now() - startTime,
+                            clientFetchTimeMs,
                         },
                     ]);
-                    break;
+                    return {
+                        ...results,
+                        clientFetchTimeMs,
+                    };
                 }
                 default:
                     return assertUnreachable(status, 'Unknown query status');
@@ -330,7 +335,7 @@ export const useInfiniteQueryResults = (
 
             return {
                 ...results,
-                clientFetchTimeMs: performance.now() - startTime,
+                clientFetchTimeMs,
             };
         },
         staleTime: Infinity, // the data will never be considered stale

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -313,7 +313,10 @@ export const useInfiniteQueryResults = (
                             1000,
                         );
                     }
-                    break;
+                    return {
+                        ...results,
+                        clientFetchTimeMs,
+                    };
                 }
                 case QueryHistoryStatus.READY: {
                     backoffRef.current = 250;
@@ -332,11 +335,6 @@ export const useInfiniteQueryResults = (
                 default:
                     return assertUnreachable(status, 'Unknown query status');
             }
-
-            return {
-                ...results,
-                clientFetchTimeMs,
-            };
         },
         staleTime: Infinity, // the data will never be considered stale
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14672 

### Description:

This fixes an issue where charts with errors in the query never got out of the loading state. We weren't handling the error status on paginated queries completely. This was especially problematic on dashbaords, because the edit controls were hidden.

To repro the issue, you can add a bad table calculation on the Explore page. You'll see it loads forever:
![Kapture 2025-05-06 at 18 49 48](https://github.com/user-attachments/assets/922ad82c-5160-4d86-a47d-210a96e4c525)

If you save that chart it will also load forever. 

Now, it shows an error:
![after](https://github.com/user-attachments/assets/e3e53574-657e-456b-a7c3-ece9a45376bd)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
