### PR TITLE
feat: implement AI tag filtering for explore visibility

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -1,6 +1,9 @@
 version: 2
 models:
   - name: events
+    config:
+      tags:
+        - ai-tag-test
     meta:
       group_details:
         events:

--- a/packages/backend/src/ee/services/AiAgentService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService.test.ts
@@ -1,0 +1,372 @@
+import { produce } from 'immer';
+import { AiAgentService } from './AiAgentService';
+
+describe('AiService', () => {
+    test('should throw when explore does not have a base table', async () => {
+        expect(() =>
+            AiAgentService.filterExplore({
+                availableTags: ['zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zip', 'zap'],
+                    tables: {
+                        // base instead of baze
+                        baze: {
+                            dimensions: {},
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toThrow('Base table not found');
+    });
+
+    test('should return explore when available tags are not configured', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: null,
+                explore: {
+                    baseTable: 'base',
+                    tags: [],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: ['zip'],
+                                },
+                            },
+                            metrics: {
+                                piz: {},
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should return undefined when available tags an empty array', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: [],
+                explore: {
+                    baseTable: 'base',
+                    tags: [],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: ['zip'],
+                                },
+                            },
+                            metrics: {
+                                piz: {},
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeUndefined();
+    });
+
+    test('should return undefined when explore or fields have no tags', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: [],
+                    tables: {
+                        base: {
+                            dimensions: {},
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toBeUndefined();
+    });
+
+    test('should return explore when explore tag matches', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zap', 'zup'],
+                    tables: {
+                        base: {
+                            dimensions: {},
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should return explore when any of the field tag matches', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zup'],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: ['zap'],
+                                },
+                            },
+                            metrics: {
+                                piz: {
+                                    tags: ['zzzzz'],
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should return explore when either explore or any of the field tag matches', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zap'],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: ['zip'],
+                                },
+                            },
+                            metrics: {
+                                piz: {
+                                    tags: ['zap'],
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should return undefined when neither explore nor any of the field tag matches', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zup'],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: [],
+                                },
+                                puz: {
+                                    tags: ['zup'],
+                                },
+                            },
+                            metrics: {
+                                piz: {},
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeUndefined();
+    });
+
+    test('should return undefined when explore+base table does not match and only joined table fields match', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore: {
+                    baseTable: 'base',
+                    tags: ['zup'],
+                    tables: {
+                        base: {
+                            dimensions: {
+                                paz: {
+                                    tags: [],
+                                },
+                                puz: {
+                                    tags: ['zup'],
+                                },
+                            },
+                            metrics: {
+                                piz: {},
+                            },
+                        },
+                        another_table: {
+                            dimensions: {
+                                sup: {
+                                    tags: ['zip', 'zap'],
+                                },
+                            },
+                            metrics: {
+                                sap: {
+                                    tags: ['zip', 'zap'],
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toBeUndefined();
+    });
+
+    test('should not filter out anything from the explore when explore has tags but base table fields does not have matching tags', async () => {
+        const explore = {
+            baseTable: 'base',
+            tags: ['zap'],
+            tables: {
+                base: {
+                    dimensions: {
+                        paz: {
+                            tags: [],
+                        },
+                        puz: {
+                            tags: ['zup'],
+                        },
+                    },
+                    metrics: {
+                        piz: {},
+                    },
+                },
+                another_table: {
+                    dimensions: {
+                        sup: {
+                            tags: ['zip', 'zap'],
+                        },
+                    },
+                    metrics: {
+                        sap: {
+                            tags: ['zip', 'zap'],
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zip', 'zap'],
+                explore,
+            }),
+        ).toStrictEqual(explore);
+    });
+
+    test('should filter out fields from the explore when explore has no tags but other table fields have matching tags', async () => {
+        const explore = {
+            baseTable: 'base',
+            tags: [],
+            tables: {
+                base: {
+                    dimensions: {
+                        paz: {
+                            tags: ['zup', 'zap'],
+                        },
+                        puz: {
+                            tags: ['zup'],
+                        },
+                    },
+                    metrics: {
+                        piz: {},
+                    },
+                },
+                another_table: {
+                    dimensions: {
+                        sup: {
+                            tags: ['zip', 'zap'],
+                        },
+                    },
+                    metrics: {
+                        sap: {
+                            tags: ['zip'],
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zap'],
+                explore,
+            }),
+        ).toStrictEqual(
+            produce(explore, (draft) => {
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete draft.tables['base'].dimensions['puz'];
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete draft.tables['base'].metrics['piz'];
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete draft.tables['another_table'].metrics['sap'];
+            }),
+        );
+    });
+
+    test('should filter out fields from the explore when explore has matching tags but other table fields have matching tags', async () => {
+        const explore = {
+            baseTable: 'base',
+            tags: ['zap'],
+            tables: {
+                base: {
+                    dimensions: {
+                        paz: {
+                            tags: ['zup', 'zap'],
+                        },
+                        puz: {
+                            tags: ['zup'],
+                        },
+                    },
+                    metrics: {
+                        piz: {},
+                    },
+                },
+                another_table: {
+                    dimensions: {
+                        sup: {
+                            tags: ['zip', 'zap'],
+                        },
+                    },
+                    metrics: {
+                        sap: {
+                            tags: ['zip'],
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['zap'],
+                explore,
+            }),
+        ).toStrictEqual(
+            produce(explore, (filteredExplore) => {
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete filteredExplore.tables['base'].dimensions['puz'];
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete filteredExplore.tables['base'].metrics['piz'];
+                // @ts-ignore
+                // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
+                delete filteredExplore.tables['another_table'].metrics['sap'];
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService.test.ts
@@ -5,13 +5,13 @@ describe('AiService', () => {
     test('should throw when explore does not have a base table', async () => {
         expect(() =>
             AiAgentService.filterExplore({
-                availableTags: ['zap'],
+                availableTags: ['ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zip', 'zap'],
+                    baseTable: 'customers',
+                    tags: ['marketing', 'ai-enabled'],
                     tables: {
-                        // base instead of baze
-                        baze: {
+                        // customer_data instead of customers
+                        customer_data: {
                             dimensions: {},
                             metrics: {},
                         },
@@ -21,22 +21,22 @@ describe('AiService', () => {
         ).toThrow('Base table not found');
     });
 
-    test('should return explore when available tags are not configured', async () => {
+    test('should return entire explore when no AI tags are configured in settings', async () => {
         expect(
             AiAgentService.filterExplore({
                 availableTags: null,
                 explore: {
-                    baseTable: 'base',
+                    baseTable: 'customers',
                     tags: [],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
-                                    tags: ['zip'],
+                                customer_name: {
+                                    tags: ['pii'],
                                 },
                             },
                             metrics: {
-                                piz: {},
+                                revenue: {},
                             },
                         },
                     },
@@ -45,22 +45,22 @@ describe('AiService', () => {
         ).toBeDefined();
     });
 
-    test('should return undefined when available tags an empty array', async () => {
+    test('should return undefined when AI tags are configured but empty', async () => {
         expect(
             AiAgentService.filterExplore({
                 availableTags: [],
                 explore: {
-                    baseTable: 'base',
+                    baseTable: 'customers',
                     tags: [],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
-                                    tags: ['zip'],
+                                customer_name: {
+                                    tags: ['pii'],
                                 },
                             },
                             metrics: {
-                                piz: {},
+                                revenue: {},
                             },
                         },
                     },
@@ -69,15 +69,15 @@ describe('AiService', () => {
         ).toBeUndefined();
     });
 
-    test('should return undefined when explore or fields have no tags', async () => {
+    test('should return undefined when explore and fields have no matching AI tags', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zap'],
+                availableTags: ['ai-enabled'],
                 explore: {
-                    baseTable: 'base',
+                    baseTable: 'customers',
                     tags: [],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {},
                             metrics: {},
                         },
@@ -87,15 +87,15 @@ describe('AiService', () => {
         ).toBeUndefined();
     });
 
-    test('should return explore when explore tag matches', async () => {
+    test('should return full explore when explore-level tag matches AI settings', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zap', 'zup'],
+                    baseTable: 'customers',
+                    tags: ['ai-enabled', 'analytics'],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {},
                             metrics: {},
                         },
@@ -105,23 +105,23 @@ describe('AiService', () => {
         ).toBeDefined();
     });
 
-    test('should return explore when any of the field tag matches', async () => {
+    test('should return explore when any field tag matches AI settings', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zup'],
+                    baseTable: 'customers',
+                    tags: ['analytics'],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
-                                    tags: ['zap'],
+                                customer_name: {
+                                    tags: ['ai-enabled'],
                                 },
                             },
                             metrics: {
-                                piz: {
-                                    tags: ['zzzzz'],
+                                revenue: {
+                                    tags: ['internal'],
                                 },
                             },
                         },
@@ -131,23 +131,23 @@ describe('AiService', () => {
         ).toBeDefined();
     });
 
-    test('should return explore when either explore or any of the field tag matches', async () => {
+    test('should return explore when both explore and field tags match AI settings', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zap'],
+                    baseTable: 'customers',
+                    tags: ['ai-enabled'],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
-                                    tags: ['zip'],
+                                customer_name: {
+                                    tags: ['marketing'],
                                 },
                             },
                             metrics: {
-                                piz: {
-                                    tags: ['zap'],
+                                revenue: {
+                                    tags: ['ai-enabled'],
                                 },
                             },
                         },
@@ -157,25 +157,25 @@ describe('AiService', () => {
         ).toBeDefined();
     });
 
-    test('should return undefined when neither explore nor any of the field tag matches', async () => {
+    test('should return undefined when neither explore nor field tags match AI settings', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zup'],
+                    baseTable: 'customers',
+                    tags: ['analytics'],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
+                                customer_name: {
                                     tags: [],
                                 },
-                                puz: {
-                                    tags: ['zup'],
+                                internal_id: {
+                                    tags: ['analytics'],
                                 },
                             },
                             metrics: {
-                                piz: {},
+                                revenue: {},
                             },
                         },
                     },
@@ -184,36 +184,36 @@ describe('AiService', () => {
         ).toBeUndefined();
     });
 
-    test('should return undefined when explore+base table does not match and only joined table fields match', async () => {
+    test('should return undefined when only joined table fields match but base table does not', async () => {
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore: {
-                    baseTable: 'base',
-                    tags: ['zup'],
+                    baseTable: 'customers',
+                    tags: ['analytics'],
                     tables: {
-                        base: {
+                        customers: {
                             dimensions: {
-                                paz: {
+                                customer_name: {
                                     tags: [],
                                 },
-                                puz: {
-                                    tags: ['zup'],
+                                internal_id: {
+                                    tags: ['analytics'],
                                 },
                             },
                             metrics: {
-                                piz: {},
+                                revenue: {},
                             },
                         },
-                        another_table: {
+                        sales: {
                             dimensions: {
-                                sup: {
-                                    tags: ['zip', 'zap'],
+                                user_email: {
+                                    tags: ['marketing', 'ai-enabled'],
                                 },
                             },
                             metrics: {
-                                sap: {
-                                    tags: ['zip', 'zap'],
+                                sales_total: {
+                                    tags: ['marketing', 'ai-enabled'],
                                 },
                             },
                         },
@@ -223,33 +223,33 @@ describe('AiService', () => {
         ).toBeUndefined();
     });
 
-    test('should not filter out anything from the explore when explore has tags but base table fields does not have matching tags', async () => {
+    test('should expose all fields when explore is tagged but base table fields lack matching tags', async () => {
         const explore = {
-            baseTable: 'base',
-            tags: ['zap'],
+            baseTable: 'customers',
+            tags: ['ai-enabled'],
             tables: {
-                base: {
+                customers: {
                     dimensions: {
-                        paz: {
+                        customer_name: {
                             tags: [],
                         },
-                        puz: {
-                            tags: ['zup'],
+                        internal_id: {
+                            tags: ['analytics'],
                         },
                     },
                     metrics: {
-                        piz: {},
+                        revenue: {},
                     },
                 },
-                another_table: {
+                sales: {
                     dimensions: {
-                        sup: {
-                            tags: ['zip', 'zap'],
+                        user_email: {
+                            tags: ['marketing', 'ai-enabled'],
                         },
                     },
                     metrics: {
-                        sap: {
-                            tags: ['zip', 'zap'],
+                        sales_total: {
+                            tags: ['marketing', 'ai-enabled'],
                         },
                     },
                 },
@@ -258,39 +258,39 @@ describe('AiService', () => {
 
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zip', 'zap'],
+                availableTags: ['marketing', 'ai-enabled'],
                 explore,
             }),
         ).toStrictEqual(explore);
     });
 
-    test('should filter out fields from the explore when explore has no tags but other table fields have matching tags', async () => {
+    test('should filter fields when explore lacks tags but base table fields have matching tags', async () => {
         const explore = {
-            baseTable: 'base',
+            baseTable: 'customers',
             tags: [],
             tables: {
-                base: {
+                customers: {
                     dimensions: {
-                        paz: {
-                            tags: ['zup', 'zap'],
+                        customer_name: {
+                            tags: ['pii', 'ai-enabled'],
                         },
-                        puz: {
-                            tags: ['zup'],
+                        internal_id: {
+                            tags: ['pii'],
                         },
                     },
                     metrics: {
-                        piz: {},
+                        revenue: {},
                     },
                 },
-                another_table: {
+                sales: {
                     dimensions: {
-                        sup: {
-                            tags: ['zip', 'zap'],
+                        user_email: {
+                            tags: ['marketing', 'ai-enabled'],
                         },
                     },
                     metrics: {
-                        sap: {
-                            tags: ['zip'],
+                        sales_total: {
+                            tags: ['marketing'],
                         },
                     },
                 },
@@ -299,51 +299,51 @@ describe('AiService', () => {
 
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zap'],
+                availableTags: ['ai-enabled'],
                 explore,
             }),
         ).toStrictEqual(
             produce(explore, (draft) => {
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete draft.tables['base'].dimensions['puz'];
+                delete draft.tables['customers'].dimensions['internal_id'];
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete draft.tables['base'].metrics['piz'];
+                delete draft.tables['customers'].metrics['revenue'];
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete draft.tables['another_table'].metrics['sap'];
+                delete draft.tables['sales'].metrics['sales_total'];
             }),
         );
     });
 
-    test('should filter out fields from the explore when explore has matching tags but other table fields have matching tags', async () => {
+    test('should filter fields when both explore and base table fields have matching tags', async () => {
         const explore = {
-            baseTable: 'base',
-            tags: ['zap'],
+            baseTable: 'customers',
+            tags: ['ai-enabled'],
             tables: {
-                base: {
+                customers: {
                     dimensions: {
-                        paz: {
-                            tags: ['zup', 'zap'],
+                        customer_name: {
+                            tags: ['pii', 'ai-enabled'],
                         },
-                        puz: {
-                            tags: ['zup'],
+                        internal_id: {
+                            tags: ['pii'],
                         },
                     },
                     metrics: {
-                        piz: {},
+                        revenue: {},
                     },
                 },
-                another_table: {
+                sales: {
                     dimensions: {
-                        sup: {
-                            tags: ['zip', 'zap'],
+                        user_email: {
+                            tags: ['marketing', 'ai-enabled'],
                         },
                     },
                     metrics: {
-                        sap: {
-                            tags: ['zip'],
+                        sales_total: {
+                            tags: ['marketing'],
                         },
                     },
                 },
@@ -352,21 +352,121 @@ describe('AiService', () => {
 
         expect(
             AiAgentService.filterExplore({
-                availableTags: ['zap'],
+                availableTags: ['ai-enabled'],
                 explore,
             }),
         ).toStrictEqual(
             produce(explore, (filteredExplore) => {
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete filteredExplore.tables['base'].dimensions['puz'];
+                delete filteredExplore.tables['customers'].dimensions[
+                    // eslint-disable-next-line @typescript-eslint/dot-notation
+                    'internal_id'
+                ];
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete filteredExplore.tables['base'].metrics['piz'];
+                delete filteredExplore.tables['customers'].metrics['revenue'];
                 // @ts-ignore
                 // eslint-disable-next-line no-param-reassign, @typescript-eslint/dot-notation
-                delete filteredExplore.tables['another_table'].metrics['sap'];
+                delete filteredExplore.tables['sales'].metrics['sales_total'];
             }),
         );
+    });
+
+    test('should handle fields with multiple tags where only some match AI settings', async () => {
+        const explore = {
+            baseTable: 'customers',
+            tags: [],
+            tables: {
+                customers: {
+                    dimensions: {
+                        customer_name: {
+                            tags: ['pii', 'sensitive', 'ai-enabled'],
+                        },
+                        customer_segment: {
+                            tags: ['marketing', 'analytics'],
+                        },
+                    },
+                    metrics: {
+                        lifetime_value: {
+                            tags: ['ai-enabled', 'finance'],
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = AiAgentService.filterExplore({
+            availableTags: ['ai-enabled'],
+            explore,
+        });
+
+        expect(result?.tables.customers.dimensions).toHaveProperty(
+            'customer_name',
+        );
+        expect(result?.tables.customers.dimensions).not.toHaveProperty(
+            'customer_segment',
+        );
+        expect(result?.tables.customers.metrics).toHaveProperty(
+            'lifetime_value',
+        );
+    });
+
+    test('should handle duplicate tags in available tags list', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['ai-enabled', 'ai-enabled', 'marketing'],
+                explore: {
+                    baseTable: 'customers',
+                    tags: ['ai-enabled'],
+                    tables: {
+                        customers: {
+                            dimensions: {},
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should handle case where field tags array contains duplicates', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['ai-enabled'],
+                explore: {
+                    baseTable: 'customers',
+                    tags: [],
+                    tables: {
+                        customers: {
+                            dimensions: {
+                                customer_name: {
+                                    tags: ['ai-enabled', 'ai-enabled', 'pii'],
+                                },
+                            },
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toBeDefined();
+    });
+
+    test('should return undefined when base table has no dimensions or metrics', async () => {
+        expect(
+            AiAgentService.filterExplore({
+                availableTags: ['ai-enabled'],
+                explore: {
+                    baseTable: 'empty_table',
+                    tags: [],
+                    tables: {
+                        empty_table: {
+                            dimensions: {},
+                            metrics: {},
+                        },
+                    },
+                },
+            }),
+        ).toBeUndefined();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -30,10 +30,8 @@ export class AiAgentService {
     private readonly slackClient: SlackClient;
 
     constructor(dependencies: AiAgentServiceDependencies) {
-        // models
         this.aiAgentModel = dependencies.aiAgentModel;
         this.slackAuthenticationModel = dependencies.slackAuthenticationModel;
-        // services
         this.featureFlagService = dependencies.featureFlagService;
         this.slackClient = dependencies.slackClient;
     }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -116,10 +116,10 @@ export class AiAgentService {
         const filteredExplore: Explore = _.update(explore, 'tables', (tables) =>
             _.mapValues(tables, (table) => ({
                 ...table,
-                metrics: _.omitBy(table.metrics, (m) =>
+                metrics: _.pickBy(table.metrics, (m) =>
                     hasMatchingTags(m.tags ?? []),
                 ),
-                dimensions: _.omitBy(table.dimensions, (d) =>
+                dimensions: _.pickBy(table.dimensions, (d) =>
                     hasMatchingTags(d.tags ?? []),
                 ),
             })),

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -24,6 +24,7 @@ import {
     FeatureFlags,
     ItemsMap,
     LightdashUser,
+    NotFoundError,
     QueryExecutionContext,
     SessionUser,
     SlackPrompt,
@@ -545,7 +546,7 @@ export class AiService {
             });
 
             if (!filteredExplore) {
-                throw new Error('Explore not found');
+                throw new NotFoundError('Explore not found');
             }
 
             return filteredExplore;

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -29,6 +29,7 @@ import {
     SlackPrompt,
     UnexpectedServerError,
     assertUnreachable,
+    filterExploreByTags,
     getErrorMessage,
     getItemId,
     isDashboardChartTileType,
@@ -501,7 +502,7 @@ export class AiService {
 
         const exploresWithDescriptions = explores
             .map((explore) =>
-                AiAgentService.filterExplore({
+                filterExploreByTags({
                     explore,
                     availableTags,
                 }),
@@ -538,7 +539,7 @@ export class AiService {
                 exploreName,
             );
 
-            const filteredExplore = await AiAgentService.filterExplore({
+            const filteredExplore = filterExploreByTags({
                 explore,
                 availableTags,
             });

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5468,94 +5468,100 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "AiAgentMessageUser": {
+                "properties": {
+                    "user": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": ["user"],
+                        "nullable": false
+                    }
+                },
+                "required": [
+                    "user",
+                    "createdAt",
+                    "message",
+                    "threadUuid",
+                    "uuid",
+                    "role"
+                ],
+                "type": "object"
+            },
+            "AiAgentMessageAssistant": {
+                "properties": {
+                    "humanScore": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "metricQuery": {
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "filtersOutput": {
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "vizConfigOutput": {
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": ["assistant"],
+                        "nullable": false
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "message",
+                    "threadUuid",
+                    "uuid",
+                    "role"
+                ],
+                "type": "object"
+            },
             "AiAgentMessage": {
                 "anyOf": [
                     {
-                        "properties": {
-                            "user": {
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "uuid": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["name", "uuid"],
-                                "type": "object"
-                            },
-                            "createdAt": {
-                                "type": "string"
-                            },
-                            "message": {
-                                "type": "string"
-                            },
-                            "threadUuid": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "role": {
-                                "type": "string",
-                                "enum": ["user"],
-                                "nullable": false
-                            }
-                        },
-                        "required": [
-                            "user",
-                            "createdAt",
-                            "message",
-                            "threadUuid",
-                            "uuid",
-                            "role"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/AiAgentMessageUser"
                     },
                     {
-                        "properties": {
-                            "humanScore": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "metricQuery": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "filtersOutput": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "vizConfigOutput": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "createdAt": {
-                                "type": "string"
-                            },
-                            "message": {
-                                "type": "string"
-                            },
-                            "threadUuid": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "role": {
-                                "type": "string",
-                                "enum": ["assistant"],
-                                "nullable": false
-                            }
-                        },
-                        "required": [
-                            "createdAt",
-                            "message",
-                            "threadUuid",
-                            "uuid",
-                            "role"
-                        ],
-                        "type": "object"
+                        "$ref": "#/components/schemas/AiAgentMessageAssistant"
                     }
                 ]
             },
@@ -12105,22 +12111,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -16013,6 +16019,9 @@
                         "properties": {
                             "pivotDetails": {
                                 "properties": {
+                                    "originalColumns": {
+                                        "$ref": "#/components/schemas/ResultColumns"
+                                    },
                                     "sortBy": {
                                         "$ref": "#/components/schemas/SortBy"
                                     },
@@ -16038,6 +16047,7 @@
                                     }
                                 },
                                 "required": [
+                                    "originalColumns",
                                     "valuesColumns",
                                     "indexColumn",
                                     "totalColumnCount"
@@ -17400,7 +17410,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1651.0",
+        "version": "0.1658.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -34,11 +34,9 @@ import {
 
 type ContentServiceArguments = {
     analytics: LightdashAnalytics;
-    // models
     projectModel: ProjectModel;
     contentModel: ContentModel;
     spaceModel: SpaceModel;
-    // services
     spaceService: SpaceService;
     dashboardService: DashboardService;
     savedChartService: SavedChartService;

--- a/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
+++ b/packages/backend/src/services/SemanticLayerService/SemanticLayerService.ts
@@ -34,10 +34,8 @@ type SearchServiceArguments = {
     analytics: LightdashAnalytics;
     projectModel: ProjectModel;
     downloadFileModel: DownloadFileModel;
-    // Clients
     schedulerClient: SchedulerClient;
     s3Client: S3Client;
-    // Services
     savedSemanticViewerChartService: SavedSemanticViewerChartService;
 };
 
@@ -50,13 +48,9 @@ export class SemanticLayerService extends BaseService {
 
     private readonly downloadFileModel: DownloadFileModel;
 
-    // Clients
-
     private readonly schedulerClient: SchedulerClient;
 
     private readonly s3Client: S3Client;
-
-    // Services
 
     private readonly savedSemanticViewerChartService: SavedSemanticViewerChartService;
 
@@ -67,9 +61,7 @@ export class SemanticLayerService extends BaseService {
         this.projectModel = args.projectModel;
         this.downloadFileModel = args.downloadFileModel;
         this.schedulerClient = args.schedulerClient;
-        // Clients
         this.s3Client = args.s3Client;
-        // Services
         this.savedSemanticViewerChartService =
             args.savedSemanticViewerChartService;
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -794,11 +794,9 @@ export class ServiceRepository
             () =>
                 new ContentService({
                     analytics: this.context.lightdashAnalytics,
-                    // models
                     projectModel: this.models.getProjectModel(),
                     contentModel: this.models.getContentModel(),
                     spaceModel: this.models.getSpaceModel(),
-                    // services
                     spaceService: this.getSpaceService(),
                     dashboardService: this.getDashboardService(),
                     savedChartService: this.getSavedChartService(),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1,7 +1,6 @@
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { ClientRepository } from '../clients/ClientRepository';
 import { LightdashConfig } from '../config/parseConfig';
-import { AiAgentService } from '../ee/services/AiAgentService';
 import { ModelRepository } from '../models/ModelRepository';
 import type { UtilRepository } from '../utils/UtilRepository';
 import { AnalyticsService } from './AnalyticsService/AnalyticsService';

--- a/packages/common/src/ee/AiAgent/filterExploreByTags.ts
+++ b/packages/common/src/ee/AiAgent/filterExploreByTags.ts
@@ -1,0 +1,104 @@
+import { concat, flatMap, intersection, mapValues, pickBy } from 'lodash';
+
+type FilterableTable = {
+    dimensions: Record<string, { tags?: string[] }>;
+    metrics: Record<string, { tags?: string[] }>;
+};
+
+type FilterableExplore<T extends FilterableTable = FilterableTable> = {
+    tags: string[];
+    baseTable: string;
+    tables: { [tableName: string]: T };
+};
+
+function hasMatchingTags(tags: string[], availableTags: string[]) {
+    return intersection(tags, availableTags).length > 0;
+}
+
+function checkIfTableFieldsHasMatchingTags<T extends FilterableTable>(
+    table: T,
+    availableTags: string[],
+) {
+    return hasMatchingTags(
+        concat(
+            flatMap(table.metrics, (m) => m.tags ?? []),
+            flatMap(table.dimensions, (d) => d.tags ?? []),
+        ),
+        availableTags,
+    );
+}
+
+function checkIfExploreHasMatchingTags<
+    E extends FilterableExplore,
+    T extends FilterableTable,
+>(e: E, baseTable: T, availableTags: string[]) {
+    if (hasMatchingTags(e.tags, availableTags)) {
+        return true;
+    }
+
+    if (checkIfTableFieldsHasMatchingTags(baseTable, availableTags)) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @description
+ *
+ * No tags are configured in settings UI:
+ *
+ * | Tagging Scenario                  | AI Visibility                    |
+ * |-----------------------------------|----------------------------------|
+ * | No tags configured in settings UI | Everything is visible by default |
+ *
+ * ---
+ *
+ * Tags are configured in settings UI:
+ *
+ * | Tagging Scenario                     | AI Visibility               |
+ * |--------------------------------------|-----------------------------|
+ * | Explore only (with matching tag)     | All fields in the Explore   |
+ * | Some fields only (with matching tag) | Only those tagged fields    |
+ * | Explore + some fields (with match)   | Only those tagged fields    |
+ * | No matching tags                     | Nothing is visible          |
+ */
+export function filterExploreByTags<E extends FilterableExplore>({
+    explore,
+    availableTags,
+}: {
+    explore: E;
+    availableTags: string[] | null;
+}) {
+    if (!availableTags) {
+        return explore;
+    }
+
+    const baseTable = explore.tables[explore.baseTable];
+    if (!baseTable) {
+        throw new Error(`Base table not found`);
+    }
+
+    if (!checkIfExploreHasMatchingTags(explore, baseTable, availableTags)) {
+        return undefined;
+    }
+
+    if (!checkIfTableFieldsHasMatchingTags(baseTable, availableTags)) {
+        return explore;
+    }
+
+    const filteredExplore: E = {
+        ...explore,
+        tables: mapValues(explore.tables, (table) => ({
+            ...table,
+            dimensions: pickBy(table.dimensions, (d) =>
+                hasMatchingTags(d.tags ?? [], availableTags),
+            ),
+            metrics: pickBy(table.metrics, (m) =>
+                hasMatchingTags(m.tags ?? [], availableTags),
+            ),
+        })),
+    };
+
+    return filteredExplore;
+}

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -145,3 +145,5 @@ export type ApiAiAgentThreadResponse = {
     status: 'ok';
     results: AiAgentThread;
 };
+
+export * from './filterExploreByTags';


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/14879

### Description:

No tags are configured in settings UI:
| Tagging Scenario                  | AI Visibility                    |
|-----------------------------------|----------------------------------|
| No tags configured in settings UI | Everything is visible by default |
---
Tags are configured in settings UI:
| Tagging Scenario                     | AI Visibility               |
|--------------------------------------|-----------------------------|
| Explore only (with matching tag)     | All fields in the Explore   |
| Some fields only (with matching tag) | Only those tagged fields    |
| Explore + some fields (with match)   | Only those tagged fields    |
| No matching tags                     | Nothing is visible          |