### PR TITLE
feat: support `tags` + `meta` under `config`

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/schema.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/schema.yml
@@ -1,18 +1,19 @@
 version: 2
 models:
   - name: customers
-    meta:
-      primary_key: customer_id
-      spotlight:
-        categories: ["experimental"]
-      joins:
-        - join: membership
-          hidden: true
-          sql_on: ${customers.customer_id} = ${membership.customer_id}
-          relationship: one-to-one
-        - join: plan
-          sql_on: ${membership.plan_id} = ${plan.id}
-          relationship: many-to-one
+    config:
+      meta:
+        primary_key: customer_id
+        spotlight:
+          categories: [ "experimental" ]
+        joins:
+          - join: membership
+            hidden: true
+            sql_on: ${customers.customer_id} = ${membership.customer_id}
+            relationship: one-to-one
+          - join: plan
+            sql_on: ${membership.plan_id} = ${plan.id}
+            relationship: many-to-one
     description: |
       # Customers
 
@@ -24,14 +25,15 @@ models:
         tests:
           - unique
           - not_null
-        meta:
-          metrics:
-            unique_customer_count:
-              type: count_distinct
-              label: Unique customer count
-              description: Total number of customers
-              spotlight:
-                categories: ["core"]
+        config:
+          meta:
+            metrics:
+              unique_customer_count:
+                type: count_distinct
+                label: Unique customer count
+                description: Total number of customers
+                spotlight:
+                  categories: [ "core" ]
       - name: first_name
         description: |
           # First name
@@ -39,137 +41,152 @@ models:
           Customer's first name. PII.
           ---
           Supports URLs
-        meta:
-          dimension:
-            type: string
-            urls:
-              - label: "URL from value"
-                url: "https://example.com/company/${value.formatted | url_encode }"
-              - label: "URL from row value"
-                url: "https://example.com/company/${row.customers.customer_id.raw | url_encode }"
-              - label: "Invalid URL with bad reference"
-                url: "https://example.com/company/${row.customer_id.raw | url_encode }"
+        config:
+          meta:
+            dimension:
+              type: string
+              urls:
+                - label: "URL from value"
+                  url: "https://example.com/company/${value.formatted | url_encode
+                    }"
+                - label: "URL from row value"
+                  url: "https://example.com/company/${row.customers.customer_id.raw
+                    | url_encode }"
+                - label: "Invalid URL with bad reference"
+                  url: "https://example.com/company/${row.customer_id.raw | url_encode
+                    }"
       - name: last_name
         description: Customer's last name. PII.
       - name: age
         description: Customer's age
-        meta:
-          dimension:
-            type: number
-            required_attributes:
-              is_admin: "true"
-          metrics:
-            average_age:
-              type: average
-              description: Average age of customers
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                is_admin: "true"
+            metrics:
+              average_age:
+                type: average
+                description: Average age of customers
       - name: created
         description: Timestamp (UTC) when customer was created
-        meta:
-          metrics:
-            date_of_first_created_customer:
-              type: min
-            date_of_most_recent_created_customer:
-              spotlight:
-                visibility: hide
-              type: max
+        config:
+          meta:
+            metrics:
+              date_of_first_created_customer:
+                type: min
+              date_of_most_recent_created_customer:
+                spotlight:
+                  visibility: hide
+                type: max
       - name: first_order
         description: Date of the customers first order
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: most_recent_order
         description: Date of the customers most recent order
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: days_since_last_order
         description: Number of days since the customers last order
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: days_between_created_and_first_order
         description: >-
           Number of days between the customer being created and making their
           first order
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: number_of_orders
         description: ""
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: customer_lifetime_value
         description: ""
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
   - name: orders
     description: |
       This table has basic information about orders, as well as some derived
       facts based on payments
 
       {{ doc("orders_status") }}
