### PR TITLE
feat(backend): implement AI agent threads API endpoints

### DIFF
--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -1,5 +1,4 @@
 ### Login
-// @no-log
 POST http://localhost:8080/api/v1/login
 Content-Type: application/json
 
@@ -8,12 +7,18 @@ Content-Type: application/json
     "password": "demo_password!"
 }
 
-
 ### List agents
 GET http://localhost:8080/api/v1/aiAgents
 Content-Type: application/json
 
-
 ### Get agent
-GET http://localhost:8080/api/v1/aiAgents/81e71729-259f-4778-aa72-649a86aa9662
+GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76
+Content-Type: application/json
+
+### Get agent threads
+GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads
+Content-Type: application/json
+
+### Get agent thread
+GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads/91ea006f-bce1-4193-9099-13dddaddfcfc
 Content-Type: application/json

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -96,7 +96,13 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentThreadSummaryListResponse> {
         this.setStatus(200);
-        throw new NotImplementedError('List agent threads not implemented');
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().listAgentThreads(
+                req.user!,
+                agentUuid,
+            ),
+        };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -109,7 +115,14 @@ export class AiAgentController extends BaseController {
         @Path() threadUuid: string,
     ): Promise<ApiAiAgentThreadResponse> {
         this.setStatus(200);
-        throw new NotImplementedError('Get agent thread not implemented');
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getAgentThread(
+                req.user!,
+                agentUuid,
+                threadUuid,
+            ),
+        };
     }
 
     protected getAiAgentService() {

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,14 +1,21 @@
 import {
     type AiAgent,
+    AiAgentMessage,
     AiAgentSummary,
-    baseAgentSchema,
+    AiAgentThreadSummary,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { DbUser, UserTableName } from '../../database/entities/users';
+import {
+    AiPromptTableName,
+    AiThreadTableName,
+    DbAiPrompt,
+    DbAiThread,
+} from '../database/entities/ai';
 import {
     AiAgentIntegrationTableName,
     AiAgentSlackIntegrationTableName,
     AiAgentTableName,
-    DbAiAgent,
     DbAiAgentIntegration,
     DbAiAgentSlackIntegration,
 } from '../database/entities/aiAgent';
@@ -147,5 +154,185 @@ export class AiAgentModel {
         });
 
         return agent;
+    }
+
+    async findThreads({
+        organizationUuid,
+        agentUuid,
+        threadUuid,
+    }: {
+        organizationUuid: string;
+        agentUuid: string;
+        threadUuid?: string;
+    }): Promise<AiAgentThreadSummary[]> {
+        const query = this.database(AiThreadTableName)
+            .join(
+                AiPromptTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiPromptTableName}.ai_thread_uuid`,
+            )
+            .join(
+                UserTableName,
+                `${AiPromptTableName}.created_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .where(
+                `${AiPromptTableName}.created_at`,
+                this.database(AiPromptTableName)
+                    .select(this.database.raw('MIN(created_at)'))
+                    .whereRaw(
+                        `${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid`,
+                    ),
+            )
+            .andWhere(
+                `${AiThreadTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .andWhere(`${AiThreadTableName}.agent_uuid`, agentUuid)
+            .select<
+                (Pick<
+                    DbAiThread,
+                    | 'ai_thread_uuid'
+                    | 'agent_uuid'
+                    | 'created_at'
+                    | 'created_from'
+                > &
+                    Pick<DbAiPrompt, 'prompt'> &
+                    Pick<DbUser, 'user_uuid'> & { user_name: string })[]
+            >(
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.agent_uuid`,
+                `${AiThreadTableName}.created_at`,
+                `${AiThreadTableName}.created_from`,
+                `${AiPromptTableName}.prompt`,
+                `${UserTableName}.user_uuid`,
+                this.database.raw(
+                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                ),
+            )
+            .orderBy(`${AiThreadTableName}.created_at`, 'desc');
+
+        if (threadUuid) {
+            void query.andWhere(
+                `${AiThreadTableName}.ai_thread_uuid`,
+                threadUuid,
+            );
+        }
+
+        const rows = await query;
+
+        return rows.map((row) => ({
+            uuid: row.ai_thread_uuid,
+            threadUuid: row.ai_thread_uuid,
+            agentUuid: row.agent_uuid!,
+            createdAt: row.created_at as unknown as string,
+            createdFrom: row.created_from,
+            firstMessage: row.prompt,
+            user: {
+                uuid: row.user_uuid,
+                name: row.user_name,
+            },
+        }));
+    }
+
+    async getThread({
+        organizationUuid,
+        agentUuid,
+        threadUuid,
+    }: {
+        organizationUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+    }): Promise<AiAgentThreadSummary> {
+        const rows = await this.findThreads({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (rows.length !== 1) {
+            throw new AiAgentNotFoundError(
+                `AI agent thread not found for uuid: ${threadUuid}`,
+            );
+        }
+
+        return rows[0];
+    }
+
+    async findThreadMessages({
+        organizationUuid,
+        threadUuid,
+    }: {
+        organizationUuid: string;
+        threadUuid: string;
+    }): Promise<AiAgentMessage[]> {
+        const rows = await this.database(AiPromptTableName)
+            .join(
+                UserTableName,
+                `${AiPromptTableName}.created_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .join(
+                AiThreadTableName,
+                `${AiPromptTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .select(
+                'ai_prompt_uuid',
+                'prompt',
+                'response',
+                'responded_at',
+                'filters_output',
+                'viz_config_output',
+                'metric_query',
+                'human_score',
+                'user_uuid',
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .select({
+                uuid: `${AiPromptTableName}.ai_prompt_uuid`,
+                created_at: `${AiPromptTableName}.created_at`,
+                user_name: this.database.raw(
+                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)`,
+                ),
+            })
+            .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
+            .andWhere(
+                `${AiThreadTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .orderBy(`${AiPromptTableName}.created_at`, 'asc');
+
+        return rows.flatMap((row) => {
+            const messages: AiAgentMessage[] = [
+                {
+                    role: 'user',
+                    uuid: row.ai_prompt_uuid,
+                    threadUuid: row.ai_thread_uuid,
+                    message: row.prompt,
+                    createdAt: row.created_at,
+                    user: {
+                        uuid: row.user_uuid,
+                        name: row.user_name,
+                    },
+                },
+            ];
+
+            if (row.responded_at != null) {
+                messages.push({
+                    role: 'assistant',
+                    uuid: row.ai_prompt_uuid,
+                    threadUuid: row.ai_thread_uuid,
+                    message: row.response,
+                    createdAt: row.responded_at,
+                    vizConfigOutput: row.viz_config_output,
+                    filtersOutput: row.filters_output,
+                    metricQuery: row.metric_query,
+                    humanScore: row.human_score,
+                });
+            }
+
+            return messages;
+        });
     }
 }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -3,6 +3,7 @@ import {
     CommercialFeatureFlags,
     ForbiddenError,
     LightdashUser,
+    NotFoundError,
     type SessionUser,
 } from '@lightdash/common';
 import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
@@ -79,5 +80,78 @@ export class AiAgentService {
         });
 
         return agents;
+    }
+
+    async listAgentThreads(user: SessionUser, agentUuid: string) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const threads = await this.aiAgentModel.findThreads({
+            organizationUuid,
+            agentUuid,
+        });
+
+        return threads;
+    }
+
+    async getAgentThread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        const messages = await this.aiAgentModel.findThreadMessages({
+            organizationUuid,
+            threadUuid,
+        });
+
+        return {
+            ...thread,
+            messages,
+        };
     }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -116,6 +116,7 @@ import { type UserWarehouseCredentials } from './types/userWarehouseCredentials'
 import { type ValidationResponse } from './types/validation';
 
 import type {
+    ApiAiAgentThreadResponse,
     ApiAiConversationMessages,
     ApiAiConversationResponse,
     ApiAiConversations,
@@ -895,7 +896,8 @@ type ApiResults =
     | ApiGetAsyncQueryResults
     | ApiUserActivityDownloadCsv['results']
     | ApiRenameFieldsResponse['results']
-    | ApiDownloadAsyncQueryResults;
+    | ApiDownloadAsyncQueryResults
+    | ApiAiAgentThreadResponse['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -205,9 +205,11 @@ export const AgentDetails: FC = () => {
                         >
                             <Tabs.List>
                                 <Tabs.Tab value="general">General</Tabs.Tab>
-                                <Tabs.Tab value="conversations">
-                                    Conversations
-                                </Tabs.Tab>
+                                {!isCreateMode && (
+                                    <Tabs.Tab value="conversations">
+                                        Conversations
+                                    </Tabs.Tab>
+                                )}
                             </Tabs.List>
 
                             <Tabs.Panel value="general" pt="xs">
@@ -309,6 +311,7 @@ export const AgentDetails: FC = () => {
                             <Tabs.Panel value="conversations" pt="xs">
                                 <ConversationsList
                                     agentUuid={agentUuid ?? ''}
+                                    agentName={form.values.name}
                                 />
                             </Tabs.Panel>
                         </Tabs>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
@@ -1,16 +1,18 @@
-import { Badge, Stack, Table, Title } from '@mantine-8/core';
+import { Badge, Loader, Stack, Table, Text, Title } from '@mantine-8/core';
 import { useState, type FC } from 'react';
 import { useAiAgentThreads } from '../hooks/useAiAgents';
 import { ThreadDetailsModal } from './ThreadDetailsModal';
 
 type ConversationsListProps = {
     agentUuid: string;
+    agentName: string;
 };
 
 export const ConversationsList: FC<ConversationsListProps> = ({
     agentUuid,
+    agentName,
 }) => {
-    const { data: threads } = useAiAgentThreads(agentUuid);
+    const { data: threads, isLoading } = useAiAgentThreads(agentUuid);
     const [selectedThreadUuid, setSelectedThreadUuid] = useState<string | null>(
         null,
     );
@@ -22,6 +24,22 @@ export const ConversationsList: FC<ConversationsListProps> = ({
     const handleModalClose = () => {
         setSelectedThreadUuid(null);
     };
+
+    if (isLoading) {
+        return (
+            <Stack align="center" justify="center" h="100%">
+                <Loader />
+            </Stack>
+        );
+    }
+
+    if (threads?.length === 0) {
+        return (
+            <Stack>
+                <Text>No conversations found</Text>
+            </Stack>
+        );
+    }
 
     return (
         <Stack>
@@ -37,7 +55,7 @@ export const ConversationsList: FC<ConversationsListProps> = ({
                     </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
-                    {threads?.results.map((thread) => (
+                    {threads?.map((thread) => (
                         <Table.Tr
                             key={thread.uuid}
                             onClick={() => handleRowClick(thread.uuid)}
@@ -71,6 +89,7 @@ export const ConversationsList: FC<ConversationsListProps> = ({
             </Table>
 
             <ThreadDetailsModal
+                agentName={agentName}
                 agentUuid={agentUuid}
                 threadUuid={selectedThreadUuid}
                 onClose={handleModalClose}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
@@ -13,25 +13,25 @@ import { type FC } from 'react';
 import { useAiAgentThread } from '../hooks/useAiAgents';
 
 type ThreadDetailsModalProps = {
+    agentName: string;
     agentUuid: string;
     threadUuid: string | null;
     onClose: () => void;
 };
 
 export const ThreadDetailsModal: FC<ThreadDetailsModalProps> = ({
+    agentName,
     agentUuid,
     threadUuid,
     onClose,
 }) => {
-    const { data: threadDetails, isLoading } = useAiAgentThread(
+    const { data: thread, isLoading } = useAiAgentThread(
         agentUuid,
         threadUuid || '',
         {
             enabled: !!threadUuid,
         },
     );
-
-    const thread = threadDetails?.results;
 
     // Format date function since date-fns is not available
     const formatDate = (dateString: string) => {
@@ -106,7 +106,8 @@ export const ThreadDetailsModal: FC<ThreadDetailsModalProps> = ({
                                             </Avatar>
                                             <Text fw={500} size="sm">
                                                 {message.role === 'assistant'
-                                                    ? 'AI Assistant'
+                                                    ? agentName ||
+                                                      'AI Assistant'
                                                     : thread.user.name}
                                             </Text>
                                             <Text size="xs" c="dimmed">

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
@@ -73,29 +73,19 @@ const updateAgent = async (data: ApiUpdateAiAgent) =>
         body: JSON.stringify(data),
     });
 
-// const listAgentThreads = async (agentUuid: string) =>
-//     lightdashApi<ApiAiAgentThreadSummaryListResponse>({
-//         url: `/api/v1/aiAgents/${agentUuid}/threads`,
-//         method: 'GET',
-//         body: undefined,
-//     });
+const listAgentThreads = async (agentUuid: string) =>
+    lightdashApi<ApiAiAgentThreadSummaryListResponse['results']>({
+        url: `/aiAgents/${agentUuid}/threads`,
+        method: 'GET',
+        body: undefined,
+    });
 
-// const getAgentThread = async (agentUuid: string, threadUuid: string) =>
-//     lightdashApi<ApiAiAgentThreadResponse>({
-//         url: `/api/v1/aiAgents/${agentUuid}/threads/${threadUuid}`,
-//         method: 'GET',
-//         body: undefined,
-//     });
-
-// Function removed - we're using mock data instead
-
-// Removing unused getAgentThread function
-// const getAgentThread = async (agentUuid: string, threadUuid: string) =>
-//     lightdashApi<ApiAiAgentThreadResponse>({
-//         url: `/api/v1/aiAgents/${agentUuid}/threads/${threadUuid}`,
-//         method: 'GET',
-//         body: undefined,
-//     });
+const getAgentThread = async (agentUuid: string, threadUuid: string) =>
+    lightdashApi<ApiAiAgentThreadResponse['results']>({
+        url: `/aiAgents/${agentUuid}/threads/${threadUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
 
 // Hooks
 export const useAiAgents = (
@@ -164,127 +154,27 @@ export const useUpdateAiAgentMutation = (
 export const useAiAgentThreads = (
     agentUuid: string,
     useQueryOptions?: UseQueryOptions<
-        ApiAiAgentThreadSummaryListResponse,
+        ApiAiAgentThreadSummaryListResponse['results'],
         ApiError
     >,
 ) =>
-    useQuery<ApiAiAgentThreadSummaryListResponse, ApiError>({
+    useQuery<ApiAiAgentThreadSummaryListResponse['results'], ApiError>({
         queryKey: getAiAgentThreadsKey(agentUuid),
-        queryFn: () =>
-            Promise.resolve({
-                status: 'ok',
-                results: [
-                    {
-                        uuid: 'thread-1',
-                        agentUuid,
-                        createdAt: new Date().toISOString(),
-                        createdFrom: 'web',
-                        firstMessage: 'How can I analyze my sales data?',
-                        user: {
-                            uuid: 'user-1',
-                            name: 'John Doe',
-                        },
-                    },
-                    {
-                        uuid: 'thread-2',
-                        agentUuid,
-                        createdAt: new Date().toISOString(),
-                        createdFrom: 'slack',
-                        firstMessage: 'Show me revenue by region',
-                        user: {
-                            uuid: 'user-2',
-                            name: 'Jane Smith',
-                        },
-                    },
-                ],
-            }),
+        queryFn: () => listAgentThreads(agentUuid),
         ...useQueryOptions,
     });
 
 export const useAiAgentThread = (
     agentUuid: string,
     threadUuid: string,
-    useQueryOptions?: UseQueryOptions<ApiAiAgentThreadResponse, ApiError>,
+    useQueryOptions?: UseQueryOptions<
+        ApiAiAgentThreadResponse['results'],
+        ApiError
+    >,
 ) => {
-    // Define the mock data function outside the query to avoid TypeScript issues
-    const getMockThreadData = (): ApiAiAgentThreadResponse => ({
-        status: 'ok',
-        results: {
-            uuid: threadUuid,
-            agentUuid,
-            createdAt: new Date().toISOString(),
-            // updatedAt: new Date().toISOString(),
-            createdFrom: threadUuid === 'thread-1' ? 'web' : 'slack',
-            firstMessage:
-                threadUuid === 'thread-1'
-                    ? 'How can I analyze my sales data?'
-                    : 'Show me revenue by region',
-            user: {
-                uuid: threadUuid === 'thread-1' ? 'user-1' : 'user-2',
-                name: threadUuid === 'thread-1' ? 'John Doe' : 'Jane Smith',
-            },
-            messages: [
-                {
-                    uuid: `msg-1-${threadUuid}`,
-                    threadUuid,
-                    message:
-                        threadUuid === 'thread-1'
-                            ? 'How can I analyze my sales data?'
-                            : 'Show me revenue by region',
-                    role: 'user',
-                    createdAt: new Date(Date.now() - 3600000).toISOString(),
-                    user: {
-                        uuid: threadUuid === 'thread-1' ? 'user-1' : 'user-2',
-                        name:
-                            threadUuid === 'thread-1'
-                                ? 'John Doe'
-                                : 'Jane Smith',
-                    },
-                },
-                {
-                    uuid: `msg-2-${threadUuid}`,
-                    threadUuid,
-                    message:
-                        threadUuid === 'thread-1'
-                            ? "You can analyze your sales data by looking at the 'Sales Overview' dashboard. It shows revenue by product, region, and time period. You can also create custom charts in the Explore section."
-                            : "Here's a breakdown of revenue by region:\n\n- North America: $1.2M\n- Europe: $950K\n- Asia: $820K\n- South America: $430K\n\nWould you like me to create a chart for this data?",
-                    role: 'assistant',
-                    createdAt: new Date(Date.now() - 3500000).toISOString(),
-                },
-                {
-                    uuid: `msg-3-${threadUuid}`,
-                    threadUuid,
-                    message:
-                        threadUuid === 'thread-1'
-                            ? 'Thanks! How do I filter by date range?'
-                            : 'Yes, please create a bar chart.',
-                    role: 'user',
-                    createdAt: new Date(Date.now() - 1800000).toISOString(),
-                    user: {
-                        uuid: threadUuid === 'thread-1' ? 'user-1' : 'user-2',
-                        name:
-                            threadUuid === 'thread-1'
-                                ? 'John Doe'
-                                : 'Jane Smith',
-                    },
-                },
-                {
-                    uuid: `msg-4-${threadUuid}`,
-                    threadUuid,
-                    message:
-                        threadUuid === 'thread-1'
-                            ? "To filter by date range, click on the date filter at the top of the dashboard. You can select predefined ranges like 'Last 7 days' or 'Last month', or set a custom range by selecting specific start and end dates."
-                            : "I've created a bar chart showing revenue by region. You can view it here: [Revenue by Region Chart](https://example.com/chart). The chart is also available in your 'Recent Explorations' list.",
-                    role: 'assistant',
-                    createdAt: new Date(Date.now() - 1700000).toISOString(),
-                },
-            ],
-        },
-    });
-
-    return useQuery<ApiAiAgentThreadResponse, ApiError>({
+    return useQuery<ApiAiAgentThreadResponse['results'], ApiError>({
         queryKey: getAiAgentThreadKey(agentUuid, threadUuid),
-        queryFn: () => Promise.resolve(getMockThreadData()),
+        queryFn: () => getAgentThread(agentUuid, threadUuid),
         ...useQueryOptions,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14831


### Description:
Implements the AI agent thread endpoints to allow users to view their conversation history with AI agents. This PR adds functionality to:

1. List all threads for a specific AI agent
2. View a specific thread with all messages between the user and the AI agent

The implementation includes:
- Database queries to retrieve thread summaries and messages
- API endpoints for accessing thread data
- HTTP examples for testing the new endpoints

