### PR TITLE
fix: save table calcs with no currency by default

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -86,7 +86,7 @@ const TableCalculationModal: FC<Props> = ({
                 separator:
                     tableCalculation?.format?.separator ||
                     NumberSeparator.DEFAULT,
-                currency: tableCalculation?.format?.currency || 'USD',
+                currency: tableCalculation?.format?.currency,
                 compact: tableCalculation?.format?.compact,
                 prefix: tableCalculation?.format?.prefix,
                 suffix: tableCalculation?.format?.suffix,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14174 

### Description:

The issue in this ticket was that downloading a chart with a table calculation with no format included `currency: USD`. It turns out we were always saving table calculations with currency USD if nothing else was specified. 

This makes is so currency is undefined if unspecified. 

To test:
- Create a chart with a table calc an no format
- Save it
- CLI download the chart
- There should be no USD

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