-    meta:
-      primary_key: order_id
-      spotlight:
-        categories:
-          - sales
-      joins:
-        - join: customers
-          sql_on: ${customers.customer_id} = ${orders.customer_id}
-          relationship: many-to-one
-      metrics:
-        completion_percentage:
-          type: number
-          sql: ${total_completed_order_amount}/${total_order_amount}
-          format: percent
-      default_time_dimension:
-        field: order_date
-        interval: MONTH
+    config:
+      meta:
+        primary_key: order_id
+        spotlight:
+          categories:
+            - sales
+        joins:
+          - join: customers
+            sql_on: ${customers.customer_id} = ${orders.customer_id}
+            relationship: many-to-one
+        metrics:
+          completion_percentage:
+            type: number
+            sql: ${total_completed_order_amount}/${total_order_amount}
+            format: percent
+        default_time_dimension:
+          field: order_date
+          interval: MONTH
     columns:
       - name: order_id
         tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
-        meta:
-          metrics:
-            unique_order_count:
-              type: count_distinct
-            completed_order_count:
-              label: Completed order count
-              description: Total number of completed orders
-              type: count_distinct
-              filters:
-                - is_completed: "true"
-            completed_or_shipped_order_count:
-              label: Completed or Shipped Order Count
-              type: count_distinct
-              filters:
-                - status:
-                    - completed
-                    - shipped
+        config:
+          meta:
+            metrics:
+              unique_order_count:
+                type: count_distinct
+              completed_order_count:
+                label: Completed order count
+                description: Total number of completed orders
+                type: count_distinct
+                filters:
+                  - is_completed: "true"
+              completed_or_shipped_order_count:
+                label: Completed or Shipped Order Count
+                type: count_distinct
+                filters:
+                  - status:
+                      - completed
+                      - shipped
 
       - name: is_completed
         description: Boolean indicating if status is completed
-        meta:
-          metrics:
-            fulfillment_rate:
-              type: average
-              format: percent
-              round: 1
-              sql: CASE WHEN ${is_completed} THEN 1 ELSE 0 END
-              show_underlying_values:
-                - amount
-                - customers.first_name
-            fulfillment_rate_with_format_expression:
-              type: average
-              format: "#,##0.0%"
-              sql: CASE WHEN ${is_completed} THEN 1 ELSE 0 END
-              show_underlying_values:
-                - amount
-                - customers.first_name
+        config:
+          meta:
+            metrics:
+              fulfillment_rate:
+                type: average
+                format: percent
+                round: 1
+                sql: CASE WHEN ${is_completed} THEN 1 ELSE 0 END
+                show_underlying_values:
+                  - amount
+                  - customers.first_name
+              fulfillment_rate_with_format_expression:
+                type: average
+                format: "#,##0.0%"
+                sql: CASE WHEN ${is_completed} THEN 1 ELSE 0 END
+                show_underlying_values:
+                  - amount
+                  - customers.first_name
       - name: customer_id
         description: Foreign key to the customers table
         tests:
@@ -179,27 +196,29 @@ models:
               field: customer_id
       - name: order_date
         description: Date (UTC) that the order was placed
-        meta:
-          dimension:
-            type: date
-            time_intervals: ["DAY", "WEEK", "MONTH", "YEAR"]
-          metrics:
-            date_of_first_order:
-              type: min
-            date_of_most_recent_order:
-              type: max
+        config:
+          meta:
+            dimension:
+              type: date
+              time_intervals: [ "DAY", "WEEK", "MONTH", "YEAR" ]
+            metrics:
+              date_of_first_order:
+                type: min
+              date_of_most_recent_order:
+                type: max
       - name: status
         description: '{{ doc("orders_status") }}'
-        meta:
-          dimension:
-            colors:
-              # Hex colors are supported in both chart config and echarts
-              "placed": "#e6fa0f"
-              "completed": "#00FF00"
-              # Rgb/rgba/name colors are not supported in chart config, but supported in echarts
-              "shipped": "rgba(47, 119, 150, 0.7)"
-              "return_pending": "orange"
-              "returned": "rgb(247, 32, 32)"
+        config:
+          meta:
+            dimension:
+              colors:
+                # Hex colors are supported in both chart config and echarts
+                "placed": "#e6fa0f"
+                "completed": "#00FF00"
+                # Rgb/rgba/name colors are not supported in chart config, but supported in echarts
+                "shipped": "rgba(47, 119, 150, 0.7)"
+                "return_pending": "orange"
+                "returned": "rgb(247, 32, 32)"
         tests:
           - accepted_values:
               values:
@@ -212,91 +231,99 @@ models:
         description: Total amount (USD) of the order
         tests:
           - not_null
