### PR TITLE
feat: exit tab mode if we're down to a single tab

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -87,9 +87,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const [isDeletingTab, setDeletingTab] = useState<boolean>(false);
 
     const defaultTab = dashboardTabs?.[0];
-    const sortedTabs = dashboardTabs?.sort((a, b) => a.order - b.order);
+    // Context: We don't want to show the "tabs mode" if there is only one tab in state
+    // This is because the tabs mode is only useful when there are multiple tabs
+    const sortedTabs =
+        dashboardTabs.length > 1
+            ? dashboardTabs?.sort((a, b) => a.order - b.order)
+            : [];
     const hasDashboardTiles = dashboardTiles && dashboardTiles.length > 0;
-    const tabsEnabled = dashboardTabs && dashboardTabs.length > 0;
+    const tabsEnabled = dashboardTabs && dashboardTabs.length > 1;
 
     const sortedTiles = dashboardTiles?.sort((a, b) => {
         if (a.y === b.y) {
@@ -183,7 +188,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             dashboardTiles?.forEach((tile) => {
                 tile.tabUuid = undefined; // set tab uuid back to null to avoid foreign key constraint error
             });
-            return; // keep all tiles if its the last tab
+            // If this is the last tab, navigate to the non-tab URL.
+            // See `const = sortedTabs` for more context.
+            void navigate(
+                `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
+                { replace: true },
+            );
+
+            return;
         }
 
         const tilesToDelete = dashboardTiles?.filter(

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -251,7 +251,7 @@ const Dashboard: FC = () => {
                 tableCalculations: [],
             });
             reset();
-            if (dashboardTabs.length > 0) {
+            if (dashboardTabs.length > 1) {
                 void navigate(
                     `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${activeTab?.uuid}`,
                     { replace: true },


### PR DESCRIPTION
Closes: #15200

### Description:

This is a UX improvement where we only show tabs if there is more than one. There's no reason to have a single tab, since we have just one dashboard.

When exiting tab mode from having one tab, we keep that tab in the database. For now that means a user cannot delete the final tab so that we keep the tab name. Maybe this isn't all that important and we can revist later.

<!-- Even better add a screenshot / gif / loom -->

![](https://cdn.zappy.app/ff7708c6c0a90dbf59907a8482ec490d.gif)