### PR TITLE
chore: use immer for explorer reducers

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -153,216 +153,163 @@ export function reducer(
             return action.payload;
         }
         case ActionType.SET_TABLE_NAME: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    tableName: action.payload,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        exploreName: action.payload,
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.tableName = action.payload;
+                draft.unsavedChartVersion.metricQuery.exploreName =
+                    action.payload;
+            });
         }
         case ActionType.SET_FETCH_RESULTS_FALSE: {
-            return { ...state, shouldFetchResults: false };
+            return produce(state, (draft) => {
+                draft.shouldFetchResults = false;
+            });
         }
         case ActionType.SET_PREVIOUSLY_FETCHED_STATE: {
-            return {
-                ...state,
-                previouslyFetchedState: action.payload,
-            };
+            return produce(state, (draft) => {
+                draft.previouslyFetchedState = action.payload;
+            });
         }
         case ActionType.TOGGLE_EXPANDED_SECTION: {
-            return {
-                ...state,
-                expandedSections: toggleArrayValue(
-                    state.expandedSections,
+            return produce(state, (draft) => {
+                draft.expandedSections = toggleArrayValue(
+                    draft.expandedSections,
                     action.payload,
-                ),
-            };
+                );
+            });
         }
         case ActionType.REMOVE_FIELD: {
-            const dimensions =
-                state.unsavedChartVersion.metricQuery.dimensions.filter(
-                    (fieldId) => fieldId !== action.payload,
-                );
-            const metrics =
-                state.unsavedChartVersion.metricQuery.metrics.filter(
-                    (fieldId) => fieldId !== action.payload,
-                );
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        dimensions,
-                        metrics,
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (s) => s.fieldId !== action.payload,
-                        ),
-                        tableCalculations:
-                            state.unsavedChartVersion.metricQuery.tableCalculations.filter(
-                                (tc) => tc.name !== action.payload,
-                            ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder:
-                            state.unsavedChartVersion.tableConfig.columnOrder.filter(
-                                (fieldId) => fieldId !== action.payload,
-                            ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const fieldToRemove = action.payload;
+                draft.unsavedChartVersion.metricQuery.dimensions =
+                    draft.unsavedChartVersion.metricQuery.dimensions.filter(
+                        (fieldId) => fieldId !== fieldToRemove,
+                    );
+                draft.unsavedChartVersion.metricQuery.metrics =
+                    draft.unsavedChartVersion.metricQuery.metrics.filter(
+                        (fieldId) => fieldId !== fieldToRemove,
+                    );
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (s) => s.fieldId !== fieldToRemove,
+                    );
+                draft.unsavedChartVersion.metricQuery.tableCalculations =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.filter(
+                        (tc) => tc.name !== fieldToRemove,
+                    );
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    draft.unsavedChartVersion.tableConfig.columnOrder.filter(
+                        (fieldId) => fieldId !== fieldToRemove,
+                    );
+            });
         }
         case ActionType.TOGGLE_DIMENSION: {
-            const dimensions = toggleArrayValue(
-                state.unsavedChartVersion.metricQuery.dimensions,
-                action.payload,
-            );
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        dimensions,
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (s) => s.fieldId !== action.payload,
-                        ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(
-                            state.unsavedChartVersion.tableConfig.columnOrder,
-                            [
-                                ...dimensions,
-                                ...state.unsavedChartVersion.metricQuery
-                                    .metrics,
-                                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                    ({ name }) => name,
-                                ),
-                            ],
-                            dimensions,
-                        ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const current =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                draft.unsavedChartVersion.metricQuery.dimensions =
+                    toggleArrayValue(current, action.payload);
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (s) => s.fieldId !== action.payload,
+                    );
+
+                const dimensionIds =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                const metricIds = draft.unsavedChartVersion.metricQuery.metrics;
+                const calcIds =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        ({ name }) => name,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(
+                        draft.unsavedChartVersion.tableConfig.columnOrder,
+                        [...dimensionIds, ...metricIds, ...calcIds],
+                        dimensionIds,
+                    );
+            });
         }
