### PR TITLE
fix: SQL Runner always sends limit 500

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -260,19 +260,15 @@ export const ContentPanel: FC = () => {
         }
     }, [queryResults, panelSizes]);
 
-    useEffect(() => {
-        if (!limit) {
-            dispatch(
-                setSqlLimit(
-                    health.data?.query.defaultLimit ?? DEFAULT_SQL_LIMIT,
-                ),
-            );
-        }
-    }, [health.data?.query.defaultLimit, dispatch, limit]);
-
     const defaultQueryLimit = useMemo(() => {
         return health.data?.query.defaultLimit ?? DEFAULT_SQL_LIMIT;
     }, [health]);
+
+    useEffect(() => {
+        if (!limit) {
+            dispatch(setSqlLimit(defaultQueryLimit));
+        }
+    }, [defaultQueryLimit, dispatch, limit]);
 
     const [activeEchartsInstance, setActiveEchartsInstance] =
         useState<EChartsInstance>();

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadFromUrl.tsx
@@ -16,14 +16,16 @@ type Props = {
     fileUrl: string | undefined;
     columnNames: string[];
     chartName?: string;
+    defaultQueryLimit?: number;
 };
 
 export const ResultsDownloadFromUrl: FC<Props> = ({
     fileUrl,
     columnNames,
     chartName,
+    defaultQueryLimit,
 }) => {
-    const [customLimit, setCustomLimit] = useState(DEFAULT_SQL_LIMIT);
+    const [customLimit, setCustomLimit] = useState(defaultQueryLimit);
     const { handleDownload, isLoading } = useDownloadResults({
         fileUrl,
         columnNames,
@@ -55,7 +57,7 @@ export const ResultsDownloadFromUrl: FC<Props> = ({
                         min={1}
                         autoFocus
                         required
-                        defaultValue={DEFAULT_SQL_LIMIT}
+                        defaultValue={customLimit}
                         onChange={(value: number) => setCustomLimit(value)}
                     />
                     <Button

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -28,6 +28,7 @@ import { TitleBreadCrumbs } from '../../../../components/Explorer/SavedChartsHea
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
 import { ResourceInfoPopup } from '../../../../components/common/ResourceInfoPopup/ResourceInfoPopup';
+import { DEFAULT_SQL_LIMIT } from '../../constants';
 import { useUpdateSqlChartMutation } from '../../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
@@ -88,11 +89,11 @@ export const HeaderEdit: FC = () => {
                 versionedData: {
                     config,
                     sql,
-                    limit,
+                    limit: limit ?? DEFAULT_SQL_LIMIT,
                 },
             });
             setInitialChartConfig(config);
-            setInitialSavedSqlChart({ sql, limit });
+            setInitialSavedSqlChart({ sql, limit: limit ?? DEFAULT_SQL_LIMIT });
         }
     }, [config, sql, mutate, limit]);
 

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -21,6 +21,7 @@ import { saveToSpaceSchema } from '../../../components/common/modal/ChartCreateM
 import { useModalSteps } from '../../../hooks/useModalSteps';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import { DEFAULT_SQL_LIMIT } from '../constants';
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { EditorTabs, updateName } from '../store/sqlRunnerSlice';
@@ -144,7 +145,7 @@ const SaveChartForm: FC<Pick<Props, 'onClose'>> = ({ onClose }) => {
                     name: form.values.name,
                     description: form.values.description || '',
                     sql,
-                    limit,
+                    limit: limit ?? DEFAULT_SQL_LIMIT,
                     config: currentVizConfig,
                     spaceUuid: spaceUuid,
                 });

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -90,7 +90,7 @@ export interface SqlRunnerState {
     sql: string;
     successfulSqlQueries: WithHistory<string | undefined>;
     hasUnrunChanges: boolean;
-    limit: number;
+    limit: number | undefined;
     activeSidebarTab: SidebarTabs;
     activeEditorTab: EditorTabs;
     selectedChartType: ChartKind | undefined;
@@ -143,7 +143,7 @@ export const initialState: SqlRunnerState = {
     sql: '',
     successfulSqlQueries: withHistory(undefined),
     hasUnrunChanges: false,
-    limit: 500,
+    limit: undefined,
     activeSidebarTab: SidebarTabs.TABLES,
     activeEditorTab: EditorTabs.SQL,
     selectedChartType: ChartKind.VERTICAL_BAR,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14407 

### Description:

There are still some limit-related UX questions in the SQL runner, but this is an improvement that specifically solves the stated issue that the SQL runner ALWAYS sends limit=500. 

On the initial SQL page (where limit can't be changed), we now use the `LIGHTDASH_QUERY_DEFAULT_LIMIT` for the query limit and the default results download. 
<img width="635" alt="Screenshot 2025-05-12 at 15 15 15" src="https://github.com/user-attachments/assets/11f4109c-12fd-4c7f-9679-bedcc41b25ec" />

On the chart page, we now respect the user-input limit
<img width="815" alt="Screenshot 2025-05-12 at 15 16 34" src="https://github.com/user-attachments/assets/970e9b8c-ce9b-43ad-9a51-8072df9f2f93" />

What this *doesn't* address:
- Limits entered in the SQL are still overridden if they are higher than the limit

To test:
- Set `LIGHTDASH_QUERY_DEFAULT_LIMIT` to something other than 500
- Check that the initial query page uses that limit
- Set the limit manually on the chart page and check that that limit is used. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
