### PR TITLE
fix: update copy on dashboard tab delete

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -94,9 +94,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
                                                 color="red"
                                                 icon={<IconTrash size={14} />}
                                             >
-                                                {sortedTabs.length === 1
-                                                    ? 'Remove Tabs Component'
-                                                    : 'Remove Tab'}
+                                                Remove Tab
                                             </Menu.Item>
                                         ) : (
                                             <Menu.Item


### PR DESCRIPTION
Uses consistent copy for tab deleting


https://github.com/user-attachments/assets/e2257dd7-ec07-491d-87a7-6dbe24fe1bc8

