### PR TITLE
feat: add XLSX download option in SQL chart page

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -10,6 +10,7 @@ import { Box } from '@mantine/core';
 import { IconAlertCircle, IconFilePencil } from '@tabler/icons-react';
 import { memo, useEffect, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
+import { ResultsDownload } from '../../features/sqlRunner/components/Download/ResultsDownload';
 import { useSavedSqlChartResults } from '../../features/sqlRunner/hooks/useSavedSqlChartResults';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
 import useSearchParams from '../../hooks/useSearchParams';
@@ -89,6 +90,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             error: chartResultsError,
             isFetching: isChartResultsFetching,
         },
+        downloadMutation,
     } = useSavedSqlChartResults({
         projectUuid,
         savedSqlUuid,
@@ -190,14 +192,21 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             title={tile.properties.title || tile.properties.chartName || ''}
             {...rest}
             extraMenuItems={
-                projectUuid &&
-                canManageSqlRunner && (
-                    <DashboardOptions
-                        isEditMode={isEditMode}
-                        projectUuid={projectUuid}
-                        slug={chartData.slug}
-                    />
-                )
+                <>
+                    {downloadMutation && (
+                        <ResultsDownload
+                            isDownloading={downloadMutation.isLoading}
+                            onDownload={downloadMutation.mutate}
+                        />
+                    )}
+                    {projectUuid && canManageSqlRunner && (
+                        <DashboardOptions
+                            isEditMode={isEditMode}
+                            projectUuid={projectUuid}
+                            slug={chartData.slug}
+                        />
+                    )}
+                </>
             }
         >
             {chartData.config.type === ChartKind.TABLE &&

--- a/packages/frontend/src/features/queryRunner/executeQuery.ts
+++ b/packages/frontend/src/features/queryRunner/executeQuery.ts
@@ -91,6 +91,7 @@ const getPivotQueryResults = async (projectUuid: string, queryUuid: string) => {
         originalColumns: query.pivotDetails
             ? query.pivotDetails.originalColumns
             : query.columns,
+        queryUuid: query.queryUuid,
     };
 };
 

--- a/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
+++ b/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
@@ -141,7 +141,9 @@ export const getSqlChartPivotChartData = async ({
     savedSqlUuid: string;
     limit?: number;
     context?: QueryExecutionContext;
-}): Promise<PivotChartData & { originalColumns: ResultColumns }> => {
+}): Promise<
+    PivotChartData & { queryUuid: string; originalColumns: ResultColumns }
+> => {
     const pivotResults = await executeSqlChartPivotQuery(projectUuid, {
         savedSqlUuid,
         context,
@@ -178,7 +180,9 @@ export const getDashboardSqlChartPivotChartData = async ({
     dashboardFilters: DashboardFilters;
     dashboardSorts: SortField[]; // TODO: check if dashboardSorts is needed, seems to be unused
     context?: QueryExecutionContext;
-}): Promise<PivotChartData & { originalColumns: ResultColumns }> => {
+}): Promise<
+    PivotChartData & { queryUuid: string; originalColumns: ResultColumns }
+> => {
     const pivotResults = await executeDashboardSqlChartPivotQuery(projectUuid, {
         dashboardUuid,
         tileUuid,

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownload.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownload.tsx
@@ -1,0 +1,85 @@
+import { DownloadFileType } from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    NumberInput,
+    Popover,
+    SegmentedControl,
+    Stack,
+    Tooltip,
+} from '@mantine/core';
+import { IconDownload } from '@tabler/icons-react';
+import { type FC, useState } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type Props2 = {
+    isDownloading: boolean;
+    onDownload: (args: {
+        limit?: number | null;
+        type?: DownloadFileType;
+    }) => void;
+    defaultQueryLimit?: number;
+};
+
+export const ResultsDownload: FC<Props2> = ({
+    isDownloading,
+    onDownload,
+    defaultQueryLimit,
+}) => {
+    const [customLimit, setCustomLimit] = useState(defaultQueryLimit);
+    const [fileType, setFileType] = useState<DownloadFileType>(
+        DownloadFileType.CSV,
+    );
+
+    return (
+        <Popover
+            withArrow
+            closeOnClickOutside={!isDownloading}
+            closeOnEscape={!isDownloading}
+        >
+            <Popover.Target>
+                <Tooltip variant="xs" label="Download results">
+                    <ActionIcon variant="default">
+                        <MantineIcon icon={IconDownload} />
+                    </ActionIcon>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Stack>
+                    <SegmentedControl
+                        size="xs"
+                        value={fileType}
+                        onChange={(value) =>
+                            setFileType(value as DownloadFileType)
+                        }
+                        data={[
+                            { label: 'CSV', value: DownloadFileType.CSV },
+                            { label: 'Excel', value: DownloadFileType.XLSX },
+                        ]}
+                    />
+                    <NumberInput
+                        size="xs"
+                        type="number"
+                        label="Row limit:"
+                        step={100}
+                        min={1}
+                        autoFocus
+                        required
+                        defaultValue={customLimit}
+                        onChange={(value: number) => setCustomLimit(value)}
+                    />
+                    <Button
+                        size="xs"
+                        ml="auto"
+                        onClick={() =>
+                            onDownload({ limit: customLimit, type: fileType })
+                        }
+                        loading={isDownloading}
+                    >
+                        Download
+                    </Button>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -20,6 +20,7 @@ import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import { ChartDownload } from '../features/sqlRunner/components/Download/ChartDownload';
+import { ResultsDownload } from '../features/sqlRunner/components/Download/ResultsDownload';
 import { ResultsDownloadFromData } from '../features/sqlRunner/components/Download/ResultsDownloadFromData';
 import { ResultsDownloadFromUrl } from '../features/sqlRunner/components/Download/ResultsDownloadFromUrl';
 import { Header } from '../features/sqlRunner/components/Header';
@@ -56,6 +57,7 @@ const ViewSqlChart = () => {
             error: chartResultsError,
             isFetching: isChartResultsFetching,
         },
+        downloadMutation,
     } = useSavedSqlChartResults({
         projectUuid: params.projectUuid,
         slug: params.slug,
@@ -126,9 +128,15 @@ const ViewSqlChart = () => {
                                 onChange={(val: TabOption) => setActiveTab(val)}
                             />
                         </Group>
-                        {(activeTab === TabOption.RESULTS ||
-                            (activeTab === TabOption.CHART &&
-                                isVizTableConfig(chartData?.config))) &&
+                        {activeTab === TabOption.RESULTS &&
+                            downloadMutation && (
+                                <ResultsDownload
+                                    isDownloading={downloadMutation.isLoading}
+                                    onDownload={downloadMutation.mutate}
+                                />
+                            )}
+                        {activeTab === TabOption.CHART &&
+                            isVizTableConfig(chartData?.config) &&
                             chartResultsData &&
                             // Table charts don't have a fileUrl,
                             // So we will download the file directly from the resultsData


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15016

**This was a POC! please use same components and logic as in** https://github.com/lightdash/lightdash/pull/15095


### Description:
Added download functionality to SQL chart tiles on dashboards. Users can now download SQL chart results directly from dashboard tiles using a new download button that offers CSV and Excel export options with customizable row limits.

The implementation includes:
- A new `ResultsDownload` component with a popover interface for selecting file type and row limit
- Integration with the existing download mutation in `useSavedSqlChartResults` hook
- Proper query UUID tracking to ensure downloads use the correct query results
- Consistent download experience between standalone SQL chart view and dashboard tiles