### PR TITLE
fix: Duplicated refresh slack channel button

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -361,6 +361,9 @@ export const AgentDetails: FC = () => {
                                                             label="Refresh Slack Channels"
                                                         >
                                                             <ActionIcon
+                                                                loading={
+                                                                    isRefreshing
+                                                                }
                                                                 variant="transparent"
                                                                 onClick={
                                                                     refreshChannels
@@ -388,36 +391,6 @@ export const AgentDetails: FC = () => {
                                                         );
                                                     }}
                                                 />
-                                                {slackInstallation?.organizationUuid && (
-                                                    <Group mt="xs" gap="none">
-                                                        <Text
-                                                            size="xs"
-                                                            c="dimmed"
-                                                        >
-                                                            Not finding the
-                                                            channel you need?
-                                                        </Text>
-                                                        <Button
-                                                            size="xs"
-                                                            variant="subtle"
-                                                            leftSection={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconRefresh
-                                                                    }
-                                                                />
-                                                            }
-                                                            loading={
-                                                                isRefreshing
-                                                            }
-                                                            onClick={
-                                                                refreshChannels
-                                                            }
-                                                        >
-                                                            Refresh Channels
-                                                        </Button>
-                                                    </Group>
-                                                )}
                                             </Fieldset>
                                         </Stack>
 


### PR DESCRIPTION
### Description:
This PR removes the duplicated `refresh channel` button in AI Agent integrations page

![image](https://github.com/user-attachments/assets/3abd1d6a-1243-4601-a5d0-e9050cd5f86c)
