### PR TITLE
fix: system prompts not working for web ui

### DIFF
--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -686,7 +686,10 @@ export class AiService {
                       organizationUuid: user.organizationUuid,
                       slackChannelId: slackOrWebAppPrompt.slackChannelId,
                   })
-                : undefined;
+                : await this.aiAgentModel.getAgent({
+                      organizationUuid: slackOrWebAppPrompt.organizationUuid,
+                      agentUuid: slackOrWebAppPrompt.agentUuid!,
+                  });
 
         const {
             getExplore,


### PR DESCRIPTION
Fixed agent settings retrieval when handling Slack or web app prompts. Before we were only getting agent settings from Slack channel prompts.