### PR TITLE
fix: custom range breaking custom dimension form

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -24,6 +24,7 @@ import {
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconX } from '@tabler/icons-react';
+import { cloneDeep } from 'lodash';
 import { useEffect, useMemo, type FC } from 'react';
 import { z } from 'zod';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -144,7 +145,9 @@ export const CustomBinDimensionModal: FC<{
 
             setFieldValue(
                 'binConfig.customRange',
-                item.customRange ? item.customRange : DEFAULT_CUSTOM_RANGE,
+                item.customRange
+                    ? cloneDeep(item.customRange)
+                    : DEFAULT_CUSTOM_RANGE,
             );
         }
     }, [setFieldValue, item, isEditing]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15232

### Description:

Reproduction of the bug: https://cln.sh/XznG4TYv

Fixed a bug in the CustomBinDimensionModal component by using lodash's cloneDeep when setting the binConfig.customRange field value.
