### PR TITLE
fix: Giving feedback updates the response time

### DIFF
--- a/packages/backend/src/ee/models/AiModel.ts
+++ b/packages/backend/src/ee/models/AiModel.ts
@@ -280,6 +280,19 @@ export class AiModel {
             .returning('ai_prompt_uuid');
     }
 
+    async updateHumanScore(data: {
+        promptUuid: string;
+        humanScore: number | null;
+    }) {
+        await this.database(AiPromptTableName)
+            .update({
+                human_score: data.humanScore,
+            })
+            .where({
+                ai_prompt_uuid: data.promptUuid,
+            });
+    }
+
     async updateSlackResponseTs(data: UpdateSlackResponseTs) {
         await this.database(AiSlackPromptTableName)
             .update({

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -695,7 +695,7 @@ export class AiAgentService {
 
     // TODO: user permissions
     async updateHumanScoreForMessage(messageUuid: string, humanScore: number) {
-        await this.aiModel.updateModelResponse({
+        await this.aiModel.updateHumanScore({
             promptUuid: messageUuid,
             humanScore,
         });

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -728,7 +728,7 @@ export class AiService {
 
     // TODO: user permissions
     async updateHumanScoreForPrompt(promptUuid: string, humanScore: number) {
-        await this.aiModel.updateModelResponse({
+        await this.aiModel.updateHumanScore({
             promptUuid,
             humanScore,
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15190

### Description:
Added a dedicated `updateHumanScore` method to properly handle scores without the need to update the whole response (including dates).
