### PR TITLE
feat: Add Slack integration steps UI for AI agents

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -3,7 +3,6 @@ import {
     ActionIcon,
     Button,
     Card,
-    Fieldset,
     Group,
     MantineProvider,
     MultiSelect,
@@ -44,6 +43,7 @@ import {
     useUpdateAiAgentMutation,
 } from '../hooks/useAiAgents';
 import { ConversationsList } from './ConversationsList';
+import { SlackIntegrationSteps } from './SlackIntegrationSteps';
 
 const formSchema: z.ZodType<
     Pick<
@@ -333,74 +333,87 @@ export const AgentDetails: FC = () => {
                                         {/* Integrations Section */}
 
                                         <Stack gap="sm">
-                                            <Group justify="space-between">
-                                                <Title order={5}>
-                                                    Integrations
-                                                </Title>
-                                            </Group>
+                                            <Title order={5}>
+                                                Integrations
+                                            </Title>
 
-                                            <Fieldset legend="Slack">
-                                                <MultiSelect
-                                                    disabled={
-                                                        isRefreshing ||
-                                                        !slackInstallation?.organizationUuid
+                                            <Stack gap="md">
+                                                <Title order={6}>Slack</Title>
+
+                                                <SlackIntegrationSteps
+                                                    slackInstallation={
+                                                        !!slackInstallation?.organizationUuid
                                                     }
-                                                    description={
-                                                        !slackInstallation?.organizationUuid
-                                                            ? 'You need to connect Slack first in the Integrations settings before you can configure AI agents.'
-                                                            : undefined
-                                                    }
-                                                    labelProps={{
-                                                        style: {
-                                                            width: '100%',
-                                                        },
-                                                    }}
-                                                    label="Channels"
-                                                    placeholder="Pick a channel"
-                                                    data={slackChannelOptions}
-                                                    value={form.values.integrations.map(
-                                                        (i) => i.channelId,
+                                                    channelsConfigured={form.values.integrations.some(
+                                                        (i) =>
+                                                            i.type ===
+                                                                'slack' &&
+                                                            i.channelId,
                                                     )}
-                                                    searchable
-                                                    rightSectionPointerEvents="all"
-                                                    rightSection={
-                                                        <Tooltip
-                                                            withArrow
-                                                            withinPortal
-                                                            label="Refresh Slack Channels"
-                                                        >
-                                                            <ActionIcon
-                                                                loading={
-                                                                    isRefreshing
-                                                                }
-                                                                variant="transparent"
-                                                                onClick={
-                                                                    refreshChannels
-                                                                }
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconRefresh
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                    }
-                                                    onChange={(value) => {
-                                                        form.setFieldValue(
-                                                            'integrations',
-                                                            value.map(
-                                                                (v) =>
-                                                                    ({
-                                                                        type: 'slack',
-                                                                        channelId:
-                                                                            v,
-                                                                    } as const),
-                                                            ),
-                                                        );
-                                                    }}
                                                 />
-                                            </Fieldset>
+
+                                                <Stack gap="xs">
+                                                    <MultiSelect
+                                                        disabled={
+                                                            isRefreshing ||
+                                                            !slackInstallation?.organizationUuid
+                                                        }
+                                                        description={
+                                                            !slackInstallation?.organizationUuid
+                                                                ? 'You need to connect Slack first in the Integrations settings before you can configure AI agents.'
+                                                                : undefined
+                                                        }
+                                                        labelProps={{
+                                                            style: {
+                                                                width: '100%',
+                                                            },
+                                                        }}
+                                                        label="Channels"
+                                                        placeholder="Pick a channel"
+                                                        data={
+                                                            slackChannelOptions
+                                                        }
+                                                        value={form.values.integrations.map(
+                                                            (i) => i.channelId,
+                                                        )}
+                                                        searchable
+                                                        rightSectionPointerEvents="all"
+                                                        rightSection={
+                                                            <Tooltip
+                                                                withArrow
+                                                                withinPortal
+                                                                label="Refresh Slack Channels"
+                                                            >
+                                                                <ActionIcon
+                                                                    variant="transparent"
+                                                                    onClick={
+                                                                        refreshChannels
+                                                                    }
+                                                                >
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconRefresh
+                                                                        }
+                                                                    />
+                                                                </ActionIcon>
+                                                            </Tooltip>
+                                                        }
+                                                        onChange={(value) => {
+                                                            form.setFieldValue(
+                                                                'integrations',
+                                                                value.map(
+                                                                    (v) =>
+                                                                        ({
+                                                                            type: 'slack',
+                                                                            channelId:
+                                                                                v,
+                                                                        } as const),
+                                                                ),
+                                                            );
+                                                        }}
+                                                    />
+                                                </Stack>
+                                            </Stack>
                                         </Stack>
 
                                         <Group justify="flex-end">

--- a/packages/frontend/src/ee/features/aiCopilot/components/SlackIntegrationSteps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SlackIntegrationSteps.tsx
@@ -1,0 +1,49 @@
+import { Anchor, Stepper } from '@mantine/core';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+
+export const SlackIntegrationSteps: FC<{
+    slackInstallation: boolean;
+    channelsConfigured: boolean;
+}> = (props) => {
+    const active = props.channelsConfigured
+        ? 2
+        : props.slackInstallation
+        ? 1
+        : 0;
+    return (
+        <Stepper active={active} size="sm" orientation="horizontal">
+            <Stepper.Step
+                label="Allow Integration access"
+                description={
+                    active === 0 ? (
+                        <Anchor
+                            component={Link}
+                            to="/generalSettings/integrations"
+                            variant="link"
+                            size="sm"
+                        >
+                            Connect your Slack account to Lightdash
+                        </Anchor>
+                    ) : null
+                }
+            />
+            <Stepper.Step
+                label="Select Channels"
+                description={
+                    active === 1
+                        ? 'Select the channels you want to connect to this agent'
+                        : null
+                }
+            />
+            <Stepper.Step
+                label="Start Using Agent"
+                description={
+                    active === 2
+                        ? 'Go to the connected channels and tag the agent to start using it'
+                        : null
+                }
+            />
+        </Stepper>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14976

### Description:
Added a Slack integration stepper component to improve the user experience when connecting AI agents to Slack:

1. Allow Integration access - Prompts users to connect their Slack account to Lightdash
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/15df4a63-4d6f-4b66-97d3-9c46f6c95d3a.png)

2. Select Channels - Guides users to select channels for the agent
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/af7b2529-0bbd-43c2-946e-a826fe0ff475.png)

3. Start Using Agent - Instructs users on how to interact with the agent in Slack
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/9d92257c-1d2f-4dfc-849f-5d0e1fbc9fea.png)

Responsiveness is not good 😬 as you can see the steps move around to make space to fit in one line


