### PR TITLE
feat: allow deleting agents

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -6,11 +6,13 @@ import {
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
     ApiErrorPayload,
+    ApiSuccessEmpty,
     ApiUpdateAiAgent,
     NotImplementedError,
 } from '@lightdash/common';
 import {
     Body,
+    Delete,
     Get,
     Hidden,
     Middlewares,
@@ -106,6 +108,23 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: agent,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{agentUuid}')
+    @OperationId('deleteAgent')
+    async deleteAgent(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.getAiAgentService().deleteAgent(req.user!, agentUuid);
+
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -302,4 +302,17 @@ export class AiAgentModel {
             };
         });
     }
+
+    async deleteAgent({
+        organizationUuid,
+        agentUuid,
+    }: {
+        organizationUuid: string;
+        agentUuid: string;
+    }): Promise<void> {
+        await this.database(AiAgentTableName)
+            .where('ai_agent_uuid', agentUuid)
+            .where('organization_uuid', organizationUuid)
+            .delete();
+    }
 }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1,5 +1,4 @@
 import {
-    AiAgentSummary,
     ApiCreateAiAgent,
     ApiUpdateAiAgent,
     CommercialFeatureFlags,
@@ -129,5 +128,31 @@ export class AiAgentService {
         });
 
         return updatedAgent;
+    }
+
+    public async deleteAgent(user: SessionUser, agentUuid: string) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.getAgent(user, agentUuid);
+        if (!agent) {
+            throw new ForbiddenError('Agent not found');
+        }
+
+        if (agent.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError('Agent not found');
+        }
+
+        return this.aiAgentModel.deleteAgent({
+            organizationUuid,
+            agentUuid,
+        });
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18748,6 +18748,66 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_deleteAgent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/aiAgents/:agentUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.deleteAgent,
+        ),
+
+        async function AiAgentController_deleteAgent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_deleteAgent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteAgent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentController_listAgentThreads: Record<
         string,
         TsoaRoute.ParameterSchema

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -32,6 +32,7 @@ import { useProjects } from '../../../../hooks/useProjects';
 import {
     useAiAgent,
     useCreateAiAgentMutation,
+    useDeleteAiAgentMutation,
     useUpdateAiAgentMutation,
 } from '../hooks/useAiAgents';
 import { ConversationsList } from './ConversationsList';
@@ -74,6 +75,7 @@ export const AgentDetails: FC = () => {
             enabled: !!agentUuid,
         },
     );
+    const { mutateAsync: deleteAgent } = useDeleteAiAgentMutation();
 
     const { data: slackInstallation } = useGetSlack();
     const {
@@ -145,9 +147,13 @@ export const AgentDetails: FC = () => {
     });
 
     const handleDelete = useCallback(async () => {
-        // You would need to implement a delete mutation
+        if (!agentUuid) {
+            return;
+        }
+
+        await deleteAgent(agentUuid);
         void navigate('/generalSettings/aiAgents');
-    }, [navigate]);
+    }, [navigate, agentUuid, deleteAgent]);
 
     if (!isCreateMode && agentUuid && !agent && !isLoadingAgent) {
         return (

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
@@ -6,6 +6,7 @@ import {
     type ApiCreateAiAgent,
     type ApiCreateAiAgentResponse,
     type ApiError,
+    type ApiSuccessEmpty,
     type ApiUpdateAiAgent,
 } from '@lightdash/common';
 import {
@@ -144,6 +145,28 @@ export const useUpdateAiAgentMutation = (
             void queryClient.invalidateQueries({
                 queryKey: getAiAgentKey(data.results.uuid),
             });
+        },
+        ...options,
+    });
+};
+
+const deleteAgent = async (agentUuid: string) =>
+    lightdashApi<ApiSuccessEmpty>({
+        version: 'v1',
+        url: `/aiAgents/${agentUuid}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useDeleteAiAgentMutation = (
+    options?: UseMutationOptions<ApiSuccessEmpty, ApiError, string>,
+) => {
+    const queryClient = useQueryClient();
+
+    return useMutation<ApiSuccessEmpty, ApiError, string>({
+        mutationFn: (agentUuid) => deleteAgent(agentUuid),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: AI_AGENTS_KEY });
         },
         ...options,
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added the ability to delete AI agents through a new API endpoint and UI integration. This PR includes:

- New DELETE endpoint for AI agents in the backend controller
- Implementation of the delete functionality in the AI agent model and service
- Frontend mutation hook for deleting agents
- Integration of the delete functionality in the agent details component

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging