### PR TITLE
fix: capture either error on use dashboard chart query

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -168,5 +168,5 @@ export const useDashboardChartReadyQuery = (
         refetchOnMount: false,
     });
 
-    return { ...queryResult, error };
+    return { ...queryResult, error: error || queryResult.error };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

The error from the chart query was overwriting the error from the results. I have no repro, but to verify, make sure charts load and charts with errors show errors. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
