### PR TITLE
fix: Show `Ask AI` button only to users who can manage Agents

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -22,6 +22,7 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             [CommercialFeatureFlags.Scim]: this.getScimFlag.bind(this),
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
+            [CommercialFeatureFlags.AiAgent]: this.getAiAgentFlag.bind(this),
         };
     }
 
@@ -101,6 +102,33 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled,
+        };
+    }
+
+    private async getAiAgentFlag({
+        featureFlagId,
+        user,
+    }: FeatureFlagLogicArgs) {
+        if (!user) {
+            throw new Error('User is required to check if AI agent is enabled');
+        }
+
+        if (!this.lightdashConfig.ai.copilot.enabled) {
+            return {
+                id: featureFlagId,
+                enabled: false,
+            };
+        }
+
+        return {
+            id: featureFlagId,
+            enabled: await isFeatureFlagEnabled(
+                CommercialFeatureFlags.AiAgent as AnyType as FeatureFlags,
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid,
+                },
+            ),
         };
     }
 }

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -2,4 +2,5 @@ export enum CommercialFeatureFlags {
     Embedding = 'embedding',
     Scim = 'scim-token-management',
     AiCopilot = 'ai-copilot',
+    AiAgent = 'ai-agent',
 }

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,11 +1,34 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
 import { Button } from '@mantine/core';
 import { IconMessageCircleStar } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
+import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
+import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 
 export const AiAgentsButton = () => {
     // Using `navigate` instead of the `Link` component to ensure round corners within a button group
     const navigate = useNavigate();
+
+    const appQuery = useApp();
+    const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
+    const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);
+
+    if (
+        !appQuery.user.isSuccess ||
+        !aiCopilotFlagQuery.isSuccess ||
+        !aiAgentFlagQuery.isSuccess
+    ) {
+        return null;
+    }
+
+    const canViewAiAgents = appQuery.user.data.ability.can('view', 'AiAgent');
+    const isAiCopilotEnabled = aiCopilotFlagQuery.data.enabled;
+    const isAiAgentEnabled = aiAgentFlagQuery.data.enabled;
+
+    if (!canViewAiAgents || !isAiCopilotEnabled || !isAiAgentEnabled) {
+        return null;
+    }
 
     return (
         <Button

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -1,11 +1,8 @@
-import { CommercialFeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Button, Group } from '@mantine/core';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import Omnibar from '../../features/omnibar';
-import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
-import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
 import { AiAgentsButton } from './AiAgentsButton';
 import BrowseMenu from './BrowseMenu';
@@ -34,11 +31,6 @@ export const MainNavBarContent: FC<Props> = ({
     const { data: hasMetrics } = useHasMetricsInCatalog({
         projectUuid: activeProjectUuid,
     });
-    const { data: aiCopilotFlag, isLoading: isAiCopilotLoading } =
-        useFeatureFlag(CommercialFeatureFlags.AiCopilot);
-
-    const { user } = useApp();
-    const canManageAiAgents = user?.data?.ability?.can('manage', 'AiAgent');
 
     return (
         <>
@@ -60,9 +52,7 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
-                            {canManageAiAgents &&
-                                !isAiCopilotLoading &&
-                                aiCopilotFlag?.enabled && <AiAgentsButton />}
+                            <AiAgentsButton />
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />
                     </>

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import Omnibar from '../../features/omnibar';
 import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
+import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
 import { AiAgentsButton } from './AiAgentsButton';
 import BrowseMenu from './BrowseMenu';
@@ -36,6 +37,9 @@ export const MainNavBarContent: FC<Props> = ({
     const { data: aiCopilotFlag, isLoading: isAiCopilotLoading } =
         useFeatureFlag(CommercialFeatureFlags.AiCopilot);
 
+    const { user } = useApp();
+    const canManageAiAgents = user?.data?.ability?.can('manage', 'AiAgent');
+
     return (
         <>
             <Group align="center" sx={{ flexShrink: 0 }}>
@@ -56,9 +60,9 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
-                            {!isAiCopilotLoading && aiCopilotFlag?.enabled && (
-                                <AiAgentsButton />
-                            )}
+                            {canManageAiAgents &&
+                                !isAiCopilotLoading &&
+                                aiCopilotFlag?.enabled && <AiAgentsButton />}
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />
                     </>


### PR DESCRIPTION
# Added AI Agent feature flag and permission checks

### Description:

Added a new AI Agent feature flag and implemented proper permission checks for the AI Agents button in the navigation bar. The button will now only be displayed if:

1. The user has the ability to view AI Agents
2. The AI Copilot feature flag is enabled
3. The new AI Agent feature flag is enabled

This ensures the AI Agents functionality is only accessible to users with appropriate permissions and when the required features are enabled.