### PR TITLE
fix: invalidate cache on embed fetch

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -29,7 +29,8 @@ import EmbedUrlForm from './EmbedUrlForm';
 
 const useEmbedConfig = (projectUuid: string) => {
     return useQuery<DecodedEmbed, ApiError>({
-        queryKey: ['embed-config'],
+        queryKey: ['embed-config', projectUuid],
+        enabled: !!projectUuid,
         queryFn: async () =>
             lightdashApi<DecodedEmbed>({
                 url: `/embed/${projectUuid}/config`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14928

### Description:

Updated the `useEmbedConfig` query to include `projectUuid` in the query key and added the `enabled` option to prevent the query from running when `projectUuid` is not available. This ensures proper caching behaviour when the project changes

before

[embed-config-before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/cd114ed2-c03e-44b1-83c1-daeac339557f.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/cd114ed2-c03e-44b1-83c1-daeac339557f.mov)

after

[embed-config-after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/8df3b27a-8868-43e7-87c3-c3bc2840c408.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/8df3b27a-8868-43e7-87c3-c3bc2840c408.mov)

