### PR TITLE
feat: add initial AI agents page

### DIFF
--- a/packages/frontend/src/components/UserSettings/AiAgentsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AiAgentsPanel/index.tsx
@@ -1,0 +1,51 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { Box, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { type FC } from 'react';
+import { AiAgents } from '../../../ee/features/aiCopilot/components/AiAgents';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { SettingsGridCard } from '../../common/Settings/SettingsCard';
+
+const AiAgentsPanel: FC = () => {
+    const { data: aiCopilotFlag, isLoading } = useFeatureFlag(
+        CommercialFeatureFlags.AiCopilot,
+    );
+
+    if (isLoading) {
+        return <Loader />;
+    }
+
+    const isAiCopilotEnabled = aiCopilotFlag?.enabled;
+
+    if (!isAiCopilotEnabled) {
+        return (
+            <SettingsGridCard>
+                <Stack spacing="sm">
+                    <Box>
+                        <Group spacing="sm">
+                            <Title order={4}>AI Agents</Title>
+                        </Group>
+                    </Box>
+                </Stack>
+
+                <Text>
+                    The AI Agents feature is not enabled for your organization.
+                </Text>
+            </SettingsGridCard>
+        );
+    }
+
+    return (
+        <SettingsGridCard>
+            <Stack spacing="sm">
+                <Title order={4}>AI Agents</Title>
+
+                <Text size="xs" color="dimmed">
+                    Create and manage your AI agents.
+                </Text>
+            </Stack>
+            <AiAgents />
+        </SettingsGridCard>
+    );
+};
+
+export default AiAgentsPanel;

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -30,8 +30,8 @@ import {
 } from '@tabler/icons-react';
 import { debounce } from 'lodash';
 import { useEffect, useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
 import { z } from 'zod';
-import ChannelProjectMappings from '../../../ee/features/aiCopilot/components/ChannelProjectMappings';
 import {
     useDeleteSlack,
     useGetSlack,
@@ -39,7 +39,6 @@ import {
     useUpdateSlackAppCustomSettingsMutation,
 } from '../../../hooks/slack/useSlack';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
-import { useProjects } from '../../../hooks/useProjects';
 import slackSvg from '../../../svgs/slack.svg';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
@@ -124,17 +123,6 @@ const SlackSettingsPanel: FC = () => {
             })) ?? []
         );
     }, [slackChannels]);
-
-    const { data: projects } = useProjects();
-
-    const projectOptions = useMemo(() => {
-        return (
-            projects?.map((project) => ({
-                value: project.projectUuid,
-                label: project.name,
-            })) ?? []
-        );
-    }, [projects]);
 
     let responsiveChannelsSearchEnabled =
         slackChannelOptions.length >= MAX_SLACK_CHANNELS || search.length > 0; // enable responvive channels search if there are more than MAX_SLACK_CHANNELS defined channels
