### PR TITLE
fix: Add ErrorBoundary to AssistantBubble component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -1,6 +1,7 @@
 import { type AiAgentMessage, type AiAgentThread } from '@lightdash/common';
 import { Divider, ScrollArea, Stack } from '@mantine-8/core';
 import { Fragment, useLayoutEffect, useRef, type FC } from 'react';
+import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { AssistantBubble, UserBubble } from './AgentChatBubbles';
 import { ChatElementsUtils } from './utils';
 
@@ -19,7 +20,9 @@ const AiThreadMessage: FC<AiThreadMessageProps> = ({
     return isUser ? (
         <UserBubble message={message} />
     ) : (
-        <AssistantBubble message={message} isPreview={isPreview} />
+        <ErrorBoundary>
+            <AssistantBubble message={message} isPreview={isPreview} />
+        </ErrorBoundary>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->



### Description:
Added an ErrorBoundary component around the AssistantBubble in the AgentChatDisplay component to prevent the entire chat interface from crashing if there's an error rendering an assistant message.