-        meta:
-          metrics:
-            average_order_size:
-              type: average
-              format: usd
-              round: 2
-            total_order_amount:
-              type: sum
-              format: usd
-              round: 2
-              default_time_dimension:
-                field: order_date
-                interval: DAY
-            total_completed_order_amount:
-              type: sum
-              format: usd
-              round: 2
-              filters:
-                - is_completed: "true"
-            total_completed_order_amount_eur:
-              type: sum
-              format: eur
-              filters:
-                - is_completed: "true"
-            total_non_completed_order_amount:
-              type: number
-              format: "$#,##0.00"
-              sql: ${total_order_amount}-${total_completed_order_amount}
-          dimension:
-            hidden: true
+        config:
+          meta:
+            metrics:
+              average_order_size:
+                type: average
+                format: usd
+                round: 2
+              total_order_amount:
+                type: sum
+                format: usd
+                round: 2
+                default_time_dimension:
+                  field: order_date
+                  interval: DAY
+              total_completed_order_amount:
+                type: sum
+                format: usd
+                round: 2
+                filters:
+                  - is_completed: "true"
+              total_completed_order_amount_eur:
+                type: sum
+                format: eur
+                filters:
+                  - is_completed: "true"
+              total_non_completed_order_amount:
+                type: number
+                format: "$#,##0.00"
+                sql: ${total_order_amount}-${total_completed_order_amount}
+            dimension:
+              hidden: true
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
         tests:
           - not_null
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
         tests:
           - not_null
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
         tests:
           - not_null
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
-        meta:
-          dimension:
-            hidden: true
+        config:
+          meta:
+            dimension:
+              hidden: true
   - name: payments
     description: This table has information about individual payments
-    meta:
-      primary_key: payment_id
-      joins:
-        - join: orders
-          sql_on: ${orders.order_id} = ${payments.order_id}
-          relationship: many-to-one
-        - join: customers
-          sql_on: ${customers.customer_id} = ${orders.customer_id}
-          relationship: many-to-one
+    config:
+      meta:
+        primary_key: payment_id
+        joins:
+          - join: orders
+            sql_on: ${orders.order_id} = ${payments.order_id}
+            relationship: many-to-one
+          - join: customers
+            sql_on: ${customers.customer_id} = ${orders.customer_id}
+            relationship: many-to-one
     columns:
       - name: payment_id
         description: This is a unique identifier for a payment
-        meta:
-          metrics:
-            unique_payment_count:
-              type: count_distinct
-              description: count of all payments
+        config:
+          meta:
+            metrics:
+              unique_payment_count:
+                type: count_distinct
+                description: count of all payments
       - name: order_id
         description: Foreign key to the orders table
       - name: payment_method
         description: Method of payment used, for example credit card
       - name: amount
         description: Total amount (AUD) of the individual payment
