### PR TITLE
chore: delete code path for not executing the query in warehouse client

### DIFF
--- a/packages/backend/src/queryBuilder.mock.ts
+++ b/packages/backend/src/queryBuilder.mock.ts
@@ -44,8 +44,8 @@ export const warehouseClientMock: WarehouseClient = {
     executeAsyncQuery: async () => ({
         queryId: null,
         queryMetadata: null,
-        totalRows: null,
-        durationMs: null,
+        totalRows: 0,
+        durationMs: 0,
     }),
     getAsyncQueryResults: async () => ({
         fields: {},
@@ -121,8 +121,8 @@ export const bigqueryClientMock: WarehouseClient = {
     executeAsyncQuery: async () => ({
         queryId: null,
         queryMetadata: null,
-        totalRows: null,
-        durationMs: null,
+        totalRows: 0,
+        durationMs: 0,
     }),
     getAsyncQueryResults: async () => ({
         fields: {},

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -578,30 +578,14 @@ export class AsyncQueryService extends ProjectService {
         /**
          * Update the query history with non null values
          * defaultPageSize is null when user never fetched the results - we don't send pagination params to the query execution endpoint
-         * warehouseExecutionTimeMs is null when warehouse doesn't support async queries - query is only executed when user fetches results
-         * totalRowCount is null when warehouse doesn't support async queries - query is only executed when user fetches results
          */
-        if (
-            queryHistory.defaultPageSize === null ||
-            queryHistory.warehouseExecutionTimeMs === null ||
-            queryHistory.totalRowCount === null
-        ) {
+        if (queryHistory.defaultPageSize === null) {
             await this.queryHistoryModel.update(
                 queryHistory.queryUuid,
                 projectUuid,
                 user.userUuid,
                 {
-                    ...(queryHistory.defaultPageSize === null
-                        ? { default_page_size: defaultedPageSize }
-                        : {}),
-                    ...(queryHistory.warehouseExecutionTimeMs === null
-                        ? {
-                              warehouse_execution_time_ms: roundedDurationMs,
-                          }
-                        : {}),
-                    ...(queryHistory.totalRowCount === null
-                        ? { total_row_count: returnObject.totalResults }
-                        : {}),
+                    default_page_size: defaultedPageSize,
                 },
             );
         }
@@ -682,8 +666,7 @@ export class AsyncQueryService extends ProjectService {
                     warehouse_query_metadata: queryMetadata,
                     status: QueryHistoryStatus.READY,
                     error: null,
-                    warehouse_execution_time_ms:
-                        durationMs !== null ? Math.round(durationMs) : null,
+                    warehouse_execution_time_ms: Math.round(durationMs),
                     total_row_count: totalRows,
                 },
             );

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -41,8 +41,8 @@ export const warehouseClientMock: WarehouseClient = {
     executeAsyncQuery: async () => ({
         queryId: null,
         queryMetadata: null,
-        totalRows: null,
-        durationMs: null,
+        totalRows: 0,
+        durationMs: 0,
     }),
     getAsyncQueryResults: async () => ({
         rows: [],

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -63,8 +63,8 @@ export type WarehouseExecuteAsyncQueryArgs = {
 export type WarehouseExecuteAsyncQuery = {
     queryId: string | null;
     queryMetadata: WarehouseQueryMetadata | null;
-    totalRows: number | null;
-    durationMs: number | null;
+    totalRows: number;
+    durationMs: number;
 };
 
 export type WarehouseGetAsyncQueryResultsArgs = WarehousePaginationArgs &

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -94,8 +94,8 @@ export const createTemporaryVirtualView = (
         executeAsyncQuery: async () => ({
             queryId: null,
             queryMetadata: null,
-            totalRows: null,
-            durationMs: null,
+            totalRows: 0,
+            durationMs: 0,
         }),
         getAsyncQueryResults: async () => ({
             fields: {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/14758

### Description:

- After enforcing saving results on all warehouses so that all support async queries, we no longer need the codepath that didn't fetch results on `warehouseClient.executeAsyncQuery`
- Enforce `resultsStreamCallback` since now that will always exist when running an async query
- Always return duration ms and row count

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
