### PR TITLE
fix: include chart names in error messages (#15251)

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -69,6 +69,7 @@ import React, {
 } from 'react';
 import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
+import { formatChartErrorMessage } from '../../utils/chartErrorUtils';
 
 import { DashboardTileComments } from '../../features/comments';
 import { DateZoomInfoOnTile } from '../../features/dateZoom';
@@ -1434,7 +1435,12 @@ export const GenericDashboardChartTile: FC<
             >
                 <SuboptimalState
                     icon={IconAlertCircle}
-                    title={error?.error?.message || 'No data available'}
+                    title={formatChartErrorMessage(
+                        dashboardChartReadyQuery?.chart?.name ||
+                            tile.properties.chartName ||
+                            undefined,
+                        error?.error?.message || 'No data available',
+                    )}
                 ></SuboptimalState>
             </TileBase>
         );
@@ -1507,6 +1513,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
     const resultsData = useInfiniteQueryResults(
         readyQuery.data?.chart.projectUuid,
         readyQuery.data?.executeQueryResponse.queryUuid,
+        readyQuery.data?.chart.name,
     );
 
     const isLoading = useMemo(() => {

--- a/packages/frontend/src/components/DashboardTiles/DashboardSemanticViewerChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSemanticViewerChartTile.tsx
@@ -17,6 +17,7 @@ import {
 import { SemanticViewerResultsRunnerFrontend } from '../../features/semanticViewer/runners/SemanticViewerResultsRunnerFrontend';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import useApp from '../../providers/App/useApp';
+import { formatChartErrorMessage } from '../../utils/chartErrorUtils';
 import getChartDataModel from '../DataViz/transformers/getChartDataModel';
 import ChartView from '../DataViz/visualizations/ChartView';
 import { Table } from '../DataViz/visualizations/Table';
@@ -195,12 +196,13 @@ const SemanticViewerChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             >
                 <SuboptimalState
                     icon={IconAlertCircle}
-                    title={
+                    title={formatChartErrorMessage(
+                        tile.properties.chartName,
                         chartQuery.error?.error?.message ??
-                        fieldsQuery.error?.error?.message ??
-                        chartResultsQuery.error?.error?.message ??
-                        'No data available'
-                    }
+                            fieldsQuery.error?.error?.message ??
+                            chartResultsQuery.error?.error?.message ??
+                            'No data available',
+                    )}
                 />
             </TileBase>
         );

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -15,6 +15,7 @@ import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFilter
 import useSearchParams from '../../hooks/useSearchParams';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import { formatChartErrorMessage } from '../../utils/chartErrorUtils';
 import ChartView from '../DataViz/visualizations/ChartView';
 import { Table } from '../DataViz/visualizations/Table';
 import LinkMenuItem from '../common/LinkMenuItem';
@@ -135,9 +136,11 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                 {!isChartLoading && (
                     <SuboptimalState
                         icon={IconAlertCircle}
-                        title={
-                            chartError?.error?.message || 'Error fetching chart'
-                        }
+                        title={formatChartErrorMessage(
+                            tile.properties.chartName,
+                            chartError?.error?.message ||
+                                'Error fetching chart',
+                        )}
                     />
                 )}
             </TileBase>
@@ -170,10 +173,11 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                 {chartResultsError && (
                     <SuboptimalState
                         icon={IconAlertCircle}
-                        title={
+                        title={formatChartErrorMessage(
+                            tile.properties.chartName,
                             chartResultsError?.error?.message ||
-                            'No data available'
-                        }
+                                'No data available',
+                        )}
                     />
                 )}
             </TileBase>

--- a/packages/frontend/src/hooks/useQueryError.ts
+++ b/packages/frontend/src/hooks/useQueryError.ts
@@ -7,11 +7,13 @@ import useToaster from './toaster/useToaster';
 type opts = {
     forbiddenToastTitle?: string;
     forceToastOnForbidden?: boolean;
+    chartName?: string;
 };
 
 const useQueryError = ({
     forbiddenToastTitle,
     forceToastOnForbidden,
+    chartName,
 }: opts = {}): Dispatch<SetStateAction<ApiError | undefined>> => {
     const queryClient = useQueryClient();
     const [errorResponse, setErrorResponse] = useState<ApiError | undefined>();
@@ -72,6 +74,9 @@ const useQueryError = ({
                     }
                 } else {
                     addToastError({
+                        title: chartName
+                            ? `Chart '${chartName}': Error`
+                            : undefined,
                         apiError: error,
                     });
                 }
@@ -81,6 +86,7 @@ const useQueryError = ({
         errorResponse,
         forbiddenToastTitle,
         forceToastOnForbidden,
+        chartName,
         queryClient,
         showToastError,
         addToastError,

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -249,10 +249,14 @@ export type InfiniteQueryResults = Partial<
 export const useInfiniteQueryResults = (
     projectUuid?: string,
     queryUuid?: string,
+    chartName?: string,
 ): InfiniteQueryResults => {
     const setErrorResponse = useQueryError({
         forceToastOnForbidden: true,
-        forbiddenToastTitle: 'Error running query',
+        forbiddenToastTitle: chartName
+            ? `Error running query for chart '${chartName}'`
+            : 'Error running query',
+        chartName,
     });
     const [fetchArgs, setFetchArgs] = useState<{
         queryUuid?: string;

--- a/packages/frontend/src/utils/chartErrorUtils.ts
+++ b/packages/frontend/src/utils/chartErrorUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Utility functions for formatting chart error messages
+ */
+
+/**
+ * Formats an error message to include the chart name for better identification
+ * @param chartName - The name of the chart that encountered the error
+ * @param errorMessage - The original error message
+ * @returns Formatted error message with chart name
+ */
+export const formatChartErrorMessage = (
+    chartName: string | undefined,
+    errorMessage: string,
+): string => {
+    // Handle cases where chart name might be undefined or empty
+    if (!chartName || chartName.trim() === '') {
+        return errorMessage;
+    }
+
+    // Format: "Chart '[ChartName]': [ErrorMessage]"
+    return `Chart '${chartName.trim()}': ${errorMessage}`;
+};


### PR DESCRIPTION
## Summary
Fixes chart error messages to include chart names for better identification when multiple charts fail on a dashboard.

## Changes
- **Add formatChartErrorMessage utility** for consistent error formatting across all chart types
- **Update DashboardChartTile** error states to show chart names in SuboptimalState components
- **Update DashboardSqlChartTile** error handling for both chart error and results error scenarios  
- **Update DashboardSemanticViewerChartTile** error messages to include chart names
- **Enhance useQueryResults** to pass chart name context to error notifications
- **Update useQueryError** to include chart names in toast notifications

## Before vs After

**Before:**
```
❌ "column 'sntaoehuanotehuasnoetuh...' does not exist"
```
No way to identify which chart failed when multiple charts break.

**After:**
```
✅ "Chart 'How many orders we have over time ?': Error"
   "column 'sntaoehuanotehuasnoetuh...' does not exist"
```
Clear chart identification + detailed error message.

## Test Plan
- [x] Tested on live development dashboard with failing chart
- [x] Verified error notifications now show chart names
- [x] Confirmed SuboptimalState components include chart names  
- [x] Validated all chart types (regular, SQL, semantic viewer)
- [x] Ensured backwards compatibility when chart names unavailable
- [x] Linting and type checking pass

## Files Changed
- `packages/frontend/src/utils/chartErrorUtils.ts` (new)
- `packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx`
- `packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx` 
- `packages/frontend/src/components/DashboardTiles/DashboardSemanticViewerChartTile.tsx`
- `packages/frontend/src/hooks/useQueryResults.ts`
- `packages/frontend/src/hooks/useQueryError.ts`

Fixes #15251

🤖 Generated with [Claude Code](https://claude.ai/code)