### PR TITLE
fix: handle object mark type in chart config

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -285,7 +285,14 @@ export class SavedChartService
                           size: JSON.stringify(
                               savedChart.chartConfig.config?.spec || {},
                           ).length,
-                          type: `${savedChart.chartConfig.config?.spec?.mark}`,
+                          type:
+                              typeof savedChart.chartConfig.config?.spec
+                                  ?.mark === 'object'
+                                  ? JSON.stringify(
+                                        savedChart.chartConfig.config?.spec
+                                            ?.mark,
+                                    )
+                                  : `${savedChart.chartConfig.config?.spec?.mark}`,
                       }
                     : undefined,
             ...countCustomDimensionsInMetricQuery(savedChart.metricQuery),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Fix chart type tracking for complex mark types in saved charts. Previously, when a chart's mark was an object rather than a simple string, it would be displayed as "[object Object]". Now, complex mark types are properly stringified to capture their full structure in analytics.

![image](https://github.com/user-attachments/assets/79a695e4-8390-454e-80d8-972a023edbc4)