@@ -254,11 +242,20 @@ const SlackSettingsPanel: FC = () => {
                                 />
                             </Group>
                             {aiCopilotFlag?.enabled && (
-                                <ChannelProjectMappings
-                                    form={form}
-                                    channelOptions={slackChannelOptions}
-                                    projectOptions={projectOptions}
-                                />
+                                <Alert
+                                    color="blue"
+                                    fz="xs"
+                                    icon={<MantineIcon icon={IconHelpCircle} />}
+                                >
+                                    Configure Slack channel project mappings{' '}
+                                    <Anchor
+                                        component={Link}
+                                        to="/generalSettings/aiAgents"
+                                    >
+                                        here
+                                    </Anchor>
+                                    .
+                                </Alert>
                             )}
                         </Stack>
                         <Stack align="end" mt="xl">

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgents.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgents.tsx
@@ -1,0 +1,203 @@
+import { type SlackAppCustomSettings } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Group,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconPlus, IconRefresh } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, type FC } from 'react';
+import { z } from 'zod';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import {
+    useGetSlack,
+    useSlackChannels,
+    useUpdateSlackAppCustomSettingsMutation,
+} from '../../../../hooks/slack/useSlack';
+import { useProjects } from '../../../../hooks/useProjects';
+import ChannelProjectMappings from './ChannelProjectMappings';
+
+const formSchema = z.object({
+    notificationChannel: z.string().min(1).nullable(),
+    appProfilePhotoUrl: z.string().url().nullable(),
+    slackChannelProjectMappings: z.array(
+        z.object({
+            projectUuid: z
+                .string({ message: 'You must select a project' })
+                .uuid({ message: 'Invalid project' }),
+            slackChannelId: z
+                .string({
+                    message: 'You must select a Slack channel',
+                })
+                .min(1),
+            availableTags: z.array(z.string().min(1)).nullable(),
+        }),
+    ),
+});
+
+export const AiAgents: FC = () => {
+    const { data: slackInstallation } = useGetSlack();
+    const organizationHasSlack = !!slackInstallation?.organizationUuid;
+
+    const { data: slackChannels } = useSlackChannels('', true, {
+        enabled: organizationHasSlack,
+    });
+
+    const { mutateAsync: updateCustomSettings, isLoading: isSubmitting } =
+        useUpdateSlackAppCustomSettingsMutation();
+
+    const form = useForm<SlackAppCustomSettings>({
+        initialValues: {
+            notificationChannel: null,
+            appProfilePhotoUrl: null,
+            slackChannelProjectMappings: [],
+        },
+        validate: zodResolver(formSchema),
+    });
+
+    useEffect(() => {
+        if (!slackInstallation) return;
+
+        const initialValues = {
+            notificationChannel: slackInstallation.notificationChannel ?? null,
+            appProfilePhotoUrl: slackInstallation.appProfilePhotoUrl ?? null,
+            slackChannelProjectMappings:
+                slackInstallation.slackChannelProjectMappings ?? [],
+        };
+
+        if (form.initialized) {
+            form.setInitialValues(initialValues);
+            form.setValues(initialValues);
+        } else {
+            form.initialize(initialValues);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [slackInstallation]);
+
+    const slackChannelOptions = useMemo(() => {
+        return (
+            slackChannels?.map((channel) => ({
+                value: channel.id,
+                label: channel.name,
+            })) ?? []
+        );
+    }, [slackChannels]);
+
+    const { data: projects } = useProjects();
+
+    const projectOptions = useMemo(() => {
+        return (
+            projects?.map((project) => ({
+                value: project.projectUuid,
+                label: project.name,
+            })) ?? []
+        );
+    }, [projects]);
+
+    const { refresh: refreshChannels, isLoading: isRefreshing } =
+        useSlackChannels('');
+
+    const handleSubmit = form.onSubmit(async (args) => {
+        if (organizationHasSlack) {
+            await updateCustomSettings(args);
+        }
+    });
+    const handleAdd = useCallback(
+        () =>
+            form.insertListItem('slackChannelProjectMappings', {
+                projectUuid: null,
+                slackChannelId: null,
+                availableTags: null,
+            }),
+        [form],
+    );
+
+    if (!organizationHasSlack) {
+        return (
+            <Stack spacing="md">
+                <Box>
+                    <Title order={5}>AI Agent Configuration</Title>
+                    <Text size="sm" color="dimmed">
+                        You need to connect Slack first in the Integrations
+                        settings before you can configure AI agents.
+                    </Text>
+                </Box>
+            </Stack>
+        );
+    }
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack>
+                <Stack spacing="xs">
+                    <Group position="apart">
+                        <Group spacing="xs">
+                            <Title order={5}>
+                                Slack Channel Project Mappings
+                            </Title>
+
+                            <Tooltip
+                                variant="xs"
+                                multiline
+                                maw={250}
+                                label={
+                                    <Text fw={500}>
+                                        Refresh Slack channel list.
+                                        <Text c="gray.4" fw={400}>
+                                            To see private channels, ensure the
+                                            bot has been invited to them.
+                                            Archived channels are not included.
+                                        </Text>
+                                    </Text>
+                                }
+                            >
+                                <ActionIcon
+                                    loading={isRefreshing}
+                                    onClick={refreshChannels}
+                                >
+                                    <MantineIcon icon={IconRefresh} />
+                                </ActionIcon>
+                            </Tooltip>
+                        </Group>
+                        <Box align="end">
+                            <Button
+                                variant="default"
+                                disabled={!form.isValid()}
+                                onClick={handleAdd}
+                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                size="xs"
+                            >
+                                Add
+                            </Button>
+                        </Box>
+                    </Group>
+                    <Text size="xs" color="dimmed">
+                        Map which project is associated with which Slack
+                        channel. When a user asks a question in a channel,
+                        Lightdash will look for the answer in the associated
+                        project.
+                    </Text>
+                </Stack>
+
+                <ChannelProjectMappings
+                    form={form}
+                    channelOptions={slackChannelOptions}
+                    projectOptions={projectOptions}
+                />
+
+                {form.isDirty() && (
+                    <Box align="end">
+                        <Button type="submit" loading={isSubmitting}>
+                            Save changes
+                        </Button>
+                    </Box>
+                )}
+            </Stack>
+        </form>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChannelProjectMappings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChannelProjectMappings.tsx
@@ -1,7 +1,6 @@
 import { type SlackAppCustomSettings } from '@lightdash/common';
 import {
     ActionIcon,
-    Button,
     Divider,
     Group,
     Paper,
@@ -9,23 +8,17 @@ import {
     Select,
     Stack,
     Text,
-    Title,
-    Tooltip,
 } from '@mantine/core';
 import type { UseFormReturnType } from '@mantine/form';
 import {
     IconArrowsHorizontal,
     IconDatabase,
     IconHash,
-    IconHelpCircle,
-    IconPlus,
-    IconRefresh,
     IconX,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { TagInput } from '../../../../components/common/TagInput/TagInput';
-import { useSlackChannels } from '../../../../hooks/slack/useSlack';
 
 type Props = {
     channelOptions: { value: string; label: string }[];
@@ -146,86 +139,30 @@ const ChannelProjectMappings: FC<Props> = ({
         [form],
     );
 
-    const handleAdd = useCallback(
-        () =>
-            form.insertListItem('slackChannelProjectMappings', {
-                projectUuid: null,
-                slackChannelId: null,
-                availableTags: null,
-            }),
-        [form],
-    );
-
-    const { refresh: refreshChannels, isLoading: isRefreshing } =
-        useSlackChannels('');
-
     return (
         <Stack spacing="sm" w="100%">
-            <Group position="apart" spacing="two" mb="two">
-                <Group spacing="two">
-                    <Title order={6} fw={500}>
-                        AI Bot channel mappings
-                    </Title>
-
-                    <Tooltip
-                        variant="xs"
-                        multiline
-                        maw={250}
-                        label="Map which project is associated with which Slack channel. When a user asks a question in a channel, Lightdash will look for the answer in the associated project."
-                    >
-                        <MantineIcon icon={IconHelpCircle} />
-                    </Tooltip>
-                </Group>
-
-                <Tooltip
-                    variant="xs"
-                    multiline
-                    maw={250}
-                    label={
-                        <Text fw={500}>
-                            Refresh Slack channel list.
-                            <Text c="gray.4" fw={400}>
-                                To see private channels, ensure the bot has been
-                                invited to them. Archived channels are not
-                                included.
-                            </Text>
-                        </Text>
-                    }
-                >
-                    <ActionIcon
-                        loading={isRefreshing}
-                        onClick={refreshChannels}
-                    >
-                        <MantineIcon icon={IconRefresh} />
-                    </ActionIcon>
-                </Tooltip>
-            </Group>
-
             <Stack spacing="sm">
-                {form.values.slackChannelProjectMappings?.map(
-                    (mapping, index) => (
-                        <ChannelProjectMapping
-                            key={`${mapping.projectUuid}-${mapping.slackChannelId}`}
-                            form={form}
-                            index={index}
-                            projectOptions={projectOptions}
-                            channelOptions={channelOptions}
-                            usedChannels={usedChannels}
-                            onDelete={() => handleDelete(index)}
-                        />
-                    ),
+                {form.values.slackChannelProjectMappings &&
+                form.values.slackChannelProjectMappings.length > 0 ? (
+                    form.values.slackChannelProjectMappings.map(
+                        (mapping, index) => (
+                            <ChannelProjectMapping
+                                key={`${mapping.projectUuid}-${mapping.slackChannelId}`}
+                                form={form}
+                                index={index}
+                                projectOptions={projectOptions}
+                                channelOptions={channelOptions}
+                                usedChannels={usedChannels}
+                                onDelete={() => handleDelete(index)}
+                            />
+                        ),
+                    )
+                ) : (
+                    <Text size="xs" color="dimmed" italic>
+                        There are no Slack channel project mappings. Create a
+                        new mapping to get started.
+                    </Text>
                 )}
-
-                <div>
-                    <Button
-                        disabled={!form.isValid()}
-                        onClick={handleAdd}
-                        leftIcon={<MantineIcon icon={IconPlus} />}
-                        size="xs"
-                    >
-                        Add New Mapping
-                    </Button>
-                </div>
             </Stack>
         </Stack>
     );

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { Box, ScrollArea, Stack, Text, Title } from '@mantine/core';
 import {
+    IconBrain,
     IconBrowser,
     IconBuildingSkyscraper,
     IconCalendarStats,
@@ -25,6 +26,7 @@ import { useMemo, type FC } from 'react';
 import { Navigate, useRoutes, type RouteObject } from 'react-router';
 import PageSpinner from '../components/PageSpinner';
 import AccessTokensPanel from '../components/UserSettings/AccessTokensPanel';
+import AiAgentsPanel from '../components/UserSettings/AiAgentsPanel';
 import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel';
 import AppearanceSettingsPanel from '../components/UserSettings/AppearanceSettingsPanel';
 import DefaultProjectPanel from '../components/UserSettings/DefaultProjectPanel';
@@ -73,6 +75,10 @@ const Settings: FC = () => {
 
     const { data: isScimTokenManagementEnabled } = useFeatureFlag(
         CommercialFeatureFlags.Scim,
+    );
+
+    const { data: aiCopilotFlag } = useFeatureFlag(
+        CommercialFeatureFlags.AiCopilot,
     );
 
     const {
@@ -307,6 +313,16 @@ const Settings: FC = () => {
             });
         }
 
+        if (
+            user?.ability.can('manage', 'Organization') &&
+            aiCopilotFlag?.enabled
+        ) {
+            allowedRoutes.push({
+                path: '/aiAgents',
+                element: <AiAgentsPanel />,
+            });
+        }
+
         return allowedRoutes;
     }, [
         isScimTokenManagementEnabled?.enabled,
@@ -317,6 +333,7 @@ const Settings: FC = () => {
         organization,
         project,
         health,
+        aiCopilotFlag?.enabled,
     ]);
     const routeElements = useRoutes(routes);
 
@@ -490,6 +507,18 @@ const Settings: FC = () => {
                                         icon={<MantineIcon icon={IconPlug} />}
                                     />
                                 )}
+
+                                {user.ability.can('manage', 'Organization') &&
+                                    aiCopilotFlag?.enabled && (
+                                        <RouterNavLink
+                                            label="AI Agents"
+                                            exact
+                                            to="/generalSettings/aiAgents"
+                                            icon={
+                                                <MantineIcon icon={IconBrain} />
+                                            }
+                                        />
+                                    )}
 
                                 {organization &&
                                     !organization.needsProject &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #14827

### Description:

- Move Slack channel mappings to /aiAgents route
- Move that form to that section (it will change anyway)
- Only show save changes button if the form is dirty.

**Screenshots with the ai copilot enabled**

![Screenshot 2025-05-15 at 15.18.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/3a10b98d-719c-40ab-bcc2-3e2aa48b5502.png)

![Screenshot 2025-05-15 at 15.18.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/0ef4f6f0-fdaf-4ff6-98ad-80000ae41988.png)

![Screenshot 2025-05-15 at 15.18.08.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/48c740ca-1ce1-4f29-a746-8ae507a35a17.png)

**without**

![Screenshot 2025-05-15 at 15.31.00.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/71bf66b7-9e30-4fb7-adb8-4cb147a29c77.png)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
