### PR TITLE
feat: improve dashboard tab styling (spacing and colors)

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -193,6 +193,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             handleBatchDeleteTiles(tilesToDelete);
         }
     };
+    const MAGIC_SCROLL_AREA_HEIGHT = 40;
 
     return (
         <DragDropContext
@@ -240,23 +241,12 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     }
                                 }}
                                 mt={tabsEnabled ? 'sm' : 'xs'}
-                                styles={
-                                    tabsEnabled
-                                        ? {
-                                              root: {
-                                                  backgroundColor: 'white',
-                                                  flexGrow: 1,
-                                              },
-                                              tabsList: {
-                                                  flexWrap: 'nowrap',
-                                              },
-                                              tab: {
-                                                  borderBottom:
-                                                      '1px solid var(--mantine-color-gray-3)',
-                                              },
-                                          }
-                                        : undefined
-                                }
+                                styles={{
+                                    tabsList: {
+                                        flexWrap: 'nowrap',
+                                        height: MAGIC_SCROLL_AREA_HEIGHT - 1,
+                                    },
+                                }}
                                 variant="outline"
                             >
                                 {sortedTabs && sortedTabs?.length > 0 && (
@@ -267,13 +257,21 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                             scrollHideDelay={200}
                                             variant="primary"
                                             scrollbarSize={6}
+                                            h={MAGIC_SCROLL_AREA_HEIGHT}
                                             styles={{
                                                 viewport: {
                                                     paddingBottom: 0,
                                                 },
                                             }}
                                         >
-                                            <Group noWrap spacing={0}>
+                                            <Group
+                                                noWrap
+                                                styles={(theme) => ({
+                                                    root: {
+                                                        gap: theme.spacing.xl,
+                                                    },
+                                                })}
+                                            >
                                                 {sortedTabs?.map((tab, idx) => {
                                                     return (
                                                         <DraggableTab
@@ -328,7 +326,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                 )}
                                 <Group
                                     grow
-                                    pt={tabsEnabled ? 'lg' : undefined}
+                                    pt={tabsEnabled ? 'sm' : undefined}
                                     pb="lg"
                                     px="xs"
                                 >

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -111,9 +111,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             shadow={isEditMode ? 'xs' : undefined}
             sx={(theme) => {
                 let border = `1px solid ${theme.colors.gray[1]}`;
-                if (tabs && tabs.length > 1) {
-                    border = `1px solid ${theme.colors.gray[3]}`;
-                }
                 if (isEditMode) {
                     border = `1px dashed ${theme.colors.blue[5]}`;
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13111

### Description:

Some simple styling changes to dashboard tabs:

1. Adds space between tabs by default—this is similar to the spacing in editMode
2. Reduces space between top charts and tab bottom
3. Remove the stroke under the active tab, although...
4. Sets the canvas background to gray (the default for no tabs) which creates a separation with the active tab

<!-- Even better add a screenshot / gif / loom -->

### Before

![](https://cdn.zappy.app/7fcddc6a1bddea899cddd078b25b6af2.png)

### After

![](https://cdn.zappy.app/f7c46823d13dda4ffa4a632a1a38715d.png)
