### PR TITLE
fix: charts stuck in loading when going back to previous useQuery state

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -324,13 +324,6 @@ export const useInfiniteQueryResults = (
                 }
                 case QueryHistoryStatus.READY: {
                     backoffRef.current = 250;
-                    setFetchedPages((prevState) => [
-                        ...prevState,
-                        {
-                            ...results,
-                            clientFetchTimeMs,
-                        },
-                    ]);
                     return {
                         ...results,
                         clientFetchTimeMs,
@@ -350,6 +343,13 @@ export const useInfiniteQueryResults = (
             setErrorResponse(nextPage.error);
         }
     }, [nextPage.error, setErrorResponse]);
+
+    useEffect(() => {
+        const pageData = nextPage.data;
+        if (pageData?.status === QueryHistoryStatus.READY) {
+            setFetchedPages((prevState) => [...prevState, pageData]);
+        }
+    }, [nextPage.data]);
 
     useEffect(() => {
         // Reset fetched pages before updating the fetch args


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Fixes chart stuck in loading when going back to previous query uuid

**Before**

https://github.com/user-attachments/assets/958d1cfd-151a-46c7-9ce4-1794a12a163a

**After**

https://github.com/user-attachments/assets/ca132a0c-4783-4208-af25-b36c09bc6f31

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
