### PR TITLE
chore: don't render hidden nodes in table tree

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -177,7 +177,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                 </Group>
             }
         >
-            <TreeNodes nodeMap={node.children} />
+            {isNavLinkOpen && <TreeNodes nodeMap={node.children} />}
         </NavLink>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -76,7 +76,12 @@ const TableTreeWrapper: FC<React.PropsWithChildren<TableTreeWrapperProps>> = ({
                 },
             }}
         >
-            {children}
+            {/* Don't render children if the table is not open. 
+                NOTE: when it is closed, we return a fragment, otherwise 
+                it thinks it has no children and doesn't render the button to open.
+                This is and issue with mantine 6. 
+            */}
+            {isOpen ? children : <></>}
         </NavLink>
     );
 };
@@ -137,6 +142,7 @@ const TableTree: FC<Props> = ({
     const Wrapper = showTableLabel ? TableTreeWrapper : EmptyWrapper;
     const [isOpen, toggle] = useToggle(isOpenByDefault);
     const isSearching = !!searchQuery && searchQuery !== '';
+
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <MantineProvider inherit theme={themeOverride}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #14638

### Description:

Doesn't mount / Unmounts hidden sections of the table tree so they don't get rendered. This helps a lot when there are a lot of sections. 
