### PR TITLE
fix: admins should be able to see private spaces on every level

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -81,6 +81,7 @@ type ResourceView2Props = Partial<MRT_TableOptions<ResourceViewItem>> & {
     };
     columnVisibility?: ColumnVisibilityConfig;
     adminContentView?: boolean;
+    initialAdminContentViewValue?: 'all' | 'shared';
 };
 
 const InfiniteResourceTable = ({
@@ -88,11 +89,12 @@ const InfiniteResourceTable = ({
     contentTypeFilter,
     columnVisibility,
     adminContentView = false,
+    initialAdminContentViewValue = 'shared',
     ...mrtProps
 }: ResourceView2Props) => {
     const [selectedAdminContentType, setSelectedAdminContentType] = useState<
         'all' | 'shared'
-    >('shared');
+    >(initialAdminContentViewValue);
     const theme = useMantineTheme();
     const navigate = useNavigate();
     const { data: spaces = [] } = useSpaceSummaries(filters.projectUuid, true);

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -134,6 +134,17 @@ const Space: FC = () => {
         subject('SavedChart', { ...space }),
     );
 
+    const userCanManageSpaceAndHasNoDirectAccessToSpace =
+        user.data?.ability?.can(
+            'manage',
+            subject('Project', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid: projectUuid,
+            }),
+        ) &&
+        !space.access.find((a) => a.userUuid === user.data?.userUuid)
+            ?.hasDirectAccess;
+
     return (
         <Page
             title={space?.name}
@@ -342,6 +353,11 @@ const Space: FC = () => {
                         [ColumnVisibility.SPACE]: false,
                     }}
                     enableBottomToolbar={false}
+                    initialAdminContentViewValue={
+                        userCanManageSpaceAndHasNoDirectAccessToSpace
+                            ? 'all'
+                            : 'shared'
+                    }
                 />
 
                 {addToSpace && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14699

### Description:

In the Space page, we now automatically set the initial view to 'all' for project admins who don't have direct access to the space, making it easier for them to see all content they can manage.

[CleanShot 2025-05-07 at 18.26.28.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/SRLEqMEevAzoFwvhnfeq/e0fa5807-d6bb-4202-8406-91aa22018315.mp4" />](https://app.graphite.dev/media/video/SRLEqMEevAzoFwvhnfeq/e0fa5807-d6bb-4202-8406-91aa22018315.mp4)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging