### PR TITLE
fix: handle undefined authenticationType snowflake

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1132,6 +1132,22 @@ export class ProjectService extends BaseService {
             savedProject,
         );
 
+        // Handle the case of Snowflake connections that are considered "leacy"
+        // This is because we defaulted to private_key (in the Frontend) for Snowflake connections
+        // that didn't have an authenticationType
+        // This is a temporary fix to ensure that we don't break existing projects
+        // that were created before we added the authenticationType field
+        if (
+            updatedProject.warehouseConnection.type ===
+                WarehouseTypes.SNOWFLAKE &&
+            updatedProject.warehouseConnection.authenticationType ===
+                'private_key' &&
+            !updatedProject.warehouseConnection.privateKey &&
+            updatedProject.warehouseConnection.password
+        ) {
+            updatedProject.warehouseConnection.authenticationType = 'password';
+        }
+
         await this.projectModel.update(projectUuid, updatedProject);
         await this.jobModel.create(job);
 

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -7,7 +7,7 @@ import {
     Stack,
     TextInput,
 } from '@mantine/core';
-import { useState, type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import FormCollapseButton from '../FormCollapseButton';
@@ -45,6 +45,27 @@ const SnowflakeForm: FC<{
         savedProject?.warehouseConnection?.type !== WarehouseTypes.SNOWFLAKE;
     const isPassthroughLoginFeatureEnabled = useFeatureFlagEnabled(
         FeatureFlags.PassthroughLogin,
+    );
+
+    useEffect(
+        function updateConnectionBasedOnProject() {
+            if (
+                savedProject?.warehouseConnection?.type ===
+                WarehouseTypes.SNOWFLAKE
+            ) {
+                if (
+                    savedProject?.warehouseConnection?.authenticationType !==
+                    undefined
+                ) {
+                    form.setFieldValue(
+                        'warehouse.authenticationType',
+                        savedProject?.warehouseConnection?.authenticationType,
+                    );
+                }
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [savedProject],
     );
 
     if (form.values.warehouse?.type !== WarehouseTypes.SNOWFLAKE) {
@@ -93,7 +114,6 @@ const SnowflakeForm: FC<{
                 <Select
                     name="warehouse.authenticationType"
                     {...form.getInputProps('warehouse.authenticationType')}
-                    defaultValue={hasPrivateKey ? 'private_key' : 'password'}
                     label="Authentication Type"
                     description="Choose between password or key pair authentication"
                     data={[


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15092

### Description:

Fixed an issue with Snowflake authentication type handling. The PR addresses two problems:

1. Added a fix in the backend to handle "legacy" Snowflake connections that were created before the `authenticationType` field was introduced. If a connection has `authenticationType` set to 'private_key' but doesn't have a private key and has a password, we now correctly set the `authenticationType` to 'password'.

2. Enhanced the Snowflake form in the frontend to properly initialize the authentication type from the saved project, removing the hardcoded default value that was causing issues.

