### PR TITLE
fix: add BOM character to CSV test expectations

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -99,7 +99,8 @@ describe('Csv service', () => {
         });
 
         expect(csvContent).toEqual(
-            `column number,column string,column date
+            // eslint-disable-next-line no-irregular-whitespace
+            `﻿column number,column string,column date
 $0.00,value_0,2020-03-16
 $1.00,value_1,2020-03-16
 $2.00,value_2,2020-03-16
@@ -132,7 +133,8 @@ $4.00,value_4,2020-03-16
         });
 
         expect(csvContent).toEqual(
-            `table column number,column string,table column date
+            // eslint-disable-next-line no-irregular-whitespace
+            `﻿table column number,column string,table column date
 0,value_0,2020-03-16
 1,value_1,2020-03-16
 2,value_2,2020-03-16


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR fixes the CSV test expectations by adding the Byte Order Mark (BOM) character to the expected CSV content. The BOM character is automatically added by the CSV service when generating CSV files, but was missing in the test expectations, causing test failures.

The PR also adds ESLint disable comments to prevent linting errors related to the irregular whitespace character (BOM) in the test strings.