+
         case ActionType.TOGGLE_METRIC: {
-            const metrics = toggleArrayValue(
-                state.unsavedChartVersion.metricQuery.metrics,
-                action.payload,
-            );
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        metrics,
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (s) => s.fieldId !== action.payload,
-                        ),
-                        metricOverrides: Object.fromEntries(
-                            Object.entries(
-                                state.unsavedChartVersion.metricQuery
-                                    .metricOverrides || {},
-                            ).filter(([key]) => key !== action.payload),
-                        ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(
-                            state.unsavedChartVersion.tableConfig.columnOrder,
-                            [
-                                ...state.unsavedChartVersion.metricQuery
-                                    .dimensions,
-                                ...metrics,
-                                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                    ({ name }) => name,
-                                ),
-                            ],
-                        ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const currentMetrics =
+                    draft.unsavedChartVersion.metricQuery.metrics;
+                draft.unsavedChartVersion.metricQuery.metrics =
+                    toggleArrayValue(currentMetrics, action.payload);
+
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (s) => s.fieldId !== action.payload,
+                    );
+
+                draft.unsavedChartVersion.metricQuery.metricOverrides =
+                    Object.fromEntries(
+                        Object.entries(
+                            draft.unsavedChartVersion.metricQuery
+                                .metricOverrides || {},
+                        ).filter(([key]) => key !== action.payload),
+                    );
+
+                const dimensionIds =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                const metricIds = draft.unsavedChartVersion.metricQuery.metrics;
+                const calcIds =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        ({ name }) => name,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(
+                        draft.unsavedChartVersion.tableConfig.columnOrder,
+                        [...dimensionIds, ...metricIds, ...calcIds],
+                    );
+            });
         }
         case ActionType.TOGGLE_SORT_FIELD: {
-            const sortFieldId = action.payload;
-            const activeFields = new Set([
-                ...state.unsavedChartVersion.metricQuery.dimensions,
-                ...state.unsavedChartVersion.metricQuery.metrics,
-                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                    (tc) => tc.name,
-                ),
-            ]);
-            if (!activeFields.has(sortFieldId)) {
-                return state;
-            }
-            const sortField = state.unsavedChartVersion.metricQuery.sorts.find(
-                (sf) => sf.fieldId === sortFieldId,
-            );
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        sorts: !sortField
-                            ? [
-                                  ...state.unsavedChartVersion.metricQuery
-                                      .sorts,
-                                  {
-                                      fieldId: sortFieldId,
-                                      descending: false,
-                                  },
-                              ]
-                            : state.unsavedChartVersion.metricQuery.sorts.reduce<
-                                  SortField[]
-                              >((acc, sf) => {
-                                  if (sf.fieldId !== sortFieldId) {
-                                      return [...acc, sf];
-                                  }
+            return produce(state, (draft) => {
+                const sortFieldId = action.payload;
+                const activeFields = new Set([
+                    ...draft.unsavedChartVersion.metricQuery.dimensions,
+                    ...draft.unsavedChartVersion.metricQuery.metrics,
+                    ...draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        (tc) => tc.name,
+                    ),
+                ]);
+                if (!activeFields.has(sortFieldId)) {
+                    return;
+                }
+                const sortField =
+                    draft.unsavedChartVersion.metricQuery.sorts.find(
+                        (sf) => sf.fieldId === sortFieldId,
+                    );
 
-                                  if (sf.descending) {
-                                      return acc;
-                                  }
-                                  return [
-                                      ...acc,
-                                      {
-                                          ...sf,
-                                          descending: true,
-                                      },
-                                  ];
-                              }, []),
-                    },
-                },
-            };
+                if (!sortField) {
+                    draft.unsavedChartVersion.metricQuery.sorts.push({
+                        fieldId: sortFieldId,
+                        descending: false,
+                    });
+                } else if (sortField.descending) {
+                    draft.unsavedChartVersion.metricQuery.sorts =
+                        draft.unsavedChartVersion.metricQuery.sorts.filter(
+                            (sf) => sf.fieldId !== sortFieldId,
+                        );
+                } else {
+                    sortField.descending = true;
+                }
+            });
         }
         case ActionType.SET_SORT_FIELDS: {
-            const activeFields = new Set([
-                ...state.unsavedChartVersion.metricQuery.dimensions,
-                ...state.unsavedChartVersion.metricQuery.metrics,
-                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                    (tc) => tc.name,
-                ),
-            ]);
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        sorts: action.payload.filter((sf) =>
-                            activeFields.has(sf.fieldId),
-                        ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const activeFields = new Set([
+                    ...draft.unsavedChartVersion.metricQuery.dimensions,
+                    ...draft.unsavedChartVersion.metricQuery.metrics,
+                    ...draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        (tc) => tc.name,
+                    ),
+                ]);
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    action.payload.filter((sf) => activeFields.has(sf.fieldId));
+            });
         }
         case ActionType.ADD_SORT_FIELD: {
             return produce(state, (newState) => {
@@ -398,566 +345,443 @@ export function reducer(
             });
         }
         case ActionType.SET_ROW_LIMIT: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        limit: action.payload,
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.metricQuery.limit = action.payload;
+            });
         }
         case ActionType.SET_TIME_ZONE: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        timezone: action.payload,
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.metricQuery.timezone = action.payload;
+            });
         }
         case ActionType.SET_FILTERS: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        filters: action.payload,
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.metricQuery.filters = action.payload;
+            });
         }
         case ActionType.ADD_ADDITIONAL_METRIC: {
-            const isMetricAlreadyInList = (
-                state.unsavedChartVersion.metricQuery.additionalMetrics || []
-            ).find((metric) => getItemId(metric) === getItemId(action.payload));
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        additionalMetrics: isMetricAlreadyInList
-                            ? state.unsavedChartVersion.metricQuery
-                                  .additionalMetrics
-                            : [
-                                  ...(state.unsavedChartVersion.metricQuery
-                                      .additionalMetrics || []),
-                                  action.payload,
-                              ],
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const isMetricAlreadyInList = (
+                    draft.unsavedChartVersion.metricQuery.additionalMetrics ||
+                    []
+                ).find(
+                    (metric) => getItemId(metric) === getItemId(action.payload),
+                );
+                if (!isMetricAlreadyInList) {
+                    draft.unsavedChartVersion.metricQuery.additionalMetrics = [
+                        ...(draft.unsavedChartVersion.metricQuery
+                            .additionalMetrics || []),
+                        action.payload,
+                    ];
+                }
+            });
         }
 
         case ActionType.ADD_CUSTOM_DIMENSION: {
-            const newCustomDimension = action.payload;
-            const allCustomDimensions = [
-                ...(state.unsavedChartVersion.metricQuery.customDimensions ||
-                    []),
-                newCustomDimension,
-            ];
+            return produce(state, (draft) => {
+                const newCustomDimension = action.payload;
+                draft.unsavedChartVersion.metricQuery.customDimensions = [
+                    ...(draft.unsavedChartVersion.metricQuery
+                        .customDimensions || []),
+                    newCustomDimension,
+                ];
 
-            const dimensions = [
-                ...state.unsavedChartVersion.metricQuery.dimensions,
-                getItemId(newCustomDimension),
-            ];
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        dimensions,
-                        customDimensions: allCustomDimensions,
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(
-                            state.unsavedChartVersion.tableConfig.columnOrder,
-                            [
-                                ...dimensions,
-                                ...state.unsavedChartVersion.metricQuery
-                                    .metrics,
-                                ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                    ({ name }) => name,
-                                ),
-                            ],
-                        ),
-                    },
-                },
-            };
+                const customDimensionId = getItemId(newCustomDimension);
+                if (
+                    !draft.unsavedChartVersion.metricQuery.dimensions.includes(
+                        customDimensionId,
+                    )
+                ) {
+                    draft.unsavedChartVersion.metricQuery.dimensions.push(
+                        customDimensionId,
+                    );
+                }
+
+                const dimensionIds =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                const metricIds = draft.unsavedChartVersion.metricQuery.metrics;
+                const calcIds =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        ({ name }) => name,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(
+                        draft.unsavedChartVersion.tableConfig.columnOrder,
+                        [...dimensionIds, ...metricIds, ...calcIds],
+                    );
+            });
         }
 
         case ActionType.EDIT_CUSTOM_DIMENSION: {
             //The id of the custom dimension changes on edit if the name was updated, so we need to update the dimension array
-            const dimensions = [
-                ...state.unsavedChartVersion.metricQuery.dimensions.filter(
-                    (dimension) =>
-                        dimension !== action.payload.previousCustomDimensionId,
-                ),
-                getItemId(action.payload.customDimension),
-            ];
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        dimensions,
-                        customDimensions:
-                            state.unsavedChartVersion.metricQuery.customDimensions?.map(
-                                (customDimension) =>
-                                    customDimension.id ===
-                                    action.payload.previousCustomDimensionId
-                                        ? action.payload.customDimension
-                                        : customDimension,
-                            ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const { previousCustomDimensionId, customDimension } =
+                    action.payload;
+                const newCustomDimensionId = getItemId(customDimension);
+
+                draft.unsavedChartVersion.metricQuery.dimensions =
+                    draft.unsavedChartVersion.metricQuery.dimensions.filter(
+                        (dimension) => dimension !== previousCustomDimensionId,
+                    );
+                if (
+                    !draft.unsavedChartVersion.metricQuery.dimensions.includes(
+                        newCustomDimensionId,
+                    )
+                ) {
+                    draft.unsavedChartVersion.metricQuery.dimensions.push(
+                        newCustomDimensionId,
+                    );
+                }
+
+                draft.unsavedChartVersion.metricQuery.customDimensions =
+                    draft.unsavedChartVersion.metricQuery.customDimensions?.map(
+                        (cd) =>
+                            cd.id === previousCustomDimensionId
+                                ? customDimension
+                                : cd,
+                    );
+            });
         }
 
         case ActionType.REMOVE_CUSTOM_DIMENSION: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        customDimensions: (
-                            state.unsavedChartVersion.metricQuery
-                                .customDimensions || []
-                        ).filter(
-                            (customDimension) =>
-                                getItemId(customDimension) !== action.payload,
-                        ),
-                        dimensions:
-                            state.unsavedChartVersion.metricQuery.dimensions.filter(
-                                (dimension) => dimension !== action.payload,
-                            ),
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (sort) => sort.fieldId !== action.payload,
-                        ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder:
-                            state.unsavedChartVersion.tableConfig.columnOrder.filter(
-                                (fieldId) => fieldId !== action.payload,
-                            ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const dimensionIdToRemove = action.payload;
+                draft.unsavedChartVersion.metricQuery.customDimensions = (
+                    draft.unsavedChartVersion.metricQuery.customDimensions || []
+                ).filter(
+                    (customDimension) =>
+                        getItemId(customDimension) !== dimensionIdToRemove,
+                );
+                draft.unsavedChartVersion.metricQuery.dimensions =
+                    draft.unsavedChartVersion.metricQuery.dimensions.filter(
+                        (dimension) => dimension !== dimensionIdToRemove,
+                    );
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (sort) => sort.fieldId !== dimensionIdToRemove,
+                    );
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    draft.unsavedChartVersion.tableConfig.columnOrder.filter(
+                        (fieldId) => fieldId !== dimensionIdToRemove,
+                    );
+            });
         }
 
         case ActionType.TOGGLE_CUSTOM_DIMENSION_MODAL: {
-            return {
-                ...state,
-                modals: {
-                    ...state.modals,
-                    customDimension: {
-                        isOpen: !state.modals.customDimension.isOpen,
-                        ...(action.payload && { ...action.payload }),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.modals.customDimension = {
+                    isOpen: !draft.modals.customDimension.isOpen,
+                    ...(action.payload && { ...action.payload }),
+                };
+            });
         }
 
         case ActionType.TOGGLE_FORMAT_MODAL: {
-            return {
-                ...state,
-                modals: {
-                    ...state.modals,
-                    format: {
-                        isOpen: !state.modals.format.isOpen,
-                        ...(action.payload && { ...action.payload }),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.modals.format = {
+                    isOpen: !draft.modals.format.isOpen,
+                    ...(action.payload && { ...action.payload }),
+                };
+            });
         }
 
         case ActionType.UPDATE_METRIC_FORMAT: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        metricOverrides: {
-                            ...state.unsavedChartVersion.metricQuery
-                                .metricOverrides,
-                            [getItemId(action.payload.metric)]: {
-                                formatOptions: action.payload.formatOptions,
-                            },
-                        },
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const { metric, formatOptions } = action.payload;
+                const metricId = getItemId(metric);
+                if (!draft.unsavedChartVersion.metricQuery.metricOverrides) {
+                    draft.unsavedChartVersion.metricQuery.metricOverrides = {};
+                }
+                draft.unsavedChartVersion.metricQuery.metricOverrides[
+                    metricId
+                ] = { formatOptions };
+            });
         }
 
         case ActionType.EDIT_ADDITIONAL_METRIC: {
-            const additionalMetricFieldId = getItemId(
-                action.payload.additionalMetric,
-            );
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        metrics:
-                            state.unsavedChartVersion.metricQuery.metrics.map(
-                                (metric) =>
-                                    metric ===
-                                    action.payload.previousAdditionalMetricName
-                                        ? additionalMetricFieldId
-                                        : metric,
-                            ),
-                        additionalMetrics:
-                            state.unsavedChartVersion.metricQuery.additionalMetrics?.map(
-                                (metric) =>
-                                    metric.uuid ===
-                                    action.payload.additionalMetric.uuid
-                                        ? action.payload.additionalMetric
-                                        : metric,
-                            ),
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.map(
-                            (sortField) =>
-                                sortField.fieldId ===
-                                action.payload.previousAdditionalMetricName
-                                    ? {
-                                          ...sortField,
-                                          fieldId: additionalMetricFieldId,
-                                      }
-                                    : sortField,
-                        ),
-                        filters: Object.entries(
-                            state.unsavedChartVersion.metricQuery.filters,
-                        ).reduce((acc, [key, value]) => {
-                            let valueDeepCopy = cloneDeep(value);
-                            if (key === 'metrics') {
-                                updateFieldIdInFilters(
-                                    valueDeepCopy,
-                                    action.payload.previousAdditionalMetricName,
-                                    additionalMetricFieldId,
-                                );
-                            }
-                            return {
-                                ...acc,
-                                [key]: valueDeepCopy,
-                            };
-                        }, {}),
-                        tableCalculations:
-                            state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                (tableCalculation) => {
-                                    let tableCalculationDeepCopy =
-                                        cloneDeep(tableCalculation);
+            return produce(state, (draft) => {
+                const { additionalMetric, previousAdditionalMetricName } =
+                    action.payload;
+                const additionalMetricFieldId = getItemId(additionalMetric);
 
-                                    tableCalculationDeepCopy.sql =
-                                        tableCalculationDeepCopy.sql.replace(
-                                            lightdashVariablePattern,
-                                            (_, fieldRef) => {
-                                                const fieldId =
-                                                    convertFieldRefToFieldId(
-                                                        fieldRef,
-                                                    );
+                draft.unsavedChartVersion.metricQuery.metrics =
+                    draft.unsavedChartVersion.metricQuery.metrics.map(
+                        (metric) =>
+                            metric === previousAdditionalMetricName
+                                ? additionalMetricFieldId
+                                : metric,
+                    );
 
-                                                if (
-                                                    fieldId ===
-                                                    action.payload
-                                                        .previousAdditionalMetricName
-                                                ) {
-                                                    return `\${${getFieldRef(
-                                                        action.payload
-                                                            .additionalMetric,
-                                                    )}}`;
-                                                }
-                                                return `\${${fieldRef}}`;
-                                            },
-                                        );
+                draft.unsavedChartVersion.metricQuery.additionalMetrics =
+                    draft.unsavedChartVersion.metricQuery.additionalMetrics?.map(
+                        (metric) =>
+                            metric.uuid === additionalMetric.uuid
+                                ? additionalMetric
+                                : metric,
+                    );
 
-                                    return tableCalculationDeepCopy;
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.map(
+                        (sortField) =>
+                            sortField.fieldId === previousAdditionalMetricName
+                                ? {
+                                      ...sortField,
+                                      fieldId: additionalMetricFieldId,
+                                  }
+                                : sortField,
+                    );
+
+                const newFilters = {
+                    ...draft.unsavedChartVersion.metricQuery.filters,
+                };
+                if (newFilters.metrics) {
+                    updateFieldIdInFilters(
+                        newFilters.metrics,
+                        previousAdditionalMetricName,
+                        additionalMetricFieldId,
+                    );
+                }
+                draft.unsavedChartVersion.metricQuery.filters = newFilters;
+
+                draft.unsavedChartVersion.metricQuery.tableCalculations =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        (tableCalculation) => {
+                            const newSql = tableCalculation.sql.replace(
+                                lightdashVariablePattern,
+                                (_, fieldRef) => {
+                                    const fieldId =
+                                        convertFieldRefToFieldId(fieldRef);
+                                    if (
+                                        fieldId === previousAdditionalMetricName
+                                    ) {
+                                        return `\${${getFieldRef(
+                                            additionalMetric,
+                                        )}}`;
+                                    }
+                                    return `\${${fieldRef}}`;
                                 },
-                            ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder:
-                            state.unsavedChartVersion.tableConfig.columnOrder.map(
-                                (fieldId) =>
-                                    fieldId ===
-                                    action.payload.previousAdditionalMetricName
-                                        ? additionalMetricFieldId
-                                        : fieldId,
-                            ),
-                    },
-                },
-            };
+                            );
+                            return {
+                                ...tableCalculation,
+                                sql: newSql,
+                            };
+                        },
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    draft.unsavedChartVersion.tableConfig.columnOrder.map(
+                        (fieldId) =>
+                            fieldId === previousAdditionalMetricName
+                                ? additionalMetricFieldId
+                                : fieldId,
+                    );
+            });
         }
 
         case ActionType.REMOVE_ADDITIONAL_METRIC: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        additionalMetrics: (
-                            state.unsavedChartVersion.metricQuery
-                                .additionalMetrics || []
-                        ).filter(
-                            (metric) => getItemId(metric) !== action.payload,
-                        ),
-                        metrics:
-                            state.unsavedChartVersion.metricQuery.metrics.filter(
-                                (metric) => metric !== action.payload,
-                            ),
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (sort) => sort.fieldId !== action.payload,
-                        ),
-                        filters: Object.entries(
-                            state.unsavedChartVersion.metricQuery.filters,
-                        ).reduce((acc, [key, value]) => {
-                            let valueDeepCopy = cloneDeep(value);
-                            if (key === 'metrics') {
-                                return {
-                                    ...acc,
-                                    [key]: removeFieldFromFilterGroup(
-                                        valueDeepCopy,
-                                        action.payload,
-                                    ),
-                                };
-                            }
+            return produce(state, (draft) => {
+                const metricIdToRemove = action.payload;
 
-                            return {
-                                ...acc,
-                                [key]: valueDeepCopy,
-                            };
-                        }, {}),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder:
-                            state.unsavedChartVersion.tableConfig.columnOrder.filter(
-                                (fieldId) => fieldId !== action.payload,
-                            ),
-                    },
-                },
-            };
+                draft.unsavedChartVersion.metricQuery.additionalMetrics = (
+                    draft.unsavedChartVersion.metricQuery.additionalMetrics ||
+                    []
+                ).filter((metric) => getItemId(metric) !== metricIdToRemove);
+
+                draft.unsavedChartVersion.metricQuery.metrics =
+                    draft.unsavedChartVersion.metricQuery.metrics.filter(
+                        (metric) => metric !== metricIdToRemove,
+                    );
+
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (sort) => sort.fieldId !== metricIdToRemove,
+                    );
+
+                const newFilters = {
+                    ...draft.unsavedChartVersion.metricQuery.filters,
+                };
+                if (newFilters.metrics) {
+                    newFilters.metrics = removeFieldFromFilterGroup(
+                        newFilters.metrics,
+                        metricIdToRemove,
+                    );
+
+                    if (newFilters.metrics) {
+                        const isAndGroupEmpty =
+                            !('and' in newFilters.metrics) ||
+                            !newFilters.metrics.and ||
+                            newFilters.metrics.and.length === 0;
+                        const isOrGroupEmpty =
+                            !('or' in newFilters.metrics) ||
+                            !newFilters.metrics.or ||
+                            newFilters.metrics.or.length === 0;
+                        if (isAndGroupEmpty && isOrGroupEmpty) {
+                            delete newFilters.metrics;
+                        }
+                    }
+                }
+                draft.unsavedChartVersion.metricQuery.filters = newFilters;
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    draft.unsavedChartVersion.tableConfig.columnOrder.filter(
+                        (fieldId) => fieldId !== metricIdToRemove,
+                    );
+            });
         }
         case ActionType.TOGGLE_ADDITIONAL_METRIC_MODAL: {
-            return {
-                ...state,
-                modals: {
-                    ...state.modals,
-                    additionalMetric: {
-                        isOpen: !state.modals.additionalMetric.isOpen,
-                        ...(action.payload && { ...action.payload }),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.modals.additionalMetric = {
+                    isOpen: !draft.modals.additionalMetric.isOpen,
+                    ...(action.payload && { ...action.payload }),
+                };
+            });
         }
         case ActionType.TOGGLE_WRITE_BACK_MODAL: {
-            return {
-                ...state,
-                modals: {
-                    ...state.modals,
-                    writeBack: {
-                        isOpen: !state.modals.writeBack.isOpen,
-                        ...(action.payload && { ...action.payload }),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.modals.writeBack = {
+                    isOpen: !draft.modals.writeBack.isOpen,
+                    ...(action.payload && { ...action.payload }),
+                };
+            });
         }
         case ActionType.SET_COLUMN_ORDER: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(action.payload, [
-                            ...state.unsavedChartVersion.metricQuery.dimensions,
-
-                            ...state.unsavedChartVersion.metricQuery.metrics,
-                            ...state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                ({ name }) => name,
-                            ),
-                        ]),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(action.payload, [
+                        ...draft.unsavedChartVersion.metricQuery.dimensions,
+                        ...draft.unsavedChartVersion.metricQuery.metrics,
+                        ...draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                            ({ name }) => name,
+                        ),
+                    ]);
+            });
         }
         case ActionType.ADD_TABLE_CALCULATION: {
-            const newTableCalculations = [
-                ...state.unsavedChartVersion.metricQuery.tableCalculations,
-                action.payload,
-            ];
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        tableCalculations: newTableCalculations,
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(
-                            state.unsavedChartVersion.tableConfig.columnOrder,
-                            [
-                                ...state.unsavedChartVersion.metricQuery
-                                    .dimensions,
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.metricQuery.tableCalculations.push(
+                    action.payload,
+                );
 
-                                ...state.unsavedChartVersion.metricQuery
-                                    .metrics,
-                                ...newTableCalculations.map(({ name }) => name),
-                            ],
-                        ),
-                    },
-                },
-            };
+                const dimensionIds =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                const metricIds = draft.unsavedChartVersion.metricQuery.metrics;
+                const calcIds =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        ({ name }) => name,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(
+                        draft.unsavedChartVersion.tableConfig.columnOrder,
+                        [...dimensionIds, ...metricIds, ...calcIds],
+                    );
+            });
         }
         case ActionType.UPDATE_TABLE_CALCULATION: {
-            return {
-                ...state,
-                metadata: {
-                    ...state.metadata,
-                    tableCalculations: getTableCalculationsMetadata(
-                        state,
-                        action.payload.oldName,
-                        action.payload.tableCalculation.name,
-                    ),
-                },
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        tableCalculations:
-                            state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                                (tableCalculation) =>
-                                    tableCalculation.name ===
-                                    action.payload.oldName
-                                        ? action.payload.tableCalculation
-                                        : tableCalculation,
-                            ),
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.map(
-                            (field) =>
-                                field.fieldId === action.payload.oldName
-                                    ? {
-                                          ...field,
-                                          fieldId:
-                                              action.payload.tableCalculation
-                                                  .name,
-                                      }
-                                    : field,
-                        ),
-                    },
-                    chartConfig: updateChartConfigWithTableCalc(
-                        state.unsavedChartVersion.chartConfig,
-                        action.payload.oldName,
-                        action.payload.tableCalculation.name,
-                    ),
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder:
-                            state.unsavedChartVersion.tableConfig.columnOrder.map(
-                                (column) =>
-                                    column === action.payload.oldName
-                                        ? action.payload.tableCalculation.name
-                                        : column,
-                            ),
-                    },
-                },
-            };
+            return produce(state, (draft) => {
+                const { oldName, tableCalculation: newTableCalculation } =
+                    action.payload;
+                const newName = newTableCalculation.name;
+
+                if (!draft.metadata) {
+                    draft.metadata = {};
+                }
+                draft.metadata.tableCalculations = getTableCalculationsMetadata(
+                    draft, // Pass draft here, assuming getTableCalculationsMetadata can handle it or doesn't mutate
+                    oldName,
+                    newName,
+                );
+
+                draft.unsavedChartVersion.metricQuery.tableCalculations =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        (tc) =>
+                            tc.name === oldName ? newTableCalculation : tc,
+                    );
+
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.map((field) =>
+                        field.fieldId === oldName
+                            ? { ...field, fieldId: newName }
+                            : field,
+                    );
+
+                draft.unsavedChartVersion.chartConfig =
+                    updateChartConfigWithTableCalc(
+                        draft.unsavedChartVersion.chartConfig,
+                        oldName,
+                        newName,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    draft.unsavedChartVersion.tableConfig.columnOrder.map(
+                        (column) => (column === oldName ? newName : column),
+                    );
+            });
         }
         case ActionType.DELETE_TABLE_CALCULATION: {
-            const newTableCalculations =
-                state.unsavedChartVersion.metricQuery.tableCalculations.filter(
-                    (tableCalculation) =>
-                        tableCalculation.name !== action.payload,
-                );
-            return {
-                ...state,
-                metadata: {
-                    ...state.metadata,
-                    tableCalculations:
-                        state.metadata?.tableCalculations?.filter(
-                            (tc) => tc.name !== action.payload,
-                        ),
-                },
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    metricQuery: {
-                        ...state.unsavedChartVersion.metricQuery,
-                        tableCalculations: newTableCalculations,
-                        sorts: state.unsavedChartVersion.metricQuery.sorts.filter(
-                            (sort) => sort.fieldId !== action.payload,
-                        ),
-                    },
-                    tableConfig: {
-                        ...state.unsavedChartVersion.tableConfig,
-                        columnOrder: calcColumnOrder(
-                            state.unsavedChartVersion.tableConfig.columnOrder,
-                            [
-                                ...state.unsavedChartVersion.metricQuery
-                                    .dimensions,
+            return produce(state, (draft) => {
+                const nameToRemove = action.payload;
+                if (draft.metadata && draft.metadata.tableCalculations) {
+                    draft.metadata.tableCalculations =
+                        draft.metadata.tableCalculations.filter(
+                            (tc) => tc.name !== nameToRemove,
+                        );
+                }
 
-                                ...state.unsavedChartVersion.metricQuery
-                                    .metrics,
-                                ...newTableCalculations.map(({ name }) => name),
-                            ],
-                        ),
-                    },
-                },
-            };
+                draft.unsavedChartVersion.metricQuery.tableCalculations =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.filter(
+                        (tc) => tc.name !== nameToRemove,
+                    );
+
+                draft.unsavedChartVersion.metricQuery.sorts =
+                    draft.unsavedChartVersion.metricQuery.sorts.filter(
+                        (sort) => sort.fieldId !== nameToRemove,
+                    );
+
+                const dimensionIds =
+                    draft.unsavedChartVersion.metricQuery.dimensions;
+                const metricIds = draft.unsavedChartVersion.metricQuery.metrics;
+                const calcIds =
+                    draft.unsavedChartVersion.metricQuery.tableCalculations.map(
+                        ({ name }) => name,
+                    );
+
+                draft.unsavedChartVersion.tableConfig.columnOrder =
+                    calcColumnOrder(
+                        draft.unsavedChartVersion.tableConfig.columnOrder,
+                        [...dimensionIds, ...metricIds, ...calcIds],
+                    );
+            });
         }
         case ActionType.SET_PIVOT_FIELDS: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    pivotConfig:
