### PR TITLE
feat: add permission checks for AI Agent management

### DIFF
--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -1,4 +1,5 @@
 ### Login
+// @no-log
 POST http://localhost:8080/api/v1/login
 Content-Type: application/json
 
@@ -7,34 +8,90 @@ Content-Type: application/json
     "password": "demo_password!"
 }
 
-### List agents
+### =============================================================================
+### AI AGENTS
+### =============================================================================
+
+### List all AI Agents
 GET http://localhost:8080/api/v1/aiAgents
 Content-Type: application/json
 
-### Get agent
-GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76
+### Get specific AI Agent
+GET http://localhost:8080/api/v1/aiAgents/AGENT_UUID
 Content-Type: application/json
 
-### Get agent threads
-GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads
-Content-Type: application/json
-
-### Get agent thread
-GET http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads/91ea006f-bce1-4193-9099-13dddaddfcfc
-Content-Type: application/json
-
-### Start agent thread
-POST http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/generate
+### Create AI Agent
+POST http://localhost:8080/api/v1/aiAgents
 Content-Type: application/json
 
 {
-    "prompt": "give me a chart of revenue by payment method"
+    "name": "My Analytics Assistant",
+    "projectUuid": PROJECT_UUID,
+    "instruction": "You are a helpful analytics assistant that helps users understand their data and create meaningful insights.",
+    "integrations": [
+        {
+            "type": "slack",
+            "channelId": "CHANNEL_ID"
+        }
+    ],
+    "tags": ["analytics", "assistant", "data"]
 }
 
-### Generate agent thread response
-POST http://localhost:8080/api/v1/aiAgents/a4a584ce-0370-4bbe-943b-3c67fcb7ef76/threads/3185ecad-58c9-44c1-af2d-a1b859bf4c77/generate
+### Update AI Agent
+PATCH http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID
 Content-Type: application/json
 
 {
-    "prompt": "what kind of charts can you make?"
+    "uuid": "AI_AGENT_UUID",
+    "name": "Updated Analytics Assistant",
+    "instruction": "You are an advanced analytics assistant specialized in business intelligence and data visualization.",
+    "tags": ["analytics", "bi", "advanced"]
+}
+
+### Delete AI Agent
+DELETE http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID
+Content-Type: application/json
+
+### =============================================================================
+### AI AGENT THREADS
+### =============================================================================
+
+### List Agent Threads
+GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads
+Content-Type: application/json
+
+### Get specific Agent Thread
+GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID
+Content-Type: application/json
+
+### Start new Agent Thread (create thread with first message)
+POST http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/generate
+Content-Type: application/json
+
+{
+    "prompt": "Can you help me analyze the sales data for the last quarter?"
+}
+
+### Generate response in existing Agent Thread
+POST http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/generate
+Content-Type: application/json
+
+{
+    "prompt": "Can you create a chart showing the trend over time?"
+}
+
+### Get Agent Thread Message Visualization
+GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/message/MESSAGE_UUID/viz
+Content-Type: application/json
+
+### =============================================================================
+### LEGACY AI ENDPOINTS (for reference)
+### =============================================================================
+
+### Dashboard summary
+POST http://localhost:8080/api/v1/ai/PROJECT_UUID/dashboard/DASHBOARD_UUID/summary
+Content-Type: application/json
+
+{
+    "context": "say something interesting"
 }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -184,9 +184,6 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        // TODO:
-        // permissions
-
         const agents = await this.aiAgentModel.findAllAgents({
             organizationUuid,
         });
