### PR TITLE
feat(cli): flag to preserve original casing of column names in generated schema files

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -27,10 +27,12 @@ type CompiledModel = {
 type GetDatabaseTableForModelArgs = {
     model: CompiledModel;
     warehouseClient: WarehouseClient;
+    preserveColumnCase: boolean;
 };
 export const getWarehouseTableForModel = async ({
     model,
     warehouseClient,
+    preserveColumnCase,
 }: GetDatabaseTableForModelArgs): Promise<WarehouseTableSchema> => {
     const tableRef = {
         database: model.database,
@@ -54,7 +56,8 @@ export const getWarehouseTableForModel = async ({
     }
     return Object.entries(table).reduce<WarehouseTableSchema>(
         (accumulator, [key, value]) => {
-            accumulator[key.toLowerCase()] = value;
+            const columnName = preserveColumnCase ? key : key.toLowerCase();
+            accumulator[columnName] = value;
             return accumulator;
         },
         {},

--- a/packages/cli/src/handlers/dbt/run.ts
+++ b/packages/cli/src/handlers/dbt/run.ts
@@ -13,6 +13,7 @@ type DbtRunHandlerOptions = DbtCompileOptions & {
     verbose: boolean;
     assumeYes: boolean;
     assumeNo: boolean;
+    preserveColumnCase: boolean;
 };
 
 export const dbtRunHandler = async (
@@ -71,6 +72,7 @@ export const dbtRunHandler = async (
         await generateHandler({
             ...options,
             excludeMeta: options.excludeMeta,
+            preserveColumnCase: options.preserveColumnCase,
         });
     }
 };

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -29,6 +29,7 @@ type GenerateHandlerOptions = CompileHandlerOptions & {
     assumeYes: boolean;
     excludeMeta: boolean;
     skipExisting?: boolean;
+    preserveColumnCase: boolean;
 };
 
 export const generateHandler = async (options: GenerateHandlerOptions) => {
@@ -102,6 +103,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
             const table = await getWarehouseTableForModel({
                 model: compiledModel,
                 warehouseClient,
+                preserveColumnCase: options.preserveColumnCase,
             });
             const { updatedYml, outputFilePath } = await findAndUpdateModelYaml(
                 {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -275,6 +275,11 @@ ${styles.bold('Examples:')}
     .option('--verbose', undefined, false)
     .option('-y, --assume-yes', 'assume yes to prompts', false)
     .option('-no, --assume-no', 'assume no to prompts', false)
+    .option(
+        '--preserve-column-case',
+        'preserve original casing of column names in generated schema files',
+        false,
+    )
     .action(dbtRunHandler);
 
 program
@@ -763,6 +768,11 @@ ${styles.bold('Examples:')}
     .option(
         '--exclude-meta',
         'exclude Lightdash metadata from the generated .yml',
+        false,
+    )
+    .option(
+        '--preserve-column-case',
+        'preserve original casing of column names in generated schema files',
         false,
     )
     .option('--verbose', undefined, false)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14798

### Description:
Added a new `--preserve-column-case` flag to the `dbt run` and `generate` commands that allows users to maintain the original casing of column names in generated schema files. By default, column names are converted to lowercase, but with this flag enabled, the original case will be preserved.
