### PR TITLE
feat: dashboard chart tile data download

### DIFF
--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -19,11 +19,12 @@ describe('Download CSV on Dashboards', () => {
         'Should download a CSV from dashboard',
         { retries: 3, pageLoadTimeout: 1000 },
         () => {
-            const downloadUrl = `/api/v1/saved/*/downloadCsv`;
+            const downloadUrl = `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/*/download`;
+
             cy.intercept({
                 method: 'POST',
                 url: downloadUrl,
-            }).as('apiDownloadCsv');
+            }).as('apiDownload');
 
             // wait for the dashboard to load
             cy.findByText('Loading dashboards').should('not.exist');
@@ -39,14 +40,14 @@ describe('Download CSV on Dashboards', () => {
             cy.contains('Days since').trigger('mouseenter');
 
             cy.findByTestId('tile-icon-more').click();
-            cy.findByText('Export CSV').click();
-            cy.get('button').contains('Export CSV').click();
+            cy.get('button').contains('Download data').click();
 
-            cy.wait('@apiDownloadCsv').then((interception) => {
+            cy.get('[data-testid=chart-export-results-button]').click();
+
+            cy.wait('@apiDownload', { timeout: 3000 }).then((interception) => {
                 expect(interception?.response?.statusCode).to.eq(200);
-
                 expect(interception?.response?.body.results).to.have.property(
-                    'jobId',
+                    'fileUrl',
                 );
             });
         },

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -42,6 +42,9 @@ describe('Download CSV on Dashboards', () => {
             cy.findByTestId('tile-icon-more').click();
             cy.get('button').contains('Download data').click();
 
+            cy.get('[data-testid=chart-export-results-button]').should(
+                'be.visible',
+            );
             cy.get('[data-testid=chart-export-results-button]').click();
 
             cy.wait('@apiDownload', { timeout: 3000 }).then((interception) => {

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -68,7 +68,7 @@ describe('Embedded dashboard', () => {
                     'mouseenter',
                 );
                 cy.findByTestId('tile-icon-more').click();
-                cy.contains('Export CSV');
+                cy.contains('Download data');
                 cy.contains('Export image');
 
                 // Check date zoom

--- a/packages/frontend/src/api/csv.ts
+++ b/packages/frontend/src/api/csv.ts
@@ -2,7 +2,6 @@ import {
     type ApiCsvUrlResponse,
     type ApiDownloadCsv,
     type ApiScheduledDownloadCsv,
-    type DashboardFilters,
     type MetricQuery,
     type PivotConfig,
 } from '@lightdash/common';
@@ -53,37 +52,6 @@ export const downloadCsv = async ({
             chartName,
             timezone: query.timezone ?? undefined,
             pivotConfig,
-        }),
-    });
-};
-
-export const downloadCsvFromSavedChart = async ({
-    chartUuid,
-    dashboardFilters,
-    tileUuid,
-    csvLimit,
-    onlyRaw,
-}: {
-    chartUuid: string;
-    dashboardFilters?: DashboardFilters;
-    tileUuid?: string;
-    // Csv properties
-    onlyRaw: boolean;
-    csvLimit: number | null | undefined;
-}) => {
-    /* TODO fix dashboardFilters timezone 
-    const timezoneFixQuery = {
-        ...query,
-        filters: convertDateFilters(query.filters),
-    };*/
-    return lightdashApi<ApiScheduledDownloadCsv>({
-        url: `/saved/${chartUuid}/downloadCsv`,
-        method: 'POST',
-        body: JSON.stringify({
-            dashboardFilters,
-            tileUuid,
-            csvLimit,
-            onlyRaw,
         }),
     });
 };

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -23,7 +23,6 @@ import {
     type ApiError,
     type Dashboard,
     type DashboardFilterRule,
-    type DashboardFilters,
     type Field,
     type FilterDashboardToRule,
     type DashboardChartTile as IDashboardChartTile,
@@ -40,6 +39,7 @@ import {
     Group,
     HoverCard,
     Menu,
+    Modal,
     Portal,
     Stack,
     Text,
@@ -100,7 +100,7 @@ import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import { FilterDashboardTo } from '../DashboardFilter/FilterDashboardTo';
-import ExportCSVModal from '../ExportCSV/ExportCSVModal';
+import ExportResults from '../ExportResults';
 import LightdashVisualization from '../LightdashVisualization';
 import VisualizationProvider from '../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
@@ -119,49 +119,12 @@ import { DashboardMinimalDownloadCsv } from './DashboardMinimalDownloadCsv';
 import EditChartMenuItem from './EditChartMenuItem';
 import TileBase from './TileBase/index';
 
-interface ExportResultAsCSVModalProps {
-    projectUuid: string;
-    chartUuid: string;
-    dashboardFilters?: DashboardFilters;
-    tileUuid?: string;
-    // Csv properties
-    rows: ApiChartAndResults['rows'];
-    onClose: () => void;
-    onConfirm: () => void;
+interface ExportGoogleSheetProps {
+    savedChart: SavedChart;
+    disabled?: boolean;
 }
 
-const ExportResultAsCSVModal: FC<ExportResultAsCSVModalProps> = ({
-    projectUuid,
-    chartUuid,
-    dashboardFilters,
-    tileUuid,
-    rows,
-    onClose,
-    onConfirm,
-}) => {
-    const getCsvLink = async (csvLimit: number | null, onlyRaw: boolean) => {
-        return downloadCsvFromSavedChart({
-            chartUuid,
-            dashboardFilters,
-            tileUuid,
-            onlyRaw,
-            csvLimit,
-        });
-    };
-
-    return (
-        <ExportCSVModal
-            projectUuid={projectUuid}
-            opened
-            totalResults={rows.length}
-            getCsvLink={getCsvLink}
-            onClose={onClose}
-            onConfirm={onConfirm}
-        />
-    );
-};
-
-const ExportGoogleSheet: FC<{ savedChart: SavedChart; disabled?: boolean }> = ({
+const ExportGoogleSheet: FC<ExportGoogleSheetProps> = ({
     savedChart,
     disabled,
 }) => {
@@ -701,7 +664,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const [dashboardTileFilterOptions, setDashboardTileFilterOptions] =
         useState<FilterDashboardToRule[]>([]);
 
-    const [isCSVExportModalOpen, setIsCSVExportModalOpen] = useState(false);
+    const [isDataExportModalOpen, setIsDataExportModalOpen] = useState(false);
 
     const onSeriesContextMenu = useCallback(
         (e: EchartSeriesClickEvent, series: EChartSeries[]) => {
@@ -863,6 +826,20 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         chart.spaceUuid,
         user.data?.ability,
     ]);
+
+    const getDownloadQueryUuid = useCallback(
+        async (csvLimit: number | null) => {
+            const result = await downloadCsvFromSavedChart({
+                chartUuid: chart.uuid,
+                dashboardFilters: appliedDashboardFilters ?? undefined,
+                tileUuid,
+                onlyRaw: false,
+                csvLimit,
+            });
+            return result.jobId;
+        },
+        [chart.uuid, appliedDashboardFilters, tileUuid],
+    );
 
     return (
         <>
@@ -1105,12 +1082,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                 }
                                                 disabled={isEditMode}
                                                 onClick={() =>
-                                                    setIsCSVExportModalOpen(
+                                                    setIsDataExportModalOpen(
                                                         true,
                                                     )
                                                 }
                                             >
-                                                Export CSV
+                                                Download data
                                             </Menu.Item>
                                         </>
                                     )}
@@ -1299,16 +1276,19 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 />
             )}
 
-            {isCSVExportModalOpen ? (
-                <ExportResultAsCSVModal
-                    projectUuid={chart.projectUuid}
-                    chartUuid={chart.uuid}
-                    tileUuid={tileUuid}
-                    dashboardFilters={appliedDashboardFilters ?? undefined}
-                    rows={rows}
-                    onClose={() => setIsCSVExportModalOpen(false)}
-                    onConfirm={() => setIsCSVExportModalOpen(false)}
-                />
+            {isDataExportModalOpen ? (
+                <Modal
+                    opened
+                    onClose={() => setIsDataExportModalOpen(false)}
+                    title="Download data"
+                    size="md"
+                >
+                    <ExportResults
+                        projectUuid={projectUuid!}
+                        totalResults={rows.length}
+                        getDownloadQueryUuid={getDownloadQueryUuid}
+                    />
+                </Modal>
             ) : null}
         </>
     );

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -19,7 +19,6 @@ import {
     isDashboardChartTileType,
     isFilterableField,
     isTableChartConfig,
-    QueryExecutionContext,
     type ApiChartAndResults,
     type ApiError,
     type Dashboard,
@@ -79,7 +78,6 @@ import {
     mergeExistingAndExpectedSeries,
 } from '../../hooks/cartesianChartConfig/utils';
 import {
-    executeAsyncDashboardChartQuery,
     useDashboardChartReadyQuery,
     type DashboardChartReadyQuery,
 } from '../../hooks/dashboard/useDashboardChartReadyQuery';
@@ -829,42 +827,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         user.data?.ability,
     ]);
 
-    const getDownloadQueryUuid = useCallback(
-        async (csvLimit: number | null) => {
-            const currentQueryUuid =
-                dashboardChartReadyQuery.executeQueryResponse.queryUuid;
-            const currentResultsTotal = rows.length;
-
-            if (
-                dashboardUuid &&
-                (csvLimit === null || csvLimit !== currentResultsTotal)
-            ) {
-                const response = await executeAsyncDashboardChartQuery(
-                    projectUuid!,
-                    {
-                        chartUuid: chart.uuid,
-                        dashboardUuid: dashboardUuid!,
-                        dashboardFilters: appliedDashboardFilters,
-                        dashboardSorts: [],
-                        context: QueryExecutionContext.DASHBOARD,
-                        invalidateCache: false,
-                        ...(csvLimit !== null && { limit: csvLimit }),
-                    },
-                );
-                return response.queryUuid;
-            }
-
-            return currentQueryUuid;
-        },
-        [
-            dashboardChartReadyQuery.executeQueryResponse.queryUuid,
-            rows.length,
-            chart.uuid,
-            appliedDashboardFilters,
-            projectUuid,
-            dashboardUuid,
-        ],
-    );
+    const getDownloadQueryUuid = useCallback(async () => {
+        return dashboardChartReadyQuery.executeQueryResponse.queryUuid;
+    }, [dashboardChartReadyQuery.executeQueryResponse.queryUuid]);
 
     return (
         <>
@@ -1320,6 +1285,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                         )}
                         hiddenFields={getHiddenTableFields(chart.chartConfig)}
                         pivotConfig={getPivotConfig(chart)}
+                        hideLimitSelection
                     />
                 </Modal>
             ) : null}

--- a/packages/frontend/src/components/DashboardTiles/DashboardMinimalDownloadCsv.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMinimalDownloadCsv.tsx
@@ -176,7 +176,7 @@ export const DashboardMinimalDownloadCsv: FC<{
                 await handleDownload();
             }}
         >
-            Export CSV
+            Download data
         </Menu.Item>
     );
 };

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -45,6 +45,7 @@ export type ExportResultsProps = {
     showTableNames?: boolean;
     chartName?: string;
     pivotConfig?: PivotConfig;
+    hideLimitSelection?: boolean;
 };
 
 const TOAST_KEY = 'exporting-results';
@@ -60,6 +61,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         showTableNames,
         chartName,
         pivotConfig,
+        hideLimitSelection = false,
     }) => {
         const { showToastError, showToastInfo, showToastWarning } =
             useToaster();
@@ -177,22 +179,30 @@ const ExportResults: FC<ExportResultsProps> = memo(
                             projectUuid: projectUuid,
                         })}
                     >
