### PR TITLE
feat: Introduce Agent Switcher

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSwitcher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSwitcher.tsx
@@ -1,0 +1,90 @@
+import { type AiAgent } from '@lightdash/common';
+import { type ComboboxItem, Group, Select, Text } from '@mantine-8/core';
+import { IconPointFilled } from '@tabler/icons-react';
+import { useNavigate } from 'react-router';
+import { LightdashUserAvatar } from '../../../../components/Avatar';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type Props = {
+    agents: Pick<AiAgent, 'name' | 'uuid' | 'imageUrl'>[];
+    selectedAgent: AiAgent;
+    projectUuid: string;
+};
+
+interface AgentSelectOption extends ComboboxItem {
+    imageUrl?: AiAgent['imageUrl'];
+}
+
+const renderSelectOption = ({
+    option,
+    checked,
+}: {
+    option: AgentSelectOption;
+    checked?: boolean;
+}) => (
+    <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+        <LightdashUserAvatar
+            size={20}
+            variant="filled"
+            name={option.label}
+            src={option.imageUrl}
+        />
+        <Text size="xs" truncate="end" flex={1}>
+            {option.label}
+        </Text>
+
+        {checked && <MantineIcon icon={IconPointFilled} size={12} />}
+    </Group>
+);
+
+export const AgentSwitcher = ({
+    agents,
+    selectedAgent,
+    projectUuid,
+}: Props) => {
+    const navigate = useNavigate();
+    const handleSelect = (value: string | null) => {
+        if (value)
+            void navigate(`/projects/${projectUuid}/ai-agents/${value}`, {
+                viewTransition: true,
+            });
+    };
+    const agentOptions = agents.map(
+        ({ name, uuid, imageUrl }) =>
+            ({
+                label: name,
+                value: uuid,
+                imageUrl: imageUrl,
+            } satisfies AgentSelectOption),
+    );
+    return (
+        <Select
+            data={agentOptions}
+            defaultValue={selectedAgent.uuid}
+            onChange={handleSelect}
+            checkIconPosition="right"
+            w="100%"
+            allowDeselect={false}
+            renderOption={renderSelectOption}
+            withScrollArea={false}
+            leftSection={
+                <LightdashUserAvatar
+                    size={22}
+                    variant="filled"
+                    name={selectedAgent.name}
+                    src={selectedAgent.imageUrl}
+                />
+            }
+            styles={(theme) => ({
+                input: {
+                    borderColor: theme.colors.gray[2],
+                    boxShadow: `var(--mantine-shadow-subtle)`,
+                    color: theme.colors.gray[7],
+                },
+                dropdown: {
+                    paddingRight: 4,
+                },
+            })}
+        />
+    );
+};

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -4,6 +4,7 @@ import {
     Loader,
     Pill,
     ScrollArea,
+    Select,
     type ButtonVariant,
     type MantineTheme,
     type MantineThemeOverride,
@@ -141,9 +142,9 @@ export const getMantine8ThemeOverride = (
                     radius: 'md',
                     shadow: 'subtle',
                     withBorder: true,
-                    sx: (theme: MantineTheme) => ({
-                        '&[data-with-border]': {
-                            border: `1px solid ${theme.colors.gray[2]}`,
+                    styles: (theme: MantineTheme) => ({
+                        root: {
+                            borderColor: theme.colors.gray[2],
                         },
                     }),
                 },
@@ -151,6 +152,12 @@ export const getMantine8ThemeOverride = (
             Loader: Loader.extend({
                 defaultProps: {
                     loaders: { ...Loader.defaultLoaders, dots: DotsLoader },
+                },
+            }),
+
+            Select: Select.extend({
+                defaultProps: {
+                    radius: 'md',
                 },
             }),
             ...overrides?.components,


### PR DESCRIPTION

Closes: #15247

### Description:

This PR introduces an Agent Switcher to easily navigate between project agents.
I've also moved things around, like reducing the settings button to just display an icon, and moved the `new thread` button down to the threads list

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/2c2cb647-824e-436e-880d-c7a237925599.png)


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/9d0a55c5-0b58-4c76-98f0-439cdf3a95ec.png)

