### PR TITLE
fix: spotlight inverse boolean

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
@@ -40,11 +40,16 @@ export const getOperatorOptions = (
 export const doesDimensionRequireValues = (dimension: CompiledDimension) =>
     dimension.type !== DimensionType.BOOLEAN;
 
+function getBooleanValueFromOperator(operator: FilterOperator) {
+    return operator === FilterOperator.EQUALS ? true : false;
+}
+
 export const createFilterRule = (
     dimension: CompiledDimension,
     operator: FilterOperator,
     values?: string[],
 ): FilterRule => {
+    const isBooleanDimension = dimension.type === DimensionType.BOOLEAN;
     return getFilterRuleWithDefaultValue(
         dimension,
         {
@@ -52,8 +57,8 @@ export const createFilterRule = (
             target: {
                 fieldId: getItemId(dimension),
             },
-            operator,
+            operator: isBooleanDimension ? FilterOperator.EQUALS : operator,
         },
-        doesDimensionRequireValues(dimension) ? values : [],
+        isBooleanDimension ? [getBooleanValueFromOperator(operator)] : values,
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14924

### Description:

For boolean filters we can't just send the operator with empty results, to fix this I kept the logic for operators the same but am overriding them when creating the filter

Before (see ticket)
**After**
![image](https://github.com/user-attachments/assets/e5301bc2-f47e-47eb-8db7-6c606bf510e2)

Metrics explorer filtering by false
![image](https://github.com/user-attachments/assets/3c357e16-0cb0-49c5-af48-10bc274defb5)

Metrics explorer filtering by true
![image](https://github.com/user-attachments/assets/46c58482-a713-45e2-924a-eb96c0eefb84)


### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
