### PR TITLE
fix: use project's dbtVersion instead of hardcoded latest

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -851,7 +851,7 @@ export class OrganizationService extends BaseService {
                 copyWarehouseConnectionFromUpstreamProject: undefined,
                 dbtConnection: setup.dbt,
                 upstreamProjectUuid: undefined,
-                dbtVersion: DbtVersionOptionLatest.LATEST,
+                dbtVersion: setup.project.dbtVersion,
             };
 
             const projectUuid = await this.projectModel.create(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/15268

> export LD_SETUP_DBT_VERSION='v1.8'

![Screenshot from 2025-06-12 09-14-05](https://github.com/user-attachments/assets/203a63ab-6f9c-4cde-80cc-7b8bbfd1c5dc)


### Description:
Use the dbt version specified in the project setup configuration instead of always defaulting to the latest version when creating a new project. This ensures that projects are created with the intended dbt version rather than automatically using the latest.