### PR TITLE
fix: refresh SQL charts on dashboards

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -65,26 +65,20 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
         const clearCacheAndFetch = useDashboardContext(
             (c) => c.clearCacheAndFetch,
         );
-        const invalidateCache = useDashboardContext((c) => c.invalidateCache);
 
         const setIsAutoRefresh = useDashboardContext((c) => c.setIsAutoRefresh);
         const isOneAtLeastFetching = isFetching > 0;
 
         const invalidateAndSetRefreshTime = useCallback(async () => {
-            if (invalidateCache) {
-                // only invalidate results queries manually if cache is invalidated in the state
-                // if it isn't, the queries will be refetched because `clearCacheAndFetch` will change `invalidateCache` to `true` which will invalidate the results queries
-                await invalidateDashboardResultsQueries();
-            }
-
             clearCacheAndFetch();
             await invalidateDashboardRelatedQueries();
+            await invalidateDashboardResultsQueries();
+
             setLastRefreshTime(new Date());
         }, [
             clearCacheAndFetch,
             invalidateDashboardRelatedQueries,
             invalidateDashboardResultsQueries,
-            invalidateCache,
         ]);
 
         const interval = useInterval(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -114,7 +114,6 @@ export const useDashboardChartReadyQuery = (
             context,
             autoRefresh,
             hasADateDimension ? granularity : null,
-            invalidateCache,
         ],
         [
             chartQuery.data?.projectUuid,
@@ -127,7 +126,6 @@ export const useDashboardChartReadyQuery = (
             autoRefresh,
             hasADateDimension,
             granularity,
-            invalidateCache,
         ],
     );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
@@ -11,7 +11,10 @@ const DASHBOARD_RELATED_QUERIES = [
     'dashboards',
 ];
 
-const DASHBOARD_RESULTS_QUERIES = ['dashboard_chart_ready_query'];
+const DASHBOARD_RESULTS_QUERIES = [
+    'dashboard_chart_ready_query',
+    'savedSqlChartResults',
+];
 
 const getPredicateFunction = (keyArray: string[]) => {
     return (query: Query) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15024 

### Description:

Refetches SQL charts on dashboards. This was pretty tricky to get right because it ran contrary to a fix we made a couple weeks ago not to *double* fetch charts. What was done and why:

- Add `savedSqlChartResults` to the query key for refetching results. Seemed like it should be enough. But then on the **first** refresh, the sql charts weren't getting fetched because `invalidateCache` in the refresh button wasn't true yet
- So, remove the check for invalidate cache in the refresh button. But then the Explore charts were double-fetching. 
- Remove invalidateCache from the explore charts query key. Explore charts still work because we now have `dashboard_chart_ready_query` as part of their key. 
- We **couldn't** just add `invalidateCache` to the SQL charts query key because that hook is used outside of dashboards. 

I verified that both types of charts refetch every time now and to not fetch twice. Here's some videos

Explore charts only fetch once on each refresh
![Explore1](https://github.com/user-attachments/assets/d7c87722-167d-43c8-98a5-05be864b5053)

SQL charts only fetch once on each refresh
![Sql1Fetch](https://github.com/user-attachments/assets/1a930ffe-a150-48ff-9dd6-7c9345e0d75b)

After this fix, all charts refresh

![After](https://github.com/user-attachments/assets/9da148fb-fb33-49b5-9672-6e6e27ba911d)
