### PR TITLE
fix: get explore query rows on ai agent service

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -121,23 +121,18 @@ export class AiAgentService {
 
         validateSelectedFieldsExistence(explore, metricQueryFields);
 
-        return this.projectService.runMetricQuery({
+        return this.projectService.runExploreQuery(
             user,
-            projectUuid,
-            metricQuery: {
+            {
                 ...metricQuery,
                 tableCalculations: [],
             },
-            exploreName: metricQuery.exploreName,
-            csvLimit: metricQuery.limit,
-            context: QueryExecutionContext.AI,
-            chartUuid: undefined,
-            queryTags: {
-                project_uuid: projectUuid,
-                user_uuid: user.userUuid,
-                organization_uuid: user.organizationUuid,
-            },
-        });
+            projectUuid,
+            metricQuery.exploreName,
+            metricQuery.limit,
+            undefined,
+            QueryExecutionContext.AI,
+        );
     }
 
     private async getIsCopilotEnabled(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15219

### Description:

![Screenshot 2025-06-06 at 17.20.08.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/9a7d983a-8f6d-49be-810b-d76e4bb21564.png)

![Screenshot 2025-06-06 at 17.20.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/d7daf30a-65e1-45eb-bfe8-5df54f54b4e9.png)

tldr;

mismatch between the `xAxis.data` 
```
"2018-01-01T00:00:00Z"
"2018-03-26T00:00:00Z"
```
and the `dataset.source` date formats:
```
"2018-01-01T00:00:00.000Z"  
"2018-03-25T23:00:00.000Z"
```

Refactored AI agent query execution to use `runExploreQuery` instead of `runMetricQuery` in the backend service. This simplifies the API call by passing parameters directly rather than using a complex object structure.

In the frontend, improved the chart visualization generation from AI queries by:
- Using default state for metric query properties
- Simplifying results data handling
- Properly passing fields to the visualization provider
- Adding itemsMap to the returned props

