### PR TITLE
fix: Missing check indicator when moving Spaces into root level 

### DIFF
--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -102,7 +102,7 @@ const TransferItemsModal = <
     });
 
     const selectedSpaceLabel = useMemo(() => {
-        if (!selectedSpaceUuid) return '';
+        if (!selectedSpaceUuid) return 'Spaces';
         return (
             spaces.find((space) => space.uuid === selectedSpaceUuid)?.name || ''
         );

--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -103,7 +103,7 @@ const Tree: React.FC<Props> = ({
 
     return (
         <MantineProvider>
-            <Box px="sm" py="xs">
+            <Box p="xs">
                 <TreeItem
                     withRootSelectable={withRootSelectable}
                     selected={!value}

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -58,12 +58,7 @@ const TreeItem: React.FC<Props> = ({
             w="100%"
             gap={rem(4)}
             h={rem(32)}
-            // This component isn't optimized for the top-level root item,
-            // so we apply a negative left margin when the chevron isn't needed.
-            // (Root spaces are always expanded and don’t require a chevron.)
-            ml={isRoot ? rem(-4) : undefined}
-            pl={withPadding ? rem(4) : undefined}
-            pr={withPadding ? 'xs' : undefined}
+            px={withPadding ? 'xs' : undefined}
             radius="sm"
             wrap="nowrap"
             onClick={onClick}
@@ -109,7 +104,7 @@ const TreeItem: React.FC<Props> = ({
                 {stringLabel}
             </Highlight>
 
-            {!isRoot && selected && (
+            {selected && (
                 <MantineIcon
                     icon={IconCheck}
                     size="lg"


### PR DESCRIPTION
Closes: #14857

### Description:

Display check ✓ icon when selecting root + some other style improvements:
- Unify tree box padding
- Balance paddings and margins of selected elements in tree (see screenshots comparing hover & selected states)
- Always destination space, even when moving into Root Space

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/90249d87-8d1c-4a0f-8dd0-3820d449da2b) | ![image](https://github.com/user-attachments/assets/d2588e0f-f597-481d-b1d2-c3c883f52c3e) | 


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
