### PR TITLE
feat: optimistically track user feedback on Agent responses

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -509,6 +509,30 @@ export const useUpdatePromptFeedbackMutation = (
     >({
         mutationFn: ({ messageUuid, humanScore }) =>
             updatePromptFeedback(messageUuid, humanScore),
+        onMutate: ({ messageUuid, humanScore }) => {
+            queryClient.setQueryData(
+                [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
+                (
+                    currentData:
+                        | ApiAiAgentThreadResponse['results']
+                        | undefined,
+                ) => {
+                    if (!currentData) return currentData;
+
+                    return {
+                        ...currentData,
+                        messages: currentData.messages.map((message) =>
+                            message.uuid === messageUuid
+                                ? {
+                                      ...message,
+                                      humanScore,
+                                  }
+                                : message,
+                        ),
+                    };
+                },
+            );
+        },
         onSuccess: () => {
             // Invalidate relevant queries to refresh the data
             void queryClient.invalidateQueries({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Optimistically track user feedback on Agent responses.

I was testing this in production today and seemed quite slow

Before:

![CleanShot 2025-06-11 at 15.20.09.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/8c62b3ac-5a8d-4495-8072-6735d501495e.gif)

After:

![CleanShot 2025-06-11 at 15.39.58.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/82acfddf-1eb4-4eee-bca7-d83a3b7ffa60.gif)

