### PR TITLE
fix: request user to refresh page when worker cant load old pivot script

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex } from '@mantine/core';
+import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC, useCallback, useEffect, useMemo } from 'react';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -130,6 +130,39 @@ const SimpleTable: FC<SimpleTableProps> = ({
     } = visualizationConfig.chartConfig;
 
     if (pivotTableData.error) {
+        const isWorkerFetchError = pivotTableData.error.includes(
+            'Failed to fetch dynamically imported module',
+        );
+        if (isWorkerFetchError) {
+            return (
+                <SuboptimalState
+                    icon={IconAlertCircle}
+                    title="Application update required"
+                    description={
+                        <Box>
+                            <Text mb="xs">
+                                Refresh your browser to load the latest version
+                                and display this visualization correctly.
+                            </Text>
+                            <Text size="sm" color="dimmed">
+                                If this persists after refreshing, contact
+                                support.
+                            </Text>
+                        </Box>
+                    }
+                    action={
+                        <Button
+                            variant="default"
+                            size={'xs'}
+                            leftIcon={<IconRefresh size={16} />}
+                            onClick={() => window.location.reload()}
+                        >
+                            Refresh page
+                        </Button>
+                    }
+                />
+            );
+        }
         return (
             <SuboptimalState
                 title="Results not available"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8806
Closes: #8216<!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Improve error handling when pivot table fails to fetch pivot script. 
Explain problem and provide action to fix it.

Before:

![before](https://private-user-images.githubusercontent.com/31848148/288144209-da57fe7c-677b-41ad-af5a-34281cf3844f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDc3NTkyMzEsIm5iZiI6MTc0Nzc1ODkzMSwicGF0aCI6Ii8zMTg0ODE0OC8yODgxNDQyMDktZGE1N2ZlN2MtNjc3Yi00MWFkLWFmNWEtMzQyODFjZjM4NDRmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA1MjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNTIwVDE2MzUzMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWE4MTA0YTM1ZjFlZGRjMzc4NDU5MjUzNTBlZGQxYWJjOWFiNmNkZjJiN2VjODhiZTI5ZDc2ZDU5MzA5NzljZTAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.MD9cIFgETnBJbPnNjqztjPNckN8iyzlR27lp6Xh_A9k)

After:

![Screenshot 2025-05-20 at 16.23.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/CIQVnVTkiLq0ysfP4597/a6490a57-e3f1-4c5c-8f7f-12fa2f5c45f5.png)

![Screenshot 2025-05-20 at 16.22.49.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/CIQVnVTkiLq0ysfP4597/1ed43278-c7e2-454c-9ddd-b24d28600d63.png)

![Screenshot 2025-05-20 at 16.22.38.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/CIQVnVTkiLq0ysfP4597/b5c20f81-9b3b-48f7-a65b-62c3ca0eaef1.png)

