### PR TITLE
feat: show agents only in project

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -331,3 +331,52 @@ export class AiAgentController extends BaseController {
         return this.services.getAiAgentService<AiAgentService>();
     }
 }
+
+@Route('/api/v1/projects/{projectUuid}/aiAgents')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class ProjectAiAgentController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listProjectAgents')
+    async listProjectAgents(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiAiAgentSummaryResponse> {
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().listAgents(
+                req.user!,
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}')
+    @OperationId('getProjectAgent')
+    async getProjectAgent(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+    ): Promise<ApiAiAgentResponse> {
+        this.setStatus(200);
+        const agent = await this.getAiAgentService().getAgent(
+            req.user!,
+            agentUuid,
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results: agent,
+        };
+    }
+
+    protected getAiAgentService() {
+        return this.services.getAiAgentService<AiAgentService>();
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -57,11 +57,13 @@ export class AiAgentModel {
     async getAgent({
         organizationUuid,
         agentUuid,
+        projectUuid,
     }: {
         organizationUuid: string;
         agentUuid: string;
+        projectUuid?: string;
     }): Promise<AiAgentSummary> {
-        const agent = await this.database(AiAgentTableName)
+        const query = this.database(AiAgentTableName)
             .select({
                 uuid: `${AiAgentTableName}.ai_agent_uuid`,
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
@@ -106,6 +108,12 @@ export class AiAgentModel {
             .groupBy(`${AiAgentTableName}.ai_agent_uuid`)
             .first<AiAgent | undefined>();
 
+        if (projectUuid) {
+            void query.where(`${AiAgentTableName}.project_uuid`, projectUuid);
+        }
+
+        const agent = await query;
+
         if (!agent) {
             throw new AiAgentNotFoundError(
                 `AI agent not found for uuid: ${agentUuid}`,
@@ -117,10 +125,12 @@ export class AiAgentModel {
 
     async findAllAgents({
         organizationUuid,
+        projectUuid,
     }: {
         organizationUuid: string;
+        projectUuid?: string;
     }): Promise<AiAgentSummary[]> {
-        const rows = await this.database(AiAgentTableName)
+        const query = this.database(AiAgentTableName)
             .select({
                 uuid: `${AiAgentTableName}.ai_agent_uuid`,
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
@@ -162,6 +172,12 @@ export class AiAgentModel {
             )
             .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
             .groupBy(`${AiAgentTableName}.ai_agent_uuid`);
+
+        if (projectUuid) {
+            void query.where(`${AiAgentTableName}.project_uuid`, projectUuid);
+        }
+
+        const rows = await query;
 
         return rows;
     }

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -190,7 +190,11 @@ export class AiAgentService {
         return this.lightdashConfig.ai.copilot.providers.openai.apiKey;
     }
 
-    public async getAgent(user: SessionUser, agentUuid: string) {
+    public async getAgent(
+        user: SessionUser,
+        agentUuid: string,
+        projectUuid?: string,
+    ) {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -207,12 +211,13 @@ export class AiAgentService {
         const agent = await this.aiAgentModel.getAgent({
             organizationUuid,
             agentUuid,
+            projectUuid,
         });
 
         return agent;
     }
 
-    public async listAgents(user: SessionUser) {
+    public async listAgents(user: SessionUser, projectUuid?: string) {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -225,6 +230,7 @@ export class AiAgentService {
 
         const agents = await this.aiAgentModel.findAllAgents({
             organizationUuid,
+            projectUuid,
         });
 
         return agents;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -20,6 +20,8 @@ import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiAgentController } from './../ee/controllers/aiAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ProjectAiAgentController } from './../ee/controllers/aiAgentController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ValidationController } from './../controllers/validationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
@@ -19756,6 +19758,134 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'createAiAgentConversation',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAiAgentController_listProjectAgents: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents',
+        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAiAgentController.prototype.listProjectAgents,
+        ),
+
+        async function ProjectAiAgentController_listProjectAgents(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAiAgentController_listProjectAgents,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAiAgentController>(
+                        ProjectAiAgentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listProjectAgents',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAiAgentController_getProjectAgent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAiAgentController.prototype.getProjectAgent,
+        ),
+
+        async function ProjectAiAgentController_getProjectAgent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAiAgentController_getProjectAgent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAiAgentController>(
+                        ProjectAiAgentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getProjectAgent',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17729,7 +17729,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1699.0",
+        "version": "0.1701.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -2,6 +2,7 @@ import { CommercialFeatureFlags } from '@lightdash/common';
 import { Button } from '@mantine/core';
 import { IconMessageCircleStar } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
+import { useActiveProject } from '../../hooks/useActiveProject';
 import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
@@ -10,6 +11,7 @@ export const AiAgentsButton = () => {
     // Using `navigate` instead of the `Link` component to ensure round corners within a button group
     const navigate = useNavigate();
 
+    const { data: project } = useActiveProject();
     const appQuery = useApp();
     const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
     const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);
@@ -26,7 +28,12 @@ export const AiAgentsButton = () => {
     const isAiCopilotEnabled = aiCopilotFlagQuery.data.enabled;
     const isAiAgentEnabled = aiAgentFlagQuery.data.enabled;
 
-    if (!canViewAiAgents || !isAiCopilotEnabled || !isAiAgentEnabled) {
+    if (
+        !canViewAiAgents ||
+        !isAiCopilotEnabled ||
+        !isAiAgentEnabled ||
+        !project
+    ) {
         return null;
     }
 
@@ -38,7 +45,7 @@ export const AiAgentsButton = () => {
             leftIcon={
                 <MantineIcon icon={IconMessageCircleStar} color="#adb5bd" />
             }
-            onClick={() => navigate('/ai-agents')}
+            onClick={() => navigate(`/projects/${project}/ai-agents`)}
         >
             Ask AI
         </Button>

--- a/packages/frontend/src/components/UserSettings/AiAgentsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AiAgentsPanel/index.tsx
@@ -9,7 +9,7 @@ import {
     Title,
 } from '@mantine-8/core';
 import { type FC } from 'react';
-import { AiAgents } from '../../../ee/features/aiCopilot/components/AiAgents';
+import { OrganizationAiAgents } from '../../../ee/features/aiCopilot/components/OrganizationAiAgents';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 
@@ -51,7 +51,7 @@ const AiAgentsPanel: FC = () => {
                     </Text>
                 </Stack>
 
-                <AiAgents />
+                <OrganizationAiAgents />
             </Card>
         </MantineProvider>
     );

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -68,12 +68,7 @@ const COMMERCIAL_AI_ROUTES: RouteObject[] = [
 
 const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     {
-        path: '/aiAgents',
-        // redirrect to ai-agents/ if path is /aiAgents
-        element: <Navigate to="/ai-agents" replace />,
-    },
-    {
-        path: '/ai-agents',
+        path: '/projects/:projectUuid/ai-agents',
         element: (
             <PrivateRoute>
                 <NavBar />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -36,7 +36,7 @@ import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import {
     useAiAgentThreadMessageViz,
     useUpdatePromptFeedbackMutation,
-} from '../../hooks/useAiAgents';
+} from '../../hooks/useOrganizationAiAgents';
 import { AiChartVisualization } from './AiChartVisualization';
 
 export const UserBubble: FC<{ message: AiAgentMessageUser<AiAgentUser> }> = ({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
@@ -1,6 +1,6 @@
 import { Badge, Loader, Stack, Table, Text, Title } from '@mantine-8/core';
 import { useState, type FC } from 'react';
-import { useAiAgentThreads } from '../hooks/useAiAgents';
+import { useAiAgentThreads } from '../hooks/useOrganizationAiAgents';
 import { ThreadDetailsModal } from './ThreadDetailsModal';
 
 type ConversationsListProps = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/OrganizationAiAgent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/OrganizationAiAgent.tsx
@@ -42,7 +42,7 @@ import {
     useCreateAiAgentMutation,
     useDeleteAiAgentMutation,
     useUpdateAiAgentMutation,
-} from '../hooks/useAiAgents';
+} from '../hooks/useOrganizationAiAgents';
 import { ConversationsList } from './ConversationsList';
 import { SlackIntegrationSteps } from './SlackIntegrationSteps';
 
@@ -72,7 +72,7 @@ const formSchema: z.ZodType<
     imageUrl: z.string().url().nullable(),
 });
 
-export const AgentDetails: FC = () => {
+export const OrganizationAiAgent: FC = () => {
     const navigate = useNavigate();
     const { agentId } = useParams<{ agentId: string }>();
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -83,12 +83,7 @@ export const AgentDetails: FC = () => {
     const isCreateMode = agentId === 'new';
     const agentUuid = !isCreateMode && agentId ? agentId : undefined;
 
-    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(
-        agentUuid || '',
-        {
-            enabled: !!agentUuid,
-        },
-    );
+    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(agentUuid);
     const { mutateAsync: deleteAgent } = useDeleteAiAgentMutation();
 
     const { data: slackInstallation } = useGetSlack();

--- a/packages/frontend/src/ee/features/aiCopilot/components/OrganizationAiAgents.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/OrganizationAiAgents.tsx
@@ -17,9 +17,9 @@ import {
     useSlackChannels,
 } from '../../../../hooks/slack/useSlack';
 import { useProjects } from '../../../../hooks/useProjects';
-import { useAiAgents } from '../hooks/useAiAgents';
+import { useAiAgents } from '../hooks/useOrganizationAiAgents';
 
-export const AiAgents: FC = () => {
+export const OrganizationAiAgents: FC = () => {
     const navigate = useNavigate();
 
     const { data: slackInstallation } = useGetSlack();

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mantine-8/core';
 import { type FC } from 'react';
 import { LightdashUserAvatar } from '../../../../components/Avatar';
-import { useAiAgentThread } from '../hooks/useAiAgents';
+import { useAiAgentThread } from '../hooks/useOrganizationAiAgents';
 
 type ThreadDetailsModalProps = {
     agentName: string;
@@ -25,13 +25,7 @@ export const ThreadDetailsModal: FC<ThreadDetailsModalProps> = ({
     threadUuid,
     onClose,
 }) => {
-    const { data: thread, isLoading } = useAiAgentThread(
-        agentUuid,
-        threadUuid || '',
-        {
-            enabled: !!threadUuid,
-        },
-    );
+    const { data: thread, isLoading } = useAiAgentThread(agentUuid, threadUuid);
 
     // Format date function since date-fns is not available
     const formatDate = (dateString: string) => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,0 +1,64 @@
+import type {
+    ApiAiAgentResponse,
+    ApiAiAgentSummaryResponse,
+    ApiError,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+const PROJECT_AI_AGENTS_KEY = 'projectAiAgents';
+
+const listProjectAgents = (projectUuid: string) =>
+    lightdashApi<ApiAiAgentSummaryResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const getProjectAgent = async (
+    projectUuid: string,
+    agentUuid: string,
+): Promise<ApiAiAgentResponse['results']> =>
+    lightdashApi<ApiAiAgentResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useProjectAiAgents = (projectUuid: string | undefined) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiAgentSummaryResponse['results'], ApiError>({
+        queryKey: [PROJECT_AI_AGENTS_KEY, projectUuid],
+        queryFn: () => listProjectAgents(projectUuid!),
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch project AI agents',
+                apiError: error.error,
+            });
+        },
+        enabled: !!projectUuid,
+    });
+};
+
+export const useProjectAiAgent = (
+    projectUuid: string | undefined,
+    agentUuid: string | undefined,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiAgentResponse['results'], ApiError>({
+        queryKey: [PROJECT_AI_AGENTS_KEY, projectUuid, agentUuid],
+        queryFn: () => getProjectAgent(projectUuid!, agentUuid!),
+        onError: (error) => {
+            showToastApiError({
+                title: `Failed to fetch project AI agent details`,
+                apiError: error.error,
+            });
+        },
+        enabled: !!projectUuid && !!agentUuid,
+    });
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -36,7 +36,7 @@ import ClampedTextWithPopover from '../../features/aiCopilot/components/ClampedT
 import {
     useAiAgent,
     useAiAgentThreads,
-} from '../../features/aiCopilot/hooks/useAiAgents';
+} from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 
 const INITIAL_MAX_THREADS = 10;
 const MAX_THREADS_INCREMENT = 10;
@@ -44,14 +44,19 @@ const MAX_THREADS_INCREMENT = 10;
 type ThreadNavLinkProps = {
     thread: AiAgentThreadSummary;
     isActive: boolean;
+    projectUuid: string;
 };
 
-const ThreadNavLink: FC<ThreadNavLinkProps> = ({ thread, isActive }) => (
+const ThreadNavLink: FC<ThreadNavLinkProps> = ({
+    thread,
+    isActive,
+    projectUuid,
+}) => (
     <NavLink
         color="gray"
         component={Link}
         key={thread.uuid}
-        to={`/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
+        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
         px="xs"
         py={4}
         mx={-8}
@@ -76,10 +81,10 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({ thread, isActive }) => (
 );
 const AgentPage = () => {
     const { user } = useApp();
-    const { agentUuid, threadUuid } = useParams();
-    const { data: threads } = useAiAgentThreads(agentUuid ?? '');
+    const { agentUuid, threadUuid, projectUuid } = useParams();
+    const { data: threads } = useAiAgentThreads(agentUuid);
 
-    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(agentUuid!);
+    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(agentUuid);
     const { data: project } = useProject(agent?.projectUuid);
 
     const updatedAt = agent?.updatedAt ? new Date(agent.updatedAt) : new Date();
@@ -98,7 +103,7 @@ const AgentPage = () => {
     }
 
     if (!agent) {
-        return <Navigate to={`/ai-agents`} />;
+        return <Navigate to={`/projects/${projectUuid}/ai-agents`} />;
     }
 
     return (
@@ -110,7 +115,7 @@ const AgentPage = () => {
                             size="compact-xs"
                             variant="subtle"
                             component={Link}
-                            to="/ai-agents"
+                            to={`/projects/${projectUuid}/ai-agents`}
                             leftSection={<MantineIcon icon={IconArrowLeft} />}
                             style={{
                                 root: {
@@ -150,7 +155,7 @@ const AgentPage = () => {
                             leftSection={<IconPlus size={16} />}
                             component={Link}
                             size="xs"
-                            to={`/ai-agents/${agent.uuid}/threads`}
+                            to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
                         >
                             New thread
                         </Button>
@@ -198,7 +203,7 @@ const AgentPage = () => {
                         </Stack>
                     )}
 
-                    {threads && threads.length > 0 && (
+                    {projectUuid && threads && threads.length > 0 && (
                         <Stack gap="xs">
                             <Title order={6}>Threads</Title>
                             <Stack gap={2}>
@@ -206,11 +211,12 @@ const AgentPage = () => {
                                     .slice(0, showMaxItems)
                                     .map((thread) => (
                                         <ThreadNavLink
+                                            key={thread.uuid}
                                             thread={thread}
                                             isActive={
                                                 thread.uuid === threadUuid
                                             }
-                                            key={thread.uuid}
+                                            projectUuid={projectUuid}
                                         />
                                     ))}
                             </Stack>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -19,7 +19,7 @@ import {
     useAiAgent,
     useAiAgentThread,
     useGenerateAgentThreadResponseMutation,
-} from '../../features/aiCopilot/hooks/useAiAgents';
+} from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 import { type AgentContext } from './AgentPage';
 
 type AiThreadMessageProps = {
@@ -38,19 +38,23 @@ const AiThreadMessage: FC<AiThreadMessageProps> = ({ message }) => {
 };
 
 const AiAgentThreadPage = () => {
-    const { agentUuid, threadUuid } = useParams();
+    const { agentUuid, threadUuid, projectUuid } = useParams();
     const { data: thread, isLoading: isLoadingThread } = useAiAgentThread(
-        agentUuid!,
-        threadUuid!,
+        agentUuid,
+        threadUuid,
     );
 
-    const agentQuery = useAiAgent(agentUuid!);
+    const agentQuery = useAiAgent(agentUuid);
     const { agent } = useOutletContext<AgentContext>();
 
     const {
         mutateAsync: generateAgentThreadResponse,
         isLoading: isGenerating,
-    } = useGenerateAgentThreadResponseMutation(agentUuid!, threadUuid!);
+    } = useGenerateAgentThreadResponseMutation(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
 
     const viewport = useRef<HTMLDivElement>(null);
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsListPage.tsx
@@ -17,19 +17,20 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { IconBook, IconHelp, IconPlus } from '@tabler/icons-react';
-import { Link } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import Page from '../../../components/common/Page/Page';
 import PageSpinner from '../../../components/PageSpinner';
 import useApp from '../../../providers/App/useApp';
-import { useAiAgents } from '../../features/aiCopilot/hooks/useAiAgents';
+import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 
 type AgentCardProps = {
     agent: AiAgent;
 };
 
 const AgentCard = ({ agent }: AgentCardProps) => {
+    const { projectUuid } = useParams();
     const { user } = useApp();
 
     return (
@@ -41,7 +42,7 @@ const AgentCard = ({ agent }: AgentCardProps) => {
                 root: { height: '100%' },
             }}
             component={Link}
-            to={`/ai-agents/${agent.uuid}/threads`}
+            to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
         >
             <Stack gap="sm" p="lg" style={{ flex: 1 }}>
                 <Group gap="sm" wrap="nowrap" align="flex-start">
@@ -105,7 +106,8 @@ const AgentCard = ({ agent }: AgentCardProps) => {
 };
 
 const AgentsListPage = () => {
-    const agentsListQuery = useAiAgents();
+    const { projectUuid } = useParams();
+    const agentsListQuery = useProjectAiAgents(projectUuid);
     const { user } = useApp();
 
     if (agentsListQuery.isLoading) {

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -15,13 +15,13 @@ import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
-import { useStartAgentThreadMutation } from '../../features/aiCopilot/hooks/useAiAgents';
+import { useStartAgentThreadMutation } from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentNewThreadPage = () => {
-    const { agentUuid } = useParams();
+    const { agentUuid, projectUuid } = useParams();
     const { mutateAsync: startAgentThread, isLoading } =
-        useStartAgentThreadMutation(agentUuid!);
+        useStartAgentThreadMutation(agentUuid, projectUuid);
     const { agent } = useOutletContext<AgentContext>();
 
     return (

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -47,7 +47,7 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import RouterNavLink from '../components/common/RouterNavLink';
 import { SettingsGridCard } from '../components/common/Settings/SettingsCard';
-import { AgentDetails } from '../ee/features/aiCopilot/components/AgentDetails';
+import { OrganizationAiAgent } from '../ee/features/aiCopilot/components/OrganizationAiAgent';
 import ScimAccessTokensPanel from '../ee/features/scim/components/ScimAccessTokensPanel';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
@@ -321,7 +321,7 @@ const Settings: FC = () => {
             });
             allowedRoutes.push({
                 path: '/aiAgents/:agentId',
-                element: <AgentDetails />,
+                element: <OrganizationAiAgent />,
             });
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15246

### Description:

This PR adds project-specific AI agents endpoints and UI. It introduces a new endpoints in `AiAgentController` to fetch AI agents scoped to a specific project. The UI has been updated to use project-specific routes for AI agents, changing from `/ai-agents` to `/projects/{projectUuid}/ai-agents`.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/41ab4e4b-f8ee-4042-8931-7ce6cabeefce.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/c7560b20-9ecc-45cb-bd37-020492b02c8b.png)

The implementation includes:
- New API endpoints for listing and getting project-specific AI agents
- Updated model and service layers to support filtering agents by project UUID
- Refactored frontend hooks to separate organization-wide and project-specific AI agent operations
- Updated navigation and routing to use project-scoped paths for AI agents