### PR TITLE
feat: allow changing agents avatar

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -79,6 +79,7 @@ export class AiAgentModel {
                      WHERE ${AiAgentInstructionVersionsTableName}.ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid
                      ORDER BY created_at DESC LIMIT 1)
                     `),
+                imageUrl: `${AiAgentTableName}.image_url`,
             } satisfies Record<keyof AiAgent, unknown>)
             .leftJoin(
                 AiAgentIntegrationTableName,
@@ -137,6 +138,7 @@ export class AiAgentModel {
                      WHERE ${AiAgentInstructionVersionsTableName}.ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid
                      ORDER BY created_at DESC LIMIT 1)
                     `),
+                imageUrl: `${AiAgentTableName}.image_url`,
             } satisfies Record<keyof AiAgentSummary, unknown>)
             .leftJoin(
                 AiAgentIntegrationTableName,
@@ -267,6 +269,7 @@ export class AiAgentModel {
                 createdAt: agent.created_at,
                 updatedAt: agent.updated_at,
                 instruction: args.instruction,
+                imageUrl: agent.image_url,
             };
         });
     }
@@ -290,6 +293,7 @@ export class AiAgentModel {
                     project_uuid: args.projectUuid,
                     tags: args.tags,
                     updated_at: updatedAt,
+                    image_url: args.imageUrl,
                 })
                 .returning('*');
 
@@ -360,6 +364,7 @@ export class AiAgentModel {
                 createdAt: agent.created_at,
                 updatedAt: agent.updated_at,
                 instruction,
+                imageUrl: agent.image_url,
             };
         });
     }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -419,6 +419,7 @@ export class AiAgentService {
             tags: body.tags,
             integrations: body.integrations,
             instruction: body.instruction,
+            imageUrl: body.imageUrl,
         });
 
         return updatedAgent;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4495,7 +4495,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction_':
+    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_':
         {
             dataType: 'refAlias',
             type: {
@@ -4544,6 +4544,14 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    imageUrl: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4552,7 +4560,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_',
             validators: {},
         },
     },
@@ -4573,7 +4581,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_':
         {
             dataType: 'refAlias',
             type: {
@@ -4622,6 +4630,14 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    imageUrl: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4630,7 +4646,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_',
             validators: {},
         },
     },
