### PR TITLE
feat: add user permissions for AI agent threads

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -398,10 +398,12 @@ export class AiAgentModel {
         organizationUuid,
         agentUuid,
         threadUuid,
+        userUuid,
     }: {
         organizationUuid: string;
         agentUuid: string;
         threadUuid?: string;
+        userUuid?: string;
     }): Promise<
         AiAgentThreadSummary<AiAgentUser & { slackUserId: string | null }>[]
     > {
@@ -466,6 +468,10 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 threadUuid,
             );
+        }
+
+        if (userUuid) {
+            void query.andWhere(`${UserTableName}.user_uuid`, userUuid);
         }
 
         const rows = await query;

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -91,6 +91,10 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'SpotlightTableConfig', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'AiAgentThread', {
+            organizationUuid: member.organizationUuid,
+            userUuid: member.userUuid,
+        });
     },
     interactive_viewer(member, { can }) {
         applyOrganizationMemberStaticAbilities.viewer(member, { can });
@@ -169,6 +173,10 @@ const applyOrganizationMemberStaticAbilities: Record<
                     role: SpaceMemberRole.ADMIN,
                 },
             },
+        });
+
+        can('create', 'AiAgentThread', {
+            organizationUuid: member.organizationUuid,
         });
     },
     editor(member, { can }) {
@@ -257,6 +265,10 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'JobStatus', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'AiAgentThread', {
+            organizationUuid: member.organizationUuid,
+            userUuid: member.userUuid,
+        });
     },
     admin(member, { can }) {
         applyOrganizationMemberStaticAbilities.developer(member, { can });
@@ -295,6 +307,12 @@ const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'Group', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'AiAgentThread', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'AiAgentThread', {
             organizationUuid: member.organizationUuid,
         });
     },

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -47,7 +47,8 @@ export type CaslSubjectNames =
     | 'PersonalAccessToken'
     | 'MetricsTree'
     | 'SpotlightTableConfig'
-    | 'ContentAsCode';
+    | 'ContentAsCode'
+    | 'AiAgentThread';
 
 export type Subject =
     | CaslSubjectNames


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Added permission checks in `AiAgentService` for viewing and creating threads
- Defined CASL abilities for AI agent threads in organization member roles
