### PR TITLE
chore: change /aiAgents to /ai-agents

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -90,7 +90,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {!isAiCopilotLoading && aiCopilotFlag?.enabled ? (
                     <Menu.Item
                         component={Link}
-                        to={`/aiAgents`}
+                        to={`/ai-agents`}
                         icon={<MantineIcon icon={IconRobot} />}
                     >
                         AI Agents (Alpha)

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -69,6 +69,11 @@ const COMMERCIAL_AI_ROUTES: RouteObject[] = [
 const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     {
         path: '/aiAgents',
+        // redirrect to ai-agents/ if path is /aiAgents
+        element: <Navigate to="/ai-agents" replace />,
+    },
+    {
+        path: '/ai-agents',
         element: (
             <PrivateRoute>
                 <NavBar />

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgents.ts
@@ -382,9 +382,12 @@ export const useStartAgentThreadMutation = (
                 }),
             );
 
-            void navigate(`/aiAgents/${agentUuid}/threads/${data.threadUuid}`, {
-                viewTransition: true,
-            });
+            void navigate(
+                `/ai-agents/${agentUuid}/threads/${data.threadUuid}`,
+                {
+                    viewTransition: true,
+                },
+            );
         },
         onError: ({ error }) => {
             showToastApiError({

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -49,7 +49,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({ thread, isActive }) => (
         color="gray"
         component={Link}
         key={thread.uuid}
-        to={`/aiAgents/${thread.agentUuid}/threads/${thread.uuid}`}
+        to={`/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
         px="xs"
         py={4}
         mx={-8}
@@ -90,7 +90,7 @@ const AgentPage = () => {
     }
 
     if (!agent) {
-        return <Navigate to={`/aiAgents`} />;
+        return <Navigate to={`/ai-agents`} />;
     }
 
     return (
@@ -102,7 +102,7 @@ const AgentPage = () => {
                             size="compact-xs"
                             variant="subtle"
                             component={Link}
-                            to="/aiAgents"
+                            to="/ai-agents"
                             leftSection={<MantineIcon icon={IconArrowLeft} />}
                             style={{
                                 root: {
@@ -142,7 +142,7 @@ const AgentPage = () => {
                             leftSection={<IconPlus size={16} />}
                             component={Link}
                             size="xs"
-                            to={`/aiAgents/${agent.uuid}/threads`}
+                            to={`/ai-agents/${agent.uuid}/threads`}
                         >
                             New thread
                         </Button>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -41,7 +41,7 @@ const AgentCard = ({ agent }: AgentCardProps) => {
                 root: { height: '100%' },
             }}
             component={Link}
-            to={`/aiAgents/${agent.uuid}/threads`}
+            to={`/ai-agents/${agent.uuid}/threads`}
         >
             <Stack gap="sm" p="lg" style={{ flex: 1 }}>
                 <Group gap="sm" wrap="nowrap" align="flex-start">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15137

### Description:

Updated URL paths for AI Agents from `/aiAgents` to `/ai-agents` to follow kebab-case convention. This includes:

- Updated navigation links in the BrowseMenu component
- Added a redirect from `/aiAgents` to `/ai-agents` in CommercialRoutes (temporary)
- Updated all internal navigation paths in useAiAgents hook, AgentPage, and AgentsListPage

