### PR TITLE
fix: use a max 32-bit signed integer for all results queries

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -52,6 +52,7 @@ import {
     isUserWithOrg,
     isVizTableConfig,
     ItemsMap,
+    MAX_SAFE_INTEGER,
     MetricQuery,
     NotFoundError,
     type Organization,
@@ -1657,7 +1658,7 @@ export class AsyncQueryService extends ProjectService {
             limit !== undefined
                 ? {
                       ...metricQuery,
-                      limit: limit ?? Number.MAX_SAFE_INTEGER,
+                      limit: limit ?? MAX_SAFE_INTEGER,
                   }
                 : metricQuery;
 

--- a/packages/common/src/constants/sqlRunner.ts
+++ b/packages/common/src/constants/sqlRunner.ts
@@ -4,3 +4,6 @@
  * when a GROUP BY query results in too many pivot columns.
  */
 export const MAX_PIVOT_COLUMN_LIMIT = 100;
+
+// Max 32-bit signed integer, as Number.MAX_SAFE_INTEGER is possibly causing issues for Redshift "all results" queries
+export const MAX_SAFE_INTEGER = 2_147_483_647;

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -2,6 +2,7 @@ import {
     ChartKind,
     isVizTableConfig,
     MAX_PIVOT_COLUMN_LIMIT,
+    MAX_SAFE_INTEGER,
     type VizTableConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
@@ -334,7 +335,7 @@ export const ContentPanel: FC = () => {
                     projectUuid,
                     sql,
                     downloadLimit === null
-                        ? Number.MAX_SAFE_INTEGER
+                        ? MAX_SAFE_INTEGER
                         : downloadLimit ?? limit,
                 );
                 return newQuery.queryUuid;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -1,5 +1,6 @@
 import {
     isVizTableConfig,
+    MAX_SAFE_INTEGER,
     type ApiError,
     type DashboardFilters,
     type IResultsRunner,
@@ -166,13 +167,13 @@ export const useSavedSqlChartResults = (
                               dashboardSorts: args.dashboardSorts,
                               savedSqlUuid,
                               context: args.context as QueryExecutionContext,
-                              limit: limit ?? Number.MAX_SAFE_INTEGER,
+                              limit: limit ?? MAX_SAFE_INTEGER,
                           })
                         : await getSqlChartPivotChartData({
                               projectUuid: projectUuid!,
                               savedSqlUuid: chartQuery.data.savedSqlUuid,
                               context: context as QueryExecutionContext,
-                              limit: limit ?? Number.MAX_SAFE_INTEGER,
+                              limit: limit ?? MAX_SAFE_INTEGER,
                           });
                 queryUuidToDownload = queryForDownload.queryUuid;
             }

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -11,6 +11,7 @@ import {
     type DownloadOptions,
     type ExecuteAsyncMetricQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
+    MAX_SAFE_INTEGER,
     type MetricQuery,
     ParameterError,
     QueryExecutionContext,
@@ -125,7 +126,7 @@ const executeAsyncQuery = (
         let queryLimit = data.query.limit;
         if (data.csvLimit !== undefined) {
             // For unlimited exports (null), use Number.MAX_SAFE_INTEGER
-            queryLimit = data.csvLimit ?? Number.MAX_SAFE_INTEGER;
+            queryLimit = data.csvLimit ?? MAX_SAFE_INTEGER;
         }
 
         return executeAsyncMetricQuery(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: an issue for client with Redshift, trying to execute an "all results" query and fails -- most likely due to the limit being set to `Number.MAX_SAFE_INTEGER`, which is too high for Redshift.

### Description:
Using max 32-bit signed integer instead - 2_147_483_647.