### PR TITLE
feat: add service account authentication for API endpoints

### DIFF
--- a/examples/api/scim-org-tokens.http
+++ b/examples/api/scim-org-tokens.http
@@ -16,7 +16,7 @@ Content-Type: application/json
 
 {
     "description": "http test",
-    "expiresAt": "2025-06-11T14:00:00.000Z"
+    "expiresAt": "2025-09-11T14:00:00.000Z"
 }
 
 ### Get token by UUID
@@ -30,3 +30,10 @@ Content-Type: application/json
 {
     "expiresAt": "2025-09-11T14:00:00.000Z"
 }
+
+
+### Logout
+GET http://localhost:8080/api/v1/logout
+### Make a request using the scim token
+GET http://localhost:8080/api/v1/scim/v2/Groups
+Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957

--- a/examples/api/service-accounts.http
+++ b/examples/api/service-accounts.http
@@ -16,6 +16,22 @@ Content-Type: application/json
 
 {
     "description": "http test",
-    "expiresAt": "2025-06-11T14:00:00.000Z",
+    "expiresAt": "2025-09-11T14:00:00.000Z",
     "scopes": ["org:admin"]
 }
+
+### Logout
+GET http://localhost:8080/api/v1/logout
+### Make a request using the service account
+GET http://localhost:8080/api/v1/org/projects
+Authorization: Bearer 3e3bd56d5f428cfdaaab961dfdac6aef
+
+#### Also test the same endpoint using api token
+GET http://localhost:8080/api/v1/org/projects
+Authorization: ApiKey 9034a7ef26151167617f9f9b412d5247
+
+### I can't use service account on an unauthorized endpoint
+GET http://localhost:8080/api/v1/org/users
+Authorization: Bearer 3e3bd56d5f428cfdaaab961dfdac6aef
+#Authorization: ApiKey 9034a7ef26151167617f9f9b412d5247
+

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -69,6 +69,7 @@ import { UtilProviderMap, UtilRepository } from './utils/UtilRepository';
 import { VERSION } from './version';
 import PrometheusMetrics from './prometheus';
 import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
+
 // We need to override this interface to have our user typing
 declare global {
     namespace Express {

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -6,6 +6,7 @@ import {
     DeactivatedAccountError,
     InvalidUser,
     LightdashMode,
+    SessionUser,
 } from '@lightdash/common';
 import { ErrorRequestHandler, Request, RequestHandler } from 'express';
 import passport from 'passport';
@@ -45,7 +46,6 @@ export const allowApiKeyAuthentication: RequestHandler = (req, res, next) => {
         next();
         return;
     }
-
     if (!lightdashConfig.auth.pat.enabled) {
         throw new AuthorizationError('Personal access tokens are disabled');
     }

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -16,6 +16,7 @@ import {
     CreateOrganization,
     KnexPaginateArgs,
     OrganizationMemberProfileUpdate,
+    ServiceAccountScope,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
     UpdateOrganization,
@@ -38,6 +39,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { authenticateServiceAccount } from '../ee/authentication/middlewares';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -156,7 +158,11 @@ export class OrganizationController extends BaseController {
      * Gets all projects of the current user's organization
      * @param req express request
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        authenticateServiceAccount([ServiceAccountScope.ORG_READ]),
+        allowApiKeyAuthentication,
+        isAuthenticated,
+    ])
     @Get('/projects')
     @OperationId('ListOrganizationProjects')
     async getProjects(

--- a/packages/backend/src/ee/authentication/middleware.mock.ts
+++ b/packages/backend/src/ee/authentication/middleware.mock.ts
@@ -1,9 +1,12 @@
-import { SessionServiceAccount } from '@lightdash/common';
+import { ServiceAccountScope, SessionServiceAccount } from '@lightdash/common';
 import express from 'express';
 import { BaseService } from '../../services/BaseService';
 
 export const mockServiceAccount: SessionServiceAccount = {
+    createdByUserUuid: 'test-user-uuid',
+    uuid: 'test-service-account-uuid',
     organizationUuid: 'test-org-uuid',
+    scopes: [ServiceAccountScope.ORG_READ],
 };
 
 export const mockRequest = {
@@ -17,7 +20,7 @@ export const mockRequest = {
     },
     services: {
         getServiceAccountService: jest.fn().mockReturnValue({
-            authenticateToken: jest.fn().mockResolvedValue(mockServiceAccount),
+            authenticate: jest.fn().mockResolvedValue(mockServiceAccount),
         }),
     },
 } as unknown as express.Request;
@@ -29,7 +32,7 @@ export const mockRequestWithInvalidToken = {
     },
     services: {
         getServiceAccountService: jest.fn().mockReturnValue({
-            authenticateToken: jest.fn().mockResolvedValue(null),
+            authenticate: jest.fn().mockResolvedValue(null),
         }),
     },
 } as unknown as express.Request;

--- a/packages/backend/src/ee/authentication/middleware.test.ts
+++ b/packages/backend/src/ee/authentication/middleware.test.ts
@@ -22,7 +22,7 @@ describe('SCIM Authentication Middleware', () => {
 
         expect(
             mockRequest.services.getServiceAccountService<ServiceAccountService>()
-                .authenticateToken,
+                .authenticate,
         ).toHaveBeenCalledWith('scim_test_token', {
             method: mockRequest.method,
             path: mockRequest.path,

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -1,6 +1,12 @@
-import { getErrorMessage, ScimError } from '@lightdash/common';
+import {
+    AuthorizationError,
+    getErrorMessage,
+    hasRequiredScopes,
+    ScimError,
+    ServiceAccountScope,
+} from '@lightdash/common';
 import { RequestHandler } from 'express';
-import { ScimService } from '../services/ScimService/ScimService';
+import { isAuthenticated } from '../../controllers/authentication';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 
 // Middleware to extract SCIM user details
@@ -32,12 +38,11 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
         // Attach SCIM serviceAccount to request
         const serviceAccount = await req.services
             .getServiceAccountService<ServiceAccountService>()
-            .authenticateToken(token, {
+            .authenticate(token, {
                 method: req.method,
                 path: req.path,
                 routePath: req.route.path,
             });
-
         if (serviceAccount) {
             req.serviceAccount = serviceAccount;
             next();
@@ -53,3 +58,80 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
         );
     }
 };
+
+// Middleware to extract service account and check scopes
+// At the moment, we can only use this middleware on methods that are not user dependant, like running queries
+export const authenticateServiceAccount =
+    (scopes: ServiceAccountScope[]): RequestHandler =>
+    async (req, res, next) => {
+        if (req.isAuthenticated()) {
+            next();
+            return;
+        }
+
+        // Check for service account headers or payload (assuming service account details are in the headers for this example)
+        const token = req.headers.authorization;
+        try {
+            // throw if no service account token is found
+            if (!token || typeof token !== 'string' || token.length === 0) {
+                throw new Error('No service account token provided');
+            }
+            // split the token into an array
+            const tokenParts = token.split(' ');
+
+            // If it is not a specific Bearer token, we do next, without throwing an error
+            // This could be an ApiKey token, or already authenticated user
+            if (tokenParts.length !== 2 || tokenParts[0] !== 'Bearer') {
+                // We will execute the next middleware
+                next();
+                return;
+            }
+
+            // extract the token from the array
+            const ServiceAccountToken = tokenParts[1];
+            // Check if the token is valid
+            if (!ServiceAccountToken) {
+                throw new AuthorizationError(
+                    'No service account token provided',
+                );
+            }
+            // Attach service account serviceAccount to request
+            const serviceAccount = await req.services
+                .getServiceAccountService<ServiceAccountService>()
+                .authenticate(ServiceAccountToken, {
+                    method: req.method,
+                    path: req.path,
+                    routePath: req.route.path,
+                });
+
+            if (!serviceAccount) {
+                throw new AuthorizationError(
+                    'Invalid service account token. Authentication failed.',
+                );
+            }
+
+            if (!hasRequiredScopes(serviceAccount.scopes, scopes)) {
+                throw new AuthorizationError(
+                    'Invalid service account token. Missing required scopes.',
+                );
+            }
+            req.serviceAccount = serviceAccount;
+
+            // Also add the admin user to the request
+            // This is for backwards compatibility with all the existing service and controller methods
+            // that rely on the user object
+            if (!serviceAccount.createdByUserUuid) {
+                throw new AuthorizationError(
+                    'Invalid service account token. Missing created by user uuid.',
+                );
+            }
+            const user = await req.services
+                .getUserService()
+                .getSessionByUserUuid(serviceAccount.createdByUserUuid);
+            req.user = user;
+
+            next();
+        } catch (error) {
+            next(new AuthorizationError(getErrorMessage(error)));
+        }
+    };

--- a/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
+++ b/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
@@ -49,11 +49,10 @@ export class ScimOrganizationAccessTokenController extends BaseController {
     async getOrganizationAccessTokens(
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ServiceAccount[] }> {
-        const results =
-            await this.getServiceAccountService().listOrganizationAccessTokens(
-                req.user!,
-                SCIM_SCOPES,
-            );
+        const results = await this.getServiceAccountService().list(
+            req.user!,
+            SCIM_SCOPES,
+        );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -75,18 +74,15 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiCreateScimServiceAccountRequest, // Service account request without scopes
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
-        const token =
-            await this.getServiceAccountService().createOrganizationAccessToken(
-                {
-                    user: req.user!,
-                    tokenDetails: {
-                        ...body,
-                        organizationUuid: req.user?.organizationUuid as string,
-                        scopes: SCIM_SCOPES,
-                    },
-                    prefix: 'scim_',
-                },
-            );
+        const token = await this.getServiceAccountService().create({
+            user: req.user!,
+            tokenDetails: {
+                ...body,
+                organizationUuid: req.user?.organizationUuid as string,
+                scopes: SCIM_SCOPES,
+            },
+            prefix: 'scim_',
+        });
         this.setStatus(201);
         return {
             status: 'ok',
@@ -108,7 +104,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Request() req: express.Request,
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
-        await this.getServiceAccountService().deleteOrganizationAccessToken({
+        await this.getServiceAccountService().delete({
             user: req.user!,
             tokenUuid,
         });
@@ -136,13 +132,10 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results:
-                await this.getServiceAccountService().getOrganizationAccessToken(
-                    {
-                        user: req.user!,
-                        tokenUuid,
-                    },
-                ),
+            results: await this.getServiceAccountService().get({
+                user: req.user!,
+                tokenUuid,
+            }),
         };
     }
 
@@ -171,15 +164,12 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results:
-                await this.getServiceAccountService().rotateOrganizationAccessToken(
-                    {
-                        user: req.user!,
-                        tokenUuid,
-                        update: body,
-                        prefix: 'scim_',
-                    },
-                ),
+            results: await this.getServiceAccountService().rotate({
+                user: req.user!,
+                tokenUuid,
+                update: body,
+                prefix: 'scim_',
+            }),
         };
     }
 

--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -46,11 +46,10 @@ export class ServiceAccountsController extends BaseController {
         const scopes = Object.values(ServiceAccountScope).filter(
             (scope) => scope !== ServiceAccountScope.SCIM_MANAGE,
         );
-        const results =
-            await this.getServiceAccountService().listOrganizationAccessTokens(
-                req.user!,
-                scopes,
-            );
+        const results = await this.getServiceAccountService().list(
+            req.user!,
+            scopes,
+        );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -71,17 +70,14 @@ export class ServiceAccountsController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiCreateServiceAccountRequest,
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
-        const token =
-            await this.getServiceAccountService().createOrganizationAccessToken(
-                {
-                    user: req.user!,
-                    tokenDetails: {
-                        ...body,
-                        organizationUuid: req.user?.organizationUuid as string,
-                    },
-                    prefix: '',
-                },
-            );
+        const token = await this.getServiceAccountService().create({
+            user: req.user!,
+            tokenDetails: {
+                ...body,
+                organizationUuid: req.user?.organizationUuid as string,
+            },
+            prefix: '',
+        });
         this.setStatus(201);
         return {
             status: 'ok',
@@ -102,7 +98,7 @@ export class ServiceAccountsController extends BaseController {
         @Request() req: express.Request,
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
-        await this.getServiceAccountService().deleteOrganizationAccessToken({
+        await this.getServiceAccountService().delete({
             user: req.user!,
             tokenUuid,
         });

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -35,6 +35,7 @@ export class ServiceAccountModel {
             description: data.description,
             lastUsedAt: data.last_used_at,
             rotatedAt: data.rotated_at,
+            createdByUserUuid: data.created_by_user_uuid,
             scopes: data.scopes as ServiceAccountScope[],
         };
     }

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -69,7 +69,7 @@ export class ServiceAccountService extends BaseService {
         }
     }
 
-    async createOrganizationAccessToken({
+    async create({
         user,
         tokenDetails,
         prefix = 'scim_',
@@ -112,7 +112,7 @@ export class ServiceAccountService extends BaseService {
         }
     }
 
-    async deleteOrganizationAccessToken({
+    async delete({
         user,
         tokenUuid,
     }: {
@@ -161,7 +161,7 @@ export class ServiceAccountService extends BaseService {
         }
     }
 
-    async rotateOrganizationAccessToken({
+    async rotate({
         user,
         tokenUuid,
         update,
@@ -220,7 +220,7 @@ export class ServiceAccountService extends BaseService {
         return newToken;
     }
 
-    async getOrganizationAccessToken({
+    async get({
         user,
         tokenUuid,
     }: {
@@ -243,7 +243,7 @@ export class ServiceAccountService extends BaseService {
         return existingToken;
     }
 
-    async listOrganizationAccessTokens(
+    async list(
         user: SessionUser,
         scopes: ServiceAccountScope[],
     ): Promise<ServiceAccount[]> {
@@ -269,7 +269,7 @@ export class ServiceAccountService extends BaseService {
         }
     }
 
-    async authenticateToken(
+    async authenticate(
         token: string,
         request: {
             method: string;
@@ -277,8 +277,6 @@ export class ServiceAccountService extends BaseService {
             routePath: string;
         },
     ): Promise<SessionServiceAccount | null> {
-        // TODO validate scope ?
-
         // return null if token is empty
         if (token === '') return null;
 
@@ -304,7 +302,10 @@ export class ServiceAccountService extends BaseService {
                 await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
                 // finally return organization uuid
                 return {
+                    createdByUserUuid: dbToken.createdByUserUuid,
+                    uuid: dbToken.uuid,
                     organizationUuid: dbToken.organizationUuid,
+                    scopes: dbToken.scopes,
                 };
             }
         } catch (error) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -143,7 +143,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ServiceAccountScope: {
         dataType: 'refEnum',
-        enums: ['scim:manage', 'org:admin'],
+        enums: ['scim:manage', 'org:admin', 'org:read'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ServiceAccount: {
@@ -183,6 +183,14 @@ const models: TsoaRoute.Models = {
                 },
                 createdAt: { dataType: 'datetime', required: true },
                 organizationUuid: { dataType: 'string', required: true },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 uuid: { dataType: 'string', required: true },
             },
             validators: {},
@@ -11629,7 +11637,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11639,7 +11647,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11649,7 +11657,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11662,7 +11670,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -58,7 +58,7 @@
                 "type": "object"
             },
             "ServiceAccountScope": {
-                "enum": ["scim:manage", "org:admin"],
+                "enum": ["scim:manage", "org:admin", "org:read"],
                 "type": "string"
             },
             "ServiceAccount": {
@@ -94,6 +94,10 @@
                     "organizationUuid": {
                         "type": "string"
                     },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "uuid": {
                         "type": "string"
                     }
@@ -106,6 +110,7 @@
                     "expiresAt",
                     "createdAt",
                     "organizationUuid",
+                    "createdByUserUuid",
                     "uuid"
                 ],
                 "type": "object"
@@ -12468,22 +12473,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17833,7 +17838,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1732.0",
+        "version": "0.1734.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -1,7 +1,14 @@
-import { type ScimSchemaType, type ServiceAccount } from '..';
+import {
+    type ScimSchemaType,
+    type ServiceAccount,
+    type ServiceAccountScope,
+} from '..';
 
 export type SessionServiceAccount = {
+    createdByUserUuid: string | null;
+    uuid: string;
     organizationUuid: string;
+    scopes: ServiceAccountScope[];
 };
 
 export interface ScimResource {

--- a/packages/common/src/ee/serviceAccounts/types.test.ts
+++ b/packages/common/src/ee/serviceAccounts/types.test.ts
@@ -1,0 +1,80 @@
+import { ServiceAccountScope, hasRequiredScopes } from './types';
+
+describe('ServiceAccountScope', () => {
+    describe('hasRequiredScopes', () => {
+        it('should return true when service account has all required scopes', () => {
+            const serviceAccountScopes = [
+                ServiceAccountScope.ORG_ADMIN,
+                ServiceAccountScope.SCIM_MANAGE,
+            ];
+            const requiredScopes = [ServiceAccountScope.ORG_ADMIN];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(true);
+        });
+
+        it('should return true when service account has parent scopes', () => {
+            const serviceAccountScopes = [ServiceAccountScope.ORG_ADMIN];
+            const requiredScopes = [ServiceAccountScope.ORG_READ];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(true);
+        });
+
+        it('should return false when service account is missing a required scope', () => {
+            const serviceAccountScopes = [ServiceAccountScope.ORG_READ];
+            const requiredScopes = [ServiceAccountScope.ORG_ADMIN];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(false);
+        });
+
+        it('should return false when service account is missing a parent scope', () => {
+            const serviceAccountScopes = [ServiceAccountScope.ORG_ADMIN];
+            const requiredScopes = [
+                ServiceAccountScope.ORG_ADMIN,
+                ServiceAccountScope.SCIM_MANAGE,
+            ];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(false);
+        });
+
+        it('should return true when service account has all required scopes and their parents', () => {
+            const serviceAccountScopes = [
+                ServiceAccountScope.ORG_ADMIN,
+                ServiceAccountScope.SCIM_MANAGE,
+            ];
+            const requiredScopes = [
+                ServiceAccountScope.ORG_ADMIN,
+                ServiceAccountScope.SCIM_MANAGE,
+            ];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(true);
+        });
+
+        it('should return true when no scopes are required', () => {
+            const serviceAccountScopes = [ServiceAccountScope.ORG_ADMIN];
+            const requiredScopes: ServiceAccountScope[] = [];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(true);
+        });
+
+        it('should return false when service account has no scopes but scopes are required', () => {
+            const serviceAccountScopes: ServiceAccountScope[] = [];
+            const requiredScopes = [ServiceAccountScope.ORG_ADMIN];
+
+            expect(
+                hasRequiredScopes(serviceAccountScopes, requiredScopes),
+            ).toBe(false);
+        });
+    });
+});

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -1,10 +1,43 @@
 export enum ServiceAccountScope {
     SCIM_MANAGE = 'scim:manage',
     ORG_ADMIN = 'org:admin',
+    ORG_READ = 'org:read',
 }
+
+/** This is a list of all the scopes, and which scopes they contain
+ * So when we check if a service account has a specific scope, or scopes
+ * For example, if a service account has the scope org:admin, it will also have the scope org:read
+ */
+const ServiceAccountScopeHierarchy: Record<
+    ServiceAccountScope,
+    ServiceAccountScope[]
+> = {
+    [ServiceAccountScope.SCIM_MANAGE]: [],
+    [ServiceAccountScope.ORG_ADMIN]: [ServiceAccountScope.ORG_READ],
+    [ServiceAccountScope.ORG_READ]: [],
+};
+
+// Helper function to check if a service account has all required scopes including parent scopes
+export const hasRequiredScopes = (
+    serviceAccountScopes: ServiceAccountScope[],
+    requiredScopes: ServiceAccountScope[],
+): boolean =>
+    requiredScopes.every((requiredScope) => {
+        // Check if the service account has the required scope directly
+        if (serviceAccountScopes.includes(requiredScope)) {
+            return true;
+        }
+
+        // Check if any of the service account's scopes include the required scope as a parent
+        return serviceAccountScopes.some((scope) => {
+            const parentScopes = ServiceAccountScopeHierarchy[scope];
+            return parentScopes.includes(requiredScope);
+        });
+    });
 
 export type ServiceAccount = {
     uuid: string;
+    createdByUserUuid: string | null;
     organizationUuid: string;
     createdAt: Date;
     expiresAt: Date | null;

--- a/packages/e2e/cypress/e2e/api/serviceAccounts.cy.ts
+++ b/packages/e2e/cypress/e2e/api/serviceAccounts.cy.ts
@@ -1,0 +1,124 @@
+const apiUrl = '/api/v1';
+
+describe('Service Accounts API', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('Should create a service account', () => {
+        const serviceAccount = {
+            description: 'e2e test service account',
+            expiresAt: '2025-09-11T14:00:00.000Z',
+            scopes: ['org:admin'],
+        };
+
+        cy.request({
+            url: `${apiUrl}/service-accounts`,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: serviceAccount,
+        }).then((resp) => {
+            expect(resp.status).to.eq(201);
+            expect(resp.body.results).to.have.property('token');
+            expect(resp.body.results).to.have.property(
+                'description',
+                serviceAccount.description,
+            );
+            expect(resp.body.results).to.have.property(
+                'expiresAt',
+                serviceAccount.expiresAt,
+            );
+            expect(resp.body.results.scopes).to.deep.equal(
+                serviceAccount.scopes,
+            );
+        });
+    });
+
+    it('Should list service accounts', () => {
+        cy.request({
+            url: `${apiUrl}/service-accounts`,
+            method: 'GET',
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+            expect(resp.body.results).to.be.an('array');
+            // Service accounts should have required properties
+            if (resp.body.results.length > 0) {
+                const firstAccount = resp.body.results[0];
+                expect(firstAccount).to.have.property('uuid');
+                expect(firstAccount).to.have.property('description');
+                expect(firstAccount).to.have.property('createdAt');
+                expect(firstAccount).to.have.property('expiresAt');
+                expect(firstAccount).to.have.property('scopes');
+            }
+        });
+    });
+
+    it('Should access authorized endpoints with service account token', () => {
+        // First create a service account
+        const serviceAccount = {
+            description: 'e2e test service account for auth',
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            scopes: ['org:admin'],
+        };
+
+        cy.request({
+            url: `${apiUrl}/service-accounts`,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: serviceAccount,
+        }).then(
+            ({
+                body: {
+                    results: { token },
+                },
+            }) => {
+                // Test accessing projects endpoint with the service account token
+                cy.logout();
+                cy.request({
+                    url: `${apiUrl}/org/projects`,
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                });
+            },
+        );
+    });
+
+    it('Should not access unauthorized endpoints with service account token', () => {
+        // First create a service account
+        const serviceAccount = {
+            description: 'e2e test service account for unauth',
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            scopes: ['org:admin'],
+        };
+
+        cy.request({
+            url: `${apiUrl}/service-accounts`,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: serviceAccount,
+        }).then(
+            ({
+                body: {
+                    results: { token },
+                },
+            }) => {
+                // Test accessing users endpoint with the service account token
+                cy.logout();
+                cy.request({
+                    url: `${apiUrl}/org/users`,
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(401);
+                });
+            },
+        );
+    });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

![image](https://github.com/user-attachments/assets/d90503d5-43d4-4357-8dba-a754b8241a31)

- I added a new middleware function to allow service account authentication based on scopes. 
- I updated a org/projects endpoint to accept this new authentication
- I created unit tests and e2e tests around this feature. 

## Limitations
Given how dependant is our codebase (controller + service) to the SessionUser (userUuid, permissions...) I added the user who created the service account to the `req` object. 

This means, these accounts will still be linked to a user, and user can't be removed. We need to fix this somehow. Some options: 
- If user does not exist (has been deleted), then use another admin from the org. (easy, stable, hacky) 
- create fake/mocked SessionUser for the service account, load `abilities`  (from scopes?) (more elegant, see below) 
- Refactor all services where this new authentication method is going to be used (long, hard to scale) 
- any other library to handle this ? 

I think the best approach would be to build a `scopeToAbility` function, and use casl to create the abilities and return a `fake` user from the Service account. 

```
const scopeToAbilities: Record<ServiceAccountScope, (args: ServiceAccountAbilitiesArgs) => void> = {
    'run:query': ({ organizationUuid, builder: { can } }) => {
        can('view', 'Project', { organizationUuid });
        can('view', 'SavedChart', { organizationUuid });
        can('view', 'Dashboard', { organizationUuid });
        can('view', 'UnderlyingData', { organizationUuid });
        can('view', 'SemanticViewer', { organizationUuid });
    },
    
    ...
    
     const builder = new AbilityBuilder<MemberAbility>(Ability);
            applyServiceAccountAbilities({
                scopes: serviceAccount.scopes,
                organizationUuid: serviceAccount.organizationUuid,
                builder,
            });

```
    
What do you think ? 

## Technical details 
- scopes are not using casl (we check roles within the middleware) 
- middleware does not use passport (implemnentation is similar to SCIM) 


### Description:
Adds service account authentication middleware to enable API access using service account tokens. This PR:

1. Introduces a new `org:read` scope for service accounts
2. Adds an `authenticateServiceAccount` middleware that validates service account tokens and scopes
3. Refactors the ServiceAccountService methods with more consistent naming
4. Updates the API examples to demonstrate how to use service accounts for authentication
5. Applies the new middleware to the organization projects endpoint as an example implementation

The changes enable users to authenticate API requests using service account tokens with specific scopes, providing a more secure and controlled way to access the API programmatically.