### PR TITLE
fix: use the correct limit for SQL-charts

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2313,7 +2313,7 @@ export class AsyncQueryService extends ProjectService {
             throw new Error('Either chartUuid or slug must be provided');
         }
 
-        const { user, projectUuid, context, invalidateCache, limit } = args;
+        const { user, projectUuid, context, invalidateCache } = args;
 
         const { hasAccess: hasViewAccess } = await this.hasSavedChartAccess(
             user,
@@ -2340,7 +2340,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid: sqlChart.organization.organizationUuid,
             sql: sqlChart.sql,
             config: sqlChart.config,
-            limit,
+            limit: sqlChart.limit,
         });
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15076

### Description:

We were not picking up the limit for saved SQL charts, so the results could look wildly different than in edit mode. This uses the saved limit. 

To test:
- Make a new SQL chart from the `events` table
- group by 'event'
- Save the chart
- The saved version should look the same
- Before this fix the saved version was very different (see the ticket)

Here's an example of the fixed version working with different limits

![Kapture 2025-05-29 at 15 52 15](https://github.com/user-attachments/assets/e654e599-c346-4fad-b62e-6e3b0dcee92e)

