### PR TITLE
feat: remove `Conversations` tab and redudant headings from agent details page

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentDetails.tsx
@@ -265,21 +265,20 @@ export const AgentDetails: FC = () => {
                                 },
                             }}
                         >
-                            <Tabs.List>
+                            {/* <Tabs.List>
                                 <Tabs.Tab value="general">General</Tabs.Tab>
                                 {!isCreateMode && (
                                     <Tabs.Tab value="conversations">
                                         Conversations
                                     </Tabs.Tab>
                                 )}
-                            </Tabs.List>
+                            </Tabs.List> */}
 
                             <Tabs.Panel value="general" pt="xs">
                                 <form onSubmit={handleSubmit}>
                                     <Stack gap="lg">
                                         {/* Basic Agent Info */}
                                         <Stack gap="sm">
-                                            <Title order={5}>Details</Title>
                                             <Group gap="sm">
                                                 <TextInput
                                                     label="Agent Name"
@@ -370,10 +369,6 @@ export const AgentDetails: FC = () => {
                                         </Stack>
 
                                         <Stack gap="sm">
-                                            <Title order={5}>
-                                                Configuration
-                                            </Title>
-
                                             <Textarea
                                                 label="Instructions"
                                                 description="Instructions set the
@@ -392,10 +387,6 @@ export const AgentDetails: FC = () => {
                                         {/* Integrations Section */}
 
                                         <Stack gap="sm">
-                                            <Title order={5}>
-                                                Integrations
-                                            </Title>
-
                                             <Stack gap="md">
                                                 <Title order={6}>Slack</Title>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removed confusing `conversations` tab from the Agent Details UI

![CleanShot 2025-06-06 at 15.21.50@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/ab8120a6-537a-4552-add9-d89f99a414ac.png)

