### PR TITLE
chore: remove inline handlers in Explore tree

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -15,6 +15,7 @@ import { ActionIcon, Group, Menu, Skeleton, Stack, Text } from '@mantine/core';
 import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
 import {
     memo,
+    useCallback,
     useEffect,
     useMemo,
     useState,
@@ -193,6 +194,25 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         }
     }, [explore, additionalMetrics, metrics, dimensions, customDimensions]);
 
+    const handleEditVirtualView = useCallback(() => {
+        startTransition(() => setIsEditVirtualViewOpen(true));
+    }, []);
+
+    const handleDeleteVirtualView = useCallback(() => {
+        setIsDeleteVirtualViewOpen(true);
+    }, []);
+
+    const breadcrumbs = useMemo(() => {
+        if (!explore) return [];
+        const items = onBack
+            ? [
+                  { title: 'Tables', onClick: onBack },
+                  { title: explore.label, active: true },
+              ]
+            : [{ title: explore.label, active: true }];
+        return items;
+    }, [onBack, explore]);
+
     if (status === 'loading') {
         return <LoadingSkeleton />;
     }
@@ -207,23 +227,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     return (
         <Stack h="100%" sx={{ flexGrow: 1 }}>
             <Group position="apart">
-                <PageBreadcrumbs
-                    size="md"
-                    items={[
-                        ...(onBack
-                            ? [
-                                  {
-                                      title: 'Tables',
-                                      onClick: onBack,
-                                  },
-                              ]
-                            : []),
-                        {
-                            title: explore.label,
-                            active: true,
-                        },
-                    ]}
-                />
+                <PageBreadcrumbs size="md" items={breadcrumbs} />
                 {canManageVirtualViews &&
                     explore.type === ExploreType.VIRTUAL && (
                         <Menu withArrow offset={-2}>
@@ -235,11 +239,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             <Menu.Dropdown>
                                 <Menu.Item
                                     icon={<MantineIcon icon={IconPencil} />}
-                                    onClick={() => {
-                                        startTransition(() => {
-                                            setIsEditVirtualViewOpen(true);
-                                        });
-                                    }}
+                                    onClick={handleEditVirtualView}
                                 >
                                     <Text fz="xs" fw={500}>
                                         Edit virtual view
@@ -248,9 +248,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                                 <Menu.Item
                                     icon={<MantineIcon icon={IconTrash} />}
                                     color="red"
-                                    onClick={() => {
-                                        setIsDeleteVirtualViewOpen(true);
-                                    }}
+                                    onClick={handleDeleteVirtualView}
                                 >
                                     <Text fz="xs" fw={500}>
                                         Delete

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -6,6 +6,7 @@ import {
 import { MantineProvider, NavLink, Text } from '@mantine/core';
 import { IconTable } from '@tabler/icons-react';
 import type { FC } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useToggle } from 'react-use';
 
 import { getMantineThemeOverride } from '../../../../mantineTheme';
@@ -29,29 +30,47 @@ const TableTreeWrapper: FC<React.PropsWithChildren<TableTreeWrapperProps>> = ({
 }) => {
     const [isHover, toggleHover] = useToggle(false);
 
+    const handleMouseEnter = useCallback(
+        () => toggleHover(true),
+        [toggleHover],
+    );
+    const handleMouseLeave = useCallback(
+        () => toggleHover(false),
+        [toggleHover],
+    );
+    const handleClosePreview = useCallback(
+        () => toggleHover(false),
+        [toggleHover],
+    );
+
+    const label = useMemo(
+        () => (
+            <TableItemDetailPreview
+                label={table.label}
+                description={table.description}
+                showPreview={isHover}
+                closePreview={handleClosePreview}
+            >
+                <Text truncate fw={600}>
+                    {table.label}
+                </Text>
+            </TableItemDetailPreview>
+        ),
+        [table.label, table.description, isHover, handleClosePreview],
+    );
+
     return (
         <NavLink
             opened={isOpen}
             onChange={toggle}
-            onMouseEnter={() => toggleHover(true)}
-            onMouseLeave={() => toggleHover(false)}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
             icon={<MantineIcon icon={IconTable} size="lg" color="gray.7" />}
-            label={
-                <TableItemDetailPreview
-                    label={table.label}
-                    description={table.description}
-                    showPreview={isHover}
-                    closePreview={() => toggleHover(false)}
-                >
-                    <Text truncate fw={600}>
-                        {table.label}
-                    </Text>
-                </TableItemDetailPreview>
-            }
+            label={label}
             styles={{
                 root: {
                     top: 0,
-                    position: 'sticky',
+                    position: 'sticky' as const,
                     backgroundColor: 'white',
                     zIndex: 1,
                 },

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -42,6 +42,13 @@ const ExploreTree: FC<ExploreTreeProps> = ({
     const [search, setSearch] = useState<string>('');
     const isSearching = !!search && search !== '';
 
+    const handleSearchChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value),
+        [],
+    );
+
+    const handleClearSearch = useCallback(() => setSearch(''), []);
+
     const searchResults = useCallback(
         (table: CompiledTable) => {
             const allValues = Object.values({
@@ -81,14 +88,14 @@ const ExploreTree: FC<ExploreTreeProps> = ({
                 icon={<MantineIcon icon={IconSearch} />}
                 rightSection={
                     search ? (
-                        <ActionIcon onClick={() => setSearch('')}>
+                        <ActionIcon onClick={handleClearSearch}>
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
                     ) : null
                 }
                 placeholder="Search metrics + dimensions"
                 value={search}
-                onChange={(e) => setSearch(e.target.value)}
+                onChange={handleSearchChange}
             />
 
             <ScrollArea


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #14638

### Description:

Removes inlined handlers from some more tree components. This is a code clean-up with along the path to improving perf in the explores page. 

To test it:
- Interact with the tables sidebar
- Select and deselect various dimensions and metrics
- Fitler
- Add custom dimensions and table calcs
- Search
- Creat, edit, delete Virtual View
- Etc. 
- Does everything work

Note that this is a step to improve perf -- it won't be fixed. 

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
