### PR TITLE
feat(backend): add AI agent thread generation endpoints

### DIFF
--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -22,3 +22,19 @@ Content-Type: application/json
 ### Get agent thread
 GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads/91ea006f-bce1-4193-9099-13dddaddfcfc
 Content-Type: application/json
+
+### Start agent thread
+POST http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/generate
+Content-Type: application/json
+
+{
+    "prompt": "give me a chart of revenue by payment method"
+}
+
+### Generate agent thread response
+POST http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads/3185ecad-58c9-44c1-af2d-a1b859bf4c77/generate
+Content-Type: application/json
+
+{
+    "prompt": "what kind of charts can you make?"
+}

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,6 +1,9 @@
 import {
     ApiAiAgentResponse,
+    ApiAiAgentStartThreadResponse,
     ApiAiAgentSummaryResponse,
+    ApiAiAgentThreadGenerateRequest,
+    ApiAiAgentThreadGenerateResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
     ApiCreateAiAgent,
@@ -8,7 +11,6 @@ import {
     ApiErrorPayload,
     ApiSuccessEmpty,
     ApiUpdateAiAgent,
-    NotImplementedError,
 } from '@lightdash/common';
 import {
     Body,
@@ -163,6 +165,56 @@ export class AiAgentController extends BaseController {
                 agentUuid,
                 threadUuid,
             ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/generate')
+    @OperationId('startAgentThread')
+    async createAgentThread(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Body() body: ApiAiAgentThreadGenerateRequest,
+    ): Promise<ApiAiAgentStartThreadResponse> {
+        this.setStatus(200);
+        const { jobId, threadUuid } =
+            await this.getAiAgentService().generateAgentThreadResponse(
+                req.user!,
+                {
+                    agentUuid,
+                    prompt: body.prompt,
+                },
+            );
+        return {
+            status: 'ok',
+            results: { jobId, threadUuid },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/generate')
+    @OperationId('generateAgentThreadResponse')
+    async generateAgentThreadResponse(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Body() body: ApiAiAgentThreadGenerateRequest,
+    ): Promise<ApiAiAgentThreadGenerateResponse> {
+        this.setStatus(200);
+        const { jobId } =
+            await this.getAiAgentService().generateAgentThreadResponse(
+                req.user!,
+                {
+                    agentUuid,
+                    threadUuid,
+                    prompt: body.prompt,
+                },
+            );
+        return {
+            status: 'ok',
+            results: { jobId },
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -112,6 +112,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),
+                    aiModel: models.getAiModel(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,4 +1,8 @@
-import { EE_SCHEDULER_TASKS, SlackPromptJobPayload } from '@lightdash/common';
+import {
+    AiAgentThreadGenerateJobPayload,
+    EE_SCHEDULER_TASKS,
+    SlackPromptJobPayload,
+} from '@lightdash/common';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 
 export class CommercialSchedulerClient extends SchedulerClient {
@@ -7,6 +11,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
         const now = new Date();
         const { id: jobId } = await graphileClient.addJob(
             EE_SCHEDULER_TASKS.SLACK_AI_PROMPT,
+            payload,
+            {
+                runAt: now, // now
+                maxAttempts: 1,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentThreadGenerate(payload: AiAgentThreadGenerateJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_THREAD_GENERATE,
             payload,
             {
                 runAt: now, // now

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -24,6 +24,16 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     payload.slackPromptUuid,
                 );
             },
+            [EE_SCHEDULER_TASKS.AI_AGENT_THREAD_GENERATE]: async (
+                payload,
+                _helpers,
+            ) => {
+                await this.aiService.generateAgentThreadResponse(
+                    payload.agentUuid,
+                    payload.threadUuid,
+                    payload.promptUuid,
+                );
+            },
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4951,6 +4951,35 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        jobId: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
         dataType: 'refAlias',
         type: {
@@ -8108,6 +8137,7 @@ const models: TsoaRoute.Models = {
             dataType: 'union',
             subSchemas: [
                 { dataType: 'enum', enums: ['slackAiPrompt'] },
+                { dataType: 'enum', enums: ['aiAgentThreadGenerate'] },
                 { dataType: 'enum', enums: ['handleScheduledDelivery'] },
                 { dataType: 'enum', enums: ['sendSlackNotification'] },
                 { dataType: 'enum', enums: ['sendEmailNotification'] },
@@ -19062,6 +19092,144 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getAgentThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_createAgentThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadGenerateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/generate',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.createAgentThread,
+        ),
+
+        async function AiAgentController_createAgentThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_createAgentThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAgentThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_generateAgentThreadResponse: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadGenerateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/generate',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.generateAgentThreadResponse,
+        ),
+
+        async function AiAgentController_generateAgentThreadResponse(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_generateAgentThreadResponse,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'generateAgentThreadResponse',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5623,6 +5623,35 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiAiAgentThreadGenerateResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "jobId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["jobId"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadGenerateRequest": {
+                "properties": {
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["prompt"],
+                "type": "object"
+            },
             "ApiJobScheduledResponse": {
                 "properties": {
                     "results": {
@@ -8996,6 +9025,7 @@
                 "type": "string",
                 "enum": [
                     "slackAiPrompt",
+                    "aiAgentThreadGenerate",
                     "handleScheduledDelivery",
                     "sendSlackNotification",
                     "sendEmailNotification",

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -124,6 +124,15 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_THREAD_GENERATE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+        'agent.uuid': payload.agentUuid,
+        'thread.uuid': payload.threadUuid,
+        'prompt.uuid': payload.promptUuid,
+    }),
+
     [SCHEDULER_TASKS.RENAME_RESOURCES]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/Ai/types.ts
+++ b/packages/common/src/ee/Ai/types.ts
@@ -101,6 +101,12 @@ export type SlackPromptJobPayload = TraceTaskBase & {
     slackPromptUuid: string;
 };
 
+export type AiAgentThreadGenerateJobPayload = TraceTaskBase & {
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+};
+
 export enum AiChatAgents {
     HUMAN = 'human',
     AI = 'ai',

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -148,4 +148,23 @@ export type ApiAiAgentThreadResponse = {
     results: AiAgentThread;
 };
 
+export type ApiAiAgentThreadGenerateRequest = {
+    prompt: string;
+};
+
+export type ApiAiAgentThreadGenerateResponse = {
+    status: 'ok';
+    results: {
+        jobId: string;
+    };
+};
+
+export type ApiAiAgentStartThreadResponse = {
+    status: 'ok';
+    results: {
+        jobId: string;
+        threadUuid: string;
+    };
+};
+
 export * from './filterExploreByTags';

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,4 +1,7 @@
-import { type SlackPromptJobPayload } from '../ee';
+import {
+    type AiAgentThreadGenerateJobPayload,
+    type SlackPromptJobPayload,
+} from '../ee';
 import { type SchedulerIndexCatalogJobPayload } from './catalog';
 import { type UploadMetricGsheetPayload } from './gdrive';
 import { type RenameResourcesPayload } from './rename';
@@ -24,6 +27,7 @@ import {
 
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
+    AI_AGENT_THREAD_GENERATE: 'aiAgentThreadGenerate',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -70,11 +74,13 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.GENERATE_DAILY_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD]: ExportCsvDashboardPayload;
     [SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_THREAD_GENERATE]: AiAgentThreadGenerateJobPayload;
     [SCHEDULER_TASKS.RENAME_RESOURCES]: RenameResourcesPayload;
 }
 
 export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_THREAD_GENERATE]: AiAgentThreadGenerateJobPayload;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15041

### Description:

This PR adds new API endpoints to support AI agent thread generation. It introduces two new endpoints:

- `POST /api/v1/aiAgents/{agentUuid}/generate` to start a new agent thread with an initial prompt
- `POST /api/v1/aiAgents/{agentUuid}/threads/{threadUuid}/generate` to generate a response in an existing thread
