### PR TITLE
feat: copy table configuration from prod to preview projects

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -26,6 +26,7 @@ import {
     CreateJob,
     CreateProject,
     CreateProjectMember,
+    CreateProjectTableConfiguration,
     CreateSnowflakeCredentials,
     CreateVirtualViewPayload,
     CreateWarehouseCredentials,
@@ -842,6 +843,32 @@ export class ProjectService extends BaseService {
             } catch (e) {
                 Sentry.captureException(e);
                 this.logger.error(`Unable to copy content on preview ${e}`);
+            }
+        }
+
+        if (
+            data.tableConfiguration === CreateProjectTableConfiguration.PROD &&
+            data.upstreamProjectUuid
+        ) {
+            try {
+                const prodTablesConfiguration =
+                    await this.projectModel.getTablesConfiguration(
+                        data.upstreamProjectUuid,
+                    );
+                this.logger.info(
+                    `Copying table configuration to preview project ${projectUuid} from prod: ${JSON.stringify(
+                        data.upstreamProjectUuid,
+                    )}`,
+                );
+                await this.projectModel.updateTablesConfiguration(
+                    projectUuid,
+                    prodTablesConfiguration,
+                );
+            } catch (e) {
+                Sentry.captureException(e);
+                this.logger.error(
+                    `Unable to copy table configuration on preview ${e}`,
+                );
             }
         }
 

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -1,5 +1,6 @@
 import {
     CreateProject,
+    CreateProjectTableConfiguration,
     DbtProjectType,
     ProjectType,
     WarehouseTypes,
@@ -71,6 +72,7 @@ type CreateProjectOptions = {
     type: ProjectType;
     startOfWeek?: number;
     upstreamProjectUuid?: string;
+    tableConfiguration?: CreateProjectTableConfiguration;
 };
 export const createProject = async (
     options: CreateProjectOptions,
@@ -137,6 +139,7 @@ export const createProject = async (
         },
         upstreamProjectUuid: options.upstreamProjectUuid,
         dbtVersion: dbtVersion.versionOption,
+        tableConfiguration: options.tableConfiguration,
     };
 
     return lightdashApi<ApiCreateProjectResults>({

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -1,5 +1,9 @@
 import * as core from '@actions/core';
-import { Project, ProjectType } from '@lightdash/common';
+import {
+    CreateProjectTableConfiguration,
+    Project,
+    ProjectType,
+} from '@lightdash/common';
 import chokidar from 'chokidar';
 import inquirer from 'inquirer';
 import path from 'path';
@@ -26,6 +30,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     verbose: boolean;
     startOfWeek?: number;
     ignoreErrors: boolean;
+    tableConfiguration: CreateProjectTableConfiguration;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -410,6 +410,11 @@ program
         true,
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
+    .option(
+        '--table-configuration <prod|all>',
+        `If set to 'prod' it will copy the table configuration from prod project`,
+        'all',
+    )
     .action(previewHandler);
 
 program
@@ -483,6 +488,11 @@ program
         true,
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
+    .option(
+        '--table-configuration <prod|all>',
+        `If set to 'prod' it will copy the table configuration from prod project`,
+        'all',
+    )
     .action(startPreviewHandler);
 
 program

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1075,6 +1075,11 @@ export const DbtProjectTypeLabels: Record<DbtProjectType, string> = {
     [DbtProjectType.NONE]: 'CLI',
 };
 
+export enum CreateProjectTableConfiguration {
+    PROD = 'prod',
+    ALL = 'all',
+}
+
 export type CreateProject = Omit<
     Project,
     | 'projectUuid'
@@ -1084,6 +1089,7 @@ export type CreateProject = Omit<
 > & {
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;
+    tableConfiguration?: CreateProjectTableConfiguration;
 };
 
 export type UpdateProject = Omit<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Added the ability to copy table configuration from production projects to preview projects. This feature allows users to specify a `--table-configuration prod` flag when creating preview projects, which will copy the table configuration from the upstream production project. This ensures that preview projects maintain the same table settings as their production counterparts.

The implementation adds a new enum `CreateProjectTableConfiguration` with options `PROD` and `ALL`, and extends the project creation process to handle copying table configurations when specified.