### PR TITLE
fix: update BigQuery authentication type label

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -89,7 +89,10 @@ const configureBigqueryWarehouse = (
         log: false,
     });
 
-    cy.selectMantine('warehouse.authenticationType', 'Private Key');
+    cy.selectMantine(
+        'warehouse.authenticationType',
+        'Service Account (JSON key file)',
+    );
 
     cy.get('[type="file"]').attachFile(warehouseConfig.bigQuery.keyFile);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  
Fixes bigquery e2e 

before:

![image](https://github.com/user-attachments/assets/07d1bb66-1079-45a4-ac58-d68696db3717)


after

![image](https://github.com/user-attachments/assets/fee1fe5e-4770-44eb-a041-60139e12686d)

### Description:
Updated the BigQuery warehouse authentication type selection in the E2E tests from "Private Key" to "Service Account (JSON key file)" to match the current UI options.