### PR TITLE
fix: allow tags when project selected

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -8,6 +8,7 @@ import {
     Select,
     Stack,
     Tabs,
+    TagsInput,
     Text,
     TextInput,
     Title,
@@ -111,7 +112,7 @@ export const AgentDetails: FC = () => {
             name: '',
             projectUuid: '',
             integrations: [],
-            tags: [],
+            tags: null,
         },
         validate: zodResolver(formSchema),
     });
@@ -126,7 +127,7 @@ export const AgentDetails: FC = () => {
                 name: agent.name,
                 projectUuid: agent.projectUuid,
                 integrations: agent.integrations,
-                tags: agent.tags,
+                tags: agent.tags && agent.tags.length > 0 ? agent.tags : null,
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -272,6 +273,20 @@ export const AgentDetails: FC = () => {
                                                     'projectUuid',
                                                 )}
                                             />
+                                            {!!form.values.projectUuid && (
+                                                <TagsInput
+                                                    label="Tags"
+                                                    placeholder="Select tags"
+                                                    onChange={(value) => {
+                                                        form.setFieldValue(
+                                                            'tags',
+                                                            value.length > 0
+                                                                ? value
+                                                                : null,
+                                                        );
+                                                    }}
+                                                />
+                                            )}
                                         </Stack>
 
                                         {/* Integrations Section */}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Added a TagsInput component to the Agent Details form that allows users to select tags when a project is selected. The component only appears when a project UUID is provided. Updated the form handling to properly manage tag values, setting them to null when empty.

![Screenshot 2025-05-22 at 15.09.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/795d941f-24f6-4363-a310-204c52ed70bf.png)