@@ -4659,7 +4675,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction_':
+    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_':
         {
             dataType: 'refAlias',
             type: {
@@ -4704,6 +4720,14 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    imageUrl: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4712,12 +4736,12 @@ const models: TsoaRoute.Models = {
     ApiCreateAiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction_',
+            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__':
         {
             dataType: 'refAlias',
             type: {
@@ -4779,6 +4803,14 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    imageUrl: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -4790,7 +4822,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -11415,7 +11447,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11425,7 +11457,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11435,7 +11467,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11448,7 +11480,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5124,7 +5124,7 @@
             "ItemsMap": {
                 "$ref": "#/components/schemas/Record_string.Field-or-TableCalculation-or-CustomDimension-or-Metric_"
             },
-            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction_": {
+            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5173,6 +5173,10 @@
                     "instruction": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -5184,13 +5188,14 @@
                     "integrations",
                     "tags",
                     "updatedAt",
-                    "instruction"
+                    "instruction",
+                    "imageUrl"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -5209,7 +5214,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5258,6 +5263,10 @@
                     "instruction": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -5269,13 +5278,14 @@
                     "integrations",
                     "tags",
                     "updatedAt",
-                    "instruction"
+                    "instruction",
+                    "imageUrl"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -5305,7 +5315,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction_": {
+            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5340,6 +5350,10 @@
                     "instruction": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -5347,15 +5361,16 @@
                     "projectUuid",
                     "integrations",
                     "tags",
-                    "instruction"
+                    "instruction",
+                    "imageUrl"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateAiAgent": {
-                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction_"
+                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_"
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5388,6 +5403,10 @@
                         "nullable": true
                     },
                     "instruction": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "imageUrl": {
                         "type": "string",
                         "nullable": true
                     }
@@ -5398,7 +5417,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__"
                     },
                     {
                         "properties": {
@@ -12297,22 +12316,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17643,7 +17662,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1682.0",
+        "version": "0.1684.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -13,7 +13,7 @@ export const baseAgentSchema = z.object({
 
     name: z.string(),
     description: z.string(),
-    imageUrl: z.string(),
+    imageUrl: z.string().url().nullable(),
 
     tags: z.array(z.string()).nullable(),
 
@@ -54,6 +54,7 @@ export type AiAgent = Pick<
     | 'createdAt'
     | 'updatedAt'
     | 'instruction'
+    | 'imageUrl'
 >;
 
 export type AiAgentSummary = Pick<
@@ -67,6 +68,7 @@ export type AiAgentSummary = Pick<
     | 'createdAt'
     | 'updatedAt'
     | 'instruction'
+    | 'imageUrl'
 >;
 
 export type AiAgentUser = {
@@ -127,13 +129,23 @@ export type ApiAiAgentSummaryResponse = {
 
 export type ApiCreateAiAgent = Pick<
     AiAgent,
-    'projectUuid' | 'integrations' | 'tags' | 'name' | 'instruction'
+    | 'projectUuid'
+    | 'integrations'
+    | 'tags'
+    | 'name'
+    | 'instruction'
+    | 'imageUrl'
 >;
 
 export type ApiUpdateAiAgent = Partial<
     Pick<
         AiAgent,
-        'projectUuid' | 'integrations' | 'tags' | 'name' | 'instruction'
+        | 'projectUuid'
+        | 'integrations'
+        | 'tags'
+        | 'name'
+        | 'instruction'
+        | 'imageUrl'
     >
 > & {
     uuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -21,6 +21,7 @@ import {
     IconArrowLeft,
     IconCheck,
     IconDatabase,
+    IconInfoCircle,
     IconRefresh,
     IconTrash,
 } from '@tabler/icons-react';
@@ -48,7 +49,12 @@ import { SlackIntegrationSteps } from './SlackIntegrationSteps';
 const formSchema: z.ZodType<
     Pick<
         BaseAiAgent,
-        'name' | 'projectUuid' | 'integrations' | 'tags' | 'instruction'
+        | 'name'
+        | 'projectUuid'
+        | 'integrations'
+        | 'tags'
+        | 'instruction'
+        | 'imageUrl'
     >
 > = z.object({
     name: z.string().min(1),
@@ -63,6 +69,7 @@ const formSchema: z.ZodType<
     ),
     tags: z.array(z.string()).nullable(),
     instruction: z.string().nullable(),
+    imageUrl: z.string().url().nullable(),
 });
 
 export const AgentDetails: FC = () => {
@@ -124,6 +131,7 @@ export const AgentDetails: FC = () => {
             integrations: [],
             tags: null,
             instruction: null,
+            imageUrl: null,
         },
         validate: zodResolver(formSchema),
     });
@@ -140,6 +148,7 @@ export const AgentDetails: FC = () => {
                 integrations: agent.integrations,
                 tags: agent.tags && agent.tags.length > 0 ? agent.tags : null,
                 instruction: agent.instruction,
+                imageUrl: agent.imageUrl,
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -227,6 +236,11 @@ export const AgentDetails: FC = () => {
                             <LightdashUserAvatar
                                 name={isCreateMode ? '+' : form.values.name}
                                 variant="filled"
+                                src={
+                                    !isCreateMode
+                                        ? form.values.imageUrl
+                                        : undefined
+                                }
                             />
 
                             <Title order={3}>
@@ -266,11 +280,56 @@ export const AgentDetails: FC = () => {
                                         {/* Basic Agent Info */}
                                         <Stack gap="sm">
                                             <Title order={5}>Details</Title>
-                                            <TextInput
-                                                label="Agent Name"
-                                                placeholder="Enter a name for this agent"
-                                                {...form.getInputProps('name')}
-                                            />
+                                            <Group gap="sm">
+                                                <TextInput
+                                                    label="Agent Name"
+                                                    placeholder="Enter a name for this agent"
+                                                    {...form.getInputProps(
+                                                        'name',
+                                                    )}
+                                                    style={{ flexGrow: 1 }}
+                                                />
+
+                                                <TextInput
+                                                    style={{ flexGrow: 1 }}
+                                                    label={
+                                                        <Group gap="xs">
+                                                            <Text>
+                                                                Avatar image URL
+                                                            </Text>
+                                                            <Tooltip
+                                                                label="Please provide an image url like https://example.com/avatar.jpg. If not provided, a default avatar will be used."
+                                                                withArrow
+                                                                withinPortal
+                                                                multiline
+                                                                maw="250px"
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconInfoCircle
+                                                                    }
+                                                                />
+                                                            </Tooltip>
+                                                        </Group>
+                                                    }
+                                                    placeholder="https://example.com/avatar.jpg"
+                                                    type="url"
+                                                    {...form.getInputProps(
+                                                        'imageUrl',
+                                                    )}
+                                                    onChange={(e) => {
+                                                        const value =
+                                                            e.target.value;
+
+                                                        form.setFieldValue(
+                                                            'imageUrl',
+                                                            value
+                                                                ? value
+                                                                : null,
+                                                        );
+                                                    }}
+                                                />
+                                            </Group>
 
                                             <Select
                                                 label="Project"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgents.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgents.tsx
@@ -66,6 +66,7 @@ export const AiAgents: FC = () => {
                 projectName: project.name,
                 channelName: channel?.name,
                 updatedAt: agent.updatedAt,
+                imageUrl: agent.imageUrl,
             };
         });
     }, [
@@ -139,6 +140,7 @@ export const AiAgents: FC = () => {
                                             size="sm"
                                             name={agent.name}
                                             variant="filled"
+                                            src={agent.imageUrl}
                                         />
 
                                         <Text size="sm" fw={500}>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -117,6 +117,7 @@ const AgentPage = () => {
                                 size="md"
                                 variant="filled"
                                 name={agent.name || 'AI'}
+                                src={agent.imageUrl}
                             />
                             <Title order={3}>{agent.name}</Title>
                         </Group>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -51,6 +51,7 @@ const AgentCard = ({ agent }: AgentCardProps) => {
                         w={54}
                         variant="filled"
                         style={{ flexShrink: 0 }}
+                        src={agent.imageUrl}
                     />
                     <Stack gap="xs">
                         <Title order={5}>{agent.name}</Title>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15149


### Description:

Users can provide an image URL when creating or updating an agent, which will be displayed in the agent list, agent details page, and in conversations. If no image URL is provided, the system will continue to use the default avatar based on the agent's name.

The implementation includes:
- Adding `imageUrl` field to the AI agent model and database
- Updating the agent creation and editing forms with a new image URL input field
- Displaying the custom images in all relevant UI components
- Adding validation to ensure the image URL is properly formatted

![Screenshot 2025-06-04 at 16.16.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/25e9d44f-ecba-4312-a233-54c7222b31bc.png)

![Screenshot 2025-06-04 at 16.16.25.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/3b03c854-1045-4cbe-b2d2-bcc10bf5262a.png)

![Screenshot 2025-06-04 at 16.16.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/7ac43e24-4021-4c06-9caa-33e381446323.png)

![Screenshot 2025-06-04 at 16.16.34.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/6bbefdf4-1ab1-4fef-bc0e-9cf2a1e18097.png)

