### PR TITLE
feat: add UTF-8 BOM support to CSV exports

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -515,7 +515,8 @@ export class CsvService extends BaseService {
     }): Promise<AttachmentUrl> {
         const fileId = CsvService.generateFileId(fileName, truncated);
         const filePath = `/tmp/${fileId}`;
-        await fsPromise.writeFile(filePath, csvContent, 'utf-8');
+        const csvWithBOM = `\uFEFF${csvContent}`;
+        await fsPromise.writeFile(filePath, csvWithBOM, 'utf-8');
 
         if (this.s3Client.isEnabled()) {
             const s3Url = await this.s3Client.uploadCsv(csvContent, fileId);

--- a/packages/frontend/src/components/DashboardTiles/DashboardMinimalDownloadCsv.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMinimalDownloadCsv.tsx
@@ -153,7 +153,8 @@ export const DashboardMinimalDownloadCsv: FC<{
             );
         });
 
-        const blob = new Blob([csvContent], {
+        const csvWithBOM = '\uFEFF' + csvContent;
+        const blob = new Blob([csvWithBOM], {
             type: 'text/csv;charset=utf-8;',
         });
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10214 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR updates the CSV export functionality to include a UTF-8 BOM at the beginning of exported files. This ensures proper character rendering—especially for non-Latin scripts like Japanese—when opening CSVs in Microsoft Excel, which otherwise fails to correctly interpret UTF-8 encoding.

Before:
![Screenshot 2025-06-07 172639](https://github.com/user-attachments/assets/c965f86b-76c4-4528-a07d-e87624a5da6c)


After:
![Screenshot 2025-06-07 174443](https://github.com/user-attachments/assets/d62133dc-1fdc-48c8-bc32-14e073beb5a5)

<!-- Even better add a screenshot / gif / loom -->

