### PR TITLE
fix: add BigQuery SSO feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -58,6 +58,8 @@ export enum FeatureFlags {
      * Enable the ability to create custom visualizations with AI
      */
     AiCustomViz = 'ai-custom-viz',
+
+    BigquerySSO = 'bigquery-sso',
 }
 
 export type FeatureFlag = {

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -88,11 +88,11 @@ const configureBigqueryWarehouse = (
     cy.get('input[name="warehouse.location"]').type(config.location, {
         log: false,
     });
-
+    /*
     cy.selectMantine(
         'warehouse.authenticationType',
         'Service Account (JSON key file)',
-    );
+    ); */
 
     cy.get('[type="file"]').attachFile(warehouseConfig.bigQuery.keyFile);
 

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
@@ -17,7 +17,7 @@ export const BigQueryDefaultValues: CreateBigqueryCredentials = {
     dataset: '',
     project: '',
     location: '',
-    authenticationType: BigqueryAuthenticationType.SSO,
+    authenticationType: BigqueryAuthenticationType.PRIVATE_KEY,
     // @ts-expect-error we need to set it as empty string to avoid overwritting saved value
     keyfileContents: '', // Not needed for sso, we will load the refresh token from the user in the backend
     executionProject: '',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

![image](https://github.com/user-attachments/assets/2cf27ea0-5352-43fa-b8ab-77fb3db0a649)

Added a feature flag `BigquerySSO` to control the availability of SSO authentication for BigQuery connections. When the flag is disabled, the UI will only show the service account authentication option and set it as the default. This allows for controlled rollout of the SSO functionality.

The changes include:
- Added a new feature flag `BigquerySSO` in featureFlags.ts
- Modified BigQueryForm to conditionally render SSO-related UI components based on the flag
- Changed the default authentication type to PRIVATE_KEY in defaultValues.ts
- Added flag checks before making BigQuery dataset API calls