### PR TITLE
fix: Context menu is active during item selection

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -692,7 +692,17 @@ const InfiniteResourceTable = ({
         ),
         enableRowActions: true,
         renderRowActions: ({ row, table: tableInstance }) => {
-            const isSelected = tableInstance.getIsSomeRowsSelected();
+            /**
+             * NOTE: TanStack selection API has some nuanced behavior:
+             * - getIsSomeRowsSelected() - Not used here. It should return true if any row is selected,
+             *   though it also returns false if all rows are selected.
+             * - getIsSomePageRowsSelected() - Returns true when some rows on the current page are selected,
+             *   but according to our testing, returns false if ALL rows are selected.
+             * To work around this issue, we use it in combination with `getIsAllPageRowsSelected()`.
+             */
+            const isSelected =
+                tableInstance.getIsSomePageRowsSelected() ||
+                tableInstance.getIsAllPageRowsSelected();
 
             return (
                 <Box


### PR DESCRIPTION
Closes: #14782

### Description:
This PR fixes a bug where the context menu remains active when selecting all rows from a table. This implementation is a temporary workaround (see code comments for details). I'll report this issue to the table library later.

### Reviewer actions
- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging