### PR TITLE
feat: make ExportResults component wrappable in a modal

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1283,7 +1283,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                 size="lg"
                                 color="gray.7"
                             />
-                            <Text fw={600}>Export CSV</Text>
+                            <Text fw={600}>Export Data</Text>
                         </Group>
                     }
                     styles={(theme) => ({

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -36,6 +36,7 @@ import {
     ActionIcon,
     Badge,
     Box,
+    Button,
     Group,
     HoverCard,
     Menu,
@@ -831,6 +832,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         return dashboardChartReadyQuery.executeQueryResponse.queryUuid;
     }, [dashboardChartReadyQuery.executeQueryResponse.queryUuid]);
 
+    const closeDataExportModal = useCallback(
+        () => setIsDataExportModalOpen(false),
+        [],
+    );
+
     return (
         <>
             <TileBase
@@ -1269,9 +1275,23 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
             {isDataExportModalOpen ? (
                 <Modal
                     opened
-                    onClose={() => setIsDataExportModalOpen(false)}
-                    title="Download data"
-                    size="md"
+                    onClose={closeDataExportModal}
+                    title={
+                        <Group spacing="xs">
+                            <MantineIcon
+                                icon={IconTableExport}
+                                size="lg"
+                                color="gray.7"
+                            />
+                            <Text fw={600}>Export CSV</Text>
+                        </Group>
+                    }
+                    styles={(theme) => ({
+                        header: {
+                            borderBottom: `1px solid ${theme.colors.gray[4]}`,
+                        },
+                        body: { padding: 0 },
+                    })}
                 >
                     <ExportResults
                         projectUuid={projectUuid!}
@@ -1286,6 +1306,33 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                         hiddenFields={getHiddenTableFields(chart.chartConfig)}
                         pivotConfig={getPivotConfig(chart)}
                         hideLimitSelection
+                        renderDialogActions={({ onExport, isExporting }) => (
+                            <Group
+                                position="right"
+                                sx={(theme) => ({
+                                    borderTop: `1px solid ${theme.colors.gray[4]}`,
+                                    bottom: 0,
+                                    padding: theme.spacing.md,
+                                })}
+                            >
+                                <Button
+                                    variant="outline"
+                                    onClick={closeDataExportModal}
+                                >
+                                    Cancel
+                                </Button>
+
+                                <Button
+                                    loading={isExporting}
+                                    onClick={async () => {
+                                        await onExport();
+                                    }}
+                                    data-testid="chart-export-results-button"
+                                >
+                                    Download
+                                </Button>
+                            </Group>
+                        )}
                     />
                 </Modal>
             ) : null}

--- a/packages/frontend/src/components/ExportCSV/index.tsx
+++ b/packages/frontend/src/components/ExportCSV/index.tsx
@@ -23,7 +23,7 @@ enum Values {
     RAW = 'raw',
 }
 
-type ExportCsvRenderProps = {
+export type ExportCsvRenderProps = {
     onExport: () => Promise<unknown>;
     isExporting: boolean;
 };

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -249,6 +249,8 @@ const ExportResults: FC<ExportResultsProps> = memo(
                             sx={{
                                 alignSelf: 'end',
                             }}
+                            my="xs"
+                            size="md"
                             leftIcon={<MantineIcon icon={IconTableExport} />}
                             onClick={exportMutation}
                             data-testid="chart-export-results-button"

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -16,13 +16,14 @@ import {
 import { notifications } from '@mantine/notifications';
 import { IconTableExport } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { memo, useState, type FC } from 'react';
+import { memo, useState, type FC, type ReactNode } from 'react';
 
 import useToaster from '../../hooks/toaster/useToaster';
 import { downloadQuery } from '../../hooks/useQueryResults';
 import useUser from '../../hooks/user/useUser';
 import { Can } from '../../providers/Ability';
 import MantineIcon from '../common/MantineIcon';
+import { type ExportCsvRenderProps } from '../ExportCSV';
 
 enum Limit {
     TABLE = 'table',
@@ -46,6 +47,7 @@ export type ExportResultsProps = {
     chartName?: string;
     pivotConfig?: PivotConfig;
     hideLimitSelection?: boolean;
+    renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
 };
 
 const TOAST_KEY = 'exporting-results';
@@ -62,6 +64,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         chartName,
         pivotConfig,
         hideLimitSelection = false,
+        renderDialogActions,
     }) => {
         const { showToastError, showToastInfo, showToastWarning } =
             useToaster();
@@ -146,32 +149,43 @@ const ExportResults: FC<ExportResultsProps> = memo(
         return (
             <Box>
                 <Stack spacing="xs" miw={300}>
-                    <Stack spacing="xs">
-                        <Text fw={500}>File format</Text>
-                        <SegmentedControl
-                            size={'xs'}
-                            value={fileType}
-                            onChange={(value) =>
-                                setFileType(value as DownloadFileType)
-                            }
-                            data={[
-                                { label: 'CSV', value: DownloadFileType.CSV },
-                                { label: 'XLSX', value: DownloadFileType.XLSX },
-                            ]}
-                        />
-                    </Stack>
+                    <Stack p={renderDialogActions ? 'md' : 0}>
+                        <Stack spacing="xs">
+                            <Text fw={500}>File format</Text>
+                            <SegmentedControl
+                                size={'xs'}
+                                value={fileType}
+                                onChange={(value) =>
+                                    setFileType(value as DownloadFileType)
+                                }
+                                data={[
+                                    {
+                                        label: 'CSV',
+                                        value: DownloadFileType.CSV,
+                                    },
+                                    {
+                                        label: 'XLSX',
+                                        value: DownloadFileType.XLSX,
+                                    },
+                                ]}
+                            />
+                        </Stack>
 
-                    <Stack spacing="xs">
-                        <Text fw={500}>Values</Text>
-                        <SegmentedControl
-                            size={'xs'}
-                            value={format}
-                            onChange={(value) => setFormat(value)}
-                            data={[
-                                { label: 'Formatted', value: Values.FORMATTED },
-                                { label: 'Raw', value: Values.RAW },
-                            ]}
-                        />
+                        <Stack spacing="xs">
+                            <Text fw={500}>Values</Text>
+                            <SegmentedControl
+                                size={'xs'}
+                                value={format}
+                                onChange={(value) => setFormat(value)}
+                                data={[
+                                    {
+                                        label: 'Formatted',
+                                        value: Values.FORMATTED,
+                                    },
+                                    { label: 'Raw', value: Values.RAW },
+                                ]}
+                            />
+                        </Stack>
                     </Stack>
 
                     <Can
@@ -228,18 +242,25 @@ const ExportResults: FC<ExportResultsProps> = memo(
                             </Alert>
                         )}
 
-                    <Button
-                        loading={isExporting}
-                        compact
-                        sx={{
-                            alignSelf: 'end',
-                        }}
-                        leftIcon={<MantineIcon icon={IconTableExport} />}
-                        onClick={exportMutation}
-                        data-testid="chart-export-results-button"
-                    >
-                        Download
-                    </Button>
+                    {!renderDialogActions ? (
+                        <Button
+                            loading={isExporting}
+                            compact
+                            sx={{
+                                alignSelf: 'end',
+                            }}
+                            leftIcon={<MantineIcon icon={IconTableExport} />}
+                            onClick={exportMutation}
+                            data-testid="chart-export-results-button"
+                        >
+                            Download
+                        </Button>
+                    ) : (
+                        renderDialogActions({
+                            onExport: exportMutation,
+                            isExporting,
+                        })
+                    )}
                 </Stack>
             </Box>
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15265

### Description:
If we wrap ExportResults in a modal, we can pass `renderDialogActions` to render appropriate footer:

<img width="452" alt="Screenshot 2025-06-12 at 15 34 27" src="https://github.com/user-attachments/assets/9b8ef379-8237-4b8d-956d-76ca76a3f263" />
