### PR TITLE
chore: fix key warning in virtual table

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -278,15 +278,16 @@ const VirtualizedTableBody: FC<{
         return Array.from({ length: pageSize }).map((_, index) => {
             return (
                 <tr key={index}>
-                    {new Array(tableColumnsCount).fill(
-                        // Same padding as CellStyles in Table.styles.ts
-                        <td style={{ padding: 8.5 }}>
-                            <Skeleton
-                                w="100%"
-                                // Removing 17px to account for the padding of the table defined in Table.styles.ts
-                                h={`calc(${ROW_HEIGHT_PX}px - 17px)`}
-                            />
-                        </td>,
+                    {Array.from({ length: tableColumnsCount }).map(
+                        (__, colIdx) => (
+                            <td key={colIdx} style={{ padding: 8.5 }}>
+                                <Skeleton
+                                    w="100%"
+                                    // Removing 17px to account for the padding of the table defined in Table.styles.ts
+                                    h={`calc(${ROW_HEIGHT_PX}px - 17px)`}
+                                />
+                            </td>
+                        ),
                     )}
                 </tr>
             );


### PR DESCRIPTION
### Description:

Fixes a `key` warning in the virtual table. I saw this and thought I should investigate. 

![Screenshot 2025-05-26 at 15.15.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xuM4z1vArnM7xaR6mJr4/1b43fb6c-4b36-4fd1-85a0-6c7a0596cd90.png)

It was harmless--just in the loading state, but I thought I'd fix it to reduce warnings.  
