### PR TITLE
feat: add generic notification email and email reporting for slug fixes

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -756,6 +756,10 @@ export default class App {
         return this.models;
     }
 
+    getClients() {
+        return this.clients;
+    }
+
     getDatabase() {
         return this.database;
     }

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -379,6 +379,7 @@ export default class EmailClient {
         subject: string,
         title: string,
         message: string,
+        attachments?: Mail.Attachment[],
     ) {
         return this.sendEmail({
             to,
@@ -390,6 +391,7 @@ export default class EmailClient {
                 host: this.lightdashConfig.siteUrl,
             },
             text: `${title}\n\n${message}`,
+            attachments,
         });
     }
 }

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -375,13 +375,13 @@ export default class EmailClient {
     }
 
     public async sendGenericNotificationEmail(
-        recipient: string,
+        to: string[],
         subject: string,
         title: string,
         message: string,
     ) {
         return this.sendEmail({
-            to: recipient,
+            to,
             subject,
             template: 'genericNotification',
             context: {

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -120,6 +120,10 @@ export default class EmailClient {
         }
     }
 
+    public canSendEmail() {
+        return !!this.transporter;
+    }
+
     public async sendPasswordRecoveryEmail(link: PasswordResetLink) {
         return this.sendEmail({
             to: link.email,
@@ -367,6 +371,25 @@ export default class EmailClient {
                 host: this.lightdashConfig.siteUrl,
             },
             text,
+        });
+    }
+
+    public async sendGenericNotificationEmail(
+        recipient: string,
+        subject: string,
+        title: string,
+        message: string,
+    ) {
+        return this.sendEmail({
+            to: recipient,
+            subject,
+            template: 'genericNotification',
+            context: {
+                title,
+                message: marked(message),
+                host: this.lightdashConfig.siteUrl,
+            },
+            text: `${title}\n\n${message}`,
         });
     }
 }

--- a/packages/backend/src/clients/EmailClient/templates/genericNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/genericNotification.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office"
+    lang="en"
+>
+    <head>
+        <meta name="x-apple-disable-message-reformatting" />
+        <meta http-equiv="X-UA-Compatible" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="target-densitydpi=device-dpi" />
+        <meta content="true" name="HandheldFriendly" />
+        <meta content="width=device-width" name="viewport" />
+        <style type="text/css">
+            table {
+                border-collapse: separate;
+                table-layout: fixed;
+                mso-table-lspace: 0pt;
+                mso-table-rspace: 0pt;
+            }
+
+            table td {
+                border-collapse: collapse;
+            }
+
+            .ExternalClass {
+                width: 100%;
+            }
+
+            .ExternalClass,
+            .ExternalClass p,
+            .ExternalClass span,
+            .ExternalClass font,
+            .ExternalClass td,
+            .ExternalClass div {
+                line-height: 100%;
+            }
+
+            * {
+                line-height: inherit;
+                text-size-adjust: 100%;
+                -ms-text-size-adjust: 100%;
+                -moz-text-size-adjust: 100%;
+                -o-text-size-adjust: 100%;
+                -webkit-text-size-adjust: 100%;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+
+            html {
+                -webkit-text-size-adjust: none !important;
+            }
+
+            img + div {
+                display: none;
+                display: none !important;
+            }
+
+            img {
+                margin: 0;
+                padding: 0;
+                -ms-interpolation-mode: bicubic;
+            }
+
+            h1,
+            h2,
+            h3,
+            p,
+            a {
+                line-height: 1;
+                overflow-wrap: normal;
+                white-space: normal;
+                word-break: break-word;
+            }
+
+            a {
+                text-decoration: none;
+            }
+
+            h1,
+            h2,
+            h3,
+            p {
+                min-width: 100% !important;
+                width: 100% !important;
+                max-width: 100% !important;
+                display: inline-block !important;
+                border: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            a[x-apple-data-detectors] {
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
+
+            a[href^='mailto'],
+            a[href^='tel'],
+            a[href^='sms'] {
+                color: inherit !important;
+                text-decoration: none !important;
+            }
+
+            @media only screen and (min-width: 481px) {
+                .hd {
+                    display: none !important;
+                }
+            }
+
+            @media only screen and (max-width: 480px) {
+                .hm {
+                    display: none !important;
+                }
+            }
+
+            [style*='Roboto'] {
+                font-family: 'Roboto', BlinkMacSystemFont, Segoe UI,
+                    Helvetica Neue, Arial, sans-serif !important;
+            }
+
+            [style*='Albert Sans'] {
+                font-family: 'Albert Sans', BlinkMacSystemFont, Segoe UI,
+                    Helvetica Neue, Arial, sans-serif !important;
+            }
+
+            .data-table {
+                border-collapse: collapse;
+                width: 100%;
+                margin-top: 20px;
+                margin-bottom: 20px;
+            }
+
+            .data-table th, .data-table td {
+                border: 1px solid #ddd;
+                padding: 8px;
+                text-align: left;
+            }
+
+            .data-table th {
+                background-color: #f2f2f2;
+                font-weight: bold;
+            }
+
+            .data-table tr:nth-child(even) {
+                background-color: #f9f9f9;
+            }
+        </style>
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Albert+Sans:wght@500;700&display=swap"
+            rel="stylesheet"
+            type="text/css"
+        />
+    </head>
+    <body
+        style="
+            min-width: 100%;
+            margin: 0px;
+            padding: 0px;
+            background-color: #292929;
+        "
+    >
+        <div style="background-color: #292929">
+            <table
+                role="presentation"
+                width="100%"
+                cellpadding="0"
+                cellspacing="0"
+                border="0"
+                align="center"
+            >
+                <tr>
+                    <td
+                        style="
+                            font-size: 0;
+                            line-height: 0;
+                            mso-line-height-rule: exactly;
+                        "
+                        valign="top"
+                        align="center"
+                    >
+                        <table
+                            role="presentation"
+                            width="100%"
+                            cellpadding="0"
+                            cellspacing="0"
+                            border="0"
+                            align="center"
+                        >
+                            <tr>
+                                <td>
+                                    <div
+                                        style="
+                                            mso-line-height-rule: exactly;
+                                            font-size: 1px;
+                                            display: none;
+                                        "
+                                    >
+                                        &nbsp;
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <table
+                                        role="presentation"
+                                        cellpadding="0"
+                                        cellspacing="0"
+                                        align="center"
+                                    >
+                                        <tr>
+                                            <td
+                                                style="
+                                                    overflow: hidden;
+                                                    width: 600px;
+                                                "
+                                            >
+                                                <table
+                                                    role="presentation"
+                                                    width="100%"
+                                                    cellpadding="0"
+                                                    cellspacing="0"
+                                                >
+                                                    <tr>
+                                                        <td>
+                                                            <table
+                                                                role="presentation"
+                                                                cellpadding="0"
+                                                                cellspacing="0"
+                                                                style="
+                                                                    margin-left: auto;
+                                                                    margin-right: auto;
+                                                                "
+                                                            >
+                                                                <tr>
+                                                                    <td
+                                                                        style="background-color:#7262FF;background-image:url({{host}}/banner.jpg);background-repeat:no-repeat;background-size:contain;background-position:right top;overflow:hidden;width:600px;padding:16px 14px 16px 14px;border-radius:4px 4px 0 0;"
+                                                                    >
+                                                                        <div
+                                                                            style="
+                                                                                display: inline-table;
+                                                                                width: 100%;
+                                                                                text-align: left;
+                                                                                vertical-align: top;
+                                                                            "
+                                                                        >
+                                                                            <div
+                                                                                style="
+                                                                                    display: inline-table;
+                                                                                    text-align: initial;
+                                                                                    vertical-align: inherit;
+                                                                                    width: 100%;
+                                                                                    max-width: 92px;
+                                                                                "
+                                                                            >
+                                                                                <table
+                                                                                    role="presentation"
+                                                                                    width="100%"
+                                                                                    cellpadding="0"
+                                                                                    cellspacing="0"
+                                                                                >
+                                                                                    <tr>
+                                                                                        <td>
+                                                                                            <div
+                                                                                                style="
+                                                                                                    font-size: 0px;
+                                                                                                "
+                                                                                            >
+                                                                                                <img
+                                                                                                    style="
+                                                                                                        display: block;
+                                                                                                        border: 0;
+                                                                                                        height: auto;
+                                                                                                        width: 100%;
+                                                                                                        margin: 0;
+                                                                                                        max-width: 100%;
+                                                                                                    "
+                                                                                                    width="122"
+                                                                                                    src="{{host}}/lightdash-logo.png"
+                                                                                                />
+                                                                                            </div>
+                                                                                        </td>
+                                                                                    </tr>
+                                                                                </table>
+                                                                            </div>
+                                                                        </div>
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>
+                                                            <table
+                                                                role="presentation"
+                                                                cellpadding="0"
+                                                                cellspacing="0"
+                                                                align="center"
+                                                            >
+                                                                <tr>
+                                                                    <td
+                                                                        style="
+                                                                            background-color: #f7f7f9;
+                                                                            overflow: hidden;
+                                                                            width: 600px;
+                                                                            padding: 40px;
+                                                                            border-radius: 0 0 4px 4px;
+                                                                        "
+                                                                    >
+                                                                        <table
+                                                                            role="presentation"
+                                                                            width="100%"
+                                                                            cellpadding="0"
+                                                                            cellspacing="0"
+                                                                        >
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="left"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <td
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <h1
+                                                                                                    style="
+                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                            Segoe UI,
+                                                                                                            Helvetica Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Roboto';
+                                                                                                        line-height: 28px;
+                                                                                                        font-weight: 500;
+                                                                                                        font-style: normal;
+                                                                                                        font-size: 24px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
+                                                                                                        color: #121212;
+                                                                                                        text-align: left;
+                                                                                                        margin-bottom: 20px;
+                                                                                                    "
+                                                                                                >
+                                                                                                    {{title}}
+                                                                                                </h1>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="left"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <td
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <div
+                                                                                                    style="
+                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                            Segoe UI,
+                                                                                                            Helvetica Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Roboto';
+                                                                                                        line-height: 24px;
+                                                                                                        font-weight: 400;
+                                                                                                        font-style: normal;
+                                                                                                        font-size: 16px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
+                                                                                                        color: #333333;
+                                                                                                        text-align: left;
+                                                                                                    "
+                                                                                                >
+                                                                                                    {{{message}}}
+                                                                                                </div>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </body>
+</html>

--- a/packages/backend/src/ee/repl/index.ts
+++ b/packages/backend/src/ee/repl/index.ts
@@ -24,15 +24,17 @@ import { getListProjectsScripts } from './scripts/listProjects';
 
     const serviceRepository = app.getServiceRepository();
     const models = app.getModels();
+    const clients = app.getClients();
     const database = app.getDatabase();
 
     Object.assign(replInstance.context, {
         common,
         serviceRepository,
         models,
+        clients,
         database,
         scripts: {
-            ...getFixDuplicateSlugsScripts(database),
+            ...getFixDuplicateSlugsScripts(database, clients),
             ...getListProjectsScripts(database),
         },
     });

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
@@ -1,8 +1,5 @@
 import { stringify } from 'csv-stringify/sync';
-import * as fs from 'fs';
 import type { Knex } from 'knex';
-import * as os from 'os';
-import * as path from 'path';
 import { ClientRepository } from '../../../clients/ClientRepository';
 import { DashboardsTableName } from '../../../database/entities/dashboards';
 import { ProjectTableName } from '../../../database/entities/projects';
@@ -189,16 +186,10 @@ export function getFixDuplicateSlugsScripts(
                         ]),
                     ]);
 
-                    // Create a temporary file for the CSV
-                    const tempDir = os.tmpdir();
                     const timestamp = new Date()
                         .toISOString()
                         .replace(/[:.]/g, '-');
                     const csvFilename = `chart-slug-updates-${timestamp}.csv`;
-                    const csvFilePath = path.join(tempDir, csvFilename);
-
-                    // Write the CSV content to the file
-                    fs.writeFileSync(csvFilePath, csvContent);
 
                     const subject = `Chart slug updates for${projectMessage}${dryRunMessage}`;
                     const title = `Chart slug updates for${projectMessage}${dryRunMessage}`;
@@ -211,10 +202,10 @@ export function getFixDuplicateSlugsScripts(
                         ? opts.emailReportTo
                         : [opts.emailReportTo];
 
-                    // Create attachment
+                    // Create attachment with content directly as string
                     const attachment = {
                         filename: csvFilename,
-                        path: csvFilePath,
+                        content: csvContent,
                         contentType: 'text/csv',
                     };
 
@@ -233,15 +224,6 @@ export function getFixDuplicateSlugsScripts(
                             ', ',
                         )}`,
                     );
-
-                    // Clean up the temporary file
-                    try {
-                        fs.unlinkSync(csvFilePath);
-                    } catch (error) {
-                        console.warn(
-                            `Failed to delete temporary CSV file: ${error}`,
-                        );
-                    }
                 } else {
                     console.warn(
                         `Email client is not configured, skipping email notification`,

--- a/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
+++ b/packages/backend/src/ee/repl/scripts/fixDuplicateSlugs.ts
@@ -13,7 +13,7 @@ export function getFixDuplicateSlugsScripts(
     async function fixDuplicateChartSlugs(opts: {
         dryRun: boolean;
         projectUuid?: string;
-        emailReportTo?: string;
+        emailReportTo?: string | string[];
     }) {
         if (!opts || !('dryRun' in opts)) {
             throw new Error('Missing dryRun option!!');
@@ -187,17 +187,22 @@ export function getFixDuplicateSlugsScripts(
                     }`;
                     const message = `${markdownTable}`;
 
+                    // Convert emailReportTo to array if it's a string
+                    const recipients = Array.isArray(opts.emailReportTo)
+                        ? opts.emailReportTo
+                        : [opts.emailReportTo];
+
                     await clients
                         .getEmailClient()
                         .sendGenericNotificationEmail(
-                            opts.emailReportTo,
+                            recipients,
                             subject,
                             title,
                             message,
                         );
 
                     console.info(
-                        `Email notification sent to ${opts.emailReportTo}`,
+                        `Email notification sent to ${recipients.join(', ')}`,
                     );
                 } else {
                     console.warn(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<img width="604" alt="Screenshot 2025-06-13 at 15 10 31" src="https://github.com/user-attachments/assets/ac9fc33a-88a4-4c80-92b5-7467bf92050e" />


### Description:
This PR adds a generic notification email template and functionality to support sending email reports with CSV attachments. It includes:

1. A new `getClients()` method in the App class to access client instances
2. A `canSendEmail()` method to check if the email client is properly configured
3. A new `sendGenericNotificationEmail()` method in EmailClient to send customizable notifications
4. A generic HTML email template that supports markdown content and tables
5. Enhanced the `fixDuplicateChartSlugs` script to generate CSV reports and send email notifications

These changes enable administrators to receive detailed reports when chart slugs are updated, with the option to include CSV attachments containing the changes made.