### PR TITLE
feat: support dashboard filters without field references

### DIFF
--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import {
     getDateGroupLabel,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
     isValidEmailAddress,
 } from '.';
@@ -21,11 +21,11 @@ describe('Common index', () => {
             const date = moment().format('YYYY-MM-DD');
 
             expect(
-                getFilterRuleWithDefaultValue(
-                    dateDayDimension,
-                    emptyValueFilter,
-                    undefined,
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: dateDayDimension,
+                    filterRule: emptyValueFilter,
+                    values: undefined,
+                }).values,
             ).toEqual([date]);
         });
 
@@ -33,11 +33,11 @@ describe('Common index', () => {
             const date = moment().format('YYYY-MM-01');
 
             expect(
-                getFilterRuleWithDefaultValue(
-                    dateMonthDimension,
-                    emptyValueFilter,
-                    undefined,
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: dateMonthDimension,
+                    filterRule: emptyValueFilter,
+                    values: undefined,
+                }).values,
             ).toEqual([date]);
         });
 
@@ -45,11 +45,11 @@ describe('Common index', () => {
             const date = moment().format('YYYY-01-01');
 
             expect(
-                getFilterRuleWithDefaultValue(
-                    dateYearDimension,
-                    emptyValueFilter,
-                    undefined,
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: dateYearDimension,
+                    filterRule: emptyValueFilter,
+                    values: undefined,
+                }).values,
             ).toEqual([date]);
         });
     });
