### PR TITLE
feat: add minio for local development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -86,3 +86,23 @@ HEADLESS_BROWSER_PORT=3000
 
 #POSTHOG_FE_API_HOST=
 #POSTHOG_BE_API_HOST=
+
+# MinIO
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+MINIO_DEFAULT_BUCKETS=default,results
+
+# S3 Configuration
+S3_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_BUCKET=default
+S3_SECRET_KEY=minioadmin
+S3_ACCESS_KEY=minioadmin
+S3_FORCE_PATH_STYLE=true # needed when using MinIO since it only supports path style
+# S3_EXPIRATION_TIME=
+
+# Results Storage Config
+# RESULTS_CACHE_S3_REGION=
+# RESULTS_CACHE_S3_BUCKET=
+# RESULTS_CACHE_S3_SECRET_KEY=
+# RESULTS_CACHE_S3_ACCESS_KEY=

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,12 +3,23 @@ volumes:
     node_modules:
 
 services:
+    minio:
+        image: bitnami/minio:latest
+        ports:
+            - '9000:9000'
+            - '9001:9001' # for minio console
+        environment:
+            - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+            - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+            - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS}
+
     lightdash-dev:
         build:
             context: ..
             dockerfile: dockerfile
             target: dev
         depends_on:
+            - minio
             - db-dev
         environment:
             - PGHOST=${PGHOST}
@@ -59,6 +70,12 @@ services:
             - GOOGLE_DRIVE_API_KEY=${GOOGLE_DRIVE_API_KEY}
             - AUTH_GOOGLE_OAUTH2_CLIENT_ID=${AUTH_GOOGLE_OAUTH2_CLIENT_ID}
             - AUTH_GOOGLE_OAUTH2_CLIENT_SECRET=${AUTH_GOOGLE_OAUTH2_CLIENT_SECRET}
+            - S3_ENDPOINT=${S3_ENDPOINT}
+            - S3_REGION=${S3_REGION}
+            - S3_BUCKET=${S3_BUCKET}
+            - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+            - S3_SECRET_KEY=${S3_SECRET_KEY}
+            - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE}
         volumes:
             - '../:/usr/app'
             - '../examples/full-jaffle-shop-demo/dbt:/usr/app/dbt'

--- a/packages/backend/src/clients/Aws/S3CacheClient.ts
+++ b/packages/backend/src/clients/Aws/S3CacheClient.ts
@@ -6,6 +6,7 @@ import {
     PutObjectCommandInput,
     S3,
     S3ServiceException,
+    type S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import {
     getErrorMessage,
@@ -28,14 +29,16 @@ export class S3CacheClient {
 
     constructor({ lightdashConfig }: S3CacheClientArguments) {
         const endpoint = lightdashConfig.s3?.endpoint;
+        const forcePathStyle = lightdashConfig.s3?.forcePathStyle;
         this.configuration = lightdashConfig.resultsCache.s3;
         const { region, accessKey, secretKey } = this.configuration;
 
         if (endpoint && region) {
-            const s3Config = {
+            const s3Config: S3ClientConfig = {
                 endpoint,
                 region,
                 apiVersion: '2006-03-01',
+                forcePathStyle,
             };
 
             if (accessKey && secretKey) {

--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -3,6 +3,7 @@ import {
     PutObjectCommandInput,
     S3,
     S3ServiceException,
+    type S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
@@ -30,10 +31,11 @@ export class S3Client {
         this.lightdashConfig = lightdashConfig;
 
         if (lightdashConfig.s3?.endpoint && lightdashConfig.s3.region) {
-            const s3Config = {
+            const s3Config: S3ClientConfig = {
                 region: lightdashConfig.s3.region,
                 apiVersion: '2006-03-01',
                 endpoint: lightdashConfig.s3.endpoint,
+                forcePathStyle: lightdashConfig.s3.forcePathStyle,
             };
 
             if (lightdashConfig.s3?.accessKey && lightdashConfig.s3.secretKey) {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -401,6 +401,7 @@ export type S3Config = {
     endpoint?: string;
     bucket?: string;
     expirationTime?: number;
+    forcePathStyle?: boolean;
 };
 export type IntercomConfig = {
     appId: string;
@@ -852,6 +853,7 @@ export const parseConfig = (): LightdashConfig => {
             secretKey: process.env.S3_SECRET_KEY,
             bucket: process.env.S3_BUCKET,
             endpoint: process.env.S3_ENDPOINT,
+            forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
             expirationTime: parseInt(
                 process.env.S3_EXPIRATION_TIME || '259200', // 3 days in seconds
                 10,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14739 

### Description:

- Adds MinIO to local dev setup
- Adds `S3_FORCE_PATH_STYLE` setting which is needed by MinIO
- Uses `bitnami/minio` so we can create default buckets: `default` and `results` (official minio doesn't let us do this)
- Minio admin page: `localhost:9001`

SQL Runner results being saved with current config
![image](https://github.com/user-attachments/assets/9dc0d178-bc6c-4661-b943-90101a7609eb)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
