### PR TITLE
fix: results page smaller than actual results

### DIFF
--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -89,7 +89,7 @@ export interface WarehouseClient {
 
     executeAsyncQuery(
         args: WarehouseExecuteAsyncQueryArgs,
-        resultsStreamCallback?: (rows: WarehouseResults['rows']) => void,
+        resultsStreamCallback: (rows: WarehouseResults['rows']) => void,
     ): Promise<WarehouseExecuteAsyncQuery>;
 
     /**

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -533,7 +533,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
 
     async executeAsyncQuery(
         { sql, tags }: WarehouseExecuteAsyncQueryArgs,
-        resultsStreamCallback?: (rows: WarehouseResults['rows']) => void,
+        resultsStreamCallback: (rows: WarehouseResults['rows']) => void,
     ): Promise<WarehouseExecuteAsyncQuery> {
         try {
             const [job] = await this.createJob(sql, {
@@ -562,11 +562,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 : 1;
 
             // If a callback is provided, stream the results to the callback
-            if (resultsStreamCallback) {
-                await this.streamResults(job, (row) =>
-                    resultsStreamCallback([row]),
-                );
-            }
+            await this.streamResults(job, (row) =>
+                resultsStreamCallback([row]),
+            );
 
             return {
                 queryId: job.id,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14820 

### Description:

- This was happening because of attempts at handling back pressure which closed the write stream too soon

Removing back pressure handling in favor of letting node handle it fixes the issue

Steps to reproduce:
1. use databricks cluster (this bug shouldn't be tied to it, but we could only reproduce there)
2. Query events, event_id, count
3. Set limit to 500
4. Notice that pagesize will be around 400 when it should be 500 for the first page so the chart doesn't load

![image](https://github.com/user-attachments/assets/3ab8eb8f-b198-4f65-a251-31a24d8144ed)

test-frontend

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
