### PR TITLE
feat: delete last dashboard tab if only one tab left

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -186,6 +186,24 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             return; // keep all tiles if its the last tab
         }
 
+        // If we're about to have only one tab left after deletion, remove that last tab too
+        if (dashboardTabs.length === 2) {
+            // Find the remaining tab
+            const remainingTab = dashboardTabs.find(
+                (tab) => tab.uuid !== tabUuid,
+            );
+            if (remainingTab) {
+                // Set all tile tab references to undefined
+                dashboardTiles?.forEach((tile) => {
+                    tile.tabUuid = undefined;
+                });
+                // Remove the last tab from the tabs list
+                setDashboardTabs([]);
+                setActiveTab(undefined);
+                return;
+            }
+        }
+
         const tilesToDelete = dashboardTiles?.filter(
             (tile) => tile.tabUuid === tabUuid,
         );


### PR DESCRIPTION
Never shows a single tab dashboard, removes the tabbed view when deleting the second to last tab.


https://github.com/user-attachments/assets/fcadaac8-653f-42c6-bc99-3eba99257f02

