### PR TITLE
feat: delete AI agent slack integrations when removing Slack installation

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -130,6 +130,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     analytics: context.lightdashAnalytics,
+                    aiAgentModel: models.getAiAgentModel(),
                 }),
             supportService: ({ models, context, repository, clients }) =>
                 new SupportService({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -507,4 +507,27 @@ export class AiAgentModel {
             return messages;
         });
     }
+
+    async deleteSlackIntegrations({
+        organizationUuid,
+    }: {
+        organizationUuid: string;
+    }): Promise<void> {
+        await this.database
+            .from(AiAgentIntegrationTableName)
+            .delete()
+            .where(
+                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
+                'IN',
+                this.database
+                    .from(AiAgentSlackIntegrationTableName)
+                    .select(
+                        `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
+                    )
+                    .where(
+                        `${AiAgentSlackIntegrationTableName}.organization_uuid`,
+                        organizationUuid,
+                    ),
+            );
+    }
 }

--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -1,8 +1,25 @@
 import { ForbiddenError, SessionUser, SlackSettings } from '@lightdash/common';
-import { SlackIntegrationService } from '../../services/SlackIntegrationService/SlackIntegrationService';
+import {
+    SlackIntegrationService,
+    SlackIntegrationServiceArguments,
+} from '../../services/SlackIntegrationService/SlackIntegrationService';
+import { AiAgentModel } from '../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../models/CommercialSlackAuthenticationModel';
 
 export class CommercialSlackIntegrationService extends SlackIntegrationService<CommercialSlackAuthenticationModel> {
+    private readonly aiAgentModel: AiAgentModel;
+
+    constructor({
+        aiAgentModel,
+        ...rest
+    }: SlackIntegrationServiceArguments<CommercialSlackAuthenticationModel> & {
+        aiAgentModel: AiAgentModel;
+    }) {
+        super(rest);
+
+        this.aiAgentModel = aiAgentModel;
+    }
+
     async getInstallationFromOrganizationUuid(user: SessionUser) {
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
@@ -25,5 +42,13 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
         };
 
         return response;
+    }
+
+    async deleteInstallationFromOrganizationUuid(user: SessionUser) {
+        await super.deleteInstallationFromOrganizationUuid(user);
+
+        await this.aiAgentModel.deleteSlackIntegrations({
+            organizationUuid: user.organizationUuid!,
+        });
     }
 }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -8,7 +8,7 @@ import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { BaseService } from '../BaseService';
 
-type SlackIntegrationServiceArguments<
+export type SlackIntegrationServiceArguments<
     T extends SlackAuthenticationModel = SlackAuthenticationModel,
 > = {
     analytics: LightdashAnalytics;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14934

### Description:

Added functionality to delete AI agent Slack integrations when a Slack installation is removed from an organization. This ensures that when a user disconnects Slack from their organization, all related AI agent Slack integrations are properly cleaned up as well.
