### PR TITLE
fix: pass bom: true to stringify

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -272,6 +272,7 @@ export class CsvService extends BaseService {
             delimiter: ',',
             header: true,
             columns: csvHeader,
+            bom: true,
         });
 
         const rowTransformer = new Transform({
@@ -337,6 +338,7 @@ export class CsvService extends BaseService {
                 delimiter: ',',
                 header: true,
                 columns: csvHeader,
+                bom: true,
             });
 
             let truncated = false;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10214 

### Description:
For the new /download endpoint, we're using `stringify` from csv-stringify package, which supported `bom: true` param in order to fix the UTF-8 BOM issue.
