### PR TITLE
fix: project validation when dashboard has filters for SQL charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1161,6 +1161,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                isSqlColumn: { dataType: 'boolean' },
                 tableName: { dataType: 'string', required: true },
                 fieldId: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1155,6 +1155,9 @@
             },
             "DashboardFieldTarget": {
                 "properties": {
+                    "isSqlColumn": {
+                        "type": "boolean"
+                    },
                     "tableName": {
                         "type": "string"
                     },
@@ -17360,7 +17363,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1643.1",
+        "version": "0.1647.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -480,6 +480,13 @@ export class ValidationService extends BaseService {
                         CreateDashboardValidation[]
                     >((acc, filter) => {
                         try {
+                            if (
+                                isDashboardFieldTarget(filter.target) &&
+                                filter.target.isSqlColumn
+                            ) {
+                                // Skip SQL column targets
+                                return acc;
+                            }
                             return containsFieldId({
                                 acc,
                                 fieldIds: existingFieldIds,
@@ -513,7 +520,8 @@ export class ValidationService extends BaseService {
                         (acc, tileTarget) => {
                             if (
                                 tileTarget &&
-                                isDashboardFieldTarget(tileTarget)
+                                isDashboardFieldTarget(tileTarget) &&
+                                !tileTarget.isSqlColumn // Skip SQL column targets
                             ) {
                                 return containsFieldId({
                                     acc,

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -94,6 +94,7 @@ export const isJoinModelRequiredFilter = (
 export type DashboardFieldTarget = {
     fieldId: string;
     tableName: string;
+    isSqlColumn?: boolean;
 };
 
 export const isDashboardFieldTarget = (

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -707,8 +707,8 @@ export const getDashboardFilterRulesForTileAndReferences = (
     references: string[],
     rules: DashboardFilterRule[],
 ): DashboardFilterRule[] =>
-    getDashboardFilterRulesForTile(tileUuid, rules, true).filter((f) =>
-        references.includes(f.target.fieldId),
+    getDashboardFilterRulesForTile(tileUuid, rules, true).filter(
+        (f) => f.target.isSqlColumn && references.includes(f.target.fieldId),
     );
 
 export const getDashboardFilterRulesForTables = (

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/TileFilterConfiguration.tsx
@@ -395,6 +395,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                                       fieldId:
                                                           value.selectedField,
                                                       tableName: 'mock_table',
+                                                      isSqlColumn: true,
                                                   }
                                                 : undefined,
                                         );
@@ -456,6 +457,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                                           fieldId: newField,
                                                           tableName:
                                                               'mock_table',
+                                                          isSqlColumn: true,
                                                       }
                                                     : undefined,
                                             );

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -173,6 +173,7 @@ const FilterConfiguration: FC<Props> = ({
                                 target = {
                                     fieldId: defaultColumn,
                                     tableName: 'mock_table',
+                                    isSqlColumn: true,
                                 };
                             } else if (defaultField) {
                                 // Set default field


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14892

### Description:
Issue one: 
Filters for explorer charts were applied to SQL charts if they have a column name that matched the filter fieldId (eg: orders_status).

Issue two:
Project validation was showing errors when dashboard has filters for SQL charts.

Before
<img width="937" alt="Screenshot 2025-05-23 at 14 37 39" src="https://github.com/user-attachments/assets/951c4162-e867-4b0f-907d-e034da871e01" />

After

<img width="941" alt="Screenshot 2025-05-23 at 14 42 44" src="https://github.com/user-attachments/assets/9efb46b7-0790-44df-b291-7264d90096c5" />

### Reviewer actions

- [ ] I have manually tested the changes in the preview environment
- [ ] I have reviewed the code
- [ ] I understand that "request changes" will block this PR from merging