### PR TITLE
feat: update filter schema to support structured outputs in AI tools

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -8,6 +8,7 @@ import {
     ApiUpdateAiAgent,
     CommercialFeatureFlags,
     filterExploreByTags,
+    FilterSchemaType,
     ForbiddenError,
     LightdashUser,
     NotFoundError,
@@ -667,7 +668,8 @@ export class AiAgentService {
                 runMetricQuery: (q) =>
                     this.runAiMetricQuery(user, projectUuid, q),
                 vizConfig: verticalBarMetricChartConfig.data,
-                filters: message.filtersOutput ?? undefined,
+                // TODO: validate before casting
+                filters: message.filtersOutput as FilterSchemaType | null,
             });
         }
 
@@ -676,7 +678,8 @@ export class AiAgentService {
                 runMetricQuery: (q) =>
                     this.runAiMetricQuery(user, projectUuid, q),
                 vizConfig: timeSeriesMetricChartConfig.data,
-                filters: message.filtersOutput ?? undefined,
+                // TODO: validate before casting
+                filters: (message.filtersOutput as FilterSchemaType) ?? null,
             });
         }
 
@@ -685,7 +688,8 @@ export class AiAgentService {
                 runMetricQuery: (q) =>
                     this.runAiMetricQuery(user, projectUuid, q),
                 config: csvFileConfig.data,
-                filters: message.filtersOutput ?? undefined,
+                // TODO: validate before casting
+                filters: (message.filtersOutput as FilterSchemaType) ?? null,
                 maxLimit: AI_DEFAULT_MAX_QUERY_LIMIT,
             });
         }

--- a/packages/backend/src/ee/services/AiService/charts/csvFile.ts
+++ b/packages/backend/src/ee/services/AiService/charts/csvFile.ts
@@ -1,7 +1,8 @@
 import {
     AiChartType,
     AiMetricQuery,
-    FilterSchema,
+    filterSchema,
+    FilterSchemaType,
     SortFieldSchema,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify/sync';
@@ -29,9 +30,9 @@ export const csvFileConfigSchema = z
             ),
         dimensions: z
             .array(z.string())
-            .optional()
+            .nullable()
             .describe(
-                '(optional) The field id for the dimensions to group the metrics by',
+                'The field id for the dimensions to group the metrics by',
             ),
         sorts: z
             .array(SortFieldSchema)
@@ -40,8 +41,8 @@ export const csvFileConfigSchema = z
             ),
         limit: z
             .number()
-            .optional()
-            .describe('(optional) The maximum number of rows in the CSV.'),
+            .nullable()
+            .describe('The maximum number of rows in the CSV.'),
         followUpTools: followUpToolsSchema.describe(
             `The actions the User can ask for after the AI has generated the CSV. NEVER include ${FollowUpTools.GENERATE_CSV} in this list.`,
         ),
@@ -52,9 +53,11 @@ export const csvFileConfigSchema = z
 
 export const generateCsvToolSchema = z.object({
     vizConfig: csvFileConfigSchema,
-    filters: FilterSchema.optional().describe(
-        'Filters to apply to the query. Filtered fields must exist in the selected explore.',
-    ),
+    filters: filterSchema
+        .nullable()
+        .describe(
+            'Filters to apply to the query. Filtered fields must exist in the selected explore.',
+        ),
 });
 
 type CsvFileConfig = z.infer<typeof csvFileConfigSchema>;
@@ -62,14 +65,19 @@ type CsvFileConfig = z.infer<typeof csvFileConfigSchema>;
 export const metricQueryCsv = async (
     config: CsvFileConfig,
     maxLimit: number,
-    filters: z.infer<typeof FilterSchema> = {},
+    filters: FilterSchemaType | null,
 ): Promise<AiMetricQuery> => ({
     exploreName: config.exploreName,
     metrics: config.metrics,
     dimensions: config.dimensions || [],
     sorts: config.sorts,
     limit: getValidAiQueryLimit(config.limit, maxLimit),
-    filters,
+    // TODO: fix types
+    filters:
+        {
+            metrics: filters?.metrics ?? undefined,
+            dimensions: filters?.dimensions ?? undefined,
+        } ?? undefined,
 });
 
 type RenderCsvFileArgs = {
@@ -77,7 +85,7 @@ type RenderCsvFileArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     config: CsvFileConfig;
-    filters?: z.infer<typeof FilterSchema>;
+    filters: FilterSchemaType | null;
     maxLimit: number;
 };
 

