### PR TITLE
fix: explore rename chart

### DIFF
--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -559,7 +559,7 @@ export class RenameService extends BaseService {
             const explores = await this.projectModel.getAllExploresFromCache(
                 projectUuid,
             );
-            // Do not filter explore errors, since the explore might be failing already, becuase of some renames
+            // Do not filter explore errors, since the explore might be failing already, because of some renames
             const exploreJoins: string[] = Object.values(explores)
                 .filter((e) =>
                     e.joinedTables?.some((j) => j.table === exploreName),

--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -704,6 +704,111 @@ describe('renameSavedChart', () => {
         expect(updatedChart).toEqual(expectedRenamedChartMocked); // toEqual doesn't check extra `undefined` fields
     });
 
+    test('should rename subscriptions saved chart model', () => {
+        const { updatedChart, hasChanges } = renameSavedChart({
+            type: RenameType.MODEL,
+            chart: {
+                ...chartMocked,
+
+                uuid: '8ecff9f3-e197-46f9-86f0-c61aa4328685',
+                projectUuid: 'a5d16d37-1360-45b5-b3f5-681fc814bc04',
+                name: 'Cloud subscription status',
+                description: 'Shows cloud subscriptions for each organization',
+                tableName: 'stripe_subscriptions',
+
+                metricQuery: {
+                    exploreName: 'stripe_subscriptions',
+                    dimensions: [
+                        'stripe_subscriptions_lightdash_organization_id',
+                        'organizations_organization_name',
+                        'stripe_subscriptions_monthly_plan_unit_amount',
+                        'stripe_subscriptions_lightdash_product_name',
+                    ],
+                    metrics: [],
+                    filters: {},
+                    sorts: [
+                        {
+                            fieldId:
+                                'stripe_subscriptions_lightdash_organization_id',
+                            descending: false,
+                        },
+                    ],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    customDimensions: [],
+                },
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            stripe_subscriptions_lightdash_organization_id: {
+                                visible: false,
+                            },
+                        },
+                        metricsAsRows: false,
+                        hideRowNumbers: false,
+                        showTableNames: true,
+                        showResultsTotal: false,
+                        showRowCalculation: false,
+                        showColumnCalculation: false,
+                        conditionalFormattings: [],
+                    },
+                },
+                tableConfig: {
+                    columnOrder: [
+                        'stripe_subscriptions_lightdash_organization_id',
+                        'organizations_organization_name',
+                        'stripe_subscriptions_monthly_plan_unit_amount',
+                        'stripe_subscriptions_lightdash_product_name',
+                    ],
+                },
+                organizationUuid: 'd413dcea-4c8f-46b6-baa5-23885490e08b',
+                spaceUuid: '1ac19157-777b-41b1-8c75-f070c7cfc8e8',
+                spaceName: 'Shared',
+                pinnedListUuid: null,
+                pinnedListOrder: null,
+                dashboardUuid: null,
+                dashboardName: null,
+                colorPalette: ['#FF6464'],
+                slug: 'cloud-subscription-status',
+            },
+            nameChanges: {
+                from: 'stripe_subscriptions',
+                to: 'subscriptions',
+                fromReference: 'stripe_subscriptions',
+                toReference: 'subscriptions',
+                fromFieldName: undefined,
+                toFieldName: undefined,
+            },
+            validate: false,
+        });
+
+        expect(hasChanges).toBe(true);
+        expect(updatedChart.tableName).toBe('subscriptions');
+        expect(updatedChart.metricQuery).toEqual({
+            exploreName: 'subscriptions',
+            dimensions: [
+                'subscriptions_lightdash_organization_id',
+                'organizations_organization_name',
+                'subscriptions_monthly_plan_unit_amount',
+                'subscriptions_lightdash_product_name',
+            ],
+            metrics: [],
+            filters: {},
+            sorts: [
+                {
+                    fieldId: 'subscriptions_lightdash_organization_id',
+                    descending: false,
+                },
+            ],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            customDimensions: [],
+        }); // toEqual doesn't check extra `undefined` fields
+    });
+
     test('should rename mocked saved chart model', () => {
         const { updatedChart, hasChanges } = renameSavedChart({
             type: RenameType.MODEL,
@@ -989,7 +1094,7 @@ describe('validateRename', () => {
         const original = { id: 'payment_123', name: 'Payment' };
         const updated = { id: 'invoice_123', name: 'Payment' };
 
-        validateRename(original, updated, 'Test Object', nameChanges);
+        validateRename(original, updated, 'Test Object', 'chart', nameChanges);
 
         expect(console.warn).not.toHaveBeenCalled();
     });
@@ -1000,7 +1105,7 @@ describe('validateRename', () => {
         // We want to log a warning about it
         const updated = { id: 'invoice_123', newProperty: 'payment_123' };
 
-        validateRename(original, updated, 'Test Object', nameChanges);
+        validateRename(original, updated, 'Test Object', 'chart', nameChanges);
 
         expect(console.warn).toHaveBeenCalled();
     });

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -128,6 +128,7 @@ export const validateRename = (
     originalObject: Object,
     updatedObject: Object,
     objectName: string,
+    objectType: 'chart' | 'dashboard' | 'alert' | 'dashboard scheduler',
     { from, fromReference, to, toReference }: NameChanges,
 ) => {
     try {
@@ -176,7 +177,7 @@ export const validateRename = (
 
             // At this point, we've tried multiple approaches and the objects are still different
             console.warn(
-                `Validation check failed: Renaming chart "${objectName}" from model "${from}" to "${to}" was not successful.`,
+                `Validation check failed: Renaming "${objectType}" "${objectName}" from model "${from}" to "${to}" was not successful.`,
             );
 
             // Since the objects appear identical in the output but are still different,
@@ -230,16 +231,10 @@ export const validateRename = (
             console.warn(
                 `Full expected: ${JSON.stringify(
                     JSON.parse(normalizedExpected),
-                    null,
-                    2,
-                )}`,
+                )}`, // Do not add new lines, this will make it harder to read on GCP
             );
             console.warn(
-                `Full actual: ${JSON.stringify(
-                    JSON.parse(normalizedActual),
-                    null,
-                    2,
-                )}`,
+                `Full actual: ${JSON.stringify(JSON.parse(normalizedActual))}`,
             );
         }
     } catch (e) {
@@ -686,7 +681,8 @@ export const renameSavedChart = ({
         };
     }
 
-    if (validate) validateRename(chart, updatedChart, chart.name, nameChanges);
+    if (validate)
+        validateRename(chart, updatedChart, chart.name, 'chart', nameChanges);
 
     return { updatedChart, hasChanges };
 };
@@ -695,6 +691,7 @@ export const renameDashboard = (
     type: RenameType,
     dashboard: DashboardDAO,
     nameChanges: NameChanges,
+    validate: boolean = false,
 ): { updatedDashboard: DashboardDAO; hasChanges: boolean } => {
     const isPrefix = type === RenameType.MODEL;
 
@@ -725,12 +722,14 @@ export const renameDashboard = (
         );
     }
 
-    validateRename(
-        dashboard,
-        updatedDashboard,
-        updatedDashboard.name,
-        nameChanges,
-    );
+    if (validate)
+        validateRename(
+            dashboard,
+            updatedDashboard,
+            updatedDashboard.name,
+            'dashboard',
+            nameChanges,
+        );
 
     return { updatedDashboard, hasChanges };
 };
@@ -739,6 +738,7 @@ export const renameAlert = (
     type: RenameType,
     alert: SchedulerAndTargets,
     nameChanges: NameChanges,
+    validate: boolean = false,
 ): { updatedAlert: SchedulerAndTargets; hasChanges: boolean } => {
     const isPrefix = type === RenameType.MODEL;
 
@@ -765,7 +765,8 @@ export const renameAlert = (
         }));
     }
 
-    validateRename(alert, updatedAlert, `Alert: ${alert.name}`, nameChanges);
+    if (validate)
+        validateRename(alert, updatedAlert, alert.name, 'alert', nameChanges);
 
     return { updatedAlert, hasChanges };
 };
@@ -774,6 +775,7 @@ export const renameDashboardScheduler = (
     type: RenameType,
     dashboardScheduler: SchedulerAndTargets,
     nameChanges: NameChanges,
+    validate: boolean = false,
 ): { updatedDashboardScheduler: SchedulerAndTargets; hasChanges: boolean } => {
     const isPrefix = type === RenameType.MODEL;
 
@@ -833,12 +835,14 @@ export const renameDashboardScheduler = (
         );
     }
 
-    validateRename(
-        dashboardScheduler,
-        updatedDashboardScheduler,
-        `Alert: ${dashboardScheduler.name}`,
-        nameChanges,
-    );
+    if (validate)
+        validateRename(
+            dashboardScheduler,
+            updatedDashboardScheduler,
+            dashboardScheduler.name,
+            'dashboard scheduler',
+            nameChanges,
+        );
 
     return { updatedDashboardScheduler, hasChanges };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

Small bugfixes for CLI and better validation logs after testing on analytics . UI renaming works as expected

Improves the explore rename functionality by:

1. Fixing how charts are filtered when renaming an explore:
   - Now properly handles explore errors during filtering
   - Correctly identifies charts that use the explore in joins
   - Adds better logging for explore and join filtering

2. Enhances validation for renamed resources:
   - Adds resource type ('chart', 'dashboard', 'alert', 'dashboard scheduler') to validation messages
   - Makes validation optional for dashboard, alert, and dashboard scheduler renames
   - Improves error logging by removing unnecessary formatting that made logs harder to read in GCP

3. Adds a test case for renaming subscriptions in saved chart models

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging