### PR TITLE
feat: add required filters for joined tables

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -29,7 +29,10 @@ import {
     type Metric,
     type Source,
 } from '../types/field';
-import { parseFilters } from '../types/filterGrammar';
+import {
+    parseFilters,
+    parseModelRequiredFilters,
+} from '../types/filterGrammar';
 import { type LightdashProjectConfig } from '../types/lightdashProjectConfig';
 import { OrderFieldsByStrategy, type GroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
@@ -570,7 +573,7 @@ export const convertTable = (
                 : OrderFieldsByStrategy.LABEL,
         groupLabel: meta.group_label,
         sqlWhere: meta.sql_filter || meta.sql_where,
-        requiredFilters: parseFilters(meta.required_filters),
+        requiredFilters: parseModelRequiredFilters(meta.required_filters),
         requiredAttributes: meta.required_attributes,
         groupDetails,
         ...(meta.default_time_dimension

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -75,6 +75,22 @@ export interface FilterRule<
 export interface MetricFilterRule
     extends FilterRule<ConditionalOperator, { fieldRef: string }> {}
 
+type JoinModelRequiredFilterTarget = {
+    fieldRef: string;
+    tableName: string;
+};
+
+export interface JoinModelRequiredFilterRule
+    extends FilterRule<ConditionalOperator, JoinModelRequiredFilterTarget> {}
+
+export type ModelRequiredFilterRule =
+    | MetricFilterRule // Keeping backwards compatibility with existing filters
+    | JoinModelRequiredFilterRule;
+
+export const isJoinModelRequiredFilter = (
+    filter: ModelRequiredFilterRule,
+): filter is JoinModelRequiredFilterRule => 'tableName' in filter.target;
+
 export type DashboardFieldTarget = {
     fieldId: string;
     tableName: string;

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -1,4 +1,4 @@
-import { type MetricFilterRule } from './filter';
+import { type ModelRequiredFilterRule } from './filter';
 import type { DefaultTimeDimension } from './timeFrames';
 
 export enum OrderFieldsByStrategy {
@@ -22,7 +22,7 @@ export type TableBase = {
     orderFieldsBy?: OrderFieldsByStrategy;
     groupLabel?: string;
     sqlWhere?: string;
-    requiredFilters?: MetricFilterRule[];
+    requiredFilters?: ModelRequiredFilterRule[];
     hidden?: boolean;
     requiredAttributes?: Record<string, string | string[]>;
     groupDetails?: Record<string, GroupType>;

--- a/packages/common/src/utils/filters.mock.ts
+++ b/packages/common/src/utils/filters.mock.ts
@@ -1,5 +1,6 @@
 import { ConditionalOperator } from '../types/conditionalRule';
-import { type Table } from '../types/explore';
+import { SupportedDbtAdapter } from '../types/dbt';
+import { type Explore, type Table } from '../types/explore';
 import {
     CustomDimensionType,
     DimensionType,
@@ -14,7 +15,8 @@ import {
     type FilterGroup,
     type FilterRule,
     type Filters,
-    type MetricFilterRule,
+    type JoinModelRequiredFilterRule,
+    type ModelRequiredFilterRule,
     type OrFilterGroup,
 } from '../types/filter';
 import type { MetricQuery } from '../types/metricQuery';
@@ -280,7 +282,9 @@ export const filterRule: FilterRule = {
     values: ['mockValue1', 'mockValue2'],
 };
 
-export const metricFilterRule = (inputFieldRef: string): MetricFilterRule => ({
+export const modelRequiredFilterRule = (
+    inputFieldRef: string,
+): ModelRequiredFilterRule => ({
     id: 'uuid',
     operator: FilterOperator.IN_THE_NEXT,
     settings: {
@@ -291,6 +295,20 @@ export const metricFilterRule = (inputFieldRef: string): MetricFilterRule => ({
     },
     values: [14],
 });
+
+export const joinedModelRequiredFilterRule = (
+    inputFieldRef: string,
+    tableName: string,
+): JoinModelRequiredFilterRule => {
+    const requiredFilterRule = modelRequiredFilterRule(inputFieldRef);
+    return {
+        ...requiredFilterRule,
+        target: {
+            ...requiredFilterRule.target,
+            tableName,
+        },
+    };
+};
 
 export const baseTable: Omit<Table, 'lineageGraph'> = {
     name: 'table',
@@ -335,6 +353,147 @@ export const expectedRequiredResetResult: FilterGroup = {
             settings: {
                 unitOfTime: 'years',
             },
+        },
+    ],
+};
+
+export const mockExplore: Explore = {
+    name: 'test',
+    label: 'Test',
+    tags: [],
+    baseTable: 'orders',
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'test',
+            schema: 'public',
+            sqlTable: 'orders',
+            metrics: {},
+            lineageGraph: {},
+            dimensions: {
+                order_date_year: {
+                    name: 'order_date_year',
+                    label: 'Order Date Year',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'order_date_year',
+                    tablesReferences: [],
+                    sql: 'order_date_year',
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                order_date_month: {
+                    name: 'order_date_month',
+                    label: 'Order Date Month',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'order_date_month',
+                    tablesReferences: [],
+                    sql: 'order_date_month',
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                order_date_week: {
+                    name: 'order_date_week',
+                    label: 'Order Date Week',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'order_date_week',
+                    sql: 'order_date_week',
+                    hidden: false,
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                status: {
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'status',
+                    sql: 'status',
+                    hidden: false,
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.BOOLEAN,
+                },
+            },
+        },
+    },
+};
+
+export const mockExploreWithJoinedTable: Explore = {
+    ...mockExplore,
+    tables: {
+        orders: {
+            ...mockExplore.tables.orders,
+            dimensions: {
+                ...mockExplore.tables.orders.dimensions,
+                customer_id: {
+                    name: 'customer_id',
+                    label: 'Customer ID',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'customer_id',
+                    sql: 'customer_id',
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    tablesReferences: [],
+                },
+            },
+        },
+        customers: {
+            name: 'customers',
+            label: 'Customers',
+            database: 'test',
+            schema: 'public',
+            sqlTable: 'customers',
+            metrics: {},
+            lineageGraph: {},
+            dimensions: {
+                id: {
+                    name: 'id',
+                    label: 'ID',
+                    table: 'customers',
+                    tableLabel: 'Customers',
+                    compiledSql: 'id',
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    sql: 'id',
+                    hidden: false,
+                },
+                created_at_week: {
+                    name: 'created_at_week',
+                    label: 'Created At Week',
+                    table: 'customers',
+                    tableLabel: 'Customers',
+                    compiledSql: 'created_at_week',
+                    sql: 'created_at_week',
+                    hidden: false,
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionName: 'created_at',
+                },
+            },
+        },
+    },
+    joinedTables: [
+        {
+            table: 'customers',
+            sqlOn: '${orders.customer_id} = ${customers.id}',
+            compiledSqlOn: '(orders.customer_id) = (customers.id)',
+            type: undefined,
         },
     ],
 };

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,7 +1,4 @@
 import { ConditionalOperator } from '../types/conditionalRule';
-import { SupportedDbtAdapter } from '../types/dbt';
-import { type Explore, type Table } from '../types/explore';
-import { DimensionType, FieldType } from '../types/field';
 import {
     type AndFilterGroup,
     type DashboardFilterRule,
@@ -14,7 +11,7 @@ import {
 import {
     addDashboardFiltersToMetricQuery,
     addFilterRule,
-    createFilterRuleFromRequiredMetricRule,
+    createFilterRuleFromModelRequiredFilterRule,
     isFilterRuleInQuery,
     overrideChartFilter,
     reduceRequiredDimensionFiltersToFilterRules,
@@ -22,7 +19,6 @@ import {
     trackWhichTimeBasedMetricFiltersToOverride,
 } from './filters';
 import {
-    baseTable,
     chartAndFilterGroup,
     chartOrFilterGroup,
     customSqlDimension,
@@ -36,9 +32,12 @@ import {
     expectedRequiredResetResult,
     expectedRequiredResult,
     filterRule,
-    metricFilterRule,
+    joinedModelRequiredFilterRule,
     metricQueryWithAndFilters,
     metricQueryWithOrFilters,
+    mockExplore,
+    mockExploreWithJoinedTable,
+    modelRequiredFilterRule,
 } from './filters.mock';
 
 jest.mock('uuid', () => ({
@@ -154,10 +153,10 @@ describe('addFilterRule', () => {
     });
 });
 
-describe('createFilterRuleFromRequiredMetricRule', () => {
+describe('createFilterRuleFromModelRequiredFilterRule', () => {
     test('should create a correct FilterRule', () => {
-        const result = createFilterRuleFromRequiredMetricRule(
-            metricFilterRule('dimension'),
+        const result = createFilterRuleFromModelRequiredFilterRule(
+            modelRequiredFilterRule('dimension'),
             'tableName',
         );
         expect(result).toEqual(
@@ -197,17 +196,12 @@ describe('reduceRequiredDimensionFiltersToFilterRules', () => {
     test('should correctly reduce required dimension filters to filter rules', () => {
         // Define mock data
         const mockRequiredFilters: MetricFilterRule[] = [
-            metricFilterRule('mockFieldRef1'),
-            metricFilterRule('mockFieldRef2'),
+            modelRequiredFilterRule('order_date_week'),
+            joinedModelRequiredFilterRule(
+                'customers.created_at_week',
+                'customers',
+            ),
         ];
-        const table: Table = {
-            ...baseTable,
-            lineageGraph: {},
-            dimensions: {
-                mockFieldRef1: dimension('mockFieldRef1', 'table'),
-                mockFieldRef2: dimension('mockFieldRef2', 'table'),
-            },
-        };
         const emptyFilters: Filters = {
             dimensions: {
                 id: 'mockGroupId',
@@ -216,13 +210,14 @@ describe('reduceRequiredDimensionFiltersToFilterRules', () => {
         };
         const result = reduceRequiredDimensionFiltersToFilterRules(
             mockRequiredFilters,
-            table,
             emptyFilters.dimensions,
+            mockExploreWithJoinedTable,
         );
         const expectedFilterRuleResult: FilterRule[] = [
-            expectedRequiredResult('mockFieldRef1', 'table'),
-            expectedRequiredResult('mockFieldRef2', 'table'),
+            expectedRequiredResult('order_date_week', 'orders'),
+            expectedRequiredResult('created_at_week', 'customers'),
         ];
+
         expect(result).toEqual(expectedFilterRuleResult);
     });
 });
@@ -245,79 +240,6 @@ describe('resetRequiredFilterRules', () => {
 });
 
 describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
-    const mockExplore: Explore = {
-        name: 'test',
-        label: 'Test',
-        tags: [],
-        baseTable: 'orders',
-        targetDatabase: SupportedDbtAdapter.POSTGRES,
-        joinedTables: [],
-        tables: {
-            orders: {
-                name: 'orders',
-                label: 'Orders',
-                database: 'test',
-                schema: 'public',
-                sqlTable: 'orders',
-                metrics: {},
-                lineageGraph: {},
-                dimensions: {
-                    order_date_year: {
-                        name: 'order_date_year',
-                        label: 'Order Date Year',
-                        table: 'orders',
-                        tableLabel: 'Orders',
-                        compiledSql: 'order_date_year',
-                        tablesReferences: [],
-                        sql: 'order_date_year',
-                        hidden: false,
-                        fieldType: FieldType.DIMENSION,
-                        type: DimensionType.DATE,
-                        timeIntervalBaseDimensionName: 'order_date',
-                    },
-                    order_date_month: {
-                        name: 'order_date_month',
-                        label: 'Order Date Month',
-                        table: 'orders',
-                        tableLabel: 'Orders',
-                        compiledSql: 'order_date_month',
-                        tablesReferences: [],
-                        sql: 'order_date_month',
-                        hidden: false,
-                        fieldType: FieldType.DIMENSION,
-                        type: DimensionType.DATE,
-                        timeIntervalBaseDimensionName: 'order_date',
-                    },
-                    order_date_week: {
-                        name: 'order_date_week',
-                        label: 'Order Date Week',
-                        table: 'orders',
-                        tableLabel: 'Orders',
-                        compiledSql: 'order_date_week',
-                        sql: 'order_date_week',
-                        hidden: false,
-                        tablesReferences: [],
-                        fieldType: FieldType.DIMENSION,
-                        type: DimensionType.DATE,
-                        timeIntervalBaseDimensionName: 'order_date',
-                    },
-                    status: {
-                        name: 'status',
-                        label: 'Status',
-                        table: 'orders',
-                        tableLabel: 'Orders',
-                        compiledSql: 'status',
-                        sql: 'status',
-                        hidden: false,
-                        tablesReferences: [],
-                        fieldType: FieldType.DIMENSION,
-                        type: DimensionType.BOOLEAN,
-                    },
-                },
-            },
-        },
-    };
-
     test('should track fields to change when dashboard filter targets base time dimension', () => {
         const metricQueryDimensionFilters: AndFilterGroup = {
             id: 'dim-filter-group',

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 import { type AnyType } from '../types/any';
 import { DashboardTileTypes, type DashboardTile } from '../types/dashboard';
-import { type Explore, type Table } from '../types/explore';
+import { type Explore } from '../types/explore';
 import {
     DimensionType,
     MetricType,
@@ -32,6 +32,7 @@ import {
     isFilterGroup,
     isFilterRule,
     isFilterRuleDefinedForFieldId,
+    isJoinModelRequiredFilter,
     type AndFilterGroup,
     type DashboardFieldTarget,
     type DashboardFilterRule,
@@ -42,7 +43,7 @@ import {
     type FilterGroupItem,
     type FilterRule,
     type Filters,
-    type MetricFilterRule,
+    type ModelRequiredFilterRule,
     type OrFilterGroup,
     type TimeBasedOverrideMap,
 } from '../types/filter';
@@ -1047,8 +1048,8 @@ export const addDashboardFiltersToMetricQuery = (
     };
 };
 
-export const createFilterRuleFromRequiredMetricRule = (
-    filter: MetricFilterRule,
+export const createFilterRuleFromModelRequiredFilterRule = (
+    filter: ModelRequiredFilterRule,
     tableName: string,
 ): FilterRule => ({
     id: filter.id,
@@ -1090,23 +1091,40 @@ export const isFilterRuleInQuery = (
 };
 
 export const reduceRequiredDimensionFiltersToFilterRules = (
-    requiredFilters: MetricFilterRule[],
-    table: Table,
+    requiredFilters: ModelRequiredFilterRule[],
     filters: FilterGroup | undefined,
-): FilterRule[] =>
-    requiredFilters.reduce<FilterRule[]>((acc, filter): FilterRule[] => {
-        const filterRule = createFilterRuleFromRequiredMetricRule(
+    explore: Explore,
+): FilterRule[] => {
+    const table = explore.tables[explore.baseTable];
+
+    return requiredFilters.reduce<FilterRule[]>((acc, filter): FilterRule[] => {
+        let dimension: Dimension | undefined;
+        // This function already takes care of falling back to the base table if the fieldRef doesn't have 2 parts (falls back to base table name)
+        const filterRule = createFilterRuleFromModelRequiredFilterRule(
             filter,
             table.name,
         );
-        const dimension = Object.values(table.dimensions).find(
-            (tc) => getItemId(tc) === filterRule.target.fieldId,
-        );
+
+        if (isJoinModelRequiredFilter(filter)) {
+            const joinedTable = explore.tables[filter.target.tableName];
+
+            if (joinedTable) {
+                dimension = Object.values(joinedTable.dimensions).find(
+                    (d) => getItemId(d) === filterRule.target.fieldId,
+                );
+            }
+        } else {
+            dimension = Object.values(table.dimensions).find(
+                (tc) => getItemId(tc) === filterRule.target.fieldId,
+            );
+        }
+
         if (dimension && !isFilterRuleInQuery(dimension, filterRule, filters)) {
             return [...acc, filterRule];
         }
         return acc;
     }, []);
+};
 
 export const resetRequiredFilterRules = (
     filterGroup: FilterGroup,

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -51,8 +51,8 @@ const FiltersCard: FC = memo(() => {
         const allRequiredFilters: FilterRule[] =
             reduceRequiredDimensionFiltersToFilterRules(
                 requiredFilters,
-                data.tables[tableName],
                 undefined,
+                data,
             );
         const allFilterRefs = allRequiredFilters.map(
             (filter) => filter.target.fieldId,
@@ -81,8 +81,8 @@ const FiltersCard: FC = memo(() => {
                 const reducedRules: FilterRule[] =
                     reduceRequiredDimensionFiltersToFilterRules(
                         requiredFilters,
-                        data.tables[tableName],
                         unsavedQueryFilters.dimensions,
+                        data,
                     );
                 // Add to the existing filter rules with the missing required filter rules
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14807 

### Description:

- Adds the ability of adding required filters to joined tables fields

On "orders" model add
```yaml
meta:
      required_filters:
        - status: "completed"
        - customers.first_name: "Jane"
```

Recompile project

![image](https://github.com/user-attachments/assets/a5eb1ce7-2257-4c3b-9ed9-1bdeb984d313)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
