### PR TITLE
feat(backend): updatedAt column for agents

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -11,11 +11,13 @@ export type DbAiAgent = {
     image_url: string | null;
     tags: string[] | null;
     created_at: Date;
+    updated_at: Date;
 };
 
 export type AiAgentTable = Knex.CompositeTableType<
     DbAiAgent,
-    Omit<DbAiAgent, 'ai_agent_uuid' | 'created_at'>
+    Omit<DbAiAgent, 'ai_agent_uuid' | 'created_at' | 'updated_at'>,
+    Partial<Omit<DbAiAgent, 'ai_agent_uuid' | 'created_at'>>
 >;
 
 export const AiAgentIntegrationTableName = 'ai_agent_integration';

--- a/packages/backend/src/ee/database/migrations/20250521173353_add_ai_agent_modified_at_column.ts
+++ b/packages/backend/src/ee/database/migrations/20250521173353_add_ai_agent_modified_at_column.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const AiAgentTableName = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(AiAgentTableName, 'updated_at')) return;
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasColumn(AiAgentTableName, 'updated_at'))) return;
+
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.dropColumn('updated_at');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -63,6 +63,8 @@ export class AiAgentModel {
                         '[]'::json
                     )
                 `),
+                updatedAt: `${AiAgentTableName}.updated_at`,
+                createdAt: `${AiAgentTableName}.created_at`,
             } satisfies Record<keyof AiAgent, unknown>)
             .leftJoin(
                 AiAgentIntegrationTableName,
@@ -114,6 +116,8 @@ export class AiAgentModel {
                             '[]'::json
                         )
                 `),
+                updatedAt: `${AiAgentTableName}.updated_at`,
+                createdAt: `${AiAgentTableName}.created_at`,
             } satisfies Record<keyof AiAgentSummary, unknown>)
             .leftJoin(
                 AiAgentIntegrationTableName,
@@ -233,15 +237,14 @@ export class AiAgentModel {
                 organizationUuid: agent.organization_uuid,
                 tags: agent.tags,
                 integrations,
+                createdAt: agent.created_at,
+                updatedAt: agent.updated_at,
             };
         });
     }
 
     async updateAgent(
-        args: Pick<
-            ApiUpdateAiAgent,
-            'name' | 'projectUuid' | 'tags' | 'integrations'
-        > & {
+        args: Omit<ApiUpdateAiAgent, 'uuid'> & {
             agentUuid: string;
             organizationUuid: string;
         },
@@ -256,6 +259,7 @@ export class AiAgentModel {
                     name: args.name,
                     project_uuid: args.projectUuid,
                     tags: args.tags,
+                    updated_at: new Date(),
                 })
                 .returning('*');
 
@@ -305,6 +309,8 @@ export class AiAgentModel {
                 organizationUuid: agent.organization_uuid,
                 tags: agent.tags,
                 integrations,
+                createdAt: agent.created_at,
+                updatedAt: agent.updated_at,
             };
         });
     }

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -21,7 +21,9 @@ export const baseAgentSchema = z.object({
         // ]),
     ),
 
-    createdAt: z.string(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+
     instructions: z.string().nullable(),
     provider: z.string(),
     model: z.string(),
@@ -37,6 +39,8 @@ export type AiAgent = Pick<
     | 'integrations'
     | 'tags'
     | 'name'
+    | 'createdAt'
+    | 'updatedAt'
 >;
 
 export type AiAgentSummary = Pick<
@@ -47,6 +51,8 @@ export type AiAgentSummary = Pick<
     | 'tags'
     | 'projectUuid'
     | 'organizationUuid'
+    | 'createdAt'
+    | 'updatedAt'
 >;
 
 export type AiAgentMessage =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: #14932

### Description:

- Created a new migration to add the `updated_at` column to the `ai_agent` table
- Updated the `DbAiAgent` type to include the new field
- Modified the `AiAgentTable` type to properly handle the new column in updates
- Updated the agent model to return the timestamps in API responses
- Ensured the `updated_at` field is set when updating an agent
- Added timestamp fields to the agent schema with proper date coercion