-        meta:
-          metrics:
-            total_revenue:
-              type: sum
-              description: Sum of all payments
+        config:
+          meta:
+            metrics:
+              total_revenue:
+                type: sum
+                description: Sum of all payments

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -6,6 +6,7 @@ import {
     convertToGroups,
     isV9MetricRef,
     type DbtColumnLightdashDimension,
+    type DbtColumnMetadata,
     type DbtMetric,
     type DbtModelColumn,
     type DbtModelNode,
@@ -91,13 +92,12 @@ const convertTimezone = (
 
 const isInterval = (
     dimensionType: DimensionType,
-    { meta }: DbtModelColumn,
+    dimension?: DbtColumnMetadata['dimension'],
 ): boolean =>
     [DimensionType.DATE, DimensionType.TIMESTAMP].includes(dimensionType) &&
-    meta.dimension?.time_intervals !== false &&
-    ((meta.dimension?.time_intervals &&
-        meta.dimension.time_intervals !== 'OFF') ||
-        !meta?.dimension?.time_intervals);
+    dimension?.time_intervals !== false &&
+    ((dimension?.time_intervals && dimension.time_intervals !== 'OFF') ||
+        !dimension?.time_intervals);
 
 const convertDimension = (
     index: number,
@@ -110,8 +110,11 @@ const convertDimension = (
     startOfWeek?: WeekDay | null,
     isAdditionalDimension?: boolean,
 ): Dimension => {
-    let type =
-        column.meta.dimension?.type || column.data_type || DimensionType.STRING;
+    const meta = {
+        ...(column.meta || {}),
+        ...(column.config?.meta || {}),
+    };
+    let type = meta.dimension?.type || column.data_type || DimensionType.STRING;
     if (!Object.values(DimensionType).includes(type)) {
         throw new MissingCatalogEntryError(
             `Could not recognise type "${type}" for dimension "${
@@ -122,20 +125,20 @@ const convertDimension = (
             {},
         );
     }
-    let name = column.meta.dimension?.name || column.name;
-    let sql = column.meta.dimension?.sql || defaultSql(column.name);
-    let label = column.meta.dimension?.label || friendlyName(name);
+    let name = meta.dimension?.name || column.name;
+    let sql = meta.dimension?.sql || defaultSql(column.name);
+    let label = meta.dimension?.label || friendlyName(name);
     if (type === DimensionType.TIMESTAMP) {
         sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
     }
     const isIntervalBase =
-        timeInterval === undefined && isInterval(type, column);
+        timeInterval === undefined && isInterval(type, meta.dimension);
 
     let timeIntervalBaseDimensionName: string | undefined;
 
     const groups: string[] = convertToGroups(
-        column.meta.dimension?.groups,
-        column.meta.dimension?.group_label,
+        meta.dimension?.groups,
+        meta.dimension?.group_label,
     );
 
     if (timeInterval) {
@@ -153,7 +156,7 @@ const convertDimension = (
             .toLowerCase()}`;
 
         groups.push(
-            column.meta.dimension?.label ??
+            meta.dimension?.label ??
                 friendlyName(timeIntervalBaseDimensionName),
         );
 
@@ -168,27 +171,25 @@ const convertDimension = (
         table: model.name,
         tableLabel,
         type,
-        description: column.meta.dimension?.description || column.description,
+        description: meta.dimension?.description || column.description,
         source,
         timeInterval,
         timeIntervalBaseDimensionName,
-        hidden: !!column.meta.dimension?.hidden,
-        format: column.meta.dimension?.format,
-        round: column.meta.dimension?.round,
-        compact: column.meta.dimension?.compact,
-        requiredAttributes: column.meta.dimension?.required_attributes,
-        colors: column.meta.dimension?.colors,
-        ...(column.meta.dimension?.urls
-            ? { urls: column.meta.dimension.urls }
-            : {}),
+        hidden: !!meta.dimension?.hidden,
+        format: meta.dimension?.format,
+        round: meta.dimension?.round,
+        compact: meta.dimension?.compact,
+        requiredAttributes: meta.dimension?.required_attributes,
+        colors: meta.dimension?.colors,
+        ...(meta.dimension?.urls ? { urls: meta.dimension.urls } : {}),
         ...(isAdditionalDimension ? { isAdditionalDimension } : {}),
         groups,
         isIntervalBase,
-        ...(column.meta.dimension && column.meta.dimension.tags
+        ...(meta.dimension && meta.dimension.tags
             ? {
-                  tags: Array.isArray(column.meta.dimension.tags)
-                      ? column.meta.dimension.tags
-                      : [column.meta.dimension.tags],
+                  tags: Array.isArray(meta.dimension.tags)
+                      ? meta.dimension.tags
+                      : [meta.dimension.tags],
               }
             : {}),
     };
@@ -214,6 +215,9 @@ const generateTableLineage = (
     );
 };
 
+/**
+ * @deprecated This function uses the old dbt metrics format.
+ */
 const convertDbtMetricToLightdashMetric = (
     metric: DbtMetric,
     tableName: string,
@@ -332,7 +336,10 @@ export const convertTable = (
     spotlightConfig: LightdashProjectConfig['spotlight'],
     startOfWeek?: WeekDay | null,
 ): Omit<Table, 'lineageGraph'> => {
-    const meta = model.config?.meta || model.meta; // Config block takes priority, then meta block
+    const meta = {
+        ...(model.meta || {}),
+        ...(model.config?.meta || {}),
+    }; // Config block takes priority, then meta block
     const tableLabel = meta.label || friendlyName(model.name);
 
     const [dimensions, metrics]: [
@@ -350,6 +357,10 @@ export const convertTable = (
                 undefined,
                 startOfWeek,
             );
+            const columnMeta = {
+                ...(column.meta || {}),
+                ...(column.config?.meta || {}),
+            };
 
             const processIntervalDimension = (
                 dim: Dimension,
@@ -360,11 +371,11 @@ export const convertTable = (
 
                     if (
                         !dim.isAdditionalDimension &&
-                        column.meta.dimension?.time_intervals &&
-                        Array.isArray(column.meta.dimension.time_intervals)
+                        columnMeta.dimension?.time_intervals &&
+                        Array.isArray(columnMeta?.dimension.time_intervals)
                     ) {
                         intervals = validateTimeFrames(
-                            column.meta.dimension.time_intervals,
+                            columnMeta.dimension.time_intervals,
                         );
                     } else if (
                         dim.isAdditionalDimension &&
@@ -392,8 +403,7 @@ export const convertTable = (
                                                   name: dim.name,
                                                   meta: {
                                                       dimension: {
-                                                          ...column.meta
-                                                              .dimension,
+                                                          ...columnMeta.dimension,
                                                           type: dim.type,
                                                           label: dim.label,
                                                           groups: dim.groups,
@@ -423,7 +433,7 @@ export const convertTable = (
             };
 
             extraDimensions = Object.entries(
-                column.meta.additional_dimensions || {},
+                columnMeta.additional_dimensions || {},
             ).reduce((acc, [subDimensionName, subDimension]) => {
                 const additionalDim = convertDimension(
                     index,
@@ -455,7 +465,7 @@ export const convertTable = (
             }, extraDimensions);
 
             const columnMetrics = Object.fromEntries(
-                Object.entries(column.meta.metrics || {}).map(
+                Object.entries(columnMeta.metrics || {}).map(
                     ([name, metric]) => [
                         name,
                         convertColumnMetric({
@@ -469,10 +479,10 @@ export const convertTable = (
                             spotlightConfig: {
                                 ...spotlightConfig,
                                 default_visibility:
-                                    model.meta.spotlight?.visibility ??
+                                    meta.spotlight?.visibility ??
                                     spotlightConfig.default_visibility,
                             },
-                            modelCategories: model.meta.spotlight?.categories,
+                            modelCategories: meta.spotlight?.categories,
                         }),
                     ],
                 ),
@@ -491,7 +501,7 @@ export const convertTable = (
     );
 
     const modelMetrics = Object.fromEntries(
-        Object.entries(model.meta.metrics || {}).map(([name, metric]) => [
+        Object.entries(meta.metrics || {}).map(([name, metric]) => [
             name,
             convertModelMetric({
                 modelName: model.name,
@@ -501,10 +511,10 @@ export const convertTable = (
                 spotlightConfig: {
                     ...spotlightConfig,
                     default_visibility:
-                        model.meta.spotlight?.visibility ??
+                        meta.spotlight?.visibility ??
                         spotlightConfig.default_visibility,
                 },
-                modelCategories: model.meta.spotlight?.categories,
+                modelCategories: meta.spotlight?.categories,
             }),
         ]),
     );
@@ -519,10 +529,10 @@ export const convertTable = (
                 {
                     ...spotlightConfig,
                     default_visibility:
-                        model.meta.spotlight?.visibility ??
+                        meta.spotlight?.visibility ??
                         spotlightConfig.default_visibility,
                 },
-                model.meta.spotlight?.categories,
+                meta.spotlight?.categories,
             ),
         ]),
     );
@@ -563,7 +573,7 @@ export const convertTable = (
         });
     }
 
-    const sqlTable = model.meta.sql_from || model.relation_name;
+    const sqlTable = meta.sql_from || model.relation_name;
     return {
         name: model.name,
         label: tableLabel,
@@ -654,7 +664,21 @@ export const convertExplores = async (
     const tableLineage = translateDbtModelsToTableLineage(models);
     const [tables, exploreErrors] = models.reduce(
         ([accTables, accErrors], model) => {
-            const meta = model.config?.meta || model.meta; // Config block takes priority, then meta block
+            const meta = {
+                ...(model.meta || {}),
+                ...(model.config?.meta || {}), // Config block takes priority, then meta block
+            };
+
+            // model.config.tags has type string[] | string | undefined - normalise it to string[]
+            const configTags =
+                typeof model.config?.tags === 'string'
+                    ? [model.config.tags]
+                    : model.config?.tags;
+
+            // model.config.tags takes priority over model.tags - if config tags is an empty list, we'll use model tags
+            const tags =
+                configTags && configTags.length > 0 ? configTags : model.tags;
+
             // If there are any errors compiling the table return an ExploreError
             try {
                 // base dimensions and metrics
@@ -685,7 +709,7 @@ export const convertExplores = async (
                 const exploreError: ExploreError = {
                     name: model.name,
                     label: meta.label || friendlyName(model.name),
-                    tags: model.tags,
+                    tags,
                     groupLabel: meta.group_label,
                     errors: [
                         {
@@ -715,13 +739,22 @@ export const convertExplores = async (
 
     const exploreCompiler = new ExploreCompiler(warehouseClient);
     const explores: (Explore | ExploreError)[] = validModels.map((model) => {
-        const meta = model.config?.meta || model.meta; // Config block takes priority, then meta block
+        const meta = {
+            ...(model.meta || {}),
+            ...(model.config?.meta || {}), // Config block takes priority, then meta block
+        };
+        const configTags =
+            typeof model.config?.tags === 'string'
+                ? [model.config.tags]
+                : model.config?.tags;
+        const tags =
+            configTags && configTags.length > 0 ? configTags : model.tags;
 
         try {
             return exploreCompiler.compileExplore({
                 name: model.name,
                 label: meta.label || friendlyName(model.name),
-                tags: model.tags || [],
+                tags: tags || [],
                 baseTable: model.name,
                 groupLabel: meta.group_label,
                 joinedTables: (meta?.joins || []).map((join) => ({

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -61,8 +61,11 @@ export type DbtModelNode = DbtRawModelNode & {
     };
 };
 export type DbtModelColumn = ColumnInfo & {
-    meta: DbtColumnMetadata;
+    meta?: DbtColumnMetadata;
     data_type?: DimensionType;
+    config?: {
+        meta?: DbtColumnMetadata;
+    };
 };
 
 type DbtLightdashFieldTags = {


### PR DESCRIPTION
I compiled dbt projects with different `dbt` versions. The table below summarises the results.

The `yaml source key` is the location of the config in the yaml files. I've included the "old way" using `meta` and `tags` and the "new way" where those keys are nested under `config`. The other columns show the location of the properties in the `manifest.json` - so it shows how the configuration is projected from the yaml files to the `manifest.json` (which is what we use as the source of truth for dbt metadata).

| yaml source key    | dbt 1.9.8 & dbt 1.10.0-rc2                 | dbt fusion          |
|--------------------|-------------------------------------|---------------------|
| model.meta (old)   | .model.meta ⚠️<br>.model.config.meta | ❌                   |
| model.tags (old)   | ❌                                   | ❌                   |
| column.meta (old)  | .column.meta                        | ❌                   |
| column.tags (old)  | .column.tags                        | ❌                   |
| model.config.meta  | .model.meta ⚠️<br>.model.config.meta | ❌⚠️                  |
| model.config.tags  | .model.tags <br>.model.config.tags  | .model.config.tags  |
| column.config.meta | .column.config.meta                 | .column.config.meta |
| column.config.tags | .column.config.tags                 | .column.config.tags |

⚠️ **Cannot** use old and new style meta syntax together. In dbt 1.9 both old and new style are sent to .model.meta and .model.config.meta
❌⚠️ **BUG** in dbt fusion where model meta doesn’t flow through

To maintain backwards compatibility:

model config is read as `.model.config.meta || .model.meta` 
model tags are read as `.model.config.tags || .model.tags`
column meta is read as `.column.config.meta || .column.meta`
column tags are read as `.column.config.tags || .column.tags`

This maintains backwards compatibility for older dbt versions while preferring the new syntax

Steps for users migrating:
- Move `meta` and `tags` for your models and columns to `config.meta` and `config.tags` 
- Both old and new style are supported in dbt 1.9 and dbt 1.10 - so you can migrate incrementally
- Just don’t use old + new style on the same model/column as this will prevent compiling

I'll update docs separately with a migration guide

test-cli test-backend test-frontend