-                        action.payload.length > 0
-                            ? {
-                                  columns: action.payload,
-                              }
-                            : undefined,
-                },
-            };
+            return produce(state, (draft) => {
+                if (action.payload.length > 0) {
+                    draft.unsavedChartVersion.pivotConfig = {
+                        columns: action.payload,
+                    };
+                } else {
+                    draft.unsavedChartVersion.pivotConfig = undefined;
+                }
+            });
         }
         case ActionType.SET_CHART_TYPE: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    chartConfig: getValidChartConfig(
-                        action.payload.chartType,
-                        state.unsavedChartVersion.chartConfig,
-                        action.payload.cachedConfigs,
-                    ),
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.chartConfig = getValidChartConfig(
+                    action.payload.chartType,
+                    draft.unsavedChartVersion.chartConfig,
+                    action.payload.cachedConfigs,
+                );
+            });
         }
         case ActionType.SET_CHART_CONFIG: {
-            return {
-                ...state,
-                unsavedChartVersion: {
-                    ...state.unsavedChartVersion,
-                    chartConfig: getValidChartConfig(
-                        action.payload.chartConfig.type,
-                        action.payload.chartConfig,
-                        action.payload.cachedConfigs,
-                    ),
-                },
-            };
+            return produce(state, (draft) => {
+                draft.unsavedChartVersion.chartConfig = getValidChartConfig(
+                    action.payload.chartConfig.type,
+                    action.payload.chartConfig,
+                    action.payload.cachedConfigs,
+                );
+            });
         }
         case ActionType.REPLACE_FIELDS: {
             const { hasChanges, chartVersion } =
@@ -966,10 +790,9 @@ export function reducer(
                     chartVersion: state.unsavedChartVersion,
                 });
             if (hasChanges) {
-                return {
-                    ...state,
-                    unsavedChartVersion: chartVersion,
-                };
+                return produce(state, (draft) => {
+                    draft.unsavedChartVersion = chartVersion;
+                });
             }
             return state;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/14638

### Description:

Uses immer for Explore Provider reducers. This is necessary to optimize this provider so that it's not creating new objects all the time. 

There are a lot of tests for these reducers now. 

To test manually:
Use the explore as much as possible
