### PR TITLE
fix: developers should be able to promote dashboards

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -197,6 +197,7 @@ const DashboardHeader = ({
         subject('Dashboard', {
             organizationUuid,
             projectUuid,
+            access: dashboard.access,
         }),
     );
 


### PR DESCRIPTION
### Description:

The problem:
'Developer' users weren't able to promote dashboards, the button wasn't available. 
<img width="891" alt="Screenshot 2025-05-13 at 16 29 42" src="https://github.com/user-attachments/assets/67ea50de-4ebb-40e1-9566-ca021460dad3" />

Solution:
We weren't passing all of the right params to the menu-item access check. In the frontend, we weren't passing the access param. This updates the FE to pass the access param. This was already correct in the BE. 

To test:
- Make a developer user
- As an admin, create a dashboard in the shared space (or anywhere accessible to the developer)
- The developer should have the option to promote the dashboard (disabled if there is no upstream)
- Change the developers permissions to viewer
- Now they should not see the option to promote

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
