### PR TITLE
feat: New Agents page structure

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4951,7 +4951,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiAgentThreadGenerateResponse: {
+    ApiAiAgentStartThreadResponse: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -4959,6 +4959,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        threadUuid: { dataType: 'string', required: true },
                         jobId: { dataType: 'string', required: true },
                     },
                     required: true,
@@ -4975,6 +4976,24 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        jobId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
@@ -11288,7 +11307,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11298,7 +11317,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11308,7 +11327,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11321,7 +11340,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5623,15 +5623,18 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ApiAiAgentThreadGenerateResponse": {
+            "ApiAiAgentStartThreadResponse": {
                 "properties": {
                     "results": {
                         "properties": {
+                            "threadUuid": {
+                                "type": "string"
+                            },
                             "jobId": {
                                 "type": "string"
                             }
                         },
-                        "required": ["jobId"],
+                        "required": ["threadUuid", "jobId"],
                         "type": "object"
                     },
                     "status": {
@@ -5650,6 +5653,26 @@
                     }
                 },
                 "required": ["prompt"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadGenerateResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "jobId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["jobId"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiJobScheduledResponse": {
@@ -12166,22 +12189,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17465,7 +17488,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1659.1",
+        "version": "0.1664.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/components/common/LinkButton.tsx
+++ b/packages/frontend/src/components/common/LinkButton.tsx
@@ -1,17 +1,18 @@
 import { Button, type ButtonProps } from '@mantine/core';
-import { IconTelescope } from '@tabler/icons-react';
+import { IconTelescope, type Icon } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { type EventData } from '../../providers/Tracking/types';
 import useTracking from '../../providers/Tracking/useTracking';
 import MantineIcon from './MantineIcon';
 
-export interface LinkButtonProps extends ButtonProps {
+export interface LinkButtonProps extends Omit<ButtonProps, 'leftIcon'> {
     href: string;
     trackingEvent?: EventData;
     target?: React.HTMLAttributeAnchorTarget;
     forceRefresh?: boolean;
     onClick?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+    leftIcon?: Icon;
 }
 
 const LinkButton: FC<LinkButtonProps> = ({
@@ -20,6 +21,7 @@ const LinkButton: FC<LinkButtonProps> = ({
     trackingEvent,
     forceRefresh = false,
     onClick,
+    leftIcon = IconTelescope,
     ...rest
 }) => {
     const navigate = useNavigate();
@@ -32,7 +34,7 @@ const LinkButton: FC<LinkButtonProps> = ({
             compact
             variant="subtle"
             href={href}
-            leftIcon={<MantineIcon icon={IconTelescope} />}
+            leftIcon={leftIcon && <MantineIcon icon={leftIcon} />}
             target={target}
             onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                 if (

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -1,7 +1,12 @@
+import { MantineProvider } from '@mantine-8/core';
 import { Navigate, Outlet, type RouteObject } from 'react-router';
 import NavBar from '../components/NavBar';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
+import AgentConversationListPage from './pages/AiAgents/AgentConversationListPage';
+import AgentConversationPage from './pages/AiAgents/AgentConversationPage';
+import AgentPage from './pages/AiAgents/AgentPage';
+import AgentsListPage from './pages/AiAgents/AgentsListPage';
 import AiConversationsPage from './pages/AiConversations';
 import EmbedDashboard from './pages/EmbedDashboard';
 import EmbedProvider from './providers/Embed/EmbedProvider';
@@ -55,9 +60,53 @@ const COMMERCIAL_AI_ROUTES: RouteObject[] = [
     },
 ];
 
+const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
+    {
+        path: '/aiAgents',
+        element: (
+            <>
+                <NavBar />
+                <MantineProvider>
+                    <Outlet />
+                </MantineProvider>
+            </>
+        ),
+        children: [
+            {
+                index: true,
+                element: <AgentsListPage />,
+            },
+            {
+                path: ':agentUuid',
+                element: <AgentPage />,
+                children: [
+                    {
+                        index: true,
+                        element: <Navigate to="threads" replace />,
+                    },
+                    {
+                        path: 'threads',
+                        children: [
+                            {
+                                index: true,
+                                element: <AgentConversationListPage />,
+                            },
+                            {
+                                path: ':threadUuid',
+                                element: <AgentConversationPage />,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+];
+
 export const CommercialWebAppRoutes = [
     ...COMMERCIAL_EMBED_ROUTES,
     ...COMMERCIAL_AI_ROUTES,
+    ...COMMERCIAL_AI_AGENTS_ROUTES,
 ];
 
 export const CommercialMobileRoutes = [...COMMERCIAL_EMBED_ROUTES];

--- a/packages/frontend/src/ee/pages/AiAgents/AgentConversationListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentConversationListPage.tsx
@@ -1,0 +1,69 @@
+import { Badge, Stack, Table } from '@mantine-8/core';
+import { useNavigate, useParams } from 'react-router';
+import PageSpinner from '../../../components/PageSpinner';
+import { useAiAgentThreads } from '../../features/aiCopilot/hooks/useAiAgents';
+
+const AgentThreadsListPage = () => {
+    const { agentUuid } = useParams();
+    const { data: threads, isLoading: isLoadingThreads } = useAiAgentThreads(
+        agentUuid ?? '',
+    );
+    const navigate = useNavigate();
+
+    const handleRowClick = (threadUuid: string) => {
+        void navigate(`/aiAgents/${agentUuid}/threads/${threadUuid}`);
+    };
+
+    if (isLoadingThreads) {
+        return <PageSpinner />;
+    }
+
+    return (
+        <Stack>
+            <Table highlightOnHover withTableBorder>
+                <Table.Thead>
+                    <Table.Tr>
+                        <Table.Th>Conversation</Table.Th>
+                        <Table.Th>User</Table.Th>
+                        <Table.Th>Created</Table.Th>
+                        <Table.Th>Source</Table.Th>
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                    {threads?.map((thread) => (
+                        <Table.Tr
+                            key={thread.uuid}
+                            onClick={() => handleRowClick(thread.uuid)}
+                            style={{
+                                cursor: 'pointer',
+                                transition: 'background-color 0.2s ease',
+                            }}
+                        >
+                            <Table.Td>{thread.firstMessage}</Table.Td>
+                            <Table.Td>{thread.user.name}</Table.Td>
+                            <Table.Td>
+                                {new Date(thread.createdAt).toLocaleString()}
+                            </Table.Td>
+                            <Table.Td>
+                                <Badge
+                                    color={
+                                        thread.createdFrom === 'slack'
+                                            ? 'indigo'
+                                            : 'blue'
+                                    }
+                                    variant="light"
+                                >
+                                    {thread.createdFrom === 'slack'
+                                        ? 'Slack'
+                                        : 'Web'}
+                                </Badge>
+                            </Table.Td>
+                        </Table.Tr>
+                    ))}
+                </Table.Tbody>
+            </Table>
+        </Stack>
+    );
+};
+
+export default AgentThreadsListPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentConversationPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentConversationPage.tsx
@@ -1,0 +1,150 @@
+import {
+    Avatar,
+    Badge,
+    Card,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import MDEditor from '@uiw/react-md-editor';
+import dayjs from 'dayjs';
+import { type FC } from 'react';
+import { useParams } from 'react-router';
+import PageSpinner from '../../../components/PageSpinner';
+import { getNameInitials } from '../../../features/comments/utils';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useAiAgentThread } from '../../features/aiCopilot/hooks/useAiAgents';
+
+type AiThreadMessageProps = {
+    actor: 'user' | 'assistant';
+    initials: string;
+    message: string;
+    messagedAt: Date;
+    humanScore?: number;
+};
+
+const AiThreadMessage: FC<AiThreadMessageProps> = ({
+    actor,
+    initials,
+    message,
+    messagedAt,
+    humanScore,
+}) => {
+    const timeAgo = useTimeAgo(messagedAt);
+
+    return (
+        <Group
+            maw="70%"
+            align="flex-start"
+            gap="sm"
+            style={{
+                marginLeft: actor === 'user' ? 'auto' : undefined,
+                flexDirection: actor === 'user' ? 'row-reverse' : 'row',
+            }}
+        >
+            <Avatar
+                color={actor === 'user' ? 'violet' : 'gray.3'}
+                radius="xl"
+                variant="filled"
+            >
+                {initials}
+            </Avatar>
+
+            <Stack
+                gap="xs"
+                align={actor === 'user' ? 'flex-end' : 'flex-start'}
+            >
+                <Tooltip label={dayjs(messagedAt).toString()} withinPortal>
+                    <Text size="xs" c="dimmed">
+                        {timeAgo}
+                    </Text>
+                </Tooltip>
+
+                <Card
+                    pos="relative"
+                    shadow="md"
+                    radius="xl"
+                    py="sm"
+                    px="lg"
+                    bg={actor === 'assistant' ? 'white' : 'blue.1'}
+                    color={actor === 'assistant' ? 'black' : 'white'}
+                    style={{
+                        overflow: 'unset',
+                        ...(actor === 'assistant'
+                            ? { borderStartStartRadius: '0px' }
+                            : actor === 'user'
+                            ? { borderStartEndRadius: '0px' }
+                            : {}),
+                    }}
+                >
+                    {message ? (
+                        <MDEditor.Markdown
+                            source={message}
+                            style={{ backgroundColor: 'transparent' }}
+                        />
+                    ) : (
+                        <Text c="dimmed">No response yet</Text>
+                    )}
+
+                    {actor === 'assistant' && humanScore !== undefined && (
+                        <Badge
+                            pos="absolute"
+                            right={10}
+                            bottom={-14}
+                            variant="filled"
+                            size="lg"
+                            fz="lg"
+                            bg={
+                                humanScore === 1
+                                    ? 'green.7'
+                                    : humanScore === -1
+                                    ? 'red.7'
+                                    : undefined
+                            }
+                        >
+                            {humanScore === 1
+                                ? '👍'
+                                : humanScore === -1
+                                ? '👎'
+                                : undefined}
+                        </Badge>
+                    )}
+                </Card>
+            </Stack>
+        </Group>
+    );
+};
+
+const AgentConversationPage = () => {
+    const { agentUuid, threadUuid } = useParams();
+    const { data: thread, isLoading: isLoadingThread } = useAiAgentThread(
+        agentUuid ?? '',
+        threadUuid ?? '',
+    );
+
+    if (isLoadingThread || !thread) {
+        return <PageSpinner />;
+    }
+
+    console.log(thread);
+    return (
+        <Stack>
+            {thread.messages.map((message) => (
+                <AiThreadMessage
+                    key={message.uuid}
+                    actor={message.role}
+                    initials={
+                        message.role === 'user'
+                            ? getNameInitials(message.user.name)
+                            : 'A'
+                    }
+                    message={message.message}
+                    messagedAt={new Date(message.createdAt)}
+                />
+            ))}
+        </Stack>
+    );
+};
+
+export default AgentConversationPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,0 +1,105 @@
+import {
+    Avatar,
+    Box,
+    Group,
+    NavLink,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { Link, Navigate, Outlet, useParams } from 'react-router';
+import LinkButton from '../../../components/common/LinkButton';
+import Page from '../../../components/common/Page/Page';
+import PageSpinner from '../../../components/PageSpinner';
+import {
+    useAiAgent,
+    useAiAgentThreads,
+} from '../../features/aiCopilot/hooks/useAiAgents';
+
+const AgentPage = () => {
+    const { agentUuid } = useParams();
+    const { data: threads } = useAiAgentThreads(agentUuid ?? '');
+
+    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(
+        agentUuid ?? '',
+    );
+
+    if (isLoadingAgent) {
+        return <PageSpinner />;
+    }
+
+    if (!agent) {
+        return <Navigate to={`/aiAgents`} />;
+    }
+
+    return (
+        <Page
+            withPaddedContent
+            sidebar={
+                <Stack gap="xl" align="stretch">
+                    <Stack align="flex-start">
+                        <LinkButton href={`/aiAgents`} leftIcon={IconArrowLeft}>
+                            All agents
+                        </LinkButton>
+                        <Group>
+                            <Avatar size="lg" radius="xl" />
+                            <Box>
+                                <Title order={3}>{agent.name}</Title>
+                                <Text size="sm" c="dimmed">
+                                    Last modified:{' '}
+                                    {new Date(
+                                        agent.updatedAt ?? new Date(),
+                                    ).toLocaleString()}
+                                </Text>
+                            </Box>
+                        </Group>
+                    </Stack>
+                    {agent.tags && (
+                        <Stack gap="xs">
+                            <Text size="md">Tags</Text>
+                            <Text size="sm" c="dimmed">
+                                {agent.tags.join(', ')}
+                            </Text>
+                        </Stack>
+                    )}
+                    {agent.instruction && (
+                        <Stack gap="xs">
+                            <Text size="md">Instructions</Text>
+                            <Text size="sm" c="dimmed">
+                                {agent.instruction}
+                            </Text>
+                        </Stack>
+                    )}
+                    {threads && (
+                        <Stack gap="xs">
+                            <Text size="md">Recent conversations</Text>
+                            {threads.slice(0, 5).map((thread) => (
+                                <NavLink
+                                    label={thread.firstMessage}
+                                    key={thread.uuid}
+                                    component={Link}
+                                    to={`/aiAgents/${agentUuid}/threads/${thread.uuid}`}
+                                />
+                            ))}
+                            <Link to={`/aiAgents/${agentUuid}/threads`}>
+                                View all
+                            </Link>
+                        </Stack>
+                    )}
+                    <Link to={`/generalSettings/aiAgents/${agentUuid}`}>
+                        Settings
+                    </Link>
+                </Stack>
+            }
+        >
+            <Group align="flex-start" gap="xl">
+                <Box style={{ flex: 1 }}>
+                    <Outlet />
+                </Box>
+            </Group>
+        </Page>
+    );
+};
+
+export default AgentPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -1,0 +1,109 @@
+import { subject } from '@casl/ability';
+import {
+    Box,
+    Button,
+    Card,
+    Grid,
+    Group,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconPlus } from '@tabler/icons-react';
+import { Link } from 'react-router';
+import Page from '../../../components/common/Page/Page';
+import PageSpinner from '../../../components/PageSpinner';
+import useApp from '../../../providers/App/useApp';
+import { useAiAgents } from '../../features/aiCopilot/hooks/useAiAgents';
+
+type AgentCardProps = {
+    name: string;
+    description: string;
+    uuid: string;
+};
+
+const AgentCard = ({ name, description, uuid }: AgentCardProps) => {
+    return (
+        <Card
+            withBorder
+            p="lg"
+            radius="md"
+            styles={{
+                root: { height: '100%' },
+            }}
+            component={Link}
+            to={`/aiAgents/${uuid}/threads`}
+        >
+            <Stack gap="sm">
+                <Group>
+                    <Box
+                        w={40}
+                        h={40}
+                        bg="gray.1"
+                        style={{
+                            borderRadius: '50%',
+                            overflow: 'hidden',
+                        }}
+                    ></Box>
+                    <Title order={4}>{name}</Title>
+                </Group>
+
+                <Text size="sm" c="dimmed">
+                    {description}
+                </Text>
+            </Stack>
+        </Card>
+    );
+};
+
+const AgentsListPage = () => {
+    const agentsListQuery = useAiAgents();
+    const { user } = useApp();
+
+    if (agentsListQuery.isLoading) {
+        return <PageSpinner />;
+    }
+
+    const userCanManageOrganization = user.data?.ability.can(
+        'manage',
+        subject('Organization', {
+            organizationUuid: user.data?.organizationUuid,
+        }),
+    );
+
+    return (
+        <Page
+            withFullHeight
+            withPaddedContent
+            title="Lightdash Agents"
+            header={
+                <Group justify="space-between" mb="lg" p="md">
+                    <Title>Lightdash Agents</Title>
+                    {userCanManageOrganization && (
+                        <Button
+                            component={Link}
+                            to="/generalSettings/aiAgents/new"
+                            leftSection={<IconPlus />}
+                        >
+                            New
+                        </Button>
+                    )}
+                </Group>
+            }
+        >
+            <Grid>
+                {agentsListQuery.data?.map((agent) => (
+                    <Grid.Col span={4} key={agent.uuid}>
+                        <AgentCard
+                            name={agent.name}
+                            description="Labore elit in dolor duis anim aute quis sit."
+                            uuid={agent.uuid}
+                        />
+                    </Grid.Col>
+                ))}
+            </Grid>
+        </Page>
+    );
+};
+
+export default AgentsListPage;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15051

### Description:
Added AI Agents UI with new routes and pages for viewing agents and their threads.

- New route structure for AI agents under `/projects/:projectUuid/ai/agents/`
- Agent list page showing all available agents 
- Agent details page with information
- Thread listing page for each agent
- Individual thread view page


