### PR TITLE
fix: reorder migration steps to index cache_key before making it non-nullable

### DIFF
--- a/packages/backend/src/database/migrations/20250529000000_make_cache_key_non_nullable.ts
+++ b/packages/backend/src/database/migrations/20250529000000_make_cache_key_non_nullable.ts
@@ -3,7 +3,12 @@ import { Knex } from 'knex';
 const QUERY_HISTORY_TABLE = 'query_history';
 
 export async function up(knex: Knex): Promise<void> {
-    // First update all null values to 'n/a'
+    // Ensure the column is indexed
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.index(['cache_key']);
+    });
+
+    // Second, update all null values to 'n/a'
     await knex(QUERY_HISTORY_TABLE)
         .update({
             // @ts-ignore ignore update type
@@ -14,11 +19,6 @@ export async function up(knex: Knex): Promise<void> {
     // Then alter the column to be non-nullable
     await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
         table.string('cache_key').notNullable().alter();
-    });
-
-    // Ensure the column is indexed
-    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
-        table.index(['cache_key']);
     });
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Reordered the migration steps for the `cache_key` column in the `query_history` table to ensure proper execution:

1. First create the index on the `cache_key` column
2. Then update null values to 'n/a'
3. Finally make the column non-nullable

This ordering prevents potential issues that could occur if we tried to create an index after making the column non-nullable.