### PR TITLE
feat: add AI agents database schema and migration

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 export const AiThreadTableName = 'ai_thread';
 
 export type DbAiThread = {
+    agent_uuid: string | null;
     ai_thread_uuid: string;
     created_at: Date;
     organization_uuid: string;
@@ -12,7 +13,10 @@ export type DbAiThread = {
 
 export type AiThreadTable = Knex.CompositeTableType<
     DbAiThread,
-    Pick<DbAiThread, 'organization_uuid' | 'project_uuid' | 'created_from'>
+    Pick<
+        DbAiThread,
+        'organization_uuid' | 'project_uuid' | 'created_from' | 'agent_uuid'
+    >
 >;
 
 export const AiSlackThreadTableName = 'ai_slack_thread';

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+export const AiAgentTableName = 'ai_agent';
+
+export type DbAiAgent = {
+    ai_agent_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    name: string;
+    description: string;
+    image_url: string;
+    tags: string[] | null;
+    created_at: Date;
+};
+
+export type AiAgentTable = Knex.CompositeTableType<DbAiAgent>;
+
+export const AiAgentIntegrationTableName = 'ai_agent_integration';
+
+export type DbAiAgentIntegration = {
+    ai_agent_integration_uuid: string;
+    ai_agent_uuid: string;
+    integration_type: string;
+    created_at: Date;
+};
+
+export type AiAgentIntegrationTable =
+    Knex.CompositeTableType<DbAiAgentIntegration>;
+
+export const AiAgentSlackIntegrationTableName = 'ai_agent_slack_integration';
+
+export type DbAiAgentSlackIntegration = {
+    ai_agent_integration_slack_uuid: string;
+    organization_uuid: string;
+    ai_agent_integration_uuid: string;
+    slack_channel_id: string;
+    created_at: Date;
+};
+
+export type AiAgentSlackIntegrationTable =
+    Knex.CompositeTableType<DbAiAgentSlackIntegration>;

--- a/packages/backend/src/ee/database/migrations/20250516162139_add_ai_agents_table.ts
+++ b/packages/backend/src/ee/database/migrations/20250516162139_add_ai_agents_table.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+const AIAgentTableName = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(AIAgentTableName)) return;
+
+    await knex.schema.createTable(AIAgentTableName, (table) => {
+        table
+            .uuid('ai_agent_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+
+        table.string('name').notNullable();
+        table.text('description');
+        table.text('image_url');
+        table.specificType('tags', 'text[]').defaultTo(null);
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AIAgentTableName))) return;
+    await knex.schema.dropTable(AIAgentTableName);
+}

