### PR TITLE
fix: sql queries causing explore not found error when not cached

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -393,11 +393,18 @@ export class AsyncQueryService<
                 status,
             };
         } else {
-            const explore = await this.getExplore(
-                user,
-                projectUuid,
-                metricQuery.exploreName,
-            );
+            let explore: Explore | undefined;
+
+            try {
+                explore = await this.getExplore(
+                    user,
+                    projectUuid,
+                    metricQuery.exploreName,
+                );
+            } catch (e) {
+                // No-op, if we don't find an explore that's fine as we're only using it to get warehouse overrides for the client
+                // SQL Runner queries don't have an explore, they use a virtual view which is not saved in the database
+            }
 
             const { warehouseClient, sshTunnel } =
                 await this._getWarehouseClient(
@@ -407,8 +414,8 @@ export class AsyncQueryService<
                         user.userUuid,
                     ),
                     {
-                        snowflakeVirtualWarehouse: explore.warehouse,
-                        databricksCompute: explore.databricksCompute,
+                        snowflakeVirtualWarehouse: explore?.warehouse,
+                        databricksCompute: explore?.databricksCompute,
                     },
                 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/14688

### Description:

**Before**
![image](https://github.com/user-attachments/assets/afa3e590-627c-466f-be83-3cf916ddc4dd)

**After**
![image](https://github.com/user-attachments/assets/82ff0bd0-f1a4-4973-8749-2fa7fa45026e)



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
