### PR TITLE
fix: format overrides for bignumber and results

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -254,7 +254,11 @@ const useBigNumberConfig = (
             );
         } else if (item !== undefined && isTableCalculation(item)) {
             return formatItemValue(item, firstRowValueRaw);
-        } else if (item !== undefined && hasValidFormatExpression(item)) {
+        } else if (
+            item !== undefined &&
+            hasValidFormatExpression(item) &&
+            !bigNumberStyle // If the big number has a comparison style, don't use the format expression returned by the backend
+        ) {
             return formatValueWithExpression(item.format, firstRowValueRaw);
         } else if (item !== undefined && hasFormatOptions(item)) {
             // Custom metrics case


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/14696

### Description:

- Overrides `format` expression instead of adding `formatOptions` from metric query overrides. In formatting logic, `format` expression always takes precedence over `formatOptions` hence why formatting overrides weren't being applied


https://github.com/user-attachments/assets/70ea517c-35f5-464e-933b-351ce04b1893



### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging
