### PR TITLE
fix: improve UI text for moving resources between spaces

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1835,7 +1835,9 @@ export class SpaceModel {
                 .first();
 
             if (isCycle) {
-                throw new ParameterError("Cannot move space to it's child");
+                throw new ParameterError(
+                    'You cannot move a space into one of its own nested-spaces. Please choose a different location.',
+                );
             }
 
             await trx.raw(

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -558,7 +558,7 @@ const SavedChartsHeader: FC = () => {
                                                 transferToSpaceModalHandlers.open
                                             }
                                         >
-                                            Transfer to space
+                                            Move chart
                                         </Menu.Item>
                                     )}
 

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -90,7 +90,7 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
                         onTransferToSpace();
                     }}
                 >
-                    Transfer to space
+                    Move
                 </Menu.Item>
 
                 <Menu.Divider />

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -486,7 +486,7 @@ const DashboardHeader = ({
                                                 transferToSpaceModalHandlers.open
                                             }
                                         >
-                                            Transfer to space
+                                            Move dashboard
                                         </Menu.Item>
                                     </>
                                 )}

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -332,7 +332,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             });
                         }}
                     >
-                        Transfer to space
+                        Move
                     </Menu.Item>
 
                     {allowDelete && (

--- a/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/index.tsx
@@ -122,7 +122,7 @@ const ShareSpaceModal: FC<ShareSpaceProps> = ({ space, projectUuid }) => {
                             >
                                 <Text color="blue.9">
                                     <Text span weight={600}>
-                                        {space.name}
+                                        "{space.name}"
                                     </Text>{' '}
                                     inherits permissions from its parent space{' '}
                                     <Text span weight={600}>

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
@@ -37,9 +37,9 @@ const SpaceCreationForm = ({
                 {parentSpaceName ? (
                     <>
                         {' '}
-                        in
+                        in{' '}
                         <Text span fw={600}>
-                            '{parentSpaceName}'
+                            "{parentSpaceName}"
                         </Text>
                     </>
                 ) : null}
@@ -60,7 +60,7 @@ const SpaceCreationForm = ({
                     <Text fw={500} color="blue">
                         Permissions will be inherited from{' '}
                         <Text span fw={600}>
-                            '{parentSpaceName}'
+                            "{parentSpaceName}"
                         </Text>
                     </Text>
                 </Alert>

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -22,6 +22,28 @@ type Props<T, U> = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     onConfirm: (spaceUuid: string | null) => void;
 };
 
+const ItemName = ({ name }: { name: string }) => {
+    return (
+        <Text fw={600} component="span">
+            "{name}"
+        </Text>
+    );
+};
+
+const getItemsText = <T extends ResourceViewItem>(items: T[]) => {
+    if (items.length === 1) {
+        return {
+            name: <ItemName name={items[0].data.name} />,
+            type: items[0].type,
+        };
+    }
+
+    return {
+        name: `${items.length} items`,
+        type: 'items',
+    };
+};
+
 const TransferItemsModal = <
     R extends ResourceViewItem,
     T extends Array<R>,
@@ -100,7 +122,7 @@ const TransferItemsModal = <
 
     return (
         <MantineModal
-            title={`Transfer ${items.length > 1 ? 'items' : 'item'}`}
+            title={`Move ${getItemsText(items).type}`}
             opened={opened}
             onClose={onClose}
             actions={
@@ -133,7 +155,7 @@ const TransferItemsModal = <
                                 disabled={newSpaceName.length === 0}
                                 onClick={createSpace}
                             >
-                                Create space & transfer
+                                Create space & move
                             </Button>
                         ) : (
                             <Button
@@ -166,8 +188,7 @@ const TransferItemsModal = <
             ) : (
                 <>
                     <Text fz="sm" fw={500}>
-                        Select a space to transfer{' '}
-                        {items.length > 1 ? 'items' : 'item'} to:
+                        Select a space to move {getItemsText(items).name} to:
                     </Text>
 
                     <SpaceSelector
@@ -181,12 +202,13 @@ const TransferItemsModal = <
                         {!isCreatingNewSpace && selectedSpaceLabel ? (
                             <Alert color="gray" sx={{ flexShrink: 0 }}>
                                 <Text fw={500}>
-                                    Transfer {items.length}{' '}
-                                    {items.length > 1 ? 'items' : 'item'}{' '}
-                                    {!isCreatingNewSpace
-                                        ? `"${selectedSpaceLabel}"`
-                                        : ''}
-                                    .
+                                    Move {getItemsText(items).name}
+                                    {' to '}
+                                    {!isCreatingNewSpace ? (
+                                        <ItemName name={selectedSpaceLabel} />
+                                    ) : (
+                                        ''
+                                    )}
                                 </Text>
                             </Alert>
                         ) : null}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14719


### Description:
Improves the UX for moving resources between spaces by:

1. Updating button and menu labels from "Transfer to space" to more intuitive "Move" or "Move [resource type]"
2. Enhancing the transfer modal with clearer messaging that shows resource names in quotes
3. Improving error message when attempting to move a space into one of its own nested spaces
4. Adding proper formatting for space names in quotes throughout the UI


![CleanShot 2025-05-07 at 16.25.01@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/df32ea92-5941-4dff-a611-f86e7193ce63.png)

![CleanShot 2025-05-07 at 16.25.10@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/629d1777-6508-4a91-8bdc-499a2780e499.png)

![CleanShot 2025-05-07 at 16.25.24@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/b0d9087a-ae96-4c45-a8ef-e02b5eb3b679.png)

![CleanShot 2025-05-07 at 16.25.38@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/e075bfc0-3404-4bf1-830d-ae2cac590623.png)

![CleanShot 2025-05-07 at 16.25.52@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/aadd08ef-3bb9-4f1c-986f-3da13b8ece1d.png)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging