### PR TITLE
fix: dashbaord comments placement

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -102,13 +102,6 @@ export const TileTitleLink = styled.a<TileTitleProps>`
         `}
 `;
 
-export const ButtonsWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    gap: 8px;
-`;
-
 export const ChartContainer = styled.div`
     flex: 1;
     overflow: hidden;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -10,7 +10,7 @@ interface HeaderContainerProps {
 export const HeaderContainer = styled.div<HeaderContainerProps>`
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
     gap: 8px;
     height: ${TILE_HEADER_HEIGHT}px;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -31,7 +31,6 @@ import MoveTileToTabModal from '../TileForms/MoveTileToTabModal';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
 
 import {
-    ButtonsWrapper,
     ChartContainer,
     HeaderContainer,
     TileTitleLink,
@@ -198,13 +197,16 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         </TitleWrapper>
                     </Group>
                 )}
-                {visibleHeaderElement && (
-                    <ButtonsWrapper className="non-draggable">
-                        {visibleHeaderElement}
-                    </ButtonsWrapper>
-                )}
-
-                <ButtonsWrapper className="non-draggable">
+                <Group
+                    spacing="xs"
+                    className="non-draggable"
+                    sx={{ marginLeft: 'auto' }}
+                >
+                    {visibleHeaderElement && (
+                        <Group spacing="xs" className="non-draggable">
+                            {visibleHeaderElement}
+                        </Group>
+                    )}
                     {(containerHovered && !titleHovered) ||
                     isMenuOpen ||
                     lockHeaderVisibility ? (
@@ -314,7 +316,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             )}
                         </>
                     ) : null}
-                </ButtonsWrapper>
+                </Group>
             </HeaderContainer>
 
             <ChartContainer className="non-draggable sentry-block ph-no-capture">


### PR DESCRIPTION
### Description:

Fix an issue with the dashboard comments button moving around when there are comments

**Before**
![Kapture 2025-05-19 at 17 16 55](https://github.com/user-attachments/assets/e301e44d-beb3-4c36-be2e-898fa9e9afac)

**After**
![after](https://github.com/user-attachments/assets/7b62c40d-e1b5-41a9-9ea3-692b3c88a282)

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
