### PR TITLE
chore: fetch sql runner results from new endpoint

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -885,7 +885,8 @@ type ApiResults =
     | ApiExecuteAsyncMetricQueryResults
     | ApiExecuteAsyncDashboardChartQueryResults
     | ApiGetAsyncQueryResults
-    | ApiUserActivityDownloadCsv['results'];
+    | ApiUserActivityDownloadCsv['results']
+    | ApiDownloadAsyncQueryResults;
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
@@ -106,18 +106,18 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('Customer id sum')
+            .contains('Age sum')
             .should('be.visible');
 
         // Add a new series
         cy.get('button[data-testid="add-y-axis-field"]').click();
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('Customer id sum')
+            .contains('Age sum')
             .should('be.visible');
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('First name count')
+            .contains('Last name count')
             .should('be.visible');
 
         // Group by first_name
@@ -125,7 +125,7 @@ describe('SQL Runner (new)', () => {
         cy.get('div[role="option"]').contains('first_name').click();
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('Customer id sum frances')
+            .contains('Age sum frances')
             .should('be.visible');
 
         // Verify that the chart is not displayed when the configuration is incomplete
@@ -156,7 +156,7 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('Customer id sum')
+            .contains('Age sum')
             .should('be.visible');
 
         // Verify that the table is displayed
@@ -229,7 +229,7 @@ describe('SQL Runner (new)', () => {
         ).should('exist');
         cy.get('div[data-testid="chart-data-table"]').should(
             'contain.text',
-            'customer_id_sum',
+            'age_sum',
         );
 
         cy.contains('label', 'SQL').click();
@@ -251,11 +251,9 @@ describe('SQL Runner (new)', () => {
             .contains('Fix errors')
             .click();
         cy.get('input[placeholder="Select X axis"]').click();
+        cy.get('div[role="option"]').contains('status').click();
+        cy.get('input[placeholder="Select Y axis"]').click();
         cy.get('div[role="option"]').contains('customer_id').click();
-        cy.get('.echarts-for-react')
-            .find('text')
-            .contains('Customer id')
-            .should('be.visible');
 
         // Verify that saving changes and going back to view page displays the chart
         cy.contains('Save').click();
@@ -265,7 +263,11 @@ describe('SQL Runner (new)', () => {
         ).should('exist');
         cy.get('.echarts-for-react')
             .find('text')
-            .contains('Customer id')
+            .contains('Customer id avg')
+            .should('be.visible');
+        cy.get('.echarts-for-react')
+            .find('text')
+            .contains('Status')
             .should('be.visible');
     });
 

--- a/packages/frontend/src/features/queryRunner/pollQueryResults.ts
+++ b/packages/frontend/src/features/queryRunner/pollQueryResults.ts
@@ -1,0 +1,25 @@
+import type { ApiGetAsyncQueryResults } from '@lightdash/common';
+import { QueryHistoryStatus } from '@lightdash/common';
+import { lightdashApi } from '../../api';
+
+export const pollForResults = async (
+    projectUuid: string,
+    queryUuid: string,
+    backoffMs: number = 250,
+): Promise<ApiGetAsyncQueryResults> => {
+    const results = await lightdashApi<ApiGetAsyncQueryResults>({
+        url: `/projects/${projectUuid}/query/${queryUuid}`,
+        version: 'v2',
+        method: 'GET',
+        body: undefined,
+    });
+
+    if (results.status === QueryHistoryStatus.PENDING) {
+        // Implement backoff: 250ms -> 500ms -> 1000ms (then stay at 1000ms)
+        const nextBackoff = Math.min(backoffMs * 2, 1000);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        return pollForResults(projectUuid, queryUuid, nextBackoff);
+    }
+
+    return results;
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlQueryRun.tsx
@@ -6,7 +6,6 @@ import {
 } from '@lightdash/common';
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import { executeSqlQuery } from '../store/thunks';
-import { useResultsFromStreamWorker } from './useResultsFromStreamWorker';
 
 export type ResultsAndColumns = {
     fileUrl: string | undefined;
@@ -31,25 +30,12 @@ export const useSqlQueryRun = (
         UseSqlQueryRunParams
     >,
 ) => {
-    const { getResultsFromStream } = useResultsFromStreamWorker();
     return useMutation<
         ResultsAndColumns | undefined,
         ApiError,
         UseSqlQueryRunParams
-    >(
-        async ({ sql, limit }) => {
-            const query = await executeSqlQuery(projectUuid, sql, limit);
-            const results = await getResultsFromStream(query.fileUrl);
-
-            return {
-                fileUrl: query.fileUrl,
-                results,
-                columns: query.columns,
-            };
-        },
-        {
-            mutationKey: ['sqlRunner', 'run'],
-            ...useMutationOptions,
-        },
-    );
+    >(async ({ sql, limit }) => executeSqlQuery(projectUuid, sql, limit), {
+        mutationKey: ['sqlRunner', 'run'],
+        ...useMutationOptions,
+    });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [Update FE Sql tiles to use the new paginated endpoints](https://github.com/lightdash/lightdash/issues/14633)

### Description:

- Uses new `POST /api/v2/projects/{projectUuid}/query/sql` to fetch results for the sql runner results table


https://github.com/user-attachments/assets/dfe5c80f-3a51-4ae7-91d8-88663a7d9836



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
