### PR TITLE
feat: lightdash generate meta under config

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -80,9 +80,11 @@ const generateModelYml = ({
         description: '',
         ...(includeMeta
             ? {
-                  meta: {
-                      dimension: {
-                          type: dimensionType,
+                  config: {
+                      meta: {
+                          dimension: {
+                              type: dimensionType,
+                          },
                       },
                   },
               }
@@ -208,7 +210,12 @@ export const findAndUpdateModelYaml = async ({
             const hasDoc = docsNames.includes(column.name);
             const newDescription = hasDoc ? `{{doc('${column.name}')}}` : '';
             const existingDescription = column.description;
-            const existingDimensionType = column.meta?.dimension?.type;
+            if (column.meta) {
+                throw new ParseError(
+                    'Detected column with `column.meta` property, these should be nested under `column.config.meta`. Please update your config before using lightdash generate',
+                );
+            }
+            const existingDimensionType = column.config?.meta?.dimension?.type;
             const dimensionType = table[column.name] as
                 | DimensionType
                 | undefined;
@@ -238,7 +245,9 @@ export const findAndUpdateModelYaml = async ({
                 columnName: column.name,
                 properties: {
                     description,
-                    meta,
+                    config: {
+                        meta,
+                    },
                 },
             });
         }

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -1,28 +1,5 @@
-import { DbtSchemaEditor, DimensionType, ParseError } from '@lightdash/common';
+import { DbtSchemaEditor, ParseError } from '@lightdash/common';
 import { promises as fs } from 'fs';
-
-type YamlColumnMeta = {
-    dimension?: {
-        type?: DimensionType;
-    };
-};
-
-type YamlColumn = {
-    name: string;
-    description?: string;
-    meta?: YamlColumnMeta;
-};
-
-export type YamlModel = {
-    name: string;
-    description?: string;
-    columns?: YamlColumn[];
-};
-
-export type YamlSchema = {
-    version?: 2;
-    models?: YamlModel[];
-};
 
 const loadYamlSchema = async (path: string): Promise<DbtSchemaEditor> => {
     try {

--- a/packages/common/src/types/yamlSchema.ts
+++ b/packages/common/src/types/yamlSchema.ts
@@ -4,6 +4,9 @@ export type YamlColumn = {
     name: string;
     description?: string;
     meta?: DbtColumnMetadata;
+    config?: {
+        meta?: DbtColumnMetadata;
+    };
 };
 
 export type YamlModel = {
@@ -11,6 +14,9 @@ export type YamlModel = {
     description?: string;
     columns?: YamlColumn[];
     meta?: DbtModelMetadata;
+    config?: {
+        meta?: DbtModelMetadata;
+    };
 };
 
 export type YamlSchema = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Throws an error for columns using `meta` - so customers need to be on 1.9 to use lightdash generate
- Updates `lighdash generate` to generate and merge `meta` under `config.meta` 

Test it on the orders model:

```shell
cd examples/full-jaffle-shop-demo/dbt
lightdash generate -s orders
```


<!-- Even better add a screenshot / gif / loom -->
