### PR TITLE
fix: clone formatOptions when setting field value

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -212,7 +212,10 @@ export const CustomMetricModal = () => {
                     setFieldValue('percentile', item.percentile);
 
                 if (item.formatOptions) {
-                    setFieldValue('format', item.formatOptions);
+                    setFieldValue('format', {
+                        // This spread is intentional to avoid @mantine/form mutating the enum object `item.formatOptions.type`
+                        ...item.formatOptions,
+                    });
                 }
             }
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15097

### Description:

Fix custom metric format options by creating a new object when setting the format field value. This prevents potential reference issues by ensuring we're not directly modifying the original object.