@@ -371,6 +368,15 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('AiAgent', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const agent = await this.aiAgentModel.createAgent({
             name: body.name,
             projectUuid: body.projectUuid,
@@ -397,6 +403,15 @@ export class AiAgentService {
             throw new ForbiddenError('Organization not found');
         }
 
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('AiAgent', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const updatedAgent = await this.aiAgentModel.updateAgent({
             agentUuid,
             name: body.name,
@@ -419,6 +434,15 @@ export class AiAgentService {
         const isCopilotEnabled = await this.getIsCopilotEnabled(user);
         if (!isCopilotEnabled) {
             throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('AiAgent', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
         }
 
         const agent = await this.getAgent(user, agentUuid);

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -175,6 +175,9 @@ const applyOrganizationMemberStaticAbilities: Record<
             },
         });
 
+        can('view', 'AiAgent', {
+            organizationUuid: member.organizationUuid,
+        });
         can('create', 'AiAgentThread', {
             organizationUuid: member.organizationUuid,
         });
@@ -263,6 +266,9 @@ const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('view', 'JobStatus', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'AiAgent', {
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'AiAgentThread', {

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -48,6 +48,7 @@ export type CaslSubjectNames =
     | 'MetricsTree'
     | 'SpotlightTableConfig'
     | 'ContentAsCode'
+    | 'AiAgent'
     | 'AiAgentThread';
 
 export type Subject =

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -6,6 +6,7 @@ import { LightdashUserAvatar } from '../../../components/Avatar';
 import LinkButton from '../../../components/common/LinkButton';
 import Page from '../../../components/common/Page/Page';
 import PageSpinner from '../../../components/PageSpinner';
+import useApp from '../../../providers/App/useApp';
 import AgentThreadCard, {
     AgentThreadCardEmpty,
 } from '../../features/aiCopilot/components/AgentThreadCard';
@@ -18,6 +19,7 @@ const INITIAL_MAX_THREADS = 10;
 const MAX_THREADS_INCREMENT = 10;
 
 const AgentPage = () => {
+    const { user } = useApp();
     const { agentUuid, threadUuid } = useParams();
     const { data: threads } = useAiAgentThreads(agentUuid ?? '');
 
@@ -67,15 +69,17 @@ const AgentPage = () => {
                         >
                             New thread
                         </Button>
-                        <Button
-                            variant="default"
-                            c="dimmed"
-                            bd="none"
-                            component={Link}
-                            to={`/generalSettings/aiAgents/${agent.uuid}`}
-                        >
-                            Settings
-                        </Button>
+                        {user?.data?.ability.can('manage', 'AiAgent') && (
+                            <Button
+                                variant="default"
+                                c="dimmed"
+                                bd="none"
+                                component={Link}
+                                to={`/generalSettings/aiAgents/${agent.uuid}`}
+                            >
+                                Settings
+                            </Button>
+                        )}
                     </Group>
                     {agent.tags && (
                         <Stack gap="xs">

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -30,6 +30,8 @@ type AgentCardProps = {
 };
 
 const AgentCard = ({ agent }: AgentCardProps) => {
+    const { user } = useApp();
+
     return (
         <Card
             withBorder
@@ -81,15 +83,17 @@ const AgentCard = ({ agent }: AgentCardProps) => {
             </Stack>
             <Divider />
             <Group justify="space-between" p="sm">
-                <Button
-                    variant="default"
-                    c="dimmed"
-                    bd="none"
-                    component={Link}
-                    to={`/generalSettings/aiAgents/${agent.uuid}`}
-                >
-                    Settings
-                </Button>
+                {user?.data?.ability.can('manage', 'AiAgent') && (
+                    <Button
+                        variant="default"
+                        c="dimmed"
+                        bd="none"
+                        component={Link}
+                        to={`/generalSettings/aiAgents/${agent.uuid}`}
+                    >
+                        Settings
+                    </Button>
+                )}
                 <Button variant="default" size="sm" px="md">
                     Start a chat
                 </Button>
@@ -106,9 +110,9 @@ const AgentsListPage = () => {
         return <PageSpinner />;
     }
 
-    const userCanManageOrganization = user.data?.ability.can(
+    const userCanManageAiAgent = user.data?.ability.can(
         'manage',
-        subject('Organization', {
+        subject('AiAgent', {
             organizationUuid: user.data?.organizationUuid,
         }),
     );
@@ -148,7 +152,7 @@ const AgentsListPage = () => {
                         </Text>
                     </Box>
                     <Group gap="xs">
-                        {userCanManageOrganization && (
+                        {userCanManageAiAgent && (
                             <Button
                                 size="xs"
                                 variant="default"

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -314,10 +314,7 @@ const Settings: FC = () => {
             });
         }
 
-        if (
-            user?.ability.can('manage', 'Organization') &&
-            aiCopilotFlag?.enabled
-        ) {
+        if (user?.ability.can('manage', 'AiAgent') && aiCopilotFlag?.enabled) {
             allowedRoutes.push({
                 path: '/aiAgents',
                 element: <AiAgentsPanel />,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: #15136

### Description:

Added permission checks for AI Agent management. Now only users with the appropriate permissions can create, update, or delete AI agents. The permissions are enforced both on the backend and frontend:

- Added 'AiAgent' to CASL subject names and rules
- Implemented permission checks in AiAgentService for create, update, and delete operations
