### PR TITLE
refactor: make jobId optional in DownloadCsv and add analytics tracking

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1077,7 +1077,7 @@ export type DownloadCsv = BaseTrack & {
         | 'download_results.error';
     userId: string;
     properties: {
-        jobId: string;
+        jobId?: string;
         organizationId?: string;
         projectId: string;
         tableId?: string;

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -416,21 +416,19 @@ export class QueryController extends BaseController {
     > {
         this.setStatus(200);
 
-        const results = await this.services
-            .getAsyncQueryService()
-            .downloadAsyncQueryResults({
-                user: req.user!,
-                projectUuid,
-                queryUuid,
-                type: body.type,
-                onlyRaw: body.onlyRaw,
-                showTableNames: body.showTableNames,
-                customLabels: body.customLabels,
-                columnOrder: body.columnOrder,
-                hiddenFields: body.hiddenFields,
-                pivotConfig: body.pivotConfig,
-                attachmentDownloadName: body.attachmentDownloadName,
-            });
+        const results = await this.services.getAsyncQueryService().download({
+            user: req.user!,
+            projectUuid,
+            queryUuid,
+            type: body.type,
+            onlyRaw: body.onlyRaw,
+            showTableNames: body.showTableNames,
+            customLabels: body.customLabels,
+            columnOrder: body.columnOrder,
+            hiddenFields: body.hiddenFields,
+            pivotConfig: body.pivotConfig,
+            attachmentDownloadName: body.attachmentDownloadName,
+        });
 
         return {
             status: 'ok',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Made `jobId` optional in the `DownloadCsv` analytics type and refactored the download functionality in the AsyncQueryService. Created a new public `download` method that wraps the existing `downloadAsyncQueryResults` method (now private) and adds analytics tracking for download events.

The QueryController now calls the new `download` method instead of directly calling `downloadAsyncQueryResults`, ensuring that download events are properly tracked.