### PR TITLE
feat: Improve instructions display

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ClampedTextWithPopover.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ClampedTextWithPopover.tsx
@@ -1,0 +1,62 @@
+import { Box, Button, Popover, ScrollArea, Text } from '@mantine-8/core';
+import { useIsLineClamped } from '../../../../hooks/useIsLineClamped';
+
+type ClampedTextWithPopoverProps = {
+    children: string;
+    maxLines?: number;
+    popoverWidth?: number;
+};
+
+const ClampedTextWithPopover = ({
+    children,
+    maxLines = 3,
+    popoverWidth = 400,
+}: ClampedTextWithPopoverProps) => {
+    const { ref, isLineClamped } = useIsLineClamped(maxLines);
+
+    return (
+        <Box>
+            <Text size="sm" lineClamp={maxLines} ref={ref}>
+                {children}
+            </Text>
+            {isLineClamped && (
+                <Popover
+                    width={popoverWidth}
+                    position="right"
+                    withArrow
+                    shadow="sm"
+                >
+                    <Popover.Target>
+                        <Button
+                            color="gray"
+                            variant="transparent"
+                            size="compact-xs"
+                            ml={-8}
+                        >
+                            See more
+                        </Button>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        <ScrollArea.Autosize
+                            type="hover"
+                            offsetScrollbars="y"
+                            scrollbars="y"
+                            mah={400}
+                        >
+                            <Text
+                                size="sm"
+                                style={{
+                                    whiteSpace: 'pre-wrap',
+                                }}
+                            >
+                                {children}
+                            </Text>
+                        </ScrollArea.Autosize>
+                    </Popover.Dropdown>
+                </Popover>
+            )}
+        </Box>
+    );
+};
+
+export default ClampedTextWithPopover;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -32,6 +32,7 @@ import Page from '../../../components/common/Page/Page';
 import { useProject } from '../../../hooks/useProject';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import useApp from '../../../providers/App/useApp';
+import ClampedTextWithPopover from '../../features/aiCopilot/components/ClampedTextWithPopover';
 import {
     useAiAgent,
     useAiAgentThreads,
@@ -169,7 +170,9 @@ const AgentPage = () => {
                         <Stack gap="xs">
                             <Title order={6}>Instructions</Title>
                             <Paper p="xs" bg="gray.0" c="gray.7">
-                                {agent.instruction}
+                                <ClampedTextWithPopover>
+                                    {agent.instruction}
+                                </ClampedTextWithPopover>
                             </Paper>
                         </Stack>
                     )}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -79,7 +79,7 @@ const AgentCard = ({ agent }: AgentCardProps) => {
                     </Stack>
                 </Group>
 
-                <Text size="sm" c="dimmed">
+                <Text size="sm" c="dimmed" lineClamp={2}>
                     {agent.instruction}
                 </Text>
             </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15155

### Description:

This PR improves the Instruction display in the `ai-agents` ui:

#### Line clamp in agent lists

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/90194251-afa6-4d60-8d75-eba2aeb0dba8.png)

#### Line clamp + popover in threads view


[Screen Recording 2025-06-06 at 13.03.37.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/HorFj8gm8QUuuIDE2vgk/10e6b1f8-f963-4f1b-9a14-f29ec12c0536.mov" />](https://app.graphite.dev/media/video/HorFj8gm8QUuuIDE2vgk/10e6b1f8-f963-4f1b-9a14-f29ec12c0536.mov)


#### Doesn't display  `show more` button if there is no need

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/6bdba3ae-982d-493b-a139-9845bd6efd22.png)

