### PR TITLE
fix: Cannot bulk move Spaces into top level Space

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -778,7 +778,7 @@ const InfiniteResourceTable = ({
     } = useContentBulkAction(filters.projectUuid);
 
     const handleBulkMoveContent = useCallback(
-        async (selectedItems: ResourceViewItem[], spaceUuid: string) => {
+        async (selectedItems: ResourceViewItem[], spaceUuid: string | null) => {
             await contentBulkAction({
                 action: {
                     type: 'move',
@@ -837,12 +837,6 @@ const InfiniteResourceTable = ({
                     spaces={spaces}
                     isLoading={isFetching || isContentBulkActionLoading}
                     onConfirm={async (spaceUuid) => {
-                        if (!spaceUuid) {
-                            throw new Error(
-                                'Space UUID is required to move items',
-                            );
-                        }
-
                         await handleBulkMoveContent(selectedItems, spaceUuid);
                     }}
                 />

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -23,7 +23,7 @@ type SpaceSelectorProps = {
     isLoading?: boolean;
     itemType: ResourceViewItemType | undefined;
     onSelectSpace: (spaceUuid: string | null) => void;
-    isRootSelectionEnabled: boolean;
+    isRootSelectionEnabled?: boolean;
 };
 
 const SpaceSelector = ({

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     assertUnreachable,
-    ResourceViewItemType,
+    type ResourceViewItemType,
     type SpaceSummary,
 } from '@lightdash/common';
 import { Paper, ScrollArea, Stack, TextInput } from '@mantine/core';
@@ -23,6 +23,7 @@ type SpaceSelectorProps = {
     isLoading?: boolean;
     itemType: ResourceViewItemType | undefined;
     onSelectSpace: (spaceUuid: string | null) => void;
+    isRootSelectionEnabled: boolean;
 };
 
 const SpaceSelector = ({
@@ -30,9 +31,9 @@ const SpaceSelector = ({
     selectedSpaceUuid,
     spaces = [],
     isLoading: _isLoading, // TODO: implement loading state for the tree.
-    itemType,
     onSelectSpace,
     children,
+    isRootSelectionEnabled,
 }: React.PropsWithChildren<SpaceSelectorProps>) => {
     const { user } = useApp();
 
@@ -102,8 +103,7 @@ const SpaceSelector = ({
                 withBorder
             >
                 <Tree
-                    // top level item can only be selected for a single space
-                    withRootSelectable={itemType === ResourceViewItemType.SPACE}
+                    withRootSelectable={isRootSelectionEnabled}
                     data={fuzzyFilteredSpaces ?? filteredSpaces}
                     value={selectedSpaceUuid}
                     onChange={onSelectSpace}

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -81,6 +81,11 @@ const TransferItemsModal = <
         return items[0].type;
     }, [isMovingSingleItem, items]);
 
+    const allSelectedItemsAreSpaces = useMemo(
+        () => items.every((i) => i.type === ResourceViewItemType.SPACE),
+        [items],
+    );
+
     const {
         selectedSpaceUuid,
         setSelectedSpaceUuid,
@@ -162,8 +167,7 @@ const TransferItemsModal = <
                             <Button
                                 disabled={
                                     !selectedSpaceUuid &&
-                                    singleItemType !==
-                                        ResourceViewItemType.SPACE
+                                    !allSelectedItemsAreSpaces
                                 }
                                 onClick={handleConfirm}
                             >
@@ -199,6 +203,7 @@ const TransferItemsModal = <
                         selectedSpaceUuid={selectedSpaceUuid}
                         onSelectSpace={setSelectedSpaceUuid}
                         isLoading={createSpaceMutation.isLoading}
+                        isRootSelectionEnabled={allSelectedItemsAreSpaces}
                     >
                         {!isCreatingNewSpace && selectedSpaceLabel ? (
                             <Alert color="gray" sx={{ flexShrink: 0 }}>


### PR DESCRIPTION
Closes: #14781  

### Description:
- Allow bulk move of Spaces into Root Space
  - Move to Root Space is disabled when trying to move other items (dashboards and charts)


### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
