### PR TITLE
feat: For slack based agent threads correctly show message author name

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -471,6 +471,35 @@ export class SlackClient {
         return fileUrl;
     }
 
+    async getUserInfo(
+        organizationUuid: string,
+        userId: string,
+    ): Promise<{
+        id: string;
+        name?: string;
+        image?: string;
+    }> {
+        const webClient = await this.getWebClient(organizationUuid);
+        const response = await webClient.users.info({ user: userId });
+
+        if (!response.ok) {
+            throw new UnexpectedServerError(
+                `Failed to get user info for ${userId}: ${response.error}`,
+            );
+        }
+        if (!response.user?.profile) {
+            throw new UnexpectedServerError(
+                `Failed to get user info for ${userId}: No profile found`,
+            );
+        }
+
+        return {
+            id: userId,
+            name: response.user.profile.real_name,
+            image: response.user.profile.image_512,
+        };
+    }
+
     /**
      * Helper method to try to upload an image to slack, so it can be used in blocks without expiration
      * If it fails, we will keep using the same URL (s3)

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -104,12 +104,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     organizationModel: models.getOrganizationModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                 }),
-            aiAgentService: ({ models, repository }) =>
+            aiAgentService: ({ models, repository, clients }) =>
                 new AiAgentService({
                     aiAgentModel: models.getAiAgentModel(),
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     featureFlagService: repository.getFeatureFlagService(),
+                    slackClient: clients.getSlackClient(),
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -55,31 +55,33 @@ export type AiAgentSummary = Pick<
     | 'updatedAt'
 >;
 
-export type AiAgentMessage =
-    | {
-          role: 'user';
-          uuid: string;
-          threadUuid: string;
-          message: string; // ai_prompt.prompt
-          createdAt: string;
+export type AiAgentMessageUser = {
+    role: 'user';
+    uuid: string;
+    threadUuid: string;
+    message: string; // ai_prompt.prompt
+    createdAt: string;
 
-          user: {
-              uuid: string;
-              name: string;
-          };
-      }
-    | {
-          role: 'assistant';
-          uuid: string;
-          threadUuid: string;
-          message: string; // ai_prompt.response
-          createdAt: string; // ai_prompt.responded_at
+    user: {
+        uuid: string;
+        name: string;
+    };
+};
 
-          vizConfigOutput?: object;
-          filtersOutput?: object;
-          metricQuery?: object;
-          humanScore?: number;
-      };
+export type AiAgentMessageAssistant = {
+    role: 'assistant';
+    uuid: string;
+    threadUuid: string;
+    message: string; // ai_prompt.response
+    createdAt: string; // ai_prompt.responded_at
+
+    vizConfigOutput?: object;
+    filtersOutput?: object;
+    metricQuery?: object;
+    humanScore?: number;
+};
+
+export type AiAgentMessage = AiAgentMessageUser | AiAgentMessageAssistant;
 
 export type AiAgentThreadSummary = {
     uuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
@@ -69,55 +69,54 @@ export const ThreadDetailsModal: FC<ThreadDetailsModalProps> = ({
 
                     <ScrollArea h={400}>
                         <Stack gap="md">
-                            {thread.messages.map((message) => (
-                                <Paper
-                                    key={message.uuid}
-                                    withBorder
-                                    p="md"
-                                    radius="md"
-                                    style={{
-                                        backgroundColor:
-                                            message.role === 'assistant'
-                                                ? '#E6F7FF'
-                                                : 'transparent',
-                                        alignSelf:
-                                            message.role === 'assistant'
-                                                ? 'flex-start'
-                                                : 'flex-end',
-                                        maxWidth: '80%',
-                                    }}
-                                >
-                                    <Stack gap="xs">
-                                        <Group gap="xs">
-                                            <AgentAvatar
-                                                name={
-                                                    message.role === 'assistant'
-                                                        ? agentName ||
-                                                          'AI Assistant'
-                                                        : thread.user.name
-                                                }
-                                            />
+                            {thread.messages.map((message) => {
+                                const name =
+                                    message.role === 'assistant'
+                                        ? agentName || 'AI Assistant'
+                                        : message.user.name;
 
-                                            <Text fw={500} size="sm">
-                                                {message.role === 'assistant'
-                                                    ? agentName ||
-                                                      'AI Assistant'
-                                                    : thread.user.name}
+                                return (
+                                    <Paper
+                                        key={message.uuid}
+                                        withBorder
+                                        p="md"
+                                        radius="md"
+                                        style={{
+                                            backgroundColor:
+                                                message.role === 'assistant'
+                                                    ? '#E6F7FF'
+                                                    : 'transparent',
+                                            alignSelf:
+                                                message.role === 'assistant'
+                                                    ? 'flex-start'
+                                                    : 'flex-end',
+                                            maxWidth: '80%',
+                                        }}
+                                    >
+                                        <Stack gap="xs">
+                                            <Group gap="xs">
+                                                <AgentAvatar name={name} />
+
+                                                <Text fw={500} size="sm">
+                                                    {name}
+                                                </Text>
+                                                <Text size="xs" c="dimmed">
+                                                    {formatDate(
+                                                        message.createdAt,
+                                                    )}
+                                                </Text>
+                                            </Group>
+                                            <Text
+                                                style={{
+                                                    whiteSpace: 'pre-wrap',
+                                                }}
+                                            >
+                                                {message.message}
                                             </Text>
-                                            <Text size="xs" c="dimmed">
-                                                {formatDate(message.createdAt)}
-                                            </Text>
-                                        </Group>
-                                        <Text
-                                            style={{
-                                                whiteSpace: 'pre-wrap',
-                                            }}
-                                        >
-                                            {message.message}
-                                        </Text>
-                                    </Stack>
-                                </Paper>
-                            ))}
+                                        </Stack>
+                                    </Paper>
+                                );
+                            })}
                         </Stack>
                     </ScrollArea>
                 </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14978

### Description:

Added Slack user profile information to AI Copilot threads. This enhancement retrieves user profile details (name and image) from Slack when displaying thread messages, ensuring that messages from Slack users show their actual names rather than generic identifiers.