@@ -57,38 +57,38 @@ describe('Common index', () => {
     describe('filter rule with default values', () => {
         test('should return with undefined values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
-                    stringDimension,
-                    emptyValueFilter,
-                    undefined,
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: stringDimension,
+                    filterRule: emptyValueFilter,
+                    values: undefined,
+                }).values,
             ).toEqual([]);
         });
         test('should return with empty values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
-                    stringDimension,
-                    emptyValueFilter,
-                    [],
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: stringDimension,
+                    filterRule: emptyValueFilter,
+                    values: [],
+                }).values,
             ).toEqual([]);
         });
         test('should return single value', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
-                    stringDimension,
-                    emptyValueFilter,
-                    ['test'],
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: stringDimension,
+                    filterRule: emptyValueFilter,
+                    values: ['test'],
+                }).values,
             ).toEqual(['test']);
         });
         test('should return multiple values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
-                    stringDimension,
-                    emptyValueFilter,
-                    ['test1', 'test2'],
-                ).values,
+                getFilterRuleFromFieldWithDefaultValue({
+                    field: stringDimension,
+                    filterRule: emptyValueFilter,
+                    values: ['test1', 'test2'],
+                }).values,
             ).toEqual(['test1', 'test2']);
         });
     });

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -249,8 +249,11 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                 onDragEnd={handleDragEnd}
             >
                 {dashboardFilters.dimensions.map((item, index) => {
-                    const field = allFilterableFieldsMap[item.target.fieldId];
+                    const field = item.target
+                        ? allFilterableFieldsMap[item.target.fieldId]
+                        : undefined;
                     const appliesToTabs = getTabsUsingFilter(item.id);
+                    const isInvalidFilter = item.target?.fieldId && !field;
                     return (
                         <DroppableArea key={item.id} id={item.id}>
                             <DraggableItem
@@ -258,7 +261,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                 id={item.id}
                                 disabled={!isEditMode || !!openPopoverId}
                             >
-                                {field ? (
+                                {!isInvalidFilter ? (
                                     <Filter
                                         key={item.id}
                                         isEditMode={isEditMode}
@@ -305,9 +308,12 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
             </DndContext>
 
             {dashboardTemporaryFilters.dimensions.map((item, index) => {
-                const field = allFilterableFieldsMap[item.target.fieldId];
+                const field = item.target
+                    ? allFilterableFieldsMap[item.target.fieldId]
+                    : undefined;
                 const appliesToTabs = getTabsUsingTemporaryFilter(item.id);
-                return field ? (
+                const isInvalidFilter = item.target?.fieldId && !field;
+                return !isInvalidFilter ? (
                     <Filter
                         key={item.id}
                         isTemporary

--- a/packages/frontend/src/components/DashboardFilter/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/Filter.tsx
@@ -81,6 +81,15 @@ const Filter: FC<Props> = ({
     const allFilterableFields = useDashboardContext(
         (c) => c.allFilterableFields,
     );
+    const sqlChartTilesMetadata = useDashboardContext(
+        (c) => c.sqlChartTilesMetadata,
+    );
+    const disabled = useMemo(() => {
+        return (
+            !allFilterableFields &&
+            Object.keys(sqlChartTilesMetadata).length === 0
+        );
+    }, [allFilterableFields, sqlChartTilesMetadata]);
     const filterableFieldsByTileUuid = useDashboardContext(
         (c) => c.filterableFieldsByTileUuid,
     );
@@ -99,13 +108,19 @@ const Filter: FC<Props> = ({
     const isDraggable = isEditMode && !isTemporary;
 
     const defaultFilterRule = useMemo(() => {
-        if (!filterableFieldsByTileUuid || !field || !filterRule) return;
+        if (!filterRule) return;
 
-        return applyDefaultTileTargets(
-            filterRule,
-            field,
-            filterableFieldsByTileUuid,
-        );
+        console.log('filterRule', filterRule);
+
+        if (filterableFieldsByTileUuid && field) {
+            return applyDefaultTileTargets(
+                filterRule,
+                field,
+                filterableFieldsByTileUuid,
+            );
+        } else {
+            return filterRule;
+        }
     }, [filterableFieldsByTileUuid, field, filterRule]);
 
     // Only used by active filters
@@ -170,9 +185,6 @@ const Filter: FC<Props> = ({
         [isCreatingNew, onSave, onUpdate, handleClose],
     );
 
-    const isPopoverDisabled =
-        !filterableFieldsByTileUuid || !allFilterableFields;
-
     return (
         <>
             <Popover
@@ -182,7 +194,7 @@ const Filter: FC<Props> = ({
                 closeOnEscape={!isSubPopoverOpen}
                 closeOnClickOutside={!isSubPopoverOpen}
                 onClose={handleClose}
-                disabled={isPopoverDisabled}
+                disabled={disabled}
                 transitionProps={{ transition: 'pop-top-left' }}
                 withArrow
                 shadow="md"
@@ -217,7 +229,7 @@ const Filter: FC<Props> = ({
                                         icon={IconFilter}
                                     />
                                 }
-                                disabled={!allFilterableFields}
+                                disabled={disabled}
                                 loading={
                                     isLoadingDashboardFilters ||
                                     isFetchingDashboardFilters
@@ -389,26 +401,24 @@ const Filter: FC<Props> = ({
                 </Popover.Target>
 
                 <Popover.Dropdown>
-                    {filterableFieldsByTileUuid && dashboardTiles && (
-                        <FilterConfiguration
-                            isCreatingNew={isCreatingNew}
-                            isEditMode={isEditMode}
-                            isTemporary={isTemporary}
-                            field={field}
-                            fields={allFilterableFields || []}
-                            tiles={dashboardTiles}
-                            tabs={dashboardTabs}
-                            activeTabUuid={activeTabUuid}
-                            originalFilterRule={originalFilterRule}
-                            availableTileFilters={filterableFieldsByTileUuid}
-                            defaultFilterRule={defaultFilterRule}
-                            onSave={handelSaveChanges}
-                            popoverProps={{
-                                onOpen: openSubPopover,
-                                onClose: closeSubPopover,
-                            }}
-                        />
-                    )}
+                    <FilterConfiguration
+                        isCreatingNew={isCreatingNew}
+                        isEditMode={isEditMode}
+                        isTemporary={isTemporary}
+                        field={field}
+                        fields={allFilterableFields || []}
+                        tiles={dashboardTiles || []}
+                        tabs={dashboardTabs}
+                        activeTabUuid={activeTabUuid}
+                        originalFilterRule={originalFilterRule}
+                        availableTileFilters={filterableFieldsByTileUuid || {}}
+                        defaultFilterRule={defaultFilterRule}
+                        onSave={handelSaveChanges}
+                        popoverProps={{
+                            onOpen: openSubPopover,
+                            onClose: closeSubPopover,
+                        }}
+                    />
                 </Popover.Dropdown>
             </Popover>
         </>

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -67,7 +67,7 @@ type Props = {
     tabs: DashboardTab[];
     activeTabUuid: string | undefined;
     availableTileFilters: Record<string, Field[] | undefined>;
-    field: Field;
+    field?: Field;
     filterRule: DashboardFilterRule;
     popoverProps?: Omit<PopoverProps, 'children'>;
     onChange: (
@@ -99,7 +99,7 @@ const TileFilterConfiguration: FC<Props> = ({
             a: Field[] | undefined,
             b: Field[] | undefined,
         ) => {
-            if (!a || !b) return 0;
+            if (!a || !b || !field) return 0;
 
             const matchA = a.some(fieldMatcher(field));
             const matchB = b.some(fieldMatcher(field));
@@ -114,6 +114,7 @@ const TileFilterConfiguration: FC<Props> = ({
             a: Field,
             b: Field,
         ) => {
+            if (!field) return 0;
             const matchA = fieldMatcher(field)(a);
             const matchB = fieldMatcher(field)(b);
             return matchA === matchB ? 0 : matchA ? -1 : 1;
@@ -156,9 +157,11 @@ const TileFilterConfiguration: FC<Props> = ({
                                       (f) =>
                                           tileConfig?.fieldId === getItemId(f),
                                   )
-                                : filters?.find((f) =>
+                                : field
+                                ? filters?.find((f) =>
                                       matchFieldExact(f)(field),
-                                  );
+                                  )
+                                : undefined;
 
                         // If tileConfig?.fieldId is set, but the field is not found in the filters, we mark it as invalid filter (missing dimension in model)
                         invalidField =
@@ -170,17 +173,24 @@ const TileFilterConfiguration: FC<Props> = ({
                                 : undefined;
                     }
 
-                    const isFilterAvailable =
-                        filters?.some(matchFieldByType(field)) ?? false;
+                    const isFilterAvailable = field
+                        ? filters?.some(matchFieldByType(field)) ?? false
+                        : false;
 
-                    const sortedFilters = filters
-                        ?.filter(matchFieldByType(field))
-                        .sort((a, b) =>
-                            sortFieldsByMatch(matchFieldByTypeAndName, a, b),
-                        )
-                        .sort((a, b) =>
-                            sortFieldsByMatch(matchFieldExact, a, b),
-                        );
+                    const sortedFilters = field
+                        ? filters
+                              ?.filter(matchFieldByType(field))
+                              .sort((a, b) =>
+                                  sortFieldsByMatch(
+                                      matchFieldByTypeAndName,
+                                      a,
+                                      b,
+                                  ),
+                              )
+                              .sort((a, b) =>
+                                  sortFieldsByMatch(matchFieldExact, a, b),
+                              )
+                        : filters;
 
                     const tileWithoutTitle =
                         !tile?.properties.title ||
@@ -383,6 +393,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                     }}
                                     checked={value.checked}
                                     onChange={(event) => {
+                                        console.log('click all');
                                         onChange(
                                             event.currentTarget.checked
                                                 ? FilterActions.ADD
@@ -448,6 +459,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                         value={value.selectedField}
                                         data={value.sortedFilters as string[]}
                                         onChange={(newField) => {
+                                            console.log('click');
                                             onChange(
                                                 FilterActions.ADD,
                                                 value.tileUuid,

--- a/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/InvalidFilter.tsx
@@ -21,6 +21,7 @@ const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
     return (
         <Tooltip
             position="top-start"
+            disabled={!filterRule.target}
             withinPortal
             offset={0}
             arrowOffset={16}
@@ -29,7 +30,7 @@ const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
                     <Text span color="gray.6">
                         Tried to reference field with unknown id:
                     </Text>
-                    <Text span> {filterRule.target.fieldId}</Text>
+                    <Text span> {filterRule.target?.fieldId}</Text>
                 </Text>
             }
         >

--- a/packages/frontend/src/components/DashboardFilter/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/index.tsx
@@ -37,7 +37,6 @@ const DashboardFilter: FC<Props> = ({ isEditMode, activeTabUuid }) => {
     const addDimensionDashboardFilter = useDashboardContext(
         (c) => c.addDimensionDashboardFilter,
     );
-    const hasChartTiles = useDashboardContext((c) => c.hasChartTiles);
 
     const handleSaveNew = useCallback(
         (
@@ -66,8 +65,6 @@ const DashboardFilter: FC<Props> = ({ isEditMode, activeTabUuid }) => {
     const handlePopoverClose = useCallback(() => {
         setPopoverId(undefined);
     }, []);
-
-    if (!hasChartTiles) return null;
 
     return (
         <FiltersProvider<Record<string, FilterableDimension>>

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -655,7 +655,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
 
             const fields = explore ? getFields(explore) : [];
             const field = fields.find(
-                (f) => getItemId(f) === filter.target.fieldId,
+                (f) => filter.target && getItemId(f) === filter.target.fieldId,
             );
 
             if (projectUuid && dashboardUuid) {
@@ -904,9 +904,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                 const field = fields.find(
                                                     (f) => {
                                                         return (
+                                                            filterRule.target &&
                                                             getItemId(f) ===
-                                                            filterRule.target
-                                                                .fieldId
+                                                                filterRule
+                                                                    .target
+                                                                    .fieldId
                                                         );
                                                     },
                                                 );
@@ -914,7 +916,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                     !field ||
                                                     !isFilterableField(field)
                                                 )
-                                                    return `Tried to reference field with unknown id: ${filterRule.target.fieldId}`;
+                                                    return `Tried to reference field with unknown id: ${filterRule.target?.fieldId}`;
 
                                                 const filterRuleLabels =
                                                     getConditionalRuleLabel(

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    convertDashboardFilterRuleToFilterRule,
     FilterOperator,
     getDimensions,
     getItemId,
@@ -47,7 +48,11 @@ const combineFilters = ({
         combinedDimensionFilters.push(metricQuery.filters.dimensions);
     }
     if (dashboardFilters) {
-        combinedDimensionFilters.push(...dashboardFilters.dimensions);
+        combinedDimensionFilters.push(
+            ...dashboardFilters.dimensions.map(
+                convertDashboardFilterRuleToFilterRule,
+            ),
+        );
     }
     if (pivotReference?.pivotValues) {
         const pivotFilter: FilterRule[] = pivotReference.pivotValues.map(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -35,7 +35,7 @@ const DateFilterInputs = <T extends ConditionalRule = DateFilterRule>(
     const { startOfWeek } = useFiltersContext();
 
     const isTimestamp =
-        (isCustomSqlDimension(field) ? field.dimensionType : field.type) ===
+        (isCustomSqlDimension(field) ? field.dimensionType : field?.type) ===
         DimensionType.TIMESTAMP;
 
     if (!isFilterRule(rule)) {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -54,7 +54,7 @@ const DefaultFilterInputs = <T extends ConditionalRule>({
         case FilterOperator.NOT_EQUALS: {
             switch (filterType) {
                 case FilterType.STRING:
-                    return isTableCalculation(field) ? (
+                    return !field || isTableCalculation(field) ? (
                         <FilterMultiStringInput
                             disabled={disabled}
                             placeholder={placeholder}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -11,7 +11,7 @@ import DefaultFilterInputs from './DefaultFilterInputs';
 
 export type FilterInputsProps<T extends ConditionalRule> = {
     filterType: FilterType;
-    field: FilterableItem;
+    field?: FilterableItem;
     rule: T;
     onChange: (value: T) => void;
     disabled?: boolean;

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -1,7 +1,7 @@
 import {
     FilterType,
     createFilterRuleFromField,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getFilterTypeFromItem,
     getItemId,
     isDateItem,
@@ -67,11 +67,11 @@ const FilterRuleForm: FC<Props> = ({
 
                     const newFilterRule = isDateItem(selectedField)
                         ? // If the field is the same type but different field, we need to update the filter rule with the new time frames
-                          getFilterRuleWithDefaultValue(
-                              selectedField,
-                              newFilterRuleBase,
-                              filterRule.values,
-                          )
+                          getFilterRuleFromFieldWithDefaultValue({
+                              field: selectedField,
+                              filterRule: newFilterRuleBase,
+                              values: filterRule.values,
+                          })
                         : newFilterRuleBase;
 
                     onChange(newFilterRule);
@@ -122,16 +122,17 @@ const FilterRuleForm: FC<Props> = ({
                     if (!value) return;
 
                     onChange(
-                        getFilterRuleWithDefaultValue(
-                            activeField,
-                            {
+                        getFilterRuleFromFieldWithDefaultValue({
+                            field: activeField,
+                            filterRule: {
                                 ...filterRule,
                                 operator: value as FilterRule['operator'],
                             },
-                            (filterRule.values?.length || 0) > 0
-                                ? filterRule.values
-                                : [1],
-                        ),
+                            values:
+                                (filterRule.values?.length || 0) > 0
+                                    ? filterRule.values
+                                    : [1],
+                        }),
                     );
                 }}
             />

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -1,4 +1,5 @@
 import {
+    convertDashboardFilterRuleToFilterRule,
     isField,
     type DashboardFilters,
     type FilterRule,
@@ -44,13 +45,13 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
             }
             return {
                 id: uuid4(),
-                and: dashboardFilters.dimensions.filter(
-                    (dimensionFilterRule) => {
+                and: dashboardFilters.dimensions
+                    .filter((dimensionFilterRule) => {
                         const isNotSelectedFilter =
                             dimensionFilterRule.id !== filterId;
                         return isNotSelectedFilter;
-                    },
-                ),
+                    })
+                    .map(convertDashboardFilterRuleToFilterRule),
             };
         },
         [dashboardFilters],

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -171,10 +171,11 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                     <Group spacing="lg">
                         {dashboardFilters &&
                             dashboardFilters.map((filter) => {
-                                const field =
-                                    fieldsWithSuggestions[
-                                        filter.target.fieldId
-                                    ];
+                                const field = filter.target
+                                    ? fieldsWithSuggestions[
+                                          filter.target.fieldId
+                                      ]
+                                    : undefined;
 
                                 if (!field) return;
 

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
@@ -1,7 +1,7 @@
 import {
     DimensionType,
     FilterOperator,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getItemId,
     type CompiledDimension,
     type FilterRule,
@@ -45,15 +45,15 @@ export const createFilterRule = (
     operator: FilterOperator,
     values?: string[],
 ): FilterRule => {
-    return getFilterRuleWithDefaultValue(
-        dimension,
-        {
+    return getFilterRuleFromFieldWithDefaultValue({
+        field: dimension,
+        filterRule: {
             id: uuidv4(),
             target: {
                 fieldId: getItemId(dimension),
             },
             operator,
         },
-        doesDimensionRequireValues(dimension) ? values : [],
-    );
+        values: doesDimensionRequireValues(dimension) ? values : [],
+    });
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerFilters.tsx
@@ -87,7 +87,9 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
     const theme = useMantineTheme();
     const { itemsMap } =
         useFiltersContext<Record<string, FilterableDimension>>();
-    const field = itemsMap[dashboardFilter.target.fieldId];
+    const field = dashboardFilter.target
+        ? itemsMap[dashboardFilter.target.fieldId]
+        : undefined;
     const [isEditing, setIsEditing] = useState(false);
 
     const filterType = useMemo(() => {
@@ -121,12 +123,17 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                         <Text span fw={500}>
                             Invalid filter
                         </Text>
-                        <Text fw={400} span>
-                            <Text span color="gray.6">
-                                Tried to reference field with unknown id:
+                        {dashboardFilter.target && (
+                            <Text fw={400} span>
+                                <Text span color="gray.6">
+                                    Tried to reference field with unknown id:
+                                </Text>
+                                <Text span>
+                                    {' '}
+                                    {dashboardFilter.target.fieldId}
+                                </Text>
                             </Text>
-                            <Text span> {dashboardFilter.target.fieldId}</Text>
-                        </Text>
+                        )}
                     </Group>
                 </Stack>
             </Group>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -525,7 +525,9 @@ const Dashboard: FC = () => {
         );
     }
     const dashboardChartTiles = dashboardTiles?.filter(
-        (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+        (tile) =>
+            tile.type === DashboardTileTypes.SAVED_CHART ||
+            tile.type === DashboardTileTypes.SQL_CHART,
     );
 
     return (

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -588,7 +588,9 @@ const DashboardProvider: React.FC<
                 .filter((f) => f.required && f.disabled)
                 .reduce<Pick<DashboardFilterRule, 'id' | 'label'>[]>(
                     (acc, f) => {
-                        const field = allFilterableFieldsMap[f.target.fieldId];
+                        const field = f.target
+                            ? allFilterableFieldsMap[f.target.fieldId]
+                            : undefined;
 
                         let label = '';
 

--- a/packages/frontend/src/utils/dashboardSavedFiltersOverride.ts
+++ b/packages/frontend/src/utils/dashboardSavedFiltersOverride.ts
@@ -30,7 +30,7 @@ const constructOverrideString = (
     updated: DashboardFilterRule,
     diffs: (keyof DashboardFilterRule)[],
 ): string | null => {
-    if (diffs.length === 0) return null;
+    if (diffs.length === 0 || !updated.target) return null;
 
     let overrideString = `${updated.target.fieldId}.${
         updated.operator || original.operator

--- a/packages/frontend/src/utils/dateFilter.ts
+++ b/packages/frontend/src/utils/dateFilter.ts
@@ -10,7 +10,9 @@ import {
 } from '@lightdash/common';
 import dayjs from 'dayjs';
 
-const convertFilterRule = <T extends FilterRule>(filterRule: T): T => {
+const convertFilterRule = <T extends Pick<FilterRule, 'values'>>(
+    filterRule: T,
+): T => {
     return {
         ...filterRule,
         values: filterRule.values?.map((value) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXX

### Description:
This PR refactors the filter rule functionality to improve type safety and support filters without fields. Key changes include:

1. Renamed `getFilterRuleWithDefaultValue` to `getFilterRuleFromFieldWithDefaultValue` and created a new `getFilterRuleWithDefaultValue` function that doesn't require a field
2. Updated the `DashboardFilterRule` type to make the `target` property optional
3. Added a `filterType` property to `FilterRule` interface
4. Created a new `createDashboardFilterRule` function that doesn't require a field
5. Moved `convertDashboardFilterRuleToFilterRule` from utils to types
6. Updated the FilterConfiguration component to support creating filters without fields
7. Added null checks for `target` property throughout the codebase

These changes enable creating filters that aren't tied to specific fields, which will be useful for custom filters and SQL-based filtering.

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging