### PR TITLE
feat: add XLSX download option in explores page

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -423,13 +423,11 @@ export class QueryController extends BaseController {
                 projectUuid,
                 queryUuid,
                 type: body.type,
-                csvLimit: body.csvLimit,
                 onlyRaw: body.onlyRaw,
                 showTableNames: body.showTableNames,
                 customLabels: body.customLabels,
                 columnOrder: body.columnOrder,
                 hiddenFields: body.hiddenFields,
-                chartName: body.chartName,
                 pivotConfig: body.pivotConfig,
             });
 

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -7,8 +7,7 @@ import {
     ApiGetAsyncQueryResults,
     ApiSuccess,
     ApiSuccessEmpty,
-    assertUnreachable,
-    DownloadFileType,
+    DownloadAsyncQueryResultsRequestParams,
     ExecuteAsyncSqlQueryRequestParams,
     isExecuteAsyncDashboardSqlChartByUuidParams,
     isExecuteAsyncSqlChartByUuidParams,
@@ -181,6 +180,7 @@ export class QueryController extends BaseController {
                 chartUuid: body.chartUuid,
                 versionUuid: body.versionUuid,
                 context: context ?? QueryExecutionContext.API,
+                limit: body.limit,
             });
 
         return {
@@ -400,13 +400,13 @@ export class QueryController extends BaseController {
     @Hidden()
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/{queryUuid}/download')
+    @Post('/{queryUuid}/download')
     @OperationId('downloadResults')
     async downloadResults(
         @Path() projectUuid: string,
         @Path() queryUuid: string,
         @Request() req: express.Request,
-        @Query() type: DownloadFileType = DownloadFileType.CSV,
+        @Body() body: Omit<DownloadAsyncQueryResultsRequestParams, 'queryUuid'>,
     ): Promise<
         ApiSuccess<
             | ApiDownloadAsyncQueryResults
@@ -422,7 +422,15 @@ export class QueryController extends BaseController {
                 user: req.user!,
                 projectUuid,
                 queryUuid,
-                type,
+                type: body.type,
+                csvLimit: body.csvLimit,
+                onlyRaw: body.onlyRaw,
+                showTableNames: body.showTableNames,
+                customLabels: body.customLabels,
+                columnOrder: body.columnOrder,
+                hiddenFields: body.hiddenFields,
+                chartName: body.chartName,
+                pivotConfig: body.pivotConfig,
             });
 
         return {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -223,6 +223,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     storageClient: clients.getResultsFileStorageClient(),
+                    csvService: repository.getCsvService(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15786,6 +15786,13 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        limit: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
                         versionUuid: { dataType: 'string' },
                         chartUuid: { dataType: 'string', required: true },
                     },
@@ -16183,6 +16190,95 @@ const models: TsoaRoute.Models = {
     DownloadFileType: {
         dataType: 'refEnum',
         enums: ['csv', 'image', 'jsonl', 's3_jsonl', 'xlsx'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'DownloadFileType' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    pivotConfig: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'PivotConfig' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    csvLimit: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    onlyRaw: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    showTableNames: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    customLabels: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'Record_string.string_' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    columnOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'array',
+                                array: { dataType: 'string' },
+                            },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    hiddenFields: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'array',
+                                array: { dataType: 'string' },
+                            },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    chartName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_DownloadAsyncQueryResultsRequestParams.queryUuid_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FeatureFlag: {
@@ -33410,14 +33506,14 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        type: {
-            default: 'csv',
-            in: 'query',
-            name: 'type',
-            ref: 'DownloadFileType',
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'Omit_DownloadAsyncQueryResultsRequestParams.queryUuid_',
         },
     };
-    app.get(
+    app.post(
         '/api/v2/projects/:projectUuid/query/:queryUuid/download',
         ...fetchMiddlewares<RequestHandler>(QueryController),
         ...fetchMiddlewares<RequestHandler>(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5035,6 +5035,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiChartType: {
+        dataType: 'refEnum',
+        enums: ['time_series_chart', 'vertical_bar_chart', 'csv'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName-or-filters_':
         {
             dataType: 'refAlias',
@@ -5095,15 +5100,7 @@ const models: TsoaRoute.Models = {
                 },
                 chartOptions: { dataType: 'object' },
                 metricQuery: { ref: 'AiMetricQuery', required: true },
-                type: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['vertical_bar_chart'] },
-                        { dataType: 'enum', enums: ['time_series_chart'] },
-                        { dataType: 'enum', enums: ['csv'] },
-                    ],
-                    required: true,
-                },
+                type: { ref: 'AiChartType', required: true },
             },
             validators: {},
         },
@@ -9356,6 +9353,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SnowflakeAuthenticationType: {
+        dataType: 'refEnum',
+        enums: ['password', 'private_key', 'sso'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     WeekDay: {
         dataType: 'refEnum',
         enums: [0, 1, 2, 3, 4, 5, 6],
@@ -9371,9 +9373,7 @@ const models: TsoaRoute.Models = {
                     authenticationType: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['password'] },
-                            { dataType: 'enum', enums: ['private_key'] },
-                            { dataType: 'enum', enums: ['sso'] },
+                            { ref: 'SnowflakeAuthenticationType' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -15777,6 +15777,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    LimitOverride: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'double' },
+                { dataType: 'enum', enums: [null] },
+                { dataType: 'undefined' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExecuteAsyncSavedChartRequestParams: {
         dataType: 'refAlias',
         type: {
@@ -15786,13 +15799,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        limit: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'double' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                        },
+                        limit: { ref: 'LimitOverride' },
                         versionUuid: { dataType: 'string' },
                         chartUuid: { dataType: 'string', required: true },
                     },
@@ -16212,14 +16219,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    csvLimit: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'enum', enums: [null] },
-                            { dataType: 'undefined' },
-                        ],
-                    },
                     onlyRaw: {
                         dataType: 'union',
                         subSchemas: [
@@ -16258,13 +16257,6 @@ const models: TsoaRoute.Models = {
                                 dataType: 'array',
                                 array: { dataType: 'string' },
                             },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    chartName: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5694,6 +5694,11 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "AiChartType": {
+                "description": "Supported AI visualization chart types",
+                "enum": ["time_series_chart", "vertical_bar_chart", "csv"],
+                "type": "string"
+            },
             "Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName-or-filters_": {
                 "properties": {
                     "metrics": {
@@ -5767,12 +5772,7 @@
                         "$ref": "#/components/schemas/AiMetricQuery"
                     },
                     "type": {
-                        "type": "string",
-                        "enum": [
-                            "vertical_bar_chart",
-                            "time_series_chart",
-                            "csv"
-                        ]
+                        "$ref": "#/components/schemas/AiChartType"
                     }
                 },
                 "required": ["results", "metricQuery", "type"],
@@ -10477,6 +10477,10 @@
                     }
                 ]
             },
+            "SnowflakeAuthenticationType": {
+                "enum": ["password", "private_key", "sso"],
+                "type": "string"
+            },
             "WeekDay": {
                 "enum": [0, 1, 2, 3, 4, 5, 6],
                 "type": "number"
@@ -10487,8 +10491,7 @@
                         "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
                     },
                     "authenticationType": {
-                        "type": "string",
-                        "enum": ["password", "private_key", "sso"]
+                        "$ref": "#/components/schemas/SnowflakeAuthenticationType"
                     },
                     "role": {
                         "type": "string"
@@ -16605,6 +16608,12 @@
                     }
                 ]
             },
+            "LimitOverride": {
+                "type": "number",
+                "format": "double",
+                "nullable": true,
+                "description": "Represents different limit override behaviors\n- undefined: use original limit from saved chart/query\n- null: no limit (unlimited results)\n- number: apply specific limit"
+            },
             "ExecuteAsyncSavedChartRequestParams": {
                 "allOf": [
                     {
@@ -16613,9 +16622,8 @@
                     {
                         "properties": {
                             "limit": {
-                                "type": "number",
-                                "format": "double",
-                                "nullable": true
+                                "$ref": "#/components/schemas/LimitOverride",
+                                "description": "Limit override for query execution:\n- undefined: use saved chart's original limit\n- null: no limit (unlimited results)\n- number: apply specific limit"
                             },
                             "versionUuid": {
                                 "type": "string"
@@ -17030,11 +17038,6 @@
                     "pivotConfig": {
                         "$ref": "#/components/schemas/PivotConfig"
                     },
-                    "csvLimit": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
                     "onlyRaw": {
                         "type": "boolean"
                     },
@@ -17055,9 +17058,6 @@
                             "type": "string"
                         },
                         "type": "array"
-                    },
-                    "chartName": {
-                        "type": "string"
                     }
                 },
                 "type": "object",
@@ -17722,7 +17722,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1685.1",
+        "version": "0.1689.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16612,6 +16612,11 @@
                     },
                     {
                         "properties": {
+                            "limit": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
                             "versionUuid": {
                                 "type": "string"
                             },
@@ -17016,6 +17021,51 @@
             "DownloadFileType": {
                 "enum": ["csv", "image", "jsonl", "s3_jsonl", "xlsx"],
                 "type": "string"
+            },
+            "Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DownloadFileType"
+                    },
+                    "pivotConfig": {
+                        "$ref": "#/components/schemas/PivotConfig"
+                    },
+                    "csvLimit": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "onlyRaw": {
+                        "type": "boolean"
+                    },
+                    "showTableNames": {
+                        "type": "boolean"
+                    },
+                    "customLabels": {
+                        "$ref": "#/components/schemas/Record_string.string_"
+                    },
+                    "columnOrder": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "hiddenFields": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "chartName": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_DownloadAsyncQueryResultsRequestParams.queryUuid_": {
+                "$ref": "#/components/schemas/Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
             },
             "FeatureFlag": {
                 "properties": {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -44,6 +44,7 @@ import type { SchedulerClient } from '../../scheduler/SchedulerClient';
 import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
+import type { CsvService } from '../CsvService/CsvService';
 import {
     allExplores,
     expectedColumns,
@@ -150,6 +151,7 @@ const getMockedAsyncQueryService = (lightdashConfig: LightdashConfig) =>
         userModel: {} as UserModel,
         savedSqlModel: {} as SavedSqlModel,
         storageClient: {} as S3ResultsFileStorageClient,
+        csvService: {} as CsvService,
     });
 
 describe('AsyncQueryService', () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -591,13 +591,11 @@ export class AsyncQueryService extends ProjectService {
         projectUuid,
         queryUuid,
         type,
-        csvLimit,
         onlyRaw = false,
         showTableNames = false,
         customLabels = {},
         columnOrder = [],
         hiddenFields = [],
-        chartName,
         pivotConfig,
     }: DownloadAsyncQueryResultsArgs): Promise<
         | ApiDownloadAsyncQueryResults
@@ -670,8 +668,6 @@ export class AsyncQueryService extends ProjectService {
                         customLabels,
                         columnOrder,
                         hiddenFields,
-                        chartName,
-                        csvLimit,
                         pivotConfig,
                     },
                 );
@@ -690,8 +686,6 @@ export class AsyncQueryService extends ProjectService {
                         customLabels,
                         columnOrder,
                         hiddenFields,
-                        chartName,
-                        csvLimit,
                         pivotConfig,
                     },
                 );
@@ -731,8 +725,6 @@ export class AsyncQueryService extends ProjectService {
             customLabels?: Record<string, string>;
             columnOrder?: string[];
             hiddenFields?: string[];
-            chartName?: string;
-            csvLimit?: number | null;
             pivotConfig?: PivotConfig;
         },
     ): Promise<{ fileUrl: string; truncated: boolean }> {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -40,13 +40,11 @@ export type DownloadAsyncQueryResultsArgs = Omit<
 > & {
     queryUuid: string;
     type?: DownloadFileType;
-    csvLimit?: number | null;
     onlyRaw?: boolean;
     showTableNames?: boolean;
     customLabels?: Record<string, string>;
     columnOrder?: string[];
     hiddenFields?: string[];
-    chartName?: string;
     pivotConfig?: PivotConfig;
 };
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -3,6 +3,7 @@ import {
     GroupByColumn,
     ItemsMap,
     MetricQuery,
+    PivotConfig,
     SortBy,
     ValuesColumn,
     type CacheMetadata,
@@ -10,6 +11,7 @@ import {
     type DateGranularity,
     type DateZoom,
     type Filters,
+    type LimitOverride,
     type PivotIndexColum,
     type QueryExecutionContext,
     type ResultsPaginationArgs,
@@ -38,6 +40,14 @@ export type DownloadAsyncQueryResultsArgs = Omit<
 > & {
     queryUuid: string;
     type?: DownloadFileType;
+    csvLimit?: number | null;
+    onlyRaw?: boolean;
+    showTableNames?: boolean;
+    customLabels?: Record<string, string>;
+    columnOrder?: string[];
+    hiddenFields?: string[];
+    chartName?: string;
+    pivotConfig?: PivotConfig;
 };
 
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
@@ -48,6 +58,7 @@ export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
 export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {
     chartUuid: string;
     versionUuid?: string;
+    limit?: LimitOverride;
 };
 
 export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -4,6 +4,7 @@ import {
     DownloadFileType,
     formatItemValue,
     formatRows,
+    getErrorMessage,
     ItemsMap,
     MetricQuery,
     PivotConfig,
@@ -13,12 +14,10 @@ import * as Excel from 'exceljs';
 import moment from 'moment';
 import { createInterface } from 'readline';
 import { Readable, Writable } from 'stream';
+import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
-import {
-    generateGenericFileId,
-    isRowValueDate,
-    isRowValueTimestamp,
-} from '../../utils/FileDownloadUtils';
+import { generateGenericFileId } from '../../utils/FileDownloadUtils';
 
 export class ExcelService {
     static generateFileId(
@@ -44,18 +43,28 @@ export class ExcelService {
             const item = itemMap[fieldId];
             const rawValue = row[fieldId];
 
-            if (!onlyRaw && item) {
-                return formatItemValue(item, rawValue);
+            if (rawValue === null || rawValue === undefined) {
+                return rawValue;
             }
 
-            // Handle date/timestamp conversion for Excel
-            if (
-                isRowValueTimestamp(rawValue, { type: DimensionType.TIMESTAMP })
-            ) {
-                return moment(rawValue).toDate();
+            // If we have item metadata and it's a date/timestamp field, convert for Excel
+            if (item && 'type' in item) {
+                if (item.type === DimensionType.TIMESTAMP) {
+                    return moment(rawValue).toDate();
+                }
+                if (item.type === DimensionType.DATE) {
+                    return moment(rawValue).toDate();
+                }
             }
-            if (isRowValueDate(rawValue, { type: DimensionType.DATE })) {
-                return moment(rawValue).toDate();
+
+            // Return raw value if onlyRaw is true
+            if (onlyRaw) {
+                return rawValue;
+            }
+
+            // Use standard Lightdash formatting if not onlyRaw and we have item metadata
+            if (item) {
+                return formatItemValue(item, rawValue);
             }
 
             return rawValue;
@@ -90,66 +99,21 @@ export class ExcelService {
             fgColor: { argb: 'FFE0E0E0' },
         };
 
-        return new Promise((resolve, reject) => {
-            // Process the readStream line by line
-            const lineReader = createInterface({
-                input: readStream,
-                crlfDelay: Infinity,
-            });
+        // Use shared streaming utility
+        const { truncated } = await ExcelService.streamJsonlData({
+            readStream,
+            onRow: (parsedRow, lineCount) => {
+                const excelRow = ExcelService.convertRowToExcel(
+                    parsedRow,
+                    itemMap,
+                    onlyRaw,
+                    sortedFieldIds,
+                );
+                worksheet.addRow(excelRow);
 
-            let lineCount = 0;
-            const MAX_LINES = 100000; // Configurable limit - Excel has ~1M row limit
-            let truncated = false;
-            let rowIndex = 2; // Start after header
-
-            lineReader.on('line', (line: string) => {
-                if (!line.trim()) return;
-
-                // eslint-disable-next-line no-plusplus
-                lineCount++;
-                if (lineCount > MAX_LINES) {
-                    truncated = true;
-                    lineReader.close();
-                    return;
-                }
-
-                try {
-                    const parsedRow = JSON.parse(line);
-                    const excelRow = ExcelService.convertRowToExcel(
-                        parsedRow,
-                        itemMap,
-                        onlyRaw,
-                        sortedFieldIds,
-                    );
-                    worksheet.addRow(excelRow);
-
-                    // Auto-adjust column widths every 1000 rows for performance
-                    if (rowIndex % 1000 === 0) {
-                        worksheet.columns.forEach((column, index) => {
-                            if (column && excelHeaders[index]) {
-                                const headerLength = excelHeaders[index].length;
-                                // eslint-disable-next-line no-param-reassign
-                                column.width = Math.max(
-                                    column.width || 0,
-                                    headerLength + 2,
-                                    15,
-                                );
-                            }
-                        });
-                    }
-
-                    // eslint-disable-next-line no-plusplus
-                    rowIndex++;
-                } catch (error) {
-                    Logger.error(
-                        `Error processing line ${lineCount}: ${error}`,
-                    );
-                }
-            });
-
-            lineReader.on('close', async () => {
-                try {
-                    // Final column width adjustment
+                // Auto-adjust column widths every 1000 rows for performance
+                const rowIndex = lineCount + 1; // +1 because headers are row 1
+                if (rowIndex % 1000 === 0) {
                     worksheet.columns.forEach((column, index) => {
                         if (column && excelHeaders[index]) {
                             const headerLength = excelHeaders[index].length;
@@ -161,20 +125,29 @@ export class ExcelService {
                             );
                         }
                     });
-
-                    // Write to stream
-                    await workbook.xlsx.write(writeStream);
-                    writeStream.end();
-                    resolve({ truncated });
-                } catch (error) {
-                    reject(error);
                 }
-            });
+            },
+            onComplete: async () => {
+                // Final column width adjustment
+                worksheet.columns.forEach((column, index) => {
+                    if (column && excelHeaders[index]) {
+                        const headerLength = excelHeaders[index].length;
+                        // eslint-disable-next-line no-param-reassign
+                        column.width = Math.max(
+                            column.width || 0,
+                            headerLength + 2,
+                            15,
+                        );
+                    }
+                });
 
-            lineReader.on('error', (error) => {
-                reject(error);
-            });
+                // Write to stream
+                await workbook.xlsx.write(writeStream);
+                writeStream.end();
+            },
         });
+
+        return { truncated };
     }
 
     static async downloadPivotTableXlsx({
@@ -184,7 +157,6 @@ export class ExcelService {
         pivotConfig,
         onlyRaw,
         customLabels,
-        fileName,
         maxColumnLimit,
     }: {
         rows: Record<string, AnyType>[];
@@ -193,7 +165,6 @@ export class ExcelService {
         pivotConfig: PivotConfig;
         onlyRaw: boolean;
         customLabels: Record<string, string> | undefined;
-        fileName: string;
         maxColumnLimit: number;
     }): Promise<Excel.Buffer> {
         // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
@@ -259,5 +230,142 @@ export class ExcelService {
 
         // Write to buffer
         return workbook.xlsx.writeBuffer();
+    }
+
+    /**
+     * Downloads pivot table XLSX from async query results file
+     * Handles loading data from JSONL storage file and generating pivot Excel file
+     */
+    static async downloadAsyncPivotTableXlsx({
+        resultsFileName,
+        fields,
+        metricQuery,
+        storageClient,
+        lightdashConfig,
+        options,
+    }: {
+        resultsFileName: string;
+        fields: ItemsMap;
+        metricQuery: MetricQuery;
+        storageClient: S3ResultsFileStorageClient; // S3ResultsFileStorageClient type
+        lightdashConfig: LightdashConfig;
+        options: {
+            onlyRaw: boolean;
+            showTableNames: boolean;
+            customLabels: Record<string, string>;
+            columnOrder: string[];
+            hiddenFields: string[];
+            pivotConfig: PivotConfig;
+        };
+    }): Promise<{ fileUrl: string; truncated: boolean }> {
+        const { onlyRaw, customLabels, pivotConfig } = options;
+
+        // Load all rows from the results file using shared streaming utility
+        const readStream = await storageClient.getDowloadStream(
+            resultsFileName,
+        );
+        const { results: rows, truncated } = await ExcelService.streamJsonlData<
+            Record<string, unknown>
+        >({
+            readStream,
+            onRow: (parsedRow) => parsedRow, // Just collect all rows
+        });
+
+        if (rows.length === 0) {
+            throw new Error('No data found in results file');
+        }
+
+        const fileName = `pivot-${resultsFileName}`;
+        const formattedFileName = ExcelService.generateFileId(fileName);
+
+        const excelBuffer = await ExcelService.downloadPivotTableXlsx({
+            rows,
+            itemMap: fields,
+            metricQuery,
+            pivotConfig,
+            onlyRaw,
+            customLabels,
+            maxColumnLimit: lightdashConfig.pivotTable.maxColumnLimit,
+        });
+
+        // Upload the Excel buffer to storage using the storage client pattern
+        return storageClient.transformResultsIntoNewFile(
+            resultsFileName,
+            formattedFileName,
+            async (_, writeStream: Writable) => {
+                // We already have the buffer, so just write it directly
+                writeStream.write(Buffer.from(excelBuffer));
+                writeStream.end();
+                return { truncated };
+            },
+        );
+    }
+
+    /**
+     * Shared utility for streaming JSONL data from storage
+     * Can be used for both row-by-row processing and collecting all rows
+     */
+    static async streamJsonlData<T>({
+        readStream,
+        onRow,
+        onComplete,
+        maxLines = 100000,
+    }: {
+        readStream: Readable;
+        onRow?: (
+            parsedRow: Record<string, unknown>,
+            lineCount: number,
+        ) => T | void;
+        onComplete?: (results: T[], truncated: boolean) => void;
+        maxLines?: number;
+    }): Promise<{ results: T[]; truncated: boolean }> {
+        return new Promise((resolve, reject) => {
+            const lineReader = createInterface({
+                input: readStream,
+                crlfDelay: Infinity,
+            });
+
+            let lineCount = 0;
+            let truncated = false;
+            const results: T[] = [];
+
+            lineReader.on('line', (line: string) => {
+                if (!line.trim()) return;
+
+                lineCount += 1;
+                if (lineCount > maxLines) {
+                    truncated = true;
+                    lineReader.close();
+                    return;
+                }
+
+                try {
+                    const parsedRow = JSON.parse(line);
+                    if (onRow) {
+                        const result = onRow(parsedRow, lineCount);
+                        if (result !== undefined) {
+                            results.push(result);
+                        }
+                    }
+                } catch (error) {
+                    Logger.error(
+                        `Error parsing line ${lineCount}: ${getErrorMessage(
+                            error,
+                        )}`,
+                    );
+                }
+            });
+
+            lineReader.on('close', async () => {
+                if (onComplete) {
+                    await onComplete(results, truncated);
+                }
+                resolve({ results, truncated });
+            });
+
+            lineReader.on('error', (error) => {
+                reject(error);
+            });
+        });
     }
 }

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -3,7 +3,11 @@ import {
     DimensionType,
     DownloadFileType,
     formatItemValue,
+    formatRows,
     ItemsMap,
+    MetricQuery,
+    PivotConfig,
+    pivotResultsAsCsv,
 } from '@lightdash/common';
 import * as Excel from 'exceljs';
 import moment from 'moment';
@@ -171,5 +175,89 @@ export class ExcelService {
                 reject(error);
             });
         });
+    }
+
+    static async downloadPivotTableXlsx({
+        rows,
+        itemMap,
+        metricQuery,
+        pivotConfig,
+        onlyRaw,
+        customLabels,
+        fileName,
+        maxColumnLimit,
+    }: {
+        rows: Record<string, AnyType>[];
+        itemMap: ItemsMap;
+        metricQuery: MetricQuery;
+        pivotConfig: PivotConfig;
+        onlyRaw: boolean;
+        customLabels: Record<string, string> | undefined;
+        fileName: string;
+        maxColumnLimit: number;
+    }): Promise<Excel.Buffer> {
+        // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
+        const formattedRows = formatRows(rows, itemMap);
+
+        const csvResults = pivotResultsAsCsv({
+            pivotConfig,
+            rows: formattedRows,
+            itemMap,
+            metricQuery,
+            customLabels,
+            onlyRaw,
+            maxColumnLimit,
+        });
+
+        // Create Excel workbook
+        const workbook = new Excel.Workbook();
+        const worksheet = workbook.addWorksheet('Pivot Table');
+
+        // Add data to worksheet
+        csvResults.forEach((row, index) => {
+            const excelRow = row.map((value) => {
+                // Handle date/timestamp conversion for Excel
+                if (typeof value === 'string') {
+                    // Check if it looks like a date/timestamp
+                    const dateValue = moment(value, moment.ISO_8601, true);
+                    if (dateValue.isValid()) {
+                        return dateValue.toDate();
+                    }
+                }
+                return value;
+            });
+            worksheet.addRow(excelRow);
+
+            // Style headers (first row)
+            if (index === 0) {
+                const headerRow = worksheet.getRow(1);
+                headerRow.font = { bold: true };
+                headerRow.fill = {
+                    type: 'pattern',
+                    pattern: 'solid',
+                    fgColor: { argb: 'FFE0E0E0' },
+                };
+            }
+        });
+
+        // Auto-adjust column widths
+        worksheet.columns.forEach((column, index) => {
+            if (column) {
+                let maxLength = 0;
+                csvResults.forEach((row) => {
+                    if (
+                        row[index] &&
+                        row[index].toString().length > maxLength
+                    ) {
+                        maxLength = row[index].toString().length;
+                    }
+                });
+                // eslint-disable-next-line no-param-reassign
+                column.width = Math.min(Math.max(maxLength + 2, 10), 50);
+            }
+        });
+
+        // Write to buffer
+        return workbook.xlsx.writeBuffer();
     }
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -514,6 +514,7 @@ export class ServiceRepository
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
                     storageClient: this.clients.getResultsFileStorageClient(),
+                    csvService: this.getCsvService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1562,3 +1562,12 @@ export const SPACE_TREE_2: TreeCreateSpace[] = [
         ],
     },
 ] as const;
+
+// Export limit utilities
+export {
+    applyLimitOverrideToQuery,
+    isUnlimitedResults,
+    processLimitOverride,
+    QUERY_LIMITS,
+    type LimitOverride,
+} from './utils/fileDownloadLimit';

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -4,9 +4,12 @@ import {
     type SortBy,
     type ValuesColumn,
 } from '../..';
+import type { LimitOverride } from '../../utils/fileDownloadLimit';
 import type { QueryExecutionContext } from '../analytics';
+import type { DownloadFileType } from '../downloadFile';
 import type { DashboardFilters, Filters } from '../filter';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
+import type { PivotConfig } from '../pivot';
 import type { DateGranularity } from '../timeFrames';
 
 type CommonPaginatedQueryRequestParams = {
@@ -29,6 +32,13 @@ export type ExecuteAsyncSavedChartRequestParams =
     CommonPaginatedQueryRequestParams & {
         chartUuid: string;
         versionUuid?: string;
+        /**
+         * Limit override for query execution:
+         * - undefined: use saved chart's original limit
+         * - null: no limit (unlimited results)
+         * - number: apply specific limit
+         */
+        limit?: LimitOverride;
     };
 
 export type ExecuteAsyncDashboardChartRequestParams =
@@ -111,6 +121,15 @@ export const isExecuteAsyncDashboardSqlChartByUuidParams = (
 
 export type DownloadAsyncQueryResultsRequestParams = {
     queryUuid: string;
+    type?: DownloadFileType;
+    csvLimit?: number | null;
+    onlyRaw?: boolean;
+    showTableNames?: boolean;
+    customLabels?: Record<string, string>;
+    columnOrder?: string[];
+    hiddenFields?: string[];
+    chartName?: string;
+    pivotConfig?: PivotConfig;
 };
 
 export type ExecuteAsyncQueryRequestParams =

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -122,13 +122,11 @@ export const isExecuteAsyncDashboardSqlChartByUuidParams = (
 export type DownloadAsyncQueryResultsRequestParams = {
     queryUuid: string;
     type?: DownloadFileType;
-    csvLimit?: number | null;
     onlyRaw?: boolean;
     showTableNames?: boolean;
     customLabels?: Record<string, string>;
     columnOrder?: string[];
     hiddenFields?: string[];
-    chartName?: string;
     pivotConfig?: PivotConfig;
 };
 

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -1,3 +1,5 @@
+import { type PivotConfig } from './pivot';
+
 export enum DownloadFileType {
     CSV = 'csv',
     IMAGE = 'image',
@@ -11,4 +13,19 @@ export type DownloadFile = {
     path: string;
     createdAt: Date;
     type: DownloadFileType;
+};
+
+/**
+ * Backwards compatible options for downloading query results
+ */
+export type DownloadOptions = {
+    fileType?: DownloadFileType;
+    csvLimit?: number | null;
+    onlyRaw?: boolean;
+    showTableNames?: boolean;
+    customLabels?: Record<string, string>;
+    columnOrder?: string[];
+    hiddenFields?: string[];
+    chartName?: string;
+    pivotConfig?: PivotConfig;
 };

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -20,12 +20,10 @@ export type DownloadFile = {
  */
 export type DownloadOptions = {
     fileType?: DownloadFileType;
-    csvLimit?: number | null;
     onlyRaw?: boolean;
     showTableNames?: boolean;
     customLabels?: Record<string, string>;
     columnOrder?: string[];
     hiddenFields?: string[];
-    chartName?: string;
     pivotConfig?: PivotConfig;
 };

--- a/packages/common/src/utils/fileDownloadLimit.ts
+++ b/packages/common/src/utils/fileDownloadLimit.ts
@@ -1,0 +1,61 @@
+/**
+ * Constants for query limit handling
+ */
+export const QUERY_LIMITS = {
+    // Use a very high number to represent "unlimited" since MetricQuery requires a limit field
+    UNLIMITED: Number.MAX_SAFE_INTEGER,
+} as const;
+
+/**
+ * Represents different limit override behaviors
+ * - undefined: use original limit from saved chart/query
+ * - null: no limit (unlimited results)
+ * - number: apply specific limit
+ */
+export type LimitOverride = number | null | undefined;
+
+/**
+ * Processes a limit override and returns the effective limit to use
+ * @param originalLimit - The original limit from the saved chart/query
+ * @param limitOverride - The limit override from the request
+ * @returns The effective limit to apply
+ */
+export function processLimitOverride(
+    originalLimit: number,
+    limitOverride: LimitOverride,
+): number {
+    if (limitOverride === undefined) {
+        // Use the original limit
+        return originalLimit;
+    }
+    if (limitOverride === null) {
+        // No limit - return unlimited constant
+        return QUERY_LIMITS.UNLIMITED;
+    }
+    // Apply the specific limit
+    return limitOverride;
+}
+
+/**
+ * Applies a limit override to a MetricQuery, returning a new query with the updated limit
+ * @param metricQuery - The original metric query
+ * @param limitOverride - The limit override to apply
+ * @returns A new MetricQuery with the updated limit
+ */
+export function applyLimitOverrideToQuery<T extends { limit: number }>(
+    metricQuery: T,
+    limitOverride: LimitOverride,
+): T {
+    const effectiveLimit = processLimitOverride(
+        metricQuery.limit,
+        limitOverride,
+    );
+    return { ...metricQuery, limit: effectiveLimit };
+}
+
+/**
+ * Type guard to check if a limit represents unlimited results
+ */
+export function isUnlimitedResults(limit: number): boolean {
+    return limit >= QUERY_LIMITS.UNLIMITED;
+}

--- a/packages/common/src/utils/fileDownloadLimit.ts
+++ b/packages/common/src/utils/fileDownloadLimit.ts
@@ -2,8 +2,9 @@
  * Constants for query limit handling
  */
 export const QUERY_LIMITS = {
-    // Use a very high number to represent "unlimited" since MetricQuery requires a limit field
-    UNLIMITED: Number.MAX_SAFE_INTEGER,
+    // Use a high but safe number to represent "unlimited" since MetricQuery requires a limit field
+    // This value is chosen to be high enough for practical unlimited use but low enough to avoid backend maxLimit issues
+    UNLIMITED: 50000,
 } as const;
 
 /**

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -120,11 +120,15 @@ describe('Download CSV on Explore', () => {
             cy.findByTestId('page-spinner').should('not.exist');
 
             // choose table and select fields
-            cy.findByText('Orders').click();
+            cy.get('[data-testid="common-sidebar"]').within(() => {
+                cy.findByText('Orders').click();
+            });
             cy.findByText('Order date').should('be.visible'); // Wait for Orders table columns to appear
-            cy.findByText('Customers').click();
-            cy.findByText('First name').click();
-            cy.findByText('Unique order count').click();
+            cy.get('[data-testid="common-sidebar"]').within(() => {
+                cy.findByText('Customers').click();
+                cy.findByText('First name').click();
+                cy.findByText('Unique order count').click();
+            });
 
             // run query
             cy.get('button').contains('Run query').click();

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -73,7 +73,7 @@ describe('Download CSV on Explore', () => {
         'Should download CSV from results on Explore',
         { retries: 3, pageLoadTimeout: 1000 },
         () => {
-            const downloadUrl = `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/orders/downloadCsv`;
+            const downloadUrl = `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/*/download`;
             cy.intercept({
                 method: 'POST',
                 url: downloadUrl,
@@ -93,8 +93,7 @@ describe('Download CSV on Explore', () => {
 
             cy.get('[data-testid=export-csv-button]').eq(1).click();
             cy.get('[data-testid=chart-export-csv-button]').click();
-
-            cy.findByText('Export CSV').click();
+            cy.get('[data-testid=chart-export-results-button]').eq(1).click();
 
             cy.wait('@apiDownloadCsv', { timeout: 3000 }).then(
                 (interception) => {
@@ -110,7 +109,7 @@ describe('Download CSV on Explore', () => {
         'Should download CSV from table chart on Explore',
         { retries: 3, pageLoadTimeout: 1000 },
         () => {
-            const downloadUrl = `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/orders/downloadCsv`;
+            const downloadUrl = `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/*/download`;
             cy.intercept({
                 method: 'POST',
                 url: downloadUrl,
@@ -141,6 +140,7 @@ describe('Download CSV on Explore', () => {
             // find by role and text
             cy.get('[data-testid=export-csv-button]').click();
             cy.get('[data-testid=chart-export-csv-button]').click();
+            cy.get('[data-testid=chart-export-results-button]').eq(1).click();
 
             cy.wait('@apiDownloadCsv').then((interception) => {
                 expect(interception?.response?.statusCode).to.eq(200);

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -71,7 +71,7 @@ describe('Download CSV on Explore', () => {
 
     it(
         'Should download CSV from results on Explore',
-        { retries: 3, pageLoadTimeout: 1000 },
+        { retries: 1, pageLoadTimeout: 1000 },
         () => {
             const downloadUrl = `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/*/download`;
             cy.intercept({
@@ -80,6 +80,7 @@ describe('Download CSV on Explore', () => {
             }).as('apiDownloadCsv');
             // choose table and select fields
             cy.findByText('Orders').click();
+            cy.findByText('Order date').should('be.visible'); // Wait for Orders table columns to appear
             cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();
@@ -119,6 +120,7 @@ describe('Download CSV on Explore', () => {
 
             // choose table and select fields
             cy.findByText('Orders').click();
+            cy.findByText('Order date').should('be.visible'); // Wait for Orders table columns to appear
             cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -91,12 +91,10 @@ describe('Download CSV on Explore', () => {
             // wait for the chart to finish loading
             cy.findByText('Loading chart').should('not.exist');
             cy.findByText('Loading results').should('not.exist');
-
-            cy.get('[data-testid=export-csv-button]').click();
-            cy.get('[data-testid=chart-export-csv-button]').should(
-                'be.visible',
-            );
-            cy.get('[data-testid=chart-export-csv-button]').click();
+            // Close chart cart
+            cy.findByTestId('Chart-card-expand').click();
+            // Export results
+            cy.get('[data-testid=export-csv-button]').first().click();
             cy.get('[data-testid=chart-export-results-button]').click();
 
             cy.wait('@apiDownload', { timeout: 3000 }).then((interception) => {
@@ -139,17 +137,13 @@ describe('Download CSV on Explore', () => {
             cy.get('[data-testid=Results-card-expand]').click();
 
             // wait for chart to be expanded and configure button to be available, then change chart type to Table
-            cy.findByText('Configure').should('be.visible');
+            cy.get('[data-testid=Chart-card-expand]').click();
             cy.findByText('Configure').click();
             cy.get('button').contains('Bar chart').click();
             cy.get('[role="menuitem"]').contains('Table').click();
 
             // find by role and text
-            cy.get('[data-testid=export-csv-button]').click();
-            cy.get('[data-testid=chart-export-csv-button]').should(
-                'be.visible',
-            );
-            cy.get('[data-testid=chart-export-csv-button]').click();
+            cy.get('[data-testid=export-csv-button]').first().click();
             cy.get('[data-testid=chart-export-results-button]').click();
 
             cy.wait('@apiDownload').then((interception) => {

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -91,16 +91,16 @@ describe('Download CSV on Explore', () => {
             cy.findByText('Loading chart').should('not.exist');
             cy.findByText('Loading results').should('not.exist');
 
-            cy.get('[data-testid=export-csv-button]').eq(1).click();
+            cy.get('[data-testid=export-csv-button]').click();
             cy.get('[data-testid=chart-export-csv-button]').click();
-            cy.get('[data-testid=chart-export-results-button]').eq(1).click();
+            cy.get('[data-testid=chart-export-results-button]').click();
 
             cy.wait('@apiDownloadCsv', { timeout: 3000 }).then(
                 (interception) => {
                     expect(interception?.response?.statusCode).to.eq(200);
                     expect(
                         interception?.response?.body.results,
-                    ).to.have.property('jobId');
+                    ).to.have.property('fileUrl');
                 },
             );
         },
@@ -140,13 +140,13 @@ describe('Download CSV on Explore', () => {
             // find by role and text
             cy.get('[data-testid=export-csv-button]').click();
             cy.get('[data-testid=chart-export-csv-button]').click();
-            cy.get('[data-testid=chart-export-results-button]').eq(1).click();
+            cy.get('[data-testid=chart-export-results-button]').click();
 
             cy.wait('@apiDownloadCsv').then((interception) => {
                 expect(interception?.response?.statusCode).to.eq(200);
 
                 expect(interception?.response?.body.results).to.have.property(
-                    'jobId',
+                    'fileUrl',
                 );
             });
         },

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,4 +1,8 @@
 import { subject } from '@casl/ability';
+import {
+    getCustomLabelsFromTableConfig,
+    getHiddenTableFields,
+} from '@lightdash/common';
 import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -49,6 +53,16 @@ const ResultsCard: FC = memo(() => {
     const getDownloadQueryUuid = useExplorerContext(
         (context) => context.actions.getDownloadQueryUuid,
     );
+
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
+    );
+
+    const customLabels = getCustomLabelsFromTableConfig(
+        unsavedChartVersion.chartConfig.config,
+    );
+
+    const hiddenFields = getHiddenTableFields(unsavedChartVersion.chartConfig);
 
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
@@ -133,6 +147,8 @@ const ResultsCard: FC = memo(() => {
                                         }
                                         getGsheetLink={getGsheetLink}
                                         columnOrder={columnOrder}
+                                        customLabels={customLabels}
+                                        hiddenFields={hiddenFields}
                                         showTableNames
                                     />
                                 </Popover.Dropdown>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { getPivotConfig, type PivotConfig } from '@lightdash/common';
 import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -50,9 +51,18 @@ const ResultsCard: FC = memo(() => {
         (context) => context.actions.getDownloadQueryUuid,
     );
 
+    const unsavedChartVersion = useExplorerContext(
+        (context) => context.state.unsavedChartVersion,
+    );
+
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    // Build pivot config from unsavedChartVersion data
+    const pivotConfig: PivotConfig | undefined = useMemo(() => {
+        return getPivotConfig(unsavedChartVersion);
+    }, [unsavedChartVersion]);
 
     const getGsheetLink = async () => {
         if (projectUuid) {
@@ -62,6 +72,7 @@ const ResultsCard: FC = memo(() => {
                 metricQuery,
                 columnOrder,
                 showTableNames: true,
+                pivotConfig,
             });
         } else {
             throw new Error('Project UUID is missing');
@@ -131,7 +142,8 @@ const ResultsCard: FC = memo(() => {
                                         }
                                         getGsheetLink={getGsheetLink}
                                         columnOrder={columnOrder}
-                                        showTableNames={false}
+                                        showTableNames
+                                        pivotConfig={pivotConfig}
                                     />
                                 </Popover.Dropdown>
                             </Popover>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,5 +1,4 @@
 import { subject } from '@casl/ability';
-import { getPivotConfig, type PivotConfig } from '@lightdash/common';
 import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -51,33 +50,9 @@ const ResultsCard: FC = memo(() => {
         (context) => context.actions.getDownloadQueryUuid,
     );
 
-    const unsavedChartVersion = useExplorerContext(
-        (context) => context.state.unsavedChartVersion,
-    );
-
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
-
-    // Build pivot config from unsavedChartVersion data
-    const pivotConfig: PivotConfig | undefined = useMemo(() => {
-        return getPivotConfig(unsavedChartVersion);
-    }, [unsavedChartVersion]);
-
-    const getGsheetLink = async () => {
-        if (projectUuid) {
-            return uploadGsheet({
-                projectUuid,
-                exploreId: tableName,
-                metricQuery,
-                columnOrder,
-                showTableNames: true,
-                pivotConfig,
-            });
-        } else {
-            throw new Error('Project UUID is missing');
-        }
-    };
 
     const resultsIsOpen = useMemo(
         () => expandedSections.includes(ExplorerSection.RESULTS),
@@ -88,6 +63,22 @@ const ResultsCard: FC = memo(() => {
         [toggleExpandedSection],
     );
     const { user } = useApp();
+
+    const getGsheetLink = async () => {
+        if (projectUuid) {
+            return uploadGsheet({
+                projectUuid,
+                exploreId: tableName,
+                metricQuery,
+                columnOrder,
+                showTableNames: true,
+                // No pivotConfig - ResultsCard only shows raw table data
+            });
+        } else {
+            throw new Error('Project UUID is missing');
+        }
+    };
+
     return (
         <CollapsableCard
             title="Results"
@@ -143,7 +134,6 @@ const ResultsCard: FC = memo(() => {
                                         getGsheetLink={getGsheetLink}
                                         columnOrder={columnOrder}
                                         showTableNames
-                                        pivotConfig={pivotConfig}
                                     />
                                 </Popover.Dropdown>
                             </Popover>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -3,7 +3,6 @@ import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
-import { downloadCsv } from '../../../api/csv';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -47,26 +46,13 @@ const ResultsCard: FC = memo(() => {
     const columnOrder = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
     );
+    const getDownloadQueryUuid = useExplorerContext(
+        (context) => context.actions.getDownloadQueryUuid,
+    );
 
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const getCsvLink = async (csvLimit: number | null, onlyRaw: boolean) => {
-        if (projectUuid) {
-            return downloadCsv({
-                projectUuid,
-                tableId: tableName,
-                query: metricQuery,
-                csvLimit,
-                onlyRaw,
-                columnOrder,
-                showTableNames: true,
-                pivotConfig: undefined, // results are always unpivoted
-            });
-        } else {
-            throw new Error('Project UUID is missing');
-        }
-    };
 
     const getGsheetLink = async () => {
         if (projectUuid) {
@@ -140,8 +126,12 @@ const ResultsCard: FC = memo(() => {
                                     <ExportSelector
                                         projectUuid={projectUuid}
                                         totalResults={totalResults}
-                                        getCsvLink={getCsvLink}
+                                        getDownloadQueryUuid={
+                                            getDownloadQueryUuid
+                                        }
                                         getGsheetLink={getGsheetLink}
+                                        columnOrder={columnOrder}
+                                        showTableNames={false}
                                     />
                                 </Popover.Dropdown>
                             </Popover>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,11 +1,8 @@
 import {
     ECHARTS_DEFAULT_COLORS,
-    getCustomLabelsFromTableConfig,
     getHiddenTableFields,
     getPivotConfig,
-    isTableChartConfig,
     NotFoundError,
-    type PivotConfig,
 } from '@lightdash/common';
 import { useDisclosure } from '@mantine/hooks';
 import { type FC, memo, useCallback, useMemo, useState } from 'react';
@@ -122,26 +119,23 @@ const VisualizationCard: FC<{
         return <CollapsableCard title="Charts" disabled />;
     }
 
-    const getGsheetLink = async (pivotConfig?: PivotConfig) => {
+    const getGsheetLink = async (
+        columnOrder: string[],
+        showTableNames: boolean,
+        customLabels?: Record<string, string>,
+    ) => {
         if (explore?.name && unsavedChartVersion?.metricQuery && projectUuid) {
             const gsheetResponse = await uploadGsheet({
                 projectUuid,
                 exploreId: explore?.name,
                 metricQuery: unsavedChartVersion?.metricQuery,
-                columnOrder: unsavedChartVersion.tableConfig.columnOrder,
-                showTableNames: isTableChartConfig(
-                    unsavedChartVersion.chartConfig.config,
-                )
-                    ? unsavedChartVersion.chartConfig.config.showTableNames ??
-                      true
-                    : true,
-                customLabels: getCustomLabelsFromTableConfig(
-                    unsavedChartVersion.chartConfig.config,
-                ),
+                columnOrder,
+                showTableNames,
+                customLabels,
                 hiddenFields: getHiddenTableFields(
                     unsavedChartVersion.chartConfig,
                 ),
-                pivotConfig: pivotConfig || getPivotConfig(unsavedChartVersion),
+                pivotConfig: getPivotConfig(unsavedChartVersion),
             });
             return gsheetResponse;
         }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,8 +1,11 @@
 import {
     ECHARTS_DEFAULT_COLORS,
+    getCustomLabelsFromTableConfig,
     getHiddenTableFields,
     getPivotConfig,
+    isTableChartConfig,
     NotFoundError,
+    type PivotConfig,
 } from '@lightdash/common';
 import { useDisclosure } from '@mantine/hooks';
 import { type FC, memo, useCallback, useMemo, useState } from 'react';
@@ -119,23 +122,26 @@ const VisualizationCard: FC<{
         return <CollapsableCard title="Charts" disabled />;
     }
 
-    const getGsheetLink = async (
-        columnOrder: string[],
-        showTableNames: boolean,
-        customLabels?: Record<string, string>,
-    ) => {
+    const getGsheetLink = async (pivotConfig?: PivotConfig) => {
         if (explore?.name && unsavedChartVersion?.metricQuery && projectUuid) {
             const gsheetResponse = await uploadGsheet({
                 projectUuid,
                 exploreId: explore?.name,
                 metricQuery: unsavedChartVersion?.metricQuery,
-                columnOrder,
-                showTableNames,
-                customLabels,
+                columnOrder: unsavedChartVersion.tableConfig.columnOrder,
+                showTableNames: isTableChartConfig(
+                    unsavedChartVersion.chartConfig.config,
+                )
+                    ? unsavedChartVersion.chartConfig.config.showTableNames ??
+                      true
+                    : true,
+                customLabels: getCustomLabelsFromTableConfig(
+                    unsavedChartVersion.chartConfig.config,
+                ),
                 hiddenFields: getHiddenTableFields(
                     unsavedChartVersion.chartConfig,
                 ),
-                pivotConfig: getPivotConfig(unsavedChartVersion),
+                pivotConfig: pivotConfig || getPivotConfig(unsavedChartVersion),
             });
             return gsheetResponse;
         }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -6,7 +6,6 @@ import {
 } from '@lightdash/common';
 import { useDisclosure } from '@mantine/hooks';
 import { type FC, memo, useCallback, useMemo, useState } from 'react';
-import { downloadCsv } from '../../../api/csv';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import { type EChartSeries } from '../../../hooks/echarts/useEchartsCartesianConfig';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
@@ -80,6 +79,9 @@ const VisualizationCard: FC<{
     const tableCalculationsMetadata = useExplorerContext(
         (context) => context.state.metadata?.tableCalculations,
     );
+    const getDownloadQueryUuid = useExplorerContext(
+        (context) => context.actions.getDownloadQueryUuid,
+    );
 
     const isOpen = useMemo(
         () => expandedSections.includes(ExplorerSection.VISUALIZATION),
@@ -117,32 +119,6 @@ const VisualizationCard: FC<{
         return <CollapsableCard title="Charts" disabled />;
     }
 
-    const getCsvLink = async (
-        csvLimit: number | null,
-        onlyRaw: boolean,
-        showTableNames: boolean,
-        columnOrder: string[],
-        customLabels?: Record<string, string>,
-    ) => {
-        if (explore?.name && unsavedChartVersion?.metricQuery && projectUuid) {
-            const csvResponse = await downloadCsv({
-                projectUuid,
-                tableId: explore?.name,
-                query: unsavedChartVersion.metricQuery,
-                csvLimit,
-                onlyRaw,
-                showTableNames,
-                columnOrder: columnOrder,
-                customLabels,
-                hiddenFields: getHiddenTableFields(
-                    unsavedChartVersion.chartConfig,
-                ),
-                pivotConfig: getPivotConfig(unsavedChartVersion),
-            });
-            return csvResponse;
-        }
-        throw new NotFoundError('no metric query defined');
-    };
     const getGsheetLink = async (
         columnOrder: string[],
         showTableNames: boolean,
@@ -211,7 +187,9 @@ const VisualizationCard: FC<{
                                 ) : null}
                                 {!!projectUuid && (
                                     <ChartDownloadMenu
-                                        getCsvLink={getCsvLink}
+                                        getDownloadQueryUuid={
+                                            getDownloadQueryUuid
+                                        }
                                         projectUuid={projectUuid}
                                         getGsheetLink={getGsheetLink}
                                     />

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -1,0 +1,229 @@
+import { subject } from '@casl/ability';
+import { DownloadFileType } from '@lightdash/common';
+import {
+    Alert,
+    Box,
+    Button,
+    NumberInput,
+    SegmentedControl,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconTableExport } from '@tabler/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { memo, useState, type FC } from 'react';
+import useHealth from '../../hooks/health/useHealth';
+import useToaster from '../../hooks/toaster/useToaster';
+import { downloadQuery } from '../../hooks/useQueryResults';
+import useUser from '../../hooks/user/useUser';
+import { Can } from '../../providers/Ability';
+import MantineIcon from '../common/MantineIcon';
+
+enum Limit {
+    TABLE = 'table',
+    ALL = 'all',
+    CUSTOM = 'custom',
+}
+
+enum Values {
+    FORMATTED = 'formatted',
+    RAW = 'raw',
+}
+
+export type ExportResultsProps = {
+    projectUuid: string;
+    totalResults: number | undefined;
+    getDownloadQueryUuid: (limit: number | null) => Promise<string>;
+    columnOrder?: string[];
+    customLabels?: Record<string, string>;
+    hiddenFields?: string[];
+    showTableNames?: boolean;
+    chartName?: string;
+};
+
+const TOAST_KEY = 'exporting-results';
+
+const ExportResults: FC<ExportResultsProps> = memo(
+    ({
+        projectUuid,
+        totalResults,
+        getDownloadQueryUuid,
+        columnOrder,
+        customLabels,
+        hiddenFields,
+        showTableNames,
+        chartName,
+    }) => {
+        const { showToastError, showToastInfo, showToastWarning } =
+            useToaster();
+
+        const user = useUser(true);
+        const [limit, setLimit] = useState<string>(Limit.TABLE);
+        const [customLimit, setCustomLimit] = useState<number>(1);
+        const [format, setFormat] = useState<string>(Values.FORMATTED);
+        const [fileType, setFileType] = useState<DownloadFileType>(
+            DownloadFileType.CSV,
+        );
+        const health = useHealth();
+
+        const { isLoading: isExporting, mutateAsync: exportMutation } =
+            useMutation(
+                ['export-results', fileType],
+                async () => {
+                    const queryUuid = await getDownloadQueryUuid(
+                        limit === Limit.CUSTOM
+                            ? customLimit
+                            : limit === Limit.TABLE
+                            ? totalResults ?? 0
+                            : null,
+                    );
+                    return downloadQuery(projectUuid, queryUuid, {
+                        fileType,
+                        onlyRaw: format === Values.RAW,
+                        columnOrder,
+                        customLabels,
+                        hiddenFields,
+                        showTableNames,
+                        chartName,
+                    });
+                },
+                {
+                    onMutate: () => {
+                        showToastInfo({
+                            title: 'Exporting results',
+                            subtitle: 'This may take a few minutes...',
+                            loading: true,
+                            key: TOAST_KEY,
+                            autoClose: false,
+                        });
+                    },
+                    onSuccess: (response) => {
+                        // Download file
+                        const link = document.createElement('a');
+                        link.href = response.fileUrl;
+                        link.setAttribute('download', ''); // empty value so browser picks the file name.
+                        document.body.appendChild(link);
+                        link.click();
+                        link.remove(); // Remove the link from the DOM
+                        // Hide toast
+                        notifications.hide(TOAST_KEY);
+
+                        if (response.truncated) {
+                            showToastWarning({
+                                title: `The results in this export have been limited.`,
+                                subtitle: `The export limit is ${health.data?.query.csvCellsLimit} cells, but your file exceeded that limit.`,
+                            });
+                        }
+                    },
+                    onError: (error: { error: Error }) => {
+                        notifications.hide(TOAST_KEY);
+
+                        showToastError({
+                            title: `Unable to download results`,
+                            subtitle: error?.error?.message,
+                        });
+                    },
+                },
+            );
+
+        if (!totalResults || totalResults <= 0) {
+            return <Alert color="gray">No data to export</Alert>;
+        }
+
+        return (
+            <Box>
+                <Stack spacing="xs" miw={300}>
+                    <SegmentedControl
+                        size={'xs'}
+                        value={fileType}
+                        onChange={(value) =>
+                            setFileType(value as DownloadFileType)
+                        }
+                        data={[
+                            { label: 'CSV', value: DownloadFileType.CSV },
+                            { label: 'XLSX', value: DownloadFileType.XLSX },
+                        ]}
+                    />
+
+                    <Stack spacing="xs">
+                        <Box>Values</Box>
+                        <SegmentedControl
+                            size={'xs'}
+                            value={format}
+                            onChange={(value) => setFormat(value)}
+                            data={[
+                                { label: 'Formatted', value: Values.FORMATTED },
+                                { label: 'Raw', value: Values.RAW },
+                            ]}
+                        />
+                    </Stack>
+
+                    <Can
+                        I="manage"
+                        this={subject('ChangeCsvResults', {
+                            organizationUuid: user.data?.organizationUuid,
+                            projectUuid: projectUuid,
+                        })}
+                    >
+                        <Stack spacing="xs">
+                            <Box>Limit</Box>
+                            <SegmentedControl
+                                size={'xs'}
+                                value={limit}
+                                onChange={(value) => setLimit(value)}
+                                data={[
+                                    {
+                                        label: 'Results in Table',
+                                        value: Limit.TABLE,
+                                    },
+                                    { label: 'All Results', value: Limit.ALL },
+                                    { label: 'Custom...', value: Limit.CUSTOM },
+                                ]}
+                            />
+                        </Stack>
+                    </Can>
+
+                    {limit === Limit.CUSTOM && (
+                        <NumberInput
+                            w="100%"
+                            size="xs"
+                            min={1}
+                            precision={0}
+                            required
+                            value={customLimit}
+                            onChange={(value) => setCustomLimit(Number(value))}
+                        />
+                    )}
+
+                    {(limit === Limit.ALL || limit === Limit.CUSTOM) && (
+                        <Alert color="gray.9" p="xs">
+                            <Text size="xs">
+                                Results are limited to{' '}
+                                {Number(
+                                    health.data?.query.csvCellsLimit || 100000,
+                                ).toLocaleString()}{' '}
+                                cells for each file
+                            </Text>
+                        </Alert>
+                    )}
+
+                    <Button
+                        loading={isExporting}
+                        compact
+                        sx={{
+                            alignSelf: 'end',
+                        }}
+                        leftIcon={<MantineIcon icon={IconTableExport} />}
+                        onClick={exportMutation}
+                        data-testid="chart-export-results-button"
+                    >
+                        Download
+                    </Button>
+                </Stack>
+            </Box>
+        );
+    },
+);
+
+export default ExportResults;

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -1,5 +1,9 @@
 import { subject } from '@casl/ability';
-import { DownloadFileType } from '@lightdash/common';
+import {
+    DownloadFileType,
+    formatDate,
+    type PivotConfig,
+} from '@lightdash/common';
 import {
     Alert,
     Box,
@@ -40,6 +44,7 @@ export type ExportResultsProps = {
     hiddenFields?: string[];
     showTableNames?: boolean;
     chartName?: string;
+    pivotConfig?: PivotConfig;
 };
 
 const TOAST_KEY = 'exporting-results';
@@ -54,6 +59,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         hiddenFields,
         showTableNames,
         chartName,
+        pivotConfig,
     }) => {
         const { showToastError, showToastInfo, showToastWarning } =
             useToaster();
@@ -85,7 +91,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         customLabels,
                         hiddenFields,
                         showTableNames,
-                        chartName,
+                        pivotConfig,
                     });
                 },
                 {
@@ -102,7 +108,13 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         // Download file
                         const link = document.createElement('a');
                         link.href = response.fileUrl;
-                        link.setAttribute('download', ''); // empty value so browser picks the file name.
+                        console.log({ chartName });
+                        link.setAttribute(
+                            'download',
+                            `${chartName || 'results'}_${formatDate(
+                                new Date(),
+                            )}.${fileType}`,
+                        );
                         document.body.appendChild(link);
                         link.click();
                         link.remove(); // Remove the link from the DOM

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -108,7 +108,6 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         // Download file
                         const link = document.createElement('a');
                         link.href = response.fileUrl;
-                        console.log({ chartName });
                         link.setAttribute(
                             'download',
                             `${chartName || 'results'}_${formatDate(

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -3,6 +3,7 @@ import {
     type ApiDownloadCsv,
     type ApiError,
     type ApiScheduledDownloadCsv,
+    type PivotConfig,
 } from '@lightdash/common';
 import { Button, Stack } from '@mantine/core';
 import { IconArrowLeft, IconFileTypeCsv } from '@tabler/icons-react';
@@ -16,6 +17,7 @@ import MantineIcon from '../common/MantineIcon';
 const ExportSelector: FC<
     ExportResultsProps & {
         getGsheetLink?: () => Promise<ApiScheduledDownloadCsv>;
+        pivotConfig?: PivotConfig;
     }
 > = memo(
     ({
@@ -28,6 +30,7 @@ const ExportSelector: FC<
         hiddenFields,
         showTableNames,
         chartName,
+        pivotConfig,
     }) => {
         const health = useHealth();
         const hasGoogleDrive =
@@ -66,6 +69,7 @@ const ExportSelector: FC<
                         hiddenFields={hiddenFields}
                         showTableNames={showTableNames}
                         chartName={chartName}
+                        pivotConfig={pivotConfig}
                     />
                 </>
             );
@@ -97,6 +101,7 @@ const ExportSelector: FC<
                 hiddenFields={hiddenFields}
                 showTableNames={showTableNames}
                 chartName={chartName}
+                pivotConfig={pivotConfig}
             />
         );
     },

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -10,73 +10,96 @@ import { useQuery } from '@tanstack/react-query';
 import { memo, useState, type FC } from 'react';
 import { ExportToGoogleSheet } from '../../features/export';
 import useHealth from '../../hooks/health/useHealth';
-import ExportCSV, { type ExportCSVProps } from '../ExportCSV';
+import ExportResults, { type ExportResultsProps } from '../ExportResults';
 import MantineIcon from '../common/MantineIcon';
 
 const ExportSelector: FC<
-    ExportCSVProps & {
+    ExportResultsProps & {
         getGsheetLink?: () => Promise<ApiScheduledDownloadCsv>;
     }
-> = memo(({ projectUuid, totalResults, getCsvLink, getGsheetLink }) => {
-    const health = useHealth();
-    const hasGoogleDrive =
-        health.data?.auth.google.oauth2ClientId !== undefined &&
-        health.data?.auth.google.googleDriveApiKey !== undefined;
+> = memo(
+    ({
+        projectUuid,
+        totalResults,
+        getDownloadQueryUuid,
+        getGsheetLink,
+        columnOrder,
+        customLabels,
+        hiddenFields,
+        showTableNames,
+        chartName,
+    }) => {
+        const health = useHealth();
+        const hasGoogleDrive =
+            health.data?.auth.google.oauth2ClientId !== undefined &&
+            health.data?.auth.google.googleDriveApiKey !== undefined;
 
-    const [exportType, setExportType] = useState<string | undefined>();
+        const [exportType, setExportType] = useState<string | undefined>();
 
-    const { data } = useQuery<ApiDownloadCsv | undefined, ApiError>({
-        queryKey: [`google-sheets`],
-        enabled: false,
-    });
+        const { data } = useQuery<ApiDownloadCsv | undefined, ApiError>({
+            queryKey: [`google-sheets`],
+            enabled: false,
+        });
 
-    const isExportingGoogleSheets = data?.status === SchedulerJobStatus.STARTED;
+        const isExportingGoogleSheets =
+            data?.status === SchedulerJobStatus.STARTED;
 
-    if (exportType === 'csv') {
+        if (exportType === 'csv') {
+            return (
+                <>
+                    <Button
+                        color="gray.6"
+                        size="xs"
+                        mb="xs"
+                        leftIcon={<IconArrowLeft size="16" />}
+                        variant="subtle"
+                        onClick={() => setExportType(undefined)}
+                    >
+                        Back to export selector
+                    </Button>
+                    <ExportResults
+                        totalResults={totalResults}
+                        getDownloadQueryUuid={getDownloadQueryUuid}
+                        projectUuid={projectUuid}
+                        columnOrder={columnOrder}
+                        customLabels={customLabels}
+                        hiddenFields={hiddenFields}
+                        showTableNames={showTableNames}
+                        chartName={chartName}
+                    />
+                </>
+            );
+        } else if (hasGoogleDrive && getGsheetLink) {
+            return (
+                <Stack spacing="xs">
+                    <Button
+                        size="xs"
+                        variant="default"
+                        onClick={() => setExportType('csv')}
+                        leftIcon={<MantineIcon icon={IconFileTypeCsv} />}
+                        disabled={isExportingGoogleSheets}
+                        data-testid="chart-export-csv-button"
+                    >
+                        Download data
+                    </Button>
+                    <ExportToGoogleSheet getGsheetLink={getGsheetLink} />
+                </Stack>
+            );
+        }
+
         return (
-            <>
-                <Button
-                    color="gray.6"
-                    size="xs"
-                    mb="xs"
-                    leftIcon={<IconArrowLeft size="16" />}
-                    variant="subtle"
-                    onClick={() => setExportType(undefined)}
-                >
-                    Back to export selector
-                </Button>
-                <ExportCSV
-                    totalResults={totalResults}
-                    getCsvLink={getCsvLink}
-                    projectUuid={projectUuid}
-                />
-            </>
+            <ExportResults
+                totalResults={totalResults}
+                getDownloadQueryUuid={getDownloadQueryUuid}
+                projectUuid={projectUuid}
+                columnOrder={columnOrder}
+                customLabels={customLabels}
+                hiddenFields={hiddenFields}
+                showTableNames={showTableNames}
+                chartName={chartName}
+            />
         );
-    } else if (hasGoogleDrive && getGsheetLink) {
-        return (
-            <Stack spacing="xs">
-                <Button
-                    size="xs"
-                    variant="default"
-                    onClick={() => setExportType('csv')}
-                    leftIcon={<MantineIcon icon={IconFileTypeCsv} />}
-                    disabled={isExportingGoogleSheets}
-                    data-testid="chart-export-csv-button"
-                >
-                    csv
-                </Button>
-                <ExportToGoogleSheet getGsheetLink={getGsheetLink} />
-            </Stack>
-        );
-    }
-
-    return (
-        <ExportCSV
-            totalResults={totalResults}
-            getCsvLink={getCsvLink}
-            projectUuid={projectUuid}
-        />
-    );
-});
+    },
+);
 
 export default ExportSelector;

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -26,13 +26,7 @@ import ChartDownloadOptions from './ChartDownloadOptions';
 
 interface ChartDownloadMenuProps {
     projectUuid: string;
-    getCsvLink?: (
-        limit: number | null,
-        onlyRaw: boolean,
-        showTableNames: boolean,
-        columnOrder: string[],
-        customLabels?: Record<string, string>,
-    ) => Promise<ApiScheduledDownloadCsv>;
+    getDownloadQueryUuid?: (limit: number | null) => Promise<string>;
     getGsheetLink?: (
         columnOrder: string[],
         showTableNames: boolean,
@@ -41,7 +35,7 @@ interface ChartDownloadMenuProps {
 }
 
 const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
-    ({ getCsvLink, getGsheetLink, projectUuid }) => {
+    ({ getDownloadQueryUuid, getGsheetLink, projectUuid }) => {
         const { chartRef, visualizationConfig, resultsData } =
             useVisualizationContext();
 
@@ -64,7 +58,8 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             [chartRef],
         );
 
-        return isTableVisualizationConfig(visualizationConfig) && getCsvLink ? (
+        return isTableVisualizationConfig(visualizationConfig) &&
+            getDownloadQueryUuid ? (
             <Can
                 I="manage"
                 this={subject('ExportCsv', {
@@ -91,22 +86,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                         <ExportSelector
                             projectUuid={projectUuid}
                             totalResults={resultsData?.totalResults}
-                            getCsvLink={async (
-                                limit: number | null,
-                                onlyRaw: boolean,
-                            ) =>
-                                getCsvLink(
-                                    limit,
-                                    onlyRaw,
-                                    visualizationConfig.chartConfig
-                                        .showTableNames,
-                                    visualizationConfig.chartConfig.columnOrder,
-                                    getCustomLabelsFromColumnProperties(
-                                        visualizationConfig.chartConfig
-                                            .columnProperties,
-                                    ),
-                                )
-                            }
+                            getDownloadQueryUuid={getDownloadQueryUuid}
                             getGsheetLink={
                                 getGsheetLink === undefined
                                     ? undefined
@@ -128,7 +108,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                 </Popover>
             </Can>
         ) : isTableVisualizationConfig(visualizationConfig) &&
-          !getCsvLink ? null : (
+          !getDownloadQueryUuid ? null : (
             <Popover
                 {...COLLAPSABLE_CARD_POPOVER_PROPS}
                 disabled={disabled}

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ChartType,
     getCustomLabelsFromColumnProperties,
+    getHiddenTableFields,
     type ApiScheduledDownloadCsv,
     type PivotConfig,
 } from '@lightdash/common';
@@ -95,6 +96,15 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             columnOrder={
                                 visualizationConfig.chartConfig.columnOrder
                             }
+                            customLabels={getCustomLabelsFromColumnProperties(
+                                visualizationConfig.chartConfig
+                                    .columnProperties,
+                            )}
+                            hiddenFields={getHiddenTableFields({
+                                type: ChartType.TABLE,
+                                config: visualizationConfig.chartConfig
+                                    .validConfig,
+                            })}
                             showTableNames={
                                 visualizationConfig.chartConfig.showTableNames
                             }

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartType,
+    getCustomLabelsFromColumnProperties,
     type ApiScheduledDownloadCsv,
     type PivotConfig,
 } from '@lightdash/common';
@@ -25,7 +26,9 @@ export type ChartDownloadMenuProps = {
     getDownloadQueryUuid: (limit: number | null) => Promise<string>;
     projectUuid: string;
     getGsheetLink?: (
-        pivotConfig?: PivotConfig,
+        columnOrder: string[],
+        showTableNames: boolean,
+        customLabels?: Record<string, string>,
     ) => Promise<ApiScheduledDownloadCsv>;
 };
 
@@ -99,7 +102,18 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             getGsheetLink={
                                 getGsheetLink === undefined
                                     ? undefined
-                                    : () => getGsheetLink(pivotConfig)
+                                    : () =>
+                                          getGsheetLink(
+                                              visualizationConfig.chartConfig
+                                                  .columnOrder,
+                                              visualizationConfig.chartConfig
+                                                  .showTableNames,
+                                              getCustomLabelsFromColumnProperties(
+                                                  visualizationConfig
+                                                      .chartConfig
+                                                      .columnProperties,
+                                              ),
+                                          )
                             }
                         />
                     </Popover.Dropdown>

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -99,6 +99,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                     flexDirection: 'column',
                                     overflowY: 'auto',
                                 }}
+                                data-testid="common-sidebar"
                             >
                                 {children}
                             </Paper>

--- a/packages/frontend/src/features/queryRunner/executeQuery.ts
+++ b/packages/frontend/src/features/queryRunner/executeQuery.ts
@@ -11,7 +11,7 @@ import { lightdashApi } from '../../api';
 import { getResultsFromStream } from '../../utils/request';
 import type { ResultsAndColumns } from '../sqlRunner/hooks/useSqlQueryRun';
 
-const pollForResults = async (
+export const pollForResults = async (
     projectUuid: string,
     queryUuid: string,
     backoffMs: number = 250,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -84,13 +84,11 @@ export const downloadQuery = async (
         method: 'POST',
         body: JSON.stringify({
             type: options.fileType || DownloadFileType.CSV,
-            csvLimit: options.csvLimit,
             onlyRaw: options.onlyRaw,
             showTableNames: options.showTableNames,
             customLabels: options.customLabels,
             columnOrder: options.columnOrder,
             hiddenFields: options.hiddenFields,
-            chartName: options.chartName,
             pivotConfig: options.pivotConfig,
         }),
         version: 'v2',

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -1,13 +1,18 @@
 import {
+    type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
     type ApiGetAsyncQueryResults,
     type ApiSuccessEmpty,
+    applyLimitOverrideToQuery,
     assertUnreachable,
     type DateGranularity,
     DEFAULT_RESULTS_PAGE_SIZE,
+    DownloadFileType,
+    type DownloadOptions,
     type ExecuteAsyncMetricQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
+    type LimitOverride,
     type MetricQuery,
     ParameterError,
     QueryExecutionContext,
@@ -19,6 +24,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { lightdashApi } from '../api';
+import { pollForResults } from '../features/queryRunner/executeQuery';
 import { convertDateFilters } from '../utils/dateFilter';
 import useQueryError from './useQueryError';
 
@@ -68,6 +74,105 @@ const executeAsyncSavedChartQuery = async (
         signal: options.signal,
     });
 
+export const downloadQuery = async (
+    projectUuid: string,
+    queryUuid: string,
+    options: DownloadOptions = {},
+) =>
+    lightdashApi<ApiDownloadAsyncQueryResultsAsCsv>({
+        url: `/projects/${projectUuid}/query/${queryUuid}/download`,
+        method: 'POST',
+        body: JSON.stringify({
+            type: options.fileType || DownloadFileType.CSV,
+            csvLimit: options.csvLimit,
+            onlyRaw: options.onlyRaw,
+            showTableNames: options.showTableNames,
+            customLabels: options.customLabels,
+            columnOrder: options.columnOrder,
+            hiddenFields: options.hiddenFields,
+            chartName: options.chartName,
+            pivotConfig: options.pivotConfig,
+        }),
+        version: 'v2',
+    });
+
+const executeAsyncQuery = (
+    data?: QueryResultsProps | null,
+    signal?: AbortSignal,
+    limitOverride?: LimitOverride,
+) => {
+    if (data?.chartUuid && data?.chartVersionUuid) {
+        return executeAsyncSavedChartQuery(
+            data.projectUuid,
+            {
+                context: QueryExecutionContext.CHART_HISTORY,
+                chartUuid: data.chartUuid,
+                versionUuid: data.chartVersionUuid,
+                limit: limitOverride,
+            },
+            { signal },
+        );
+    } else if (data?.chartUuid) {
+        return executeAsyncSavedChartQuery(
+            data.projectUuid,
+            {
+                context: QueryExecutionContext.CHART,
+                chartUuid: data.chartUuid,
+                limit: limitOverride,
+            },
+            { signal },
+        );
+    } else if (data?.query) {
+        // For metric queries, apply the limit override to the query itself
+        const query =
+            limitOverride !== undefined
+                ? applyLimitOverrideToQuery(data.query, limitOverride)
+                : data.query;
+
+        return executeAsyncMetricQuery(
+            data.projectUuid,
+            {
+                context: QueryExecutionContext.EXPLORE,
+                query: {
+                    ...query,
+                    filters: convertDateFilters(query.filters),
+                    timezone: query.timezone ?? undefined,
+                    exploreName: data.tableId,
+                    dateZoom: data.dateZoomGranularity
+                        ? {
+                              granularity: data.dateZoomGranularity,
+                          }
+                        : undefined,
+                },
+                invalidateCache: true, // Note: do not cache explore queries
+            },
+            { signal },
+        );
+    }
+    return Promise.reject(new ParameterError('Missing QueryResultsProps'));
+};
+
+export const executeQueryAndWaitForResults = async (
+    data?: QueryResultsProps | null,
+    limitOverride?: LimitOverride,
+) => {
+    if (!data) throw new Error('Missing data');
+
+    const query = await executeAsyncQuery(data, undefined, limitOverride);
+
+    const results = await pollForResults(data.projectUuid, query.queryUuid);
+
+    if (results.status === QueryHistoryStatus.ERROR) {
+        throw new Error(results.error || 'Error executing SQL query');
+    }
+
+    if (results.status !== QueryHistoryStatus.READY) {
+        throw new Error('Unexpected query status');
+    }
+
+    return results;
+};
+
 export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
     const setErrorResponse = useQueryError({
         forceToastOnForbidden: true,
@@ -78,49 +183,7 @@ export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
         enabled: !!data,
         queryKey: ['create-query', data],
         queryFn: ({ signal }) => {
-            if (data?.chartUuid && data?.chartVersionUuid) {
-                return executeAsyncSavedChartQuery(
-                    data.projectUuid,
-                    {
-                        context: QueryExecutionContext.CHART_HISTORY,
-                        chartUuid: data.chartUuid,
-                        versionUuid: data.chartVersionUuid,
-                    },
-                    { signal },
-                );
-            } else if (data?.chartUuid) {
-                return executeAsyncSavedChartQuery(
-                    data.projectUuid,
-                    {
-                        context: QueryExecutionContext.CHART,
-                        chartUuid: data.chartUuid,
-                    },
-                    { signal },
-                );
-            } else if (data?.query) {
-                return executeAsyncMetricQuery(
-                    data.projectUuid,
-                    {
-                        context: QueryExecutionContext.EXPLORE,
-                        query: {
-                            ...data.query,
-                            filters: convertDateFilters(data.query.filters),
-                            timezone: data.query.timezone ?? undefined,
-                            exploreName: data.tableId,
-                            dateZoom: data.dateZoomGranularity
-                                ? {
-                                      granularity: data.dateZoomGranularity,
-                                  }
-                                : undefined,
-                        },
-                        invalidateCache: true, // Note: do not cache explore queries
-                    },
-                    { signal },
-                );
-            }
-            return Promise.reject(
-                new ParameterError('Missing QueryResultsProps'),
-            );
+            return executeAsyncQuery(data, signal);
         },
     });
 

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1297,7 +1297,13 @@ const ExplorerProvider: FC<
     const getDownloadQueryUuid = useCallback(
         async (limit: number | null) => {
             let queryUuid = queryResults.queryUuid;
-            if (limit !== null && limit !== queryResults.totalResults) {
+            // Always execute a new query if:
+            // 1. limit is null (meaning "all results" - should ignore existing query limits)
+            // 2. limit is different from current totalResults
+            if (
+                limit === null ||
+                (limit !== null && limit !== queryResults.totalResults)
+            ) {
                 const downloadQuery = await executeQueryAndWaitForResults(
                     validQueryArgs,
                     limit,

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -345,5 +345,6 @@ export interface ExplorerContextType {
             formatOptions: CustomFormat | undefined;
         }) => void;
         replaceFields: (fieldsToReplace: ReplaceCustomFields[string]) => void;
+        getDownloadQueryUuid: (limit: number | null) => Promise<string>;
     };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15012 
Closes: [#15014](https://github.com/lightdash/lightdash/issues/15014)

### Description:
Refactored the export functionality to improve the user experience and code organization. This PR:

- Created a new `ExportResults` component that replaces the old `ExportCSV` component
- Added support for XLSX file exports alongside CSV
- Improved the UI with better segmented controls for export options
- Centralized the download logic through a new `getDownloadQueryUuid` method
- Removed duplicate code for CSV generation across different components
- Enhanced error handling and user feedback during the export process
- Updated the download button label to be more descriptive ("Download data" instead of "csv")

The new export UI provides clearer options for users to select file format, value formatting, and result limits.

test-frontend