### PR TITLE
fix: skip default space creation for preview projects

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -428,24 +428,26 @@ export class ProjectModel {
                 data.warehouseConnection,
             );
 
-            const slug = await generateUniqueSpaceSlug(
-                'Shared',
-                project.project_id,
-                {
-                    trx,
-                },
-            );
+            if (data.type !== ProjectType.PREVIEW) {
+                const slug = await generateUniqueSpaceSlug(
+                    'Shared',
+                    project.project_id,
+                    {
+                        trx,
+                    },
+                );
 
-            const path = getLtreePathFromSlug(slug);
+                const path = getLtreePathFromSlug(slug);
 
-            await trx(SpaceTableName).insert({
-                project_id: project.project_id,
-                name: 'Shared',
-                is_private: false,
-                slug,
-                parent_space_uuid: null,
-                path,
-            });
+                await trx(SpaceTableName).insert({
+                    project_id: project.project_id,
+                    name: 'Shared',
+                    is_private: false,
+                    slug,
+                    parent_space_uuid: null,
+                    path,
+                });
+            }
 
             return project.project_uuid;
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14692

### Description:
Skip creating a "Shared" space for preview projects.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging