### PR TITLE
fix: ai agent project permissions

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -311,7 +311,10 @@ export class AiAgentService {
             allUsers &&
             user.ability.can(
                 'manage',
-                subject('AiAgent', { organizationUuid }),
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
             );
 
         if (allUsers && !canViewAllThreads) {
@@ -399,8 +402,9 @@ export class AiAgentService {
             user.ability.cannot(
                 'view',
                 subject('AiAgentThread', {
-                    organizationUuid,
+                    projectUuid: agent.projectUuid,
                     userUuid: thread.user.uuid,
+                    organizationUuid,
                 }),
             )
         ) {
@@ -470,7 +474,10 @@ export class AiAgentService {
         if (
             user.ability.cannot(
                 'manage',
-                subject('AiAgent', { organizationUuid }),
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: body.projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -505,7 +512,10 @@ export class AiAgentService {
         if (
             user.ability.cannot(
                 'manage',
-                subject('AiAgent', { organizationUuid }),
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -536,18 +546,21 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('AiAgent', { organizationUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const agent = await this.getAgent(user, agentUuid);
         if (!agent) {
             throw new ForbiddenError('Agent not found');
+        }
+
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
         }
 
         if (agent.organizationUuid !== organizationUuid) {
@@ -607,6 +620,7 @@ export class AiAgentService {
                     'view',
                     subject('AiAgentThread', {
                         organizationUuid,
+                        projectUuid: agent.projectUuid,
                         userUuid: thread.user.uuid,
                     }),
                 )
@@ -620,6 +634,7 @@ export class AiAgentService {
                     'create',
                     subject('AiAgentThread', {
                         organizationUuid,
+                        projectUuid: agent.projectUuid,
                     }),
                 )
             ) {

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -460,6 +460,77 @@ describe('Organization member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('AiAgent', () => {
+                it('can manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_ADMIN.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent from another organization', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { organizationUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can view all AiAgentThreads in the organization', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_ADMIN.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can manage all AiAgentThreads in the organization', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_ADMIN.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view AiAgentThread from another organization', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid: '5678',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgentThread from another organization', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid: '5678',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is an editor', () => {
@@ -951,6 +1022,68 @@ describe('Organization member permissions', () => {
                         ability.can(
                             'view',
                             subject('JobStatus', { organizationUuid: '54678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgent', () => {
+                it('can manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_DEVELOPER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent from another organization', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { organizationUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can manage only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_DEVELOPER.organizationUuid,
+                                userUuid: ORGANIZATION_DEVELOPER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_DEVELOPER.organizationUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgentThread from another organization', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid: '5678',
+                            }),
                         ),
                     ).toEqual(false);
                 });
@@ -1632,6 +1765,96 @@ describe('Organization member permissions', () => {
             it('cannot view the SemanticViewer', () => {
                 expect(ability.can('view', 'SemanticViewer')).toEqual(false);
             });
+
+            describe('AiAgent', () => {
+                it('cannot view AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can view only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                                userUuid: ORGANIZATION_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                                userUuid: ORGANIZATION_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot create AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgentThread from another organization', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid: '5678',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is an interactive viewer', () => {
@@ -1929,6 +2152,107 @@ describe('Organization member permissions', () => {
                         subject('Job', { userUuid: 'another-user-uuid' }),
                     ),
                 ).toEqual(false);
+            });
+
+            describe('AiAgent', () => {
+                it('can view AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgent from another organization', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { organizationUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can create AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can view only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                                userUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                organizationUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.organizationUuid,
+                                userUuid:
+                                    ORGANIZATION_INTERACTIVE_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot create AiAgentThread in another organization', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', {
+                                organizationUuid: '5678',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
             });
         });
     });

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -434,6 +434,64 @@ describe('Project member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('AiAgent', () => {
+                it('can manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent from another project', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can view all AiAgentThreads in the project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can manage all AiAgentThreads in the project', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view AiAgentThread from another project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgentThread from another project', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is an editor', () => {
@@ -850,6 +908,94 @@ describe('Project member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('AiAgent', () => {
+                it('can view AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgent from another project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can view only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_EDITOR.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can manage only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_EDITOR.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgentThread from another project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is an developer', () => {
@@ -913,6 +1059,61 @@ describe('Project member permissions', () => {
                         ability.can(
                             'view',
                             subject('JobStatus', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgent', () => {
+                it('can manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent from another project', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can manage only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_DEVELOPER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgentThread from another project', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
                         ),
                     ).toEqual(false);
                 });
@@ -1346,6 +1547,82 @@ describe('Project member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('AiAgent', () => {
+                it('cannot view AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can view only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot create AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', { projectUuid }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgentThread from another project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is a interactive viewer', () => {
@@ -1521,6 +1798,91 @@ describe('Project member permissions', () => {
                         subject('UnderlyingData', { projectUuid }),
                     ),
                 ).toEqual(true);
+            });
+
+            describe('AiAgent', () => {
+                it('can view AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage AiAgent', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgent', { projectUuid }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot view AiAgent from another project', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgent', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
+
+            describe('AiAgentThread', () => {
+                it('can create AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', { projectUuid }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can view only his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_INTERACTIVE_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot view other users AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: 'another-user-uuid',
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot manage his own AiAgentThread', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('AiAgentThread', {
+                                projectUuid,
+                                userUuid: PROJECT_INTERACTIVE_VIEWER.userUuid,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('cannot create AiAgentThread in another project', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('AiAgentThread', { projectUuid: '5678' }),
+                        ),
+                    ).toEqual(false);
+                });
             });
         });
     });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -68,6 +68,10 @@ export const projectMemberAbilities: Record<
         can('view', 'SpotlightTableConfig', {
             projectUuid: member.projectUuid,
         });
+        can('view', 'AiAgentThread', {
+            projectUuid: member.projectUuid,
+            userUuid: member.userUuid,
+        });
     },
     interactive_viewer(member, { can }) {
         projectMemberAbilities.viewer(member, { can });
@@ -136,6 +140,12 @@ export const projectMemberAbilities: Record<
                 },
             },
         });
+        can('view', 'AiAgent', {
+            projectUuid: member.projectUuid,
+        });
+        can('create', 'AiAgentThread', {
+            projectUuid: member.projectUuid,
+        });
     },
     editor(member, { can }) {
         projectMemberAbilities.interactive_viewer(member, { can });
@@ -161,6 +171,11 @@ export const projectMemberAbilities: Record<
         });
         can('manage', 'MetricsTree', {
             projectUuid: member.projectUuid,
+        });
+
+        can('manage', 'AiAgentThread', {
+            projectUuid: member.projectUuid,
+            userUuid: member.userUuid,
         });
     },
     developer(member, { can }) {
@@ -204,6 +219,13 @@ export const projectMemberAbilities: Record<
         can('view', 'JobStatus', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'AiAgent', {
+            projectUuid: member.projectUuid,
+        });
+        can('manage', 'AiAgentThread', {
+            projectUuid: member.projectUuid,
+            userUuid: member.userUuid,
+        });
     },
     admin(member, { can }) {
         projectMemberAbilities.developer(member, { can });
@@ -229,6 +251,12 @@ export const projectMemberAbilities: Record<
         });
 
         can('manage', 'SavedChart', {
+            projectUuid: member.projectUuid,
+        });
+        can('view', 'AiAgentThread', {
+            projectUuid: member.projectUuid,
+        });
+        can('manage', 'AiAgentThread', {
             projectUuid: member.projectUuid,
         });
     },

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -40,7 +40,10 @@ const Button = ({ projectUuid }: { projectUuid: string }) => {
 
 export const AiAgentsButton = () => {
     const { data: projectUuid } = useActiveProject();
-    const canViewAiAgents = useAiAgentPermission({ action: 'view' });
+    const canViewAiAgents = useAiAgentPermission({
+        action: 'view',
+        projectUuid: projectUuid ?? undefined,
+    });
     const appQuery = useApp();
     const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
     const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentPermission.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentPermission.ts
@@ -3,14 +3,17 @@ import useApp from '../../../../providers/App/useApp';
 
 export const useAiAgentPermission = ({
     action,
+    projectUuid,
 }: {
     action: 'manage' | 'view';
+    projectUuid?: string;
 }) => {
     const { user } = useApp();
     return user.data?.ability.can(
         action,
         subject('AiAgent', {
             organizationUuid: user.data?.organizationUuid,
+            projectUuid,
         }),
     );
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -78,7 +78,10 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
     const { data: threads } = useAiAgentThreads(agentUuid);
-    const canManageAgents = useAiAgentPermission({ action: 'manage' });
+    const canManageAgents = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
 
     const { data: agentsList } = useProjectAiAgents(projectUuid!);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15369

### Description:

Tested for project roles that are _higher_ than the organization ones

For example

### **org member + project developer** 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/13c209b7-3160-4647-a0c1-4caa1d0c5b91" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/afcd8193-dfac-4365-b6f6-9961f8e2d525" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3e8d9b86-49ab-483f-bd55-0baca793fdca" />

### **org member + project viewer**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/764113f7-34e1-43a3-b1ba-136c74f40b4c" />

⚠️ once I switched project, I was redirected from /ai-agents back to home
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3e36e04c-1bee-48de-8f0b-c27bb6f1d0d5" />

### **org member + project interactive viewer (from the project above ^ )**

⚠️  Now I can see the Ask AI
<img width="300" alt="image" src="https://github.com/user-attachments/assets/459c3f0a-5c4a-4cbc-843e-75b2e781d3cd" />

(me, the admin, will create a new agent for this user)

interactive viewer can now chat **but can't creat/edit agents**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5c1fc3ee-0d30-4d01-86db-37f9535f3c09" />


