### PR TITLE
chore: add authentication tracking to project analytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -551,7 +551,7 @@ export type ConditionalFormattingRuleSavedEvent = BaseTrack & {
     };
 };
 
-type ProjectEvent = BaseTrack & {
+export type ProjectEvent = BaseTrack & {
     event: 'project.updated' | 'project.created';
     userId: string;
     properties: {
@@ -564,6 +564,8 @@ type ProjectEvent = BaseTrack & {
         isPreview: boolean;
         method: RequestMethod;
         copiedFromProjectUuid?: string;
+        authenticationType?: string;
+        requireUserCredentials?: boolean;
     };
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## How to see dev rudderstack eevents

[Screencast from 2025-06-10 08-46-06.webm](https://github.com/user-attachments/assets/c6011530-1e14-4743-ac56-4a1b8d4676e9)

## Project updated events

[Screencast from 2025-06-10 08-49-57.webm](https://github.com/user-attachments/assets/15ac57ca-f654-4abc-b57c-37c569701500)


Closes:  https://github.com/lightdash/lightdash-internal-work/issues/3444

### Description:
Added authentication type and user credentials tracking to project analytics events. Created a reusable `getAnalyticProperties` method to standardize analytics data collection across project creation and update flows. This ensures consistent tracking of warehouse authentication methods and user credential requirements.