-                        <Stack spacing="xs">
-                            <Box>Limit</Box>
-                            <SegmentedControl
-                                size={'xs'}
-                                value={limit}
-                                onChange={(value) => setLimit(value)}
-                                data={[
-                                    {
-                                        label: 'Results in Table',
-                                        value: Limit.TABLE,
-                                    },
-                                    { label: 'All Results', value: Limit.ALL },
-                                    { label: 'Custom...', value: Limit.CUSTOM },
-                                ]}
-                            />
-                        </Stack>
+                        {!hideLimitSelection ? (
+                            <Stack spacing="xs">
+                                <Box>Limit</Box>
+                                <SegmentedControl
+                                    size={'xs'}
+                                    value={limit}
+                                    onChange={(value) => setLimit(value)}
+                                    data={[
+                                        {
+                                            label: 'Results in Table',
+                                            value: Limit.TABLE,
+                                        },
+                                        {
+                                            label: 'All Results',
+                                            value: Limit.ALL,
+                                        },
+                                        {
+                                            label: 'Custom...',
+                                            value: Limit.CUSTOM,
+                                        },
+                                    ]}
+                                />
+                            </Stack>
+                        ) : null}
                     </Can>
 
                     {limit === Limit.CUSTOM && (

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -19,7 +19,7 @@ import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
-const executeAsyncDashboardChartQuery = async (
+export const executeAsyncDashboardChartQuery = async (
     projectUuid: string,
     data: ExecuteAsyncDashboardChartRequestParams,
 ): Promise<ApiExecuteAsyncDashboardChartQueryResults> =>

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -19,7 +19,7 @@ import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
-export const executeAsyncDashboardChartQuery = async (
+const executeAsyncDashboardChartQuery = async (
     projectUuid: string,
     data: ExecuteAsyncDashboardChartRequestParams,
 ): Promise<ApiExecuteAsyncDashboardChartQueryResults> =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15015

### Description
Extending the new /download endpoint onto dashboard chart tiles.

#### Before
| menu | download option  |
|:-:|:-:|
| ![Screenshot 2025-06-09 at 21.20.02.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yF4RSYW2o5tuXO8E416G/fbaede4a-94f0-4c67-9e22-19e4a0fff9ae.png)  | ![Screenshot 2025-06-09 at 21.20.07.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yF4RSYW2o5tuXO8E416G/a62e89c0-0053-4ff3-9366-46350737a0a1.png) |

#### After

| menu | download option  |
|:-:|:-:|
| ![Screenshot 2025-06-09 at 21.20.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yF4RSYW2o5tuXO8E416G/48ae323f-a64e-47ef-9ef9-e2a8ce848754.png) | ![Screenshot 2025-06-09 at 21.20.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/yF4RSYW2o5tuXO8E416G/dac021c2-39d4-4e02-9db1-0b026d935f55.png) |
