### PR TITLE
fix: prevent empty dashboards from downloading all charts

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -202,7 +202,7 @@ export const downloadContent = async (
             `Downloaded ${contentAsCode.offset} of ${contentAsCode.total} ${type}`,
         );
         contentAsCode.missingIds.forEach((missingId) => {
-            console.warn(styles.warning(`\nNo chart with id "${missingId}"`));
+            console.warn(styles.warning(`\nNo ${type} with id "${missingId}"`));
         });
 
         if ('dashboards' in contentAsCode) {
@@ -242,7 +242,7 @@ export const downloadContent = async (
                         ),
                     ];
                 },
-                chartSlugs,
+                [],
             );
         } else {
             const outputDir = await createDirForContent(
@@ -344,7 +344,7 @@ export const downloadHandler = async (
 
             // If any filter is provided, we download all charts for these dashboard
             // We don't need to do this if we download everything (no filters)
-            if (hasFilters) {
+            if (hasFilters && chartSlugs.length > 0) {
                 spinner.start(
                     `Downloading ${chartSlugs.length} charts linked to dashboards`,
                 );


### PR DESCRIPTION
## Summary
- Fixed empty dashboards downloading all charts instead of 0 charts
- Fixed hardcoded error messages showing wrong content type
- Fixed chart slug accumulation bug across API calls

## Root Cause
When downloading a dashboard with no charts, `chartSlugs` would be an empty array, but the `hasFilters` condition would still trigger chart downloads with no filters, causing all charts in the project to be downloaded.

## Solution
Added `&& chartSlugs.length > 0` condition to only download charts when there are actually charts to download.

## Test Plan
- [x] Manual testing with empty dashboard "empty" - now downloads 0 charts ✅
- [x] Existing functionality preserved for dashboards with charts
- [x] Error messages now show correct content type
- [x] No chart slug accumulation across calls

Fixes #14833

🤖 Generated with [Claude Code](https://claude.ai/code)