### PR TITLE
fix: required dashboard filters for SQL charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1162,11 +1162,17 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DimensionType: {
+        dataType: 'refEnum',
+        enums: ['string', 'number', 'timestamp', 'date', 'boolean'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardFieldTarget: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                fallbackType: { ref: 'DimensionType' },
                 isSqlColumn: { dataType: 'boolean' },
                 tableName: { dataType: 'string', required: true },
                 fieldId: { dataType: 'string', required: true },
@@ -1557,11 +1563,6 @@ const models: TsoaRoute.Models = {
     'FieldType.DIMENSION': {
         dataType: 'refEnum',
         enums: ['dimension'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DimensionType: {
-        dataType: 'refEnum',
-        enums: ['string', 'number', 'timestamp', 'date', 'boolean'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Record_string.string-or-string-Array_': {
@@ -15801,19 +15802,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    LimitOverride: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { dataType: 'double' },
-                { dataType: 'enum', enums: [null] },
-                { dataType: 'undefined' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExecuteAsyncSavedChartRequestParams: {
         dataType: 'refAlias',
         type: {
@@ -15823,7 +15811,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        limit: { ref: 'LimitOverride' },
+                        limit: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                                { dataType: 'undefined' },
+                            ],
+                        },
                         versionUuid: { dataType: 'string' },
                         chartUuid: { dataType: 'string', required: true },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1153,8 +1153,15 @@
                     }
                 ]
             },
+            "DimensionType": {
+                "enum": ["string", "number", "timestamp", "date", "boolean"],
+                "type": "string"
+            },
             "DashboardFieldTarget": {
                 "properties": {
+                    "fallbackType": {
+                        "$ref": "#/components/schemas/DimensionType"
+                    },
                     "isSqlColumn": {
                         "type": "boolean"
                     },
@@ -1605,10 +1612,6 @@
             },
             "FieldType.DIMENSION": {
                 "enum": ["dimension"],
-                "type": "string"
-            },
-            "DimensionType": {
-                "enum": ["string", "number", "timestamp", "date", "boolean"],
                 "type": "string"
             },
             "Record_string.string-or-string-Array_": {
@@ -16615,12 +16618,6 @@
                     }
                 ]
             },
-            "LimitOverride": {
-                "type": "number",
-                "format": "double",
-                "nullable": true,
-                "description": "Represents different limit override behaviors\n- undefined: use original limit from saved chart/query\n- null: no limit (unlimited results)\n- number: apply specific limit"
-            },
             "ExecuteAsyncSavedChartRequestParams": {
                 "allOf": [
                     {
@@ -16629,7 +16626,9 @@
                     {
                         "properties": {
                             "limit": {
-                                "$ref": "#/components/schemas/LimitOverride",
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true,
                                 "description": "Limit override for query execution:\n- undefined: use saved chart's original limit\n- null: no limit (unlimited results)\n- number: apply specific limit"
                             },
                             "versionUuid": {
@@ -17729,7 +17728,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1701.0",
+        "version": "0.1703.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -1,5 +1,6 @@
 import { type AnyType } from './any';
 import { ConditionalOperator, type ConditionalRule } from './conditionalRule';
+import { type DimensionType } from './field';
 import type { SchedulerFilterRule } from './scheduler';
 
 export enum FilterType {
@@ -94,7 +95,8 @@ export const isJoinModelRequiredFilter = (
 export type DashboardFieldTarget = {
     fieldId: string;
     tableName: string;
-    isSqlColumn?: boolean;
+    isSqlColumn?: boolean; // If true, fieldId is a SQL column name and tableName is redundant
+    fallbackType?: DimensionType; // Used to infer filter type when field/column is not available
 };
 
 export const isDashboardFieldTarget = (

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -452,6 +452,7 @@ const getDefaultTileSqlTargets = (
                 fieldId: filterableField.reference,
                 tableName: `sql_chart`,
                 isSqlColumn: true,
+                fallbackType: filterableField.type,
             },
         };
     }, {});
@@ -478,6 +479,7 @@ export const createDashboardFilterRuleFromSqlColumn = ({
                 fieldId: column.reference,
                 tableName: 'sql_chart',
                 isSqlColumn: true,
+                fallbackType: column.type,
             },
             tileTargets: getDefaultTileSqlTargets(column, availableTileColumns),
             disabled: !isTemporary,

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/Filter.tsx
@@ -1,5 +1,6 @@
 import {
     applyDefaultTileTargets,
+    DimensionType,
     getFilterTypeFromItemType,
     type DashboardFilterRule,
     type FilterableDimension,
@@ -83,11 +84,9 @@ const Filter: FC<Props> = ({
         (c) => c.sqlChartTilesMetadata,
     );
     const disabled = useMemo(() => {
-        return (
-            !allFilterableFields &&
-            Object.keys(sqlChartTilesMetadata).length === 0
-        );
-    }, [allFilterableFields, sqlChartTilesMetadata]);
+        // Wait for fields to be loaded unless is SQL column
+        return !allFilterableFields && !filterRule.target.isSqlColumn;
+    }, [allFilterableFields, filterRule]);
     const filterableFieldsByTileUuid = useDashboardContext(
         (c) => c.filterableFieldsByTileUuid,
     );
@@ -136,7 +135,13 @@ const Filter: FC<Props> = ({
                     column.reference,
                 );
             }
-            return;
+            return getConditionalRuleLabel(
+                filterRule,
+                getFilterTypeFromItemType(
+                    filterRule.target.fallbackType ?? DimensionType.STRING,
+                ),
+                filterRule.target.fieldId,
+            );
         }
     }, [filterRule, field, sqlChartTilesMetadata]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15161

## Description:

Before:
<img width="1551" alt="Screenshot 2025-06-09 at 11 51 25" src="https://github.com/user-attachments/assets/ec2aef23-d7aa-4232-ad28-3aa568588c70" />

After:
<img width="1441" alt="Screenshot 2025-06-09 at 12 48 10" src="https://github.com/user-attachments/assets/36ff3182-c8d4-458d-b026-56e9febfb9ef" />
<img width="1441" alt="Screenshot 2025-06-09 at 12 48 37" src="https://github.com/user-attachments/assets/37648565-9b1c-44de-9c3b-9678758e8105" />

### AI Description:
Added support for fallback type in dashboard filter targets to improve filter handling when fields or columns are not immediately available. This allows filters to function properly even when the underlying data structure is still loading or when using SQL columns.

Key changes:
- Added `fallbackType` property to `DashboardFieldTarget` to infer filter types when fields/columns aren't available
- Improved filter display logic to use fallback types when needed
- Fixed filter configuration to properly handle cases where field data is still loading
- Reordered some type definitions for better organization