--- a/packages/backend/src/ee/database/migrations/20250516162927_add_ai_agent_integrations_table.ts
+++ b/packages/backend/src/ee/database/migrations/20250516162927_add_ai_agent_integrations_table.ts
@@ -1,0 +1,69 @@
+import { Knex } from 'knex';
+
+const AIAgentIntegrationTableName = 'ai_agent_integration';
+const AIAgentSlackIntegrationTableName = 'ai_agent_slack_integration';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AIAgentIntegrationTableName))) {
+        await knex.schema.createTable(AIAgentIntegrationTableName, (table) => {
+            table
+                .uuid('ai_agent_integration_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('ai_agent_uuid')
+                .references('ai_agent_uuid')
+                .inTable('ai_agent')
+                .onDelete('CASCADE')
+                .notNullable();
+            table.enum('integration_type', ['slack']).notNullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        });
+    }
+
+    if (!(await knex.schema.hasTable(AIAgentSlackIntegrationTableName))) {
+        await knex.schema.createTable(
+            AIAgentSlackIntegrationTableName,
+            (table) => {
+                table
+                    .uuid('ai_agent_integration_slack_uuid')
+                    .primary()
+                    .defaultTo(knex.raw('uuid_generate_v4()'));
+                table
+                    .uuid('organization_uuid')
+                    .notNullable()
+                    .references('organization_uuid')
+                    .inTable('organizations')
+                    .onDelete('CASCADE');
+                table
+                    .uuid('ai_agent_integration_uuid')
+                    .notNullable()
+                    .unique()
+                    .references('ai_agent_integration_uuid')
+                    .inTable('ai_agent_integration')
+                    .onDelete('CASCADE');
+                table.text('slack_channel_id').notNullable();
+                table
+                    .timestamp('created_at', { useTz: false })
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+
+                table.unique(['organization_uuid', 'slack_channel_id']);
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // drop in reverse order
+    if (await knex.schema.hasTable('ai_agent_slack_integration')) {
+        await knex.schema.dropTable('ai_agent_slack_integration');
+    }
+
+    if (await knex.schema.hasTable('ai_agent_integration')) {
+        await knex.schema.dropTable('ai_agent_integration');
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20250516163327_add_ai_agent_uuid_to_ai_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20250516163327_add_ai_agent_uuid_to_ai_thread.ts
@@ -1,0 +1,76 @@
+import { Knex } from 'knex';
+
+const AIThreadTableName = 'ai_thread';
+const AIAgentTableName = 'ai_agent';
+const AIAgentIntegrationTableName = 'ai_agent_integration';
+const AIAgentSlackIntegrationTableName = 'ai_agent_slack_integration';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AIThreadTableName, (table) => {
+        table
+            .uuid('agent_uuid')
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('CASCADE');
+    });
+
+    const slackMappings = await knex('slack_channel_project_mappings').select(
+        'slack_channel_project_mapping_uuid',
+        'project_uuid',
+        'organization_uuid',
+        'slack_channel_id',
+        'available_tags',
+    );
+
+    for await (const mapping of slackMappings) {
+        const [agent] = await knex(AIAgentTableName)
+            .insert({
+                project_uuid: mapping.project_uuid,
+                organization_uuid: mapping.organization_uuid,
+                name: '',
+                description: '',
+                image_url: '',
+                tags: mapping.available_tags,
+            })
+            .returning('ai_agent_uuid');
+
+        const [integration] = await knex(AIAgentIntegrationTableName)
+            .insert({
+                ai_agent_uuid: agent.ai_agent_uuid,
+                integration_type: 'slack',
+            })
+            .returning('ai_agent_integration_uuid');
+
+        await knex(AIAgentSlackIntegrationTableName).insert({
+            ai_agent_integration_uuid: integration.ai_agent_integration_uuid,
+            organization_uuid: mapping.organization_uuid,
+            slack_channel_id: mapping.slack_channel_id,
+        });
+
+        await knex.raw(
+            `
+                UPDATE ai_thread t
+                SET
+                    agent_uuid = ?
+                FROM
+                    ai_slack_thread st
+                WHERE
+                    st.ai_thread_uuid = t.ai_thread_uuid
+                    AND t.organization_uuid = ?
+                    AND st.slack_channel_id = ?`,
+            [
+                agent.ai_agent_uuid,
+                mapping.organization_uuid,
+                mapping.slack_channel_id,
+            ],
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AIThreadTableName, (table) => {
+        table.dropForeign(['agent_uuid']);
+        table.dropColumn('agent_uuid');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -96,13 +96,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getCatalogService() as CommercialCatalogService,
                     userModel: models.getUserModel(),
                     aiModel: models.getAiModel(),
+                    aiAgentModel: models.getAiAgentModel(),
                     projectModel: models.getProjectModel(),
                     openAi: new OpenAi(), // TODO This should go in client repository as soon as it is available
                     slackClient: clients.getSlackClient(),
                     lightdashConfig: context.lightdashConfig,
                     organizationModel: models.getOrganizationModel(),
-                    slackAuthenticationModel:
-                        models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     featureFlagService: repository.getFeatureFlagService(),
                 }),
             aiAgentService: ({ models, repository }) =>
@@ -290,6 +289,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 schedulerClient:
                     context.clients.getSchedulerClient() as CommercialSchedulerClient,
                 aiModel: context.models.getAiModel(),
+                aiAgentModel: context.models.getAiAgentModel(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -9,6 +9,7 @@ import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import LicenseClient from './clients/License/LicenseClient';
 import OpenAi from './clients/OpenAi';
 import { CommercialSlackBot } from './clients/Slack/SlackBot';
+import { AiAgentModel } from './models/AiAgentModel';
 import { AiModel } from './models/AiModel';
 import { CommercialCatalogModel } from './models/CommercialCatalogModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
@@ -106,6 +107,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             aiAgentService: ({ models, repository }) =>
                 new AiAgentService({
+                    aiAgentModel: models.getAiAgentModel(),
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     featureFlagService: repository.getFeatureFlagService(),
@@ -223,6 +225,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
         },
         modelProviders: {
             aiModel: ({ database }) => new AiModel({ database }),
+            aiAgentModel: ({ database }) => new AiAgentModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),
             dashboardSummaryModel: ({ database }) =>
                 new DashboardSummaryModel({ database }),

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,4 +1,11 @@
+import { type AiAgent } from '@lightdash/common';
 import { Knex } from 'knex';
+import {
+    AiAgentIntegrationTableName,
+    AiAgentSlackIntegrationTableName,
+    AiAgentTableName,
+} from '../database/entities/aiAgent';
+import { AiAgentNotFoundError } from '../services/AiService/utils/errors';
 
 type Dependencies = {
     database: Knex;
@@ -9,5 +16,54 @@ export class AiAgentModel {
 
     constructor(dependencies: Dependencies) {
         this.database = dependencies.database;
+    }
+
+    async getAgentBySlackChannelId({
+        organizationUuid,
+        slackChannelId,
+    }: {
+        organizationUuid: string;
+        slackChannelId: string;
+    }): Promise<AiAgent> {
+        // TODO: when `getAgent(uuid: string) is implemented, this should use it instead
+        const agent = await this.database(AiAgentTableName)
+            .select({
+                uuid: `${AiAgentTableName}.ai_agent_uuid`,
+                organizationUuid: `${AiAgentTableName}.organization_uuid`,
+                projectUuid: `${AiAgentTableName}.project_uuid`,
+                tags: `${AiAgentTableName}.tags`,
+                integrations: this.database.raw(`
+                    json_agg(
+                        json_build_object(
+                            'type', ${AiAgentIntegrationTableName}.integration_type,
+                            'channelId', ${AiAgentSlackIntegrationTableName}.slack_channel_id
+                        )
+                    )`),
+            } satisfies Record<keyof AiAgent, unknown>)
+            .join(
+                AiAgentIntegrationTableName,
+                `${AiAgentTableName}.ai_agent_uuid`,
+                `${AiAgentIntegrationTableName}.ai_agent_uuid`,
+            )
+            .join(
+                AiAgentSlackIntegrationTableName,
+                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
+                `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
+            )
+            .where({
+                [`${AiAgentTableName}.organization_uuid`]: organizationUuid,
+                [`${AiAgentSlackIntegrationTableName}.slack_channel_id`]:
+                    slackChannelId,
+            })
+            .groupBy(`${AiAgentTableName}.ai_agent_uuid`)
+            .first();
+
+        if (!agent) {
+            throw new AiAgentNotFoundError(
+                `AI agent not found for slack channel ID: ${slackChannelId}`,
+            );
+        }
+
+        return agent;
     }
 }

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class AiAgentModel {
+    private database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+}

--- a/packages/backend/src/ee/models/AiModel.ts
+++ b/packages/backend/src/ee/models/AiModel.ts
@@ -43,6 +43,7 @@ export class AiModel {
                 projectUuid: 'project_uuid',
                 createdAt: 'created_at',
                 createdFrom: 'created_from',
+                agentUuid: 'agent_uuid',
             })
             .where({ ai_thread_uuid: uuid })
             .first();
@@ -92,13 +93,17 @@ export class AiModel {
                 Array<
                     Pick<
                         DbAiThread,
-                        'ai_thread_uuid' | 'created_at' | 'created_from'
+                        | 'ai_thread_uuid'
+                        | 'created_at'
+                        | 'created_from'
+                        | 'agent_uuid'
                     > &
                         Pick<DbAiPrompt, 'prompt'> &
                         Pick<DbUser, 'user_uuid'> & { user_name: string }
                 >
             >(
                 `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.agent_uuid`,
                 `${AiThreadTableName}.created_at`,
                 `${AiThreadTableName}.created_from`,
                 `${AiPromptTableName}.prompt`,
@@ -176,6 +181,7 @@ export class AiModel {
                 projectUuid: `${AiThreadTableName}.project_uuid`,
                 promptUuid: `${AiPromptTableName}.ai_prompt_uuid`,
                 threadUuid: `${AiPromptTableName}.ai_thread_uuid`,
+                agentUuid: `${AiThreadTableName}.agent_uuid`,
                 createdByUserUuid: `${AiPromptTableName}.created_by_user_uuid`,
                 prompt: `${AiPromptTableName}.prompt`,
                 createdAt: `${AiPromptTableName}.created_at`,
@@ -213,6 +219,7 @@ export class AiModel {
                     organization_uuid: data.organizationUuid,
                     project_uuid: data.projectUuid,
                     created_from: data.createdFrom,
+                    agent_uuid: data.agentUuid,
                 })
                 .returning('ai_thread_uuid');
             if (row === undefined) {
@@ -307,6 +314,7 @@ export class AiModel {
                 projectUuid: `${AiThreadTableName}.project_uuid`,
                 promptUuid: `${AiPromptTableName}.ai_prompt_uuid`,
                 threadUuid: `${AiPromptTableName}.ai_thread_uuid`,
+                agentUuid: `${AiThreadTableName}.agent_uuid`,
                 createdByUserUuid: `${AiPromptTableName}.created_by_user_uuid`,
                 userUuid: `${AiWebAppPromptTableName}.user_uuid`,
                 prompt: `${AiPromptTableName}.prompt`,
@@ -328,6 +336,7 @@ export class AiModel {
                     organization_uuid: data.organizationUuid,
                     project_uuid: data.projectUuid,
                     created_from: data.createdFrom,
+                    agent_uuid: data.agentUuid,
                 })
                 .returning('ai_thread_uuid');
             if (row === undefined) {

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1,26 +1,22 @@
-import {
-    type AiAgent,
-    CommercialFeatureFlags,
-    ForbiddenError,
-    LightdashUser,
-    NotFoundError,
-    type SessionUser,
-} from '@lightdash/common';
-
 import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { AiAgentModel } from '../models/AiAgentModel';
 import type { CommercialSlackAuthenticationModel } from '../models/CommercialSlackAuthenticationModel';
 
 type AiAgentServiceDependencies = {
+    aiAgentModel: AiAgentModel;
     slackAuthenticationModel: CommercialSlackAuthenticationModel;
     featureFlagService: FeatureFlagService;
 };
 
 export class AiAgentService {
+    private readonly aiAgentModel: AiAgentModel;
+
     private readonly slackAuthenticationModel: CommercialSlackAuthenticationModel;
 
     private readonly featureFlagService: FeatureFlagService;
 
     constructor(dependencies: AiAgentServiceDependencies) {
+        this.aiAgentModel = dependencies.aiAgentModel;
         this.slackAuthenticationModel = dependencies.slackAuthenticationModel;
         this.featureFlagService = dependencies.featureFlagService;
     }

--- a/packages/backend/src/ee/services/AiService/utils/errors.ts
+++ b/packages/backend/src/ee/services/AiService/utils/errors.ts
@@ -11,3 +11,10 @@ export class AiSlackMappingNotFoundError extends Error {
         this.name = 'AiSlackMappingNotFoundError';
     }
 }
+
+export class AiAgentNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AiAgentNotFoundError';
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -95,6 +95,7 @@ export type ModelManifest = {
     resultsFileModel: ResultsFileModel;
     /** An implementation signature for these models are not available at this stage */
     aiModel: unknown;
+    aiAgentModel: unknown;
     embedModel: unknown;
     dashboardSummaryModel: unknown;
     scimOrganizationAccessTokenModel: unknown;
@@ -519,6 +520,10 @@ export class ModelRepository
 
     public getAiModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiModel');
+    }
+
+    public getAiAgentModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentModel');
     }
 
     public getEmbedModel<ModelImplT>(): ModelImplT {

--- a/packages/common/src/ee/Ai/types.ts
+++ b/packages/common/src/ee/Ai/types.ts
@@ -7,6 +7,7 @@ export type AiThread = {
     projectUuid: string;
     createdAt: Date;
     createdFrom: string;
+    agentUuid: string | null;
 };
 
 export type CreateSlackThread = {
@@ -16,6 +17,7 @@ export type CreateSlackThread = {
     slackUserId: string;
     slackChannelId: string;
     slackThreadTs: string;
+    agentUuid: string | null;
 };
 
 export type CreateWebAppThread = {
@@ -23,11 +25,13 @@ export type CreateWebAppThread = {
     projectUuid: string;
     userUuid: string;
     createdFrom: 'web_app';
+    agentUuid: string | null;
 };
 
 export type AiPrompt = {
     organizationUuid: string;
     projectUuid: string;
+    agentUuid: string | null;
     promptUuid: string;
     threadUuid: string;
     createdByUserUuid: string;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -11,10 +11,7 @@ export type BaseAiAgent = {
     description: string;
     imageUrl: string;
 
-    dataSources: {
-        // null means all tags are available
-        fieldNameTags: string[] | null; // slack_project_mappings.available_tags
-    };
+    tags: string[] | null;
 
     integrations: {
         type: AiAgentIntegrationType;
@@ -22,7 +19,6 @@ export type BaseAiAgent = {
     }[];
 
     createdAt: string;
-    updatedAt: string;
 
     instructions: string | null;
     provider: 'openai';
@@ -31,12 +27,12 @@ export type BaseAiAgent = {
 
 export type AiAgent = Pick<
     BaseAiAgent,
-    'uuid' | 'projectUuid' | 'organizationUuid' | 'integrations' | 'dataSources'
+    'uuid' | 'projectUuid' | 'organizationUuid' | 'integrations' | 'tags'
 >;
 
 export type AiAgentSummary = Pick<
     AiAgent,
-    'uuid' | 'projectUuid' | 'organizationUuid' | 'integrations' | 'dataSources'
+    'uuid' | 'projectUuid' | 'organizationUuid' | 'integrations' | 'tags'
 >;
 
 export type AiAgentMessage =
@@ -93,12 +89,12 @@ export type ApiAiAgentSummaryResponse = {
 
 export type ApiCreateAiAgent = Pick<
     AiAgent,
-    'projectUuid' | 'integrations' | 'dataSources'
+    'projectUuid' | 'integrations' | 'tags'
 >;
 
 export type ApiUpdateAiAgent = {
     uuid: AiAgent['uuid'];
-    dataSources?: AiAgent['dataSources'];
+    tags?: AiAgent['tags'];
     integrations?: AiAgent['integrations'];
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14847

### Description:
Add database schema for AI Agents, migrate old slack-first schema

- Creates `ai_agent` table to store agent configurations with name, description, and data sources
- Creates `ai_agent_integration` table to manage integrations (currently supporting Slack)
- Adds `agent_uuid` column to the existing `ai_thread` table
- Includes a migration to convert existing Slack channel mappings to the new agent structure
- Migrations are revertable and do not delete any data
- All the existing features work as expected

Before:
![mermaid_before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/8b4e071e-4fc9-4483-a01a-0b3e290622f3.png)

After:

![updated_diagram.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/4fdc5fc6-0f9b-43e8-84cc-8e58e5e834d7.png)

