### PR TITLE
fix: filter dashboard versions by dashboard ID

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1139,9 +1139,10 @@ export class SavedChartModel {
                 // filter by last version
                 `${DashboardVersionsTableName}.dashboard_version_id`,
                 this.database.raw(`(select dashboard_version_id
-                            from ${DashboardVersionsTableName}
-                            order by ${DashboardVersionsTableName}.created_at desc
-                            limit 1)`),
+                    from ${DashboardVersionsTableName} dv
+                    where dv.dashboard_id = ${DashboardsTableName}.dashboard_id
+                    order by dv.created_at desc
+                    limit 1)`),
             );
 
         const chartsNotInTilesUuids = await this.database(SavedChartsTableName)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15001 

### Description:
Fixed a bug in the SQL query that filters dashboard versions. The previous query was selecting the latest dashboard version across all dashboards, rather than the latest version for each specific dashboard. This change ensures that we correctly filter by the last version of each dashboard by adding a where clause to match the dashboard_id.

before:

![image](https://github.com/user-attachments/assets/614090b2-8b12-43bc-b977-0b3f5eb45027)


after: 

![image](https://github.com/user-attachments/assets/6199e86c-9613-4d12-a770-b60ccbd2ec52)
