### PR TITLE
fix: dont render conversations tab in create mode

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -318,12 +318,14 @@ export const AgentDetails: FC = () => {
                                     </Group>
                                 </form>
                             </Tabs.Panel>
-                            <Tabs.Panel value="conversations" pt="xs">
-                                <ConversationsList
-                                    agentUuid={agentUuid ?? ''}
-                                    agentName={form.values.name}
-                                />
-                            </Tabs.Panel>
+                            {!isCreateMode && (
+                                <Tabs.Panel value="conversations" pt="xs">
+                                    <ConversationsList
+                                        agentUuid={agentUuid ?? ''}
+                                        agentName={form.values.name}
+                                    />
+                                </Tabs.Panel>
+                            )}
                         </Tabs>
                     </Stack>
                 </Card>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Hide the Conversations tab when creating a new agent. 

