### PR TITLE
fix: column not exists for sql chart queries

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -46,7 +46,6 @@ import {
     NotFoundError,
     type Organization,
     PivotIndexColum,
-    prefixPivotConfigurationReferences,
     type Project,
     QueryExecutionContext,
     QueryHistoryStatus,
@@ -1636,6 +1635,8 @@ export class AsyncQueryService extends ProjectService {
             },
         );
 
+        // ! VizColumns, virtualView, dimensions and query are not needed for SQL queries since we pass just sql the to `executeAsyncQuery`
+        // ! We keep them here for backwards compatibility until we remove them as a required argument
         const vizColumns = columns.map((col) => ({
             reference: col.name,
             type: col.type,
@@ -1651,13 +1652,6 @@ export class AsyncQueryService extends ProjectService {
         const dimensions = Object.values(
             virtualView.tables[virtualView.baseTable].dimensions,
         ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
-
-        const prefixedPivotConfiguration = pivotConfiguration
-            ? prefixPivotConfigurationReferences(
-                  pivotConfiguration,
-                  `${virtualView.name}`,
-              )
-            : undefined;
 
         const query: MetricQuery = {
             exploreName: virtualView.name,
@@ -1687,7 +1681,7 @@ export class AsyncQueryService extends ProjectService {
                 invalidateCache,
             },
             warehouseConnection,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
         );
 
         return {
@@ -1738,6 +1732,8 @@ export class AsyncQueryService extends ProjectService {
             },
         );
 
+        // ! VizColumns, virtualView, dimensions and query are not needed for SQL queries since we pass just sql the to `executeAsyncQuery`
+        // ! We keep them here for backwards compatibility until we remove them as a required argument
         const vizColumns = columns.map((col) => ({
             reference: col.name,
             type: col.type,
@@ -1754,17 +1750,14 @@ export class AsyncQueryService extends ProjectService {
             virtualView.tables[virtualView.baseTable].dimensions,
         ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
 
-        const prefixedPivotConfiguration =
+        const pivotConfiguration =
             !isVizTableConfig(sqlChart.config) && sqlChart.config.fieldConfig
-                ? prefixPivotConfigurationReferences(
-                      {
-                          indexColumn: sqlChart.config.fieldConfig.x,
-                          valuesColumns: sqlChart.config.fieldConfig.y,
-                          groupByColumns: sqlChart.config.fieldConfig.groupBy,
-                          sortBy: sqlChart.config.fieldConfig.sortBy,
-                      },
-                      `${virtualView.name}`,
-                  )
+                ? {
+                      indexColumn: sqlChart.config.fieldConfig.x,
+                      valuesColumns: sqlChart.config.fieldConfig.y,
+                      groupByColumns: sqlChart.config.fieldConfig.groupBy,
+                      sortBy: sqlChart.config.fieldConfig.sortBy,
+                  }
                 : undefined;
 
         const query: MetricQuery = {
@@ -1780,7 +1773,7 @@ export class AsyncQueryService extends ProjectService {
         };
         return {
             query,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
             virtualView,
             queryTags,
             warehouseConnection,
@@ -1817,7 +1810,7 @@ export class AsyncQueryService extends ProjectService {
             queryTags,
             query,
             virtualView,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
         } = await this.prepareSqlChartAsyncQueryArgs({
             user,
             context,
@@ -1840,7 +1833,7 @@ export class AsyncQueryService extends ProjectService {
                 invalidateCache,
             },
             warehouseConnection,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
         );
 
         return {
@@ -1886,7 +1879,7 @@ export class AsyncQueryService extends ProjectService {
             queryTags,
             query,
             virtualView,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
         } = await this.prepareSqlChartAsyncQueryArgs({
             user,
             context,
@@ -1938,7 +1931,7 @@ export class AsyncQueryService extends ProjectService {
                 invalidateCache,
             },
             warehouseConnection,
-            prefixedPivotConfiguration,
+            pivotConfiguration,
         );
 
         return {

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -17,7 +17,6 @@ import {
     type VizTableConfig,
 } from '../visualizations/types';
 import { type Dashboard } from './dashboard';
-import { convertFieldRefToFieldId } from './field';
 import { type Organization } from './organization';
 import { type Project } from './projects';
 import { type RawResultRow } from './results';
@@ -225,41 +224,5 @@ export type ApiGithubDbtWritePreview = {
         path: string;
         files: string[];
         owner: string;
-    };
-};
-
-export const prefixPivotConfigurationReferences = (
-    config: {
-        indexColumn: PivotIndexColum;
-        valuesColumns: ValuesColumn[];
-        groupByColumns: GroupByColumn[] | undefined;
-        sortBy: SortBy | undefined;
-    },
-    prefix: string,
-) => {
-    if (!config || !config.indexColumn) {
-        return undefined;
-    }
-    return {
-        ...config,
-        indexColumn: {
-            ...config.indexColumn,
-            reference: convertFieldRefToFieldId(
-                config.indexColumn.reference,
-                prefix,
-            ),
-        },
-        valuesColumns: config.valuesColumns.map((col) => ({
-            ...col,
-            reference: convertFieldRefToFieldId(col.reference, prefix),
-        })),
-        groupByColumns: config.groupByColumns?.map((col) => ({
-            ...col,
-            reference: convertFieldRefToFieldId(col.reference, prefix),
-        })),
-        sortBy: config.sortBy?.map((sort) => ({
-            ...sort,
-            reference: convertFieldRefToFieldId(sort.reference, prefix),
-        })),
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/14788

### Description:

- We're using the `sql` directly in `runAsyncQuery` now which means that for sql runner charts and queries we don't need to prefix the pivot configuration anymore

**Before**
![image](https://github.com/user-attachments/assets/d9c8b594-3230-432c-a62d-09797ec71dda)

**After**
![image](https://github.com/user-attachments/assets/b1342722-5284-45f0-a082-81feea386800)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
