### PR TITLE
fix: handle empty rows in CSV export

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -49,6 +49,7 @@ import { stringify } from 'csv-stringify';
 import * as fs from 'fs';
 import * as fsPromise from 'fs/promises';
 
+import isNil from 'lodash/isNil';
 import moment, { MomentInput } from 'moment';
 import { nanoid } from 'nanoid';
 import { pipeline, Readable, Transform, TransformCallback } from 'stream';
@@ -283,9 +284,13 @@ export class CsvService extends BaseService {
         const fileId = CsvService.generateFileId(fileName, truncated);
         const writeStream = fs.createWriteStream(`/tmp/${fileId}`);
 
-        const sortedFieldIds = Object.keys(rows[0])
-            .filter((id) => selectedFieldIds.includes(id))
-            .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
+        const sortedFieldIds = isNil(rows[0])
+            ? []
+            : Object.keys(rows[0])
+                  .filter((id) => selectedFieldIds.includes(id))
+                  .sort(
+                      (a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b),
+                  );
 
         const csvHeader = sortedFieldIds.map((id) => {
             if (customLabels[id]) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Fix CSV export when rows array contains null values by adding a null check before accessing the first row. This prevents the application from crashing when trying to export empty data sets.

The change adds a check using Lodash's `isNil` function to safely handle cases where the first row might be null or undefined, returning an empty array for field IDs in such cases.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging