### PR TITLE
fix: Navigation enabled when selecting rows

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -499,6 +499,8 @@ const InfiniteResourceTable = ({
             },
         },
         mantineTableBodyRowProps: ({ row }) => {
+            const isTableSelectionActive =
+                table.getIsSomeRowsSelected() || table.getIsAllRowsSelected();
             const isSelected = row.getIsSelected();
 
             return {
@@ -525,15 +527,13 @@ const InfiniteResourceTable = ({
                 },
 
                 onClick: () => {
-                    if (
-                        table.getIsSomeRowsSelected() ||
-                        table.getIsAllRowsSelected()
-                    ) {
-                        return null;
+                    if (isTableSelectionActive) {
+                        row.toggleSelected();
+                    } else {
+                        void navigate(
+                            getResourceUrl(filters.projectUuid, row.original),
+                        );
                     }
-                    void navigate(
-                        getResourceUrl(filters.projectUuid, row.original),
-                    );
                 },
             };
         },

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -525,6 +525,12 @@ const InfiniteResourceTable = ({
                 },
 
                 onClick: () => {
+                    if (
+                        table.getIsSomeRowsSelected() ||
+                        table.getIsAllRowsSelected()
+                    ) {
+                        return null;
+                    }
                     void navigate(
                         getResourceUrl(filters.projectUuid, row.original),
                     );


### PR DESCRIPTION
Closes: #14784 

### Description:
- `InfiniteResourceTable`: Disable item navigation when selecting rows in table
  - Navigation is still enabled in the item title

### Reviewer actions

- [x] I have manually tested the changes in the preview environment
- [x] I have reviewed the code
- [x] I understand that "request changes" will block this PR from merging
