### PR TITLE
feat: add PDF download button to Microsoft Teams notifications

### DIFF
--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -65,6 +65,7 @@ export class MicrosoftTeamsClient {
         ctaUrl,
         image,
         footer,
+        pdfUrl,
         thresholds = [],
     }: {
         webhookUrl: string;
@@ -74,6 +75,8 @@ export class MicrosoftTeamsClient {
         ctaUrl: string;
         image: string;
         footer: string;
+        pdfUrl?: string;
+
         thresholds?: ThresholdOptions[];
     }): Promise<void> {
         if (!this.lightdashConfig.microsoftTeams.enabled) {
@@ -164,6 +167,15 @@ export class MicrosoftTeamsClient {
                                 title: 'Open in Lightdash',
                                 url: ctaUrl,
                             },
+                            ...(pdfUrl
+                                ? [
+                                      {
+                                          type: 'Action.OpenUrl',
+                                          title: 'Download PDF',
+                                          url: pdfUrl,
+                                      },
+                                  ]
+                                : []),
                         ],
                     },
                 },

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -918,6 +918,7 @@ export default class SchedulerTask {
                         webhookUrl: webhook,
                         ...getBlocksArgs,
                         image: imageUrl,
+                        pdfUrl: pdfFile?.source,
                     });
             } else if (format === SchedulerFormat.CSV) {
                 if (savedChartUuid) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/14812

Before (or without pdf) 

![image](https://github.com/user-attachments/assets/defece1a-fefd-4eb8-8d8d-649c35151fd1)


After

![Screenshot from 2025-05-26 09-33-24](https://github.com/user-attachments/assets/3fba93d8-403b-4b5c-9513-4ff1dfd5e807)



### Description:
Added PDF download functionality to Microsoft Teams notifications. When a scheduled delivery includes a PDF file, a "Download PDF" button will now appear alongside the "Open in Lightdash" button in the Teams notification card, allowing users to directly access the PDF from the notification.