### PR TITLE
fix: correctly send invalidate cache on refresh

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -114,6 +114,7 @@ export const useDashboardChartReadyQuery = (
             context,
             autoRefresh,
             hasADateDimension ? granularity : null,
+            invalidateCache,
         ],
         [
             chartQuery.data?.projectUuid,
@@ -126,6 +127,7 @@ export const useDashboardChartReadyQuery = (
             autoRefresh,
             hasADateDimension,
             granularity,
+            invalidateCache,
         ],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15272

### Description:

Dashboard refresh button wasn't sending the right invalidateCache value, so charts weren't being updated. 

There were a couple issues with refetching charts lately and we had, then removed this from the query key. Putting it back there fixes this issue and I have verified that both other issues are still fixed too. 1) Charts don't double fetch, 2) SQL charts do refetch. Here's some videos. 

Here is the point of this ticket -- the refresh button refreshes the cache:
![Kapture 2025-06-11 at 16.59.15.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xuM4z1vArnM7xaR6mJr4/8c9d8bdf-c72d-460c-a1cf-6ecb0bc83357.gif)

An explore chart does not double fetch:
![Kapture 2025-06-11 at 17.00.16.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xuM4z1vArnM7xaR6mJr4/6510118c-39be-4aaa-b118-e0a7067cee84.gif)

A sql chart fetches once as well:
![Kapture 2025-06-11 at 17.03.05.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xuM4z1vArnM7xaR6mJr4/4ecf8110-8a35-46e3-889f-68d470fb08d1.gif)

