### PR TITLE
feat: use chart name as download file name through ContentDisposition

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -429,6 +429,7 @@ export class QueryController extends BaseController {
                 columnOrder: body.columnOrder,
                 hiddenFields: body.hiddenFields,
                 pivotConfig: body.pivotConfig,
+                attachmentDownloadName: body.attachmentDownloadName,
             });
 
         return {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -607,6 +607,7 @@ export class AsyncQueryService extends ProjectService {
         columnOrder = [],
         hiddenFields = [],
         pivotConfig,
+        attachmentDownloadName,
     }: DownloadAsyncQueryResultsArgs): Promise<
         | ApiDownloadAsyncQueryResults
         | ApiDownloadAsyncQueryResultsAsCsv
@@ -707,6 +708,7 @@ export class AsyncQueryService extends ProjectService {
                             columnOrder,
                             hiddenFields,
                             pivotConfig,
+                            attachmentDownloadName,
                         },
                     });
                 }
@@ -725,6 +727,7 @@ export class AsyncQueryService extends ProjectService {
                         hiddenFields,
                         pivotConfig,
                     },
+                    attachmentDownloadName,
                 );
             case DownloadFileType.XLSX:
                 // Check if this is a pivot table download
@@ -742,6 +745,7 @@ export class AsyncQueryService extends ProjectService {
                             columnOrder,
                             hiddenFields,
                             pivotConfig,
+                            attachmentDownloadName,
                         },
                     });
                 }
@@ -761,6 +765,7 @@ export class AsyncQueryService extends ProjectService {
                         hiddenFields,
                         pivotConfig,
                     },
+                    attachmentDownloadName,
                 );
             case undefined:
             case DownloadFileType.JSONL:
@@ -800,6 +805,7 @@ export class AsyncQueryService extends ProjectService {
             hiddenFields?: string[];
             pivotConfig?: PivotConfig;
         },
+        attachmentDownloadName?: string,
     ): Promise<{ fileUrl: string; truncated: boolean }> {
         // Generate a unique filename
         const formattedFileName = service.generateFileId(resultsFileName);
@@ -863,6 +869,7 @@ export class AsyncQueryService extends ProjectService {
                     truncated,
                 };
             },
+            attachmentDownloadName,
         );
     }
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -45,6 +45,7 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    attachmentDownloadName?: string;
 };
 
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -1464,6 +1464,7 @@ This method can be memory intensive
             columnOrder: string[];
             hiddenFields: string[];
             pivotConfig: PivotConfig;
+            attachmentDownloadName?: string;
         };
     }): Promise<{ fileUrl: string; truncated: boolean }> {
         const {
@@ -1490,7 +1491,8 @@ This method can be memory intensive
             throw new Error('No data found in results file');
         }
 
-        const fileName = `pivot-${resultsFileName}`;
+        const fileName =
+            options.attachmentDownloadName || `pivot-${resultsFileName}`;
 
         const attachmentUrl = await this.downloadPivotTableCsv({
             name: fileName,

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -256,6 +256,7 @@ export class ExcelService {
             columnOrder: string[];
             hiddenFields: string[];
             pivotConfig: PivotConfig;
+            attachmentDownloadName?: string;
         };
     }): Promise<{ fileUrl: string; truncated: boolean }> {
         const { onlyRaw, customLabels, pivotConfig } = options;
@@ -275,7 +276,8 @@ export class ExcelService {
             throw new Error('No data found in results file');
         }
 
-        const fileName = `pivot-${resultsFileName}`;
+        const fileName =
+            options.attachmentDownloadName || `pivot-${resultsFileName}`;
         const formattedFileName = ExcelService.generateFileId(fileName);
 
         const excelBuffer = await ExcelService.downloadPivotTableXlsx({

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -128,6 +128,7 @@ export type DownloadAsyncQueryResultsRequestParams = {
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    attachmentDownloadName?: string;
 };
 
 export type ExecuteAsyncQueryRequestParams =

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -26,4 +26,5 @@ export type DownloadOptions = {
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    attachmentDownloadName?: string;
 };

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -58,6 +58,10 @@ const ResultsCard: FC = memo(() => {
         (context) => context.state.unsavedChartVersion,
     );
 
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
+    );
+
     const customLabels = getCustomLabelsFromTableConfig(
         unsavedChartVersion.chartConfig.config,
     );
@@ -149,6 +153,7 @@ const ResultsCard: FC = memo(() => {
                                         columnOrder={columnOrder}
                                         customLabels={customLabels}
                                         hiddenFields={hiddenFields}
+                                        chartName={savedChart?.name}
                                         showTableNames
                                     />
                                 </Popover.Dropdown>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -191,6 +191,7 @@ const VisualizationCard: FC<{
                                             getDownloadQueryUuid
                                         }
                                         projectUuid={projectUuid}
+                                        chartName={savedChart?.name}
                                         getGsheetLink={getGsheetLink}
                                     />
                                 )}

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -96,6 +96,9 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         hiddenFields,
                         showTableNames,
                         pivotConfig,
+                        attachmentDownloadName: chartName
+                            ? `${chartName}_${formatDate(new Date())}`
+                            : undefined,
                     });
                 },
                 {

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -26,6 +26,7 @@ import { createPivotConfigFromVisualization } from './chartDownloadUtils';
 export type ChartDownloadMenuProps = {
     getDownloadQueryUuid: (limit: number | null) => Promise<string>;
     projectUuid: string;
+    chartName?: string;
     getGsheetLink?: (
         columnOrder: string[],
         showTableNames: boolean,
@@ -34,7 +35,7 @@ export type ChartDownloadMenuProps = {
 };
 
 const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
-    ({ getDownloadQueryUuid, getGsheetLink, projectUuid }) => {
+    ({ getDownloadQueryUuid, getGsheetLink, projectUuid, chartName }) => {
         const { chartRef, visualizationConfig, resultsData, pivotDimensions } =
             useVisualizationContext();
 
@@ -108,6 +109,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             showTableNames={
                                 visualizationConfig.chartConfig.showTableNames
                             }
+                            chartName={chartName}
                             pivotConfig={pivotConfig}
                             getGsheetLink={
                                 getGsheetLink === undefined

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -89,6 +89,7 @@ export const downloadQuery = async (
             columnOrder: options.columnOrder,
             hiddenFields: options.hiddenFields,
             pivotConfig: options.pivotConfig,
+            attachmentDownloadName: options.attachmentDownloadName,
         }),
         version: 'v2',
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15281

### Description:
We were setting downloaded S3 files a `ContentDisposition` header containing filename - which is a long cache key and doesn't indicate which file it is very well. Now we're passing chartName and write that header using it.

Along the way, we sanitize it, so the CSV export file for "How much revenue do we have per payment method each month?" chart will be `how_much_revenue_do_we_have_per_payment_method_each_month_2025_06_11.csv`