### PR TITLE
chore: update SQL chart column metadata to include type information

### DIFF
--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import {
     getDateGroupLabel,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
     isValidEmailAddress,
 } from '.';
@@ -21,7 +21,7 @@ describe('Common index', () => {
             const date = moment().format('YYYY-MM-DD');
 
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     dateDayDimension,
                     emptyValueFilter,
                     undefined,
@@ -33,7 +33,7 @@ describe('Common index', () => {
             const date = moment().format('YYYY-MM-01');
 
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     dateMonthDimension,
                     emptyValueFilter,
                     undefined,
@@ -45,7 +45,7 @@ describe('Common index', () => {
             const date = moment().format('YYYY-01-01');
 
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     dateYearDimension,
                     emptyValueFilter,
                     undefined,
@@ -57,7 +57,7 @@ describe('Common index', () => {
     describe('filter rule with default values', () => {
         test('should return with undefined values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     stringDimension,
                     emptyValueFilter,
                     undefined,
@@ -66,7 +66,7 @@ describe('Common index', () => {
         });
         test('should return with empty values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     stringDimension,
                     emptyValueFilter,
                     [],
@@ -75,7 +75,7 @@ describe('Common index', () => {
         });
         test('should return single value', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     stringDimension,
                     emptyValueFilter,
                     ['test'],
@@ -84,7 +84,7 @@ describe('Common index', () => {
         });
         test('should return multiple values', async () => {
             expect(
-                getFilterRuleWithDefaultValue(
+                getFilterRuleFromFieldWithDefaultValue(
                     stringDimension,
                     emptyValueFilter,
                     ['test1', 'test2'],

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -195,11 +195,11 @@ export const isWithValueFilter = (filterOperator: FilterOperator) =>
     filterOperator !== FilterOperator.NOT_NULL;
 
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
-    field: FilterableField,
+    filterType: FilterType,
+    field: FilterableField | undefined,
     filterRule: T,
     values?: AnyType[] | null,
 ): T => {
-    const filterType = getFilterTypeFromItem(field);
     const filterRuleDefaults: Partial<FilterRule> = {};
 
     if (
@@ -213,6 +213,7 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                 const value = values ? values[0] : undefined;
 
                 const isTimestamp =
+                    !field ||
                     (isCustomSqlDimension(field)
                         ? field.dimensionType
                         : field.type) === DimensionType.TIMESTAMP;
@@ -313,11 +314,23 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
     };
 };
 
+export const getFilterRuleFromFieldWithDefaultValue = <T extends FilterRule>(
+    field: FilterableField,
+    filterRule: T,
+    values?: AnyType[] | null,
+): T =>
+    getFilterRuleWithDefaultValue(
+        getFilterTypeFromItem(field),
+        field,
+        filterRule,
+        values,
+    );
+
 export const createFilterRuleFromField = (
     field: FilterableField,
     value?: AnyType,
 ): FilterRule =>
-    getFilterRuleWithDefaultValue(
+    getFilterRuleFromFieldWithDefaultValue(
         field,
         {
             id: uuidv4(),
@@ -394,7 +407,7 @@ export const createDashboardFilterRuleFromField = ({
     isTemporary: boolean;
     value?: unknown;
 }): FilterDashboardToRule =>
-    getFilterRuleWithDefaultValue(
+    getFilterRuleFromFieldWithDefaultValue(
         field,
         {
             id: uuidv4(),

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/FilterSettings.tsx
@@ -1,7 +1,7 @@
 import {
     FilterOperator,
     FilterType,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getFilterTypeFromItem,
     supportsSingleValue,
     type DashboardFilterRule,
@@ -64,7 +64,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
 
     const handleChangeFilterOperator = (operator: FilterRule['operator']) => {
         onChangeFilterRule(
-            getFilterRuleWithDefaultValue(field, {
+            getFilterRuleFromFieldWithDefaultValue(field, {
                 ...filterRule,
                 operator,
             }),
@@ -244,7 +244,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                             onChangeFilterRule(
                                                 e.currentTarget.checked
                                                     ? newFilter
-                                                    : getFilterRuleWithDefaultValue(
+                                                    : getFilterRuleFromFieldWithDefaultValue(
                                                           field,
                                                           newFilter,
                                                           null,
@@ -268,7 +268,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                 onChangeFilterRule(
                                     e.currentTarget.checked
                                         ? newFilter
-                                        : getFilterRuleWithDefaultValue(
+                                        : getFilterRuleFromFieldWithDefaultValue(
                                               field,
                                               newFilter,
                                               null,

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -219,7 +219,10 @@ const TileFilterConfiguration: FC<Props> = ({
         const tileWithTargetColumns = Object.entries(
             sqlChartTilesMetadata,
         ).reduce<TileWithTargetColumns[]>(
-            (acc, [tileUuid, { columns }], index) => {
+            (acc, [tileUuid, metadata], index) => {
+                const columns = metadata.columns.map(
+                    ({ reference }) => reference,
+                );
                 const tile = tiles.find((t) => t.uuid === tileUuid);
                 if (!tile) {
                     return acc;

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -162,7 +162,8 @@ const FilterConfiguration: FC<Props> = ({
                         // Find fallback target
                         if (!target) {
                             const defaultColumn: string | undefined =
-                                sqlChartTilesMetadata[tileUuid]?.columns[0];
+                                sqlChartTilesMetadata[tileUuid]?.columns[0]
+                                    ?.reference;
                             const defaultField = getDefaultField(
                                 availableTileFilters[tileUuid] ?? [],
                                 selectedField,

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -6,6 +6,7 @@ import {
     isVizPieChartConfig,
     isVizTableConfig,
     type DashboardSqlChartTile,
+    type ResultColumn,
 } from '@lightdash/common';
 import { Box } from '@mantine/core';
 import { IconAlertCircle, IconFilePencil } from '@tabler/icons-react';
@@ -131,7 +132,12 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
     // Update SQL chart columns in the dashboard context
     useEffect(() => {
         if (chartResultsData?.resultsRunner) {
-            const columns = chartResultsData.resultsRunner.getColumnNames();
+            const columns = chartResultsData.resultsRunner
+                .getPivotQueryDimensions()
+                .map<ResultColumn>(({ reference, dimensionType }) => ({
+                    reference,
+                    type: dimensionType,
+                }));
             updateSqlChartTilesMetadata(tile.uuid, { columns });
         }
     }, [

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -1,7 +1,7 @@
 import {
     FilterType,
     createFilterRuleFromField,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getFilterTypeFromItem,
     getItemId,
     isDateItem,
@@ -67,7 +67,7 @@ const FilterRuleForm: FC<Props> = ({
 
                     const newFilterRule = isDateItem(selectedField)
                         ? // If the field is the same type but different field, we need to update the filter rule with the new time frames
-                          getFilterRuleWithDefaultValue(
+                          getFilterRuleFromFieldWithDefaultValue(
                               selectedField,
                               newFilterRuleBase,
                               filterRule.values,
@@ -122,7 +122,7 @@ const FilterRuleForm: FC<Props> = ({
                     if (!value) return;
 
                     onChange(
-                        getFilterRuleWithDefaultValue(
+                        getFilterRuleFromFieldWithDefaultValue(
                             activeField,
                             {
                                 ...filterRule,

--- a/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
+++ b/packages/frontend/src/features/metricsCatalog/utils/metricExploreFilter.ts
@@ -1,7 +1,7 @@
 import {
     DimensionType,
     FilterOperator,
-    getFilterRuleWithDefaultValue,
+    getFilterRuleFromFieldWithDefaultValue,
     getItemId,
     type CompiledDimension,
     type FilterRule,
@@ -50,7 +50,7 @@ export const createFilterRule = (
     values?: string[],
 ): FilterRule => {
     const isBooleanDimension = dimension.type === DimensionType.BOOLEAN;
-    return getFilterRuleWithDefaultValue(
+    return getFilterRuleFromFieldWithDefaultValue(
         dimension,
         {
             id: uuidv4(),

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -6,6 +6,7 @@ import {
     type DashboardFilters,
     type DateGranularity,
     type FilterableDimension,
+    type ResultColumn,
     type SortField,
 } from '@lightdash/common';
 import { type Dispatch, type SetStateAction } from 'react';
@@ -15,7 +16,7 @@ import {
 } from '../../features/comments';
 
 export type SqlChartTileMetadata = {
-    columns: string[];
+    columns: ResultColumn[];
 };
 export type DashboardContextType = {
     projectUuid?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: https://github.com/lightdash/lightdash/issues/14969

### Description:
This PR updates the SQL chart tile metadata to include column type information. Previously, only column references were stored, but now we're storing both the reference and type for each column. This change ensures that dashboard filters have access to the correct column type information when configuring filters.

Key changes:
- Updated `SqlChartTileMetadata` type to store `ResultColumn` objects (with reference and type) instead of just strings
- Modified `DashboardSqlChartTile` to extract both reference and type from query dimensions
- Updated filter configuration components to properly access column references from the new metadata structure

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging