### PR TITLE
fix: remove s3 acl since it is not necessary

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -74,7 +74,6 @@ export class S3Client {
                 Key: fileId,
                 Body: file,
                 ContentType: contentType,
-                ACL: 'private',
                 ContentDisposition: `attachment; filename="${fileId}"`,
             },
         });
@@ -173,7 +172,6 @@ export class S3Client {
                 Key: fileId,
                 Body: buffer,
                 ContentType: `application/jsonl`,
-                ACL: 'private',
                 ContentDisposition: `attachment; filename="${fileId}"`,
             },
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15129 

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
- Using ACL in S3 seem cause error on streaming upload to GCS
- Since S3 has disable using of ACL, it worth for deleting this setting
- This PR delete using of ACL from stream upload logic
<!-- Even better add a screenshot / gif / loom -->