--- a/packages/backend/src/ee/services/AiService/charts/timeSeriesChart.ts
+++ b/packages/backend/src/ee/services/AiService/charts/timeSeriesChart.ts
@@ -1,7 +1,8 @@
 import {
     AiChartType,
     AiMetricQuery,
-    FilterSchema,
+    filterSchema,
+    FilterSchemaType,
     MetricQuery,
     SortFieldSchema,
 } from '@lightdash/common';
@@ -21,9 +22,9 @@ export const timeSeriesMetricChartConfigSchema = z.object({
     title: z
         .string()
         .describe(
-            '(optional) The title of the chart. If not provided the chart will have no title.',
+            'The title of the chart. If not provided the chart will have no title.',
         )
-        .optional(),
+        .nullable(),
     exploreName: z
         .string()
         .describe(
@@ -47,24 +48,20 @@ export const timeSeriesMetricChartConfigSchema = z.object({
         ),
     breakdownByDimension: z
         .string()
-        .optional()
         .nullable()
         .describe(
-            '(optional) The field id of the dimension used to split the metrics into series for each dimension value. For example if you wanted to split a metric into multiple series based on City you would use the City dimension field id here. If this is not provided then the metric will be displayed as a single series.',
+            'The field id of the dimension used to split the metrics into series for each dimension value. For example if you wanted to split a metric into multiple series based on City you would use the City dimension field id here. If this is not provided then the metric will be displayed as a single series.',
         ),
     lineType: z
         .union([z.literal('line'), z.literal('area')])
         .describe(
-            '(optional) default line. The type of line to display. If area then the area under the line will be filled in.',
-        )
-        .default('line'),
+            'default line. The type of line to display. If area then the area under the line will be filled in.',
+        ),
     limit: z
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
-        .optional()
-        .describe(
-            `(optional, max: ${AI_DEFAULT_MAX_QUERY_LIMIT}) The total number of data points allowed on the chart.`,
-        ),
+        .nullable()
+        .describe(`The total number of data points allowed on the chart.`),
     followUpTools: followUpToolsSchema.describe(
         `The actions the User can ask for after the AI has generated the chart. NEVER include ${FollowUpTools.GENERATE_TIME_SERIES_VIZ} in this list.`,
     ),
@@ -72,9 +69,11 @@ export const timeSeriesMetricChartConfigSchema = z.object({
 
 export const generateTimeSeriesVizConfigToolSchema = z.object({
     vizConfig: timeSeriesMetricChartConfigSchema,
-    filters: FilterSchema.optional().describe(
-        'Filters to apply to the query. Filtered fields must exist in the selected explore.',
-    ),
+    filters: filterSchema
+        .nullable()
+        .describe(
+            'Filters to apply to the query. Filtered fields must exist in the selected explore.',
+        ),
 });
 
 type TimeSeriesMetricChartConfig = z.infer<
@@ -83,7 +82,7 @@ type TimeSeriesMetricChartConfig = z.infer<
 
 export const metricQueryTimeSeriesChartMetric = (
     config: TimeSeriesMetricChartConfig,
-    filters: z.infer<typeof FilterSchema> = {},
+    filters: FilterSchemaType | null,
 ): AiMetricQuery => {
     const metrics = config.yMetrics;
     const dimensions = [
@@ -98,7 +97,12 @@ export const metricQueryTimeSeriesChartMetric = (
         limit: getValidAiQueryLimit(limit),
         sorts,
         exploreName: config.exploreName,
-        filters,
+        // TODO: fix types
+        filters:
+            {
+                metrics: filters?.metrics ?? undefined,
+                dimensions: filters?.dimensions ?? undefined,
+            } ?? undefined,
     };
 };
 
@@ -170,7 +174,7 @@ type RenderTimeseriesChartArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     vizConfig: TimeSeriesMetricChartConfig;
-    filters?: z.infer<typeof FilterSchema>;
+    filters: FilterSchemaType | null;
 };
 
 export const renderTimeseriesChart = async ({

--- a/packages/backend/src/ee/services/AiService/charts/verticalBarChart.ts
+++ b/packages/backend/src/ee/services/AiService/charts/verticalBarChart.ts
@@ -1,7 +1,8 @@
 import {
     AiChartType,
     AiMetricQuery,
-    FilterSchema,
+    filterSchema,
+    FilterSchemaType,
     MetricQuery,
     SortFieldSchema,
 } from '@lightdash/common';
@@ -41,18 +42,15 @@ export const verticalBarMetricChartConfigSchema = z.object({
         ),
     breakdownByDimension: z
         .string()
-        .optional()
         .nullable()
         .describe(
-            '(optional) The field id of the dimension used to split the metrics into groups along the x-axis. If stacking is false then this will create multiple bars around each x value, if stacking is true then this will create multiple bars for each metric stacked on top of each other',
+            'The field id of the dimension used to split the metrics into groups along the x-axis. If stacking is false then this will create multiple bars around each x value, if stacking is true then this will create multiple bars for each metric stacked on top of each other',
         ),
     stackBars: z
         .boolean()
-        .default(false)
-        .optional()
         .nullable()
         .describe(
-            '(optional) Default false. If using breakdownByDimension then this will stack the bars on top of each other instead of side by side.',
+            'If using breakdownByDimension then this will stack the bars on top of each other instead of side by side.',
         ),
     xAxisType: z
         .union([z.literal('category'), z.literal('time')])
@@ -62,22 +60,19 @@ export const verticalBarMetricChartConfigSchema = z.object({
     limit: z
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
-        .optional()
+        .nullable()
         .describe(
-            `(optional, max: ${AI_DEFAULT_MAX_QUERY_LIMIT}) The total number of data points / bars allowed on the chart.`,
+            `The total number of data points / bars allowed on the chart.`,
         ),
     xAxisLabel: z
         .string()
-        .optional()
-        .describe('(optional) A helpful label to explain the x-axis'),
+        .nullable()
+        .describe('A helpful label to explain the x-axis'),
     yAxisLabel: z
         .string()
-        .optional()
-        .describe('(optional) A helpful label to explain the y-axis'),
-    title: z
-        .string()
-        .optional()
-        .describe('(optional) a descriptive title for the chart'),
+        .nullable()
+        .describe('A helpful label to explain the y-axis'),
+    title: z.string().nullable().describe('a descriptive title for the chart'),
     followUpTools: followUpToolsSchema.describe(
         `The actions the User can ask for after the AI has generated the chart. NEVER include ${FollowUpTools.GENERATE_BAR_VIZ} in this list.`,
     ),
@@ -85,9 +80,11 @@ export const verticalBarMetricChartConfigSchema = z.object({
 
 export const generateBarVizConfigToolSchema = z.object({
     vizConfig: verticalBarMetricChartConfigSchema,
-    filters: FilterSchema.optional().describe(
-        'Filters to apply to the query. Filtered fields must exist in the selected explore.',
-    ),
+    filters: filterSchema
+        .nullable()
+        .describe(
+            'Filters to apply to the query. Filtered fields must exist in the selected explore.',
+        ),
 });
 
 type VerticalBarMetricChartConfig = z.infer<
@@ -96,7 +93,7 @@ type VerticalBarMetricChartConfig = z.infer<
 
 export const metricQueryVerticalBarChartMetric = (
     config: VerticalBarMetricChartConfig,
-    filters: z.infer<typeof FilterSchema> = {},
+    filters: FilterSchemaType | null,
 ): AiMetricQuery => {
     const metrics = config.yMetrics;
     const dimensions = [
@@ -110,7 +107,12 @@ export const metricQueryVerticalBarChartMetric = (
         limit: getValidAiQueryLimit(limit),
         sorts,
         exploreName: config.exploreName,
-        filters,
+        // TODO: fix types
+        filters:
+            {
+                metrics: filters?.metrics ?? undefined,
+                dimensions: filters?.dimensions ?? undefined,
+            } ?? undefined,
     };
 };
 
@@ -183,7 +185,7 @@ type RenderVerticalBarMetricChartArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     vizConfig: VerticalBarMetricChartConfig;
-    filters?: z.infer<typeof FilterSchema>;
+    filters: FilterSchemaType | null;
 };
 
 export const renderVerticalBarMetricChart = async ({

--- a/packages/backend/src/ee/services/AiService/utils/aiCopilot/validators.ts
+++ b/packages/backend/src/ee/services/AiService/utils/aiCopilot/validators.ts
@@ -75,7 +75,7 @@ export function validateFilterRules(
 Error: the field with id "${
                     rule.target.fieldId
                 }" does not exist in the selected explore.
-FilterRule: 
+FilterRule:
 
 \`\`\`json
 ${JSON.stringify(rule, null, 2)}
@@ -106,7 +106,7 @@ ${filterRuleErrorStrings}`);
 
 export const AI_DEFAULT_MAX_QUERY_LIMIT = 1000;
 export function getValidAiQueryLimit(
-    limit: number | undefined,
+    limit: number | null,
     maxLimit: number = AI_DEFAULT_MAX_QUERY_LIMIT, // ! Allow limit override
 ) {
     if (!limit) {

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -91,11 +91,14 @@ export const runAgent = async ({
         compatibility: 'strict',
     });
 
-    const model = openai('gpt-4.1');
+    const model = openai('gpt-4.1', {
+        structuredOutputs: true,
+    });
 
     const result = await generateText({
         model,
         tools,
+        toolChoice: 'auto',
         messages,
         maxSteps: 10,
         maxRetries: 3,

--- a/packages/backend/src/ee/services/ai/tools/getOneLineResult.ts
+++ b/packages/backend/src/ee/services/ai/tools/getOneLineResult.ts
@@ -9,11 +9,9 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
-export const aiGetOneLineResultToolSchema = z.object({
-    metricQuery: lighterMetricQuerySchema.describe(
-        'Metric query to run to get the result',
-    ), // ! DO NOT USE AIMETRICQUERY HERE, ZOD CANNOT GET THE TYPE CORRECTLY
-});
+export const aiGetOneLineResultToolSchema = lighterMetricQuerySchema.describe(
+    'Metric query to run to get the result',
+);
 
 type Dependencies = {
     runMiniMetricQuery: RunMiniMetricQueryFn;
@@ -42,7 +40,7 @@ Rules for fetching the result:
 - Only apply sort if needed and make sure sort "fieldId"s are from the selected "Metric" and "Dimension" "fieldId"s.
 `,
         parameters: schema,
-        execute: async ({ metricQuery }) => {
+        execute: async (metricQuery) => {
             try {
                 const prompt = await getPrompt();
 
@@ -52,7 +50,15 @@ Rules for fetching the result:
                 });
 
                 await updateProgress('🔍 Fetching the results...');
-                const result = await runMiniMetricQuery(metricQuery);
+                const result = await runMiniMetricQuery({
+                    ...metricQuery,
+                    filters:
+                        {
+                            metrics: metricQuery.filters?.metrics ?? undefined,
+                            dimensions:
+                                metricQuery.filters?.dimensions ?? undefined,
+                        } ?? undefined,
+                });
 
                 if (result.rows.length > 1) {
                     throw new Error(

--- a/packages/common/src/ee/Ai/schemas.ts
+++ b/packages/common/src/ee/Ai/schemas.ts
@@ -150,10 +150,15 @@ export const FilterGroupSchema = z.union([
     OrFilterGroupSchema,
 ]);
 
-export const FilterSchema = z.object({
-    dimensions: FilterGroupSchema.optional(),
-    metrics: FilterGroupSchema.optional(),
+// TODO: This schema was designed to closely match the existing filter types,
+// but LLM providers require that all fields be explicitly defined and present.
+// https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required
+export const filterSchema = z.object({
+    dimensions: FilterGroupSchema.nullable(),
+    metrics: FilterGroupSchema.nullable(),
 });
+
+export type FilterSchemaType = z.infer<typeof filterSchema>;
 
 export const GenerateQueryFiltersToolSchema = z.object({
     exploreName: z.string().describe('Name of the selected explore'),
@@ -168,10 +173,8 @@ export const SortFieldSchema = z.object({
     ),
     descending: z
         .boolean()
-        .optional()
-        .default(true)
         .describe(
-            '(optional, default true). If true sorts in descending order, if false sorts in ascending order',
+            'If true sorts in descending order, if false sorts in ascending order',
         ),
 });
 
@@ -183,29 +186,29 @@ export const SortFieldSchema = z.object({
 //     type: z.nativeEnum(CustomFormatType).describe('Type of custom format'),
 //     round: z
 //         .number()
-//         .optional()
+//         .nullable()
 //         .describe('Number of decimal places to round to'),
 //     separator: z
 //         .nativeEnum(NumberSeparator)
-//         .optional()
+//         .nullable()
 //         .describe('Separator for thousands'),
 //     // TODO: this should be enum but currencies is loosely typed
-//     currency: z.string().optional().describe('Three-letter currency code'),
-//     compact: CompactOrAliasSchema.optional().describe('Compact number format'),
-//     prefix: z.string().optional().describe('Prefix to add to the number'),
-//     suffix: z.string().optional().describe('Suffix to add to the number'),
+//     currency: z.string().nullable().describe('Three-letter currency code'),
+//     compact: CompactOrAliasSchema.nullable().describe('Compact number format'),
+//     prefix: z.string().nullable().describe('Prefix to add to the number'),
+//     suffix: z.string().nullable().describe('Suffix to add to the number'),
 // });
 
 // export const TableCalculationSchema = z.object({
 //   // TODO: I don't know what this is
-//   index: z.number().optional().describe('Index of the table calculation'),
+//   index: z.number().nullable().describe('Index of the table calculation'),
 //   name: z.string().min(1).describe('Name of the table calculation'),
 //   displayName: z
 //       .string()
 //       .min(1)
 //       .describe('Display name of the table calculation'),
 //   sql: z.string().min(1).describe('SQL for the table calculation'),
-//   format: CustomFormatSchema.optional().describe(
+//   format: CustomFormatSchema.nullable().describe(
 //       'Format of the table calculation',
 //   ),
 // });
@@ -225,7 +228,7 @@ export const lighterMetricQuerySchema = z.object({
         .describe(
             'Dimensions to break down the metric into groups. @example: ["orders_status", "customers_first_name"]',
         ),
-    filters: FilterSchema.describe('Filters to apply to the query'),
+    filters: filterSchema.describe('Filters to apply to the query'),
     sorts: z
         .array(SortFieldSchema)
         .describe(
@@ -245,7 +248,7 @@ export const lighterMetricQuerySchema = z.object({
     // additionalMetrics: z
     //     .array(z.unknown())
     //     .max(0)
-    //     .optional()
+    //     .nullable()
     //     .describe(
     //         'Additional metrics to compute in the explore - not supported yet',
     //     ),
@@ -253,7 +256,7 @@ export const lighterMetricQuerySchema = z.object({
     // customDimensions: z
     //     .array(z.unknown())
     //     .max(0)
-    //     .optional()
+    //     .nullable()
     //     .describe('Custom dimensions to group by in the explore'),
     // metadata: z
     //     .object({
@@ -263,7 +266,7 @@ export const lighterMetricQuerySchema = z.object({
     //             name: z.string().describe('Name of the date dimension'),
     //         }),
     //     })
-    //     .optional()
+    //     .nullable()
     //     .describe('Metadata about the query'),
 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
This PR updates the filter schema types to work better with LLM providers by making all fields explicitly defined and present. It replaces `optional()` with `nullable()` in various schema definitions to ensure compatibility with structured outputs in OpenAI's API.

Key changes:
- Created a new `filterSchema` with nullable fields instead of optional ones
- Added `FilterSchemaType` export for type safety
- Updated chart generation tools (vertical bar, time series, CSV) to use the new filter schema
- Added proper type casting in the AiAgentService
- Updated the OpenAI model configuration to use structured outputs
- Fixed the getOneLineResult tool to properly handle the new filter structure

These changes ensure our AI tools work correctly with OpenAI's structured output requirements, which specify that "all fields must be required" in schemas.