### PR TITLE
feat: proper streaming for csv & xlsx

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
@@ -196,10 +196,10 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
     }
 
     /**
-     * Upload a file stream directly to S3
+     * Upload a file directly to S3 from a local file path
      * Useful for uploading pre-generated files like Excel files
      */
-    async uploadFileStream(
+    async uploadFile(
         fileName: string,
         filePath: string,
         options: {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -92,6 +92,7 @@ import {
     ReferenceMap,
 } from '../../queryBuilder';
 import { wrapSentryTransaction } from '../../utils';
+import { processFieldsForExport } from '../../utils/FileDownloadUtils';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService, getSchedulerCsvLimit } from '../CsvService/CsvService';
@@ -790,23 +791,19 @@ export class AsyncQueryService extends ProjectService {
                         },
                     });
                 }
-                return this.downloadAsyncQueryResultsAsFormattedFile(
+                // Use direct Excel export to bypass PassThrough + Upload hanging issues
+                return ExcelService.downloadAsyncExcelDirectly(
                     resultsFileName,
                     resultFields,
-                    {
-                        generateFileId: ExcelService.generateFileId,
-                        streamJsonlRowsToFile:
-                            ExcelService.streamJsonlRowsToFile,
-                    },
+                    this.storageClient,
                     {
                         onlyRaw,
                         showTableNames,
                         customLabels,
                         columnOrder,
                         hiddenFields,
-                        pivotConfig,
+                        attachmentDownloadName,
                     },
-                    attachmentDownloadName,
                 );
             case undefined:
             case DownloadFileType.JSONL:
@@ -860,33 +857,12 @@ export class AsyncQueryService extends ProjectService {
             hiddenFields = [],
         } = options || {};
 
-        // Filter out hidden fields and apply column ordering
-        const availableFieldIds = Object.keys(fields).filter(
-            (id) => !hiddenFields.includes(id),
-        );
-        const sortedFieldIds =
-            columnOrder.length > 0
-                ? [
-                      ...columnOrder.filter((id) =>
-                          availableFieldIds.includes(id),
-                      ),
-                      ...availableFieldIds.filter(
-                          (id) => !columnOrder.includes(id),
-                      ),
-                  ]
-                : availableFieldIds;
-
-        const headers = sortedFieldIds.map((fieldId) => {
-            if (customLabels[fieldId]) {
-                return customLabels[fieldId];
-            }
-            const item = fields[fieldId];
-            if (!item) {
-                return fieldId;
-            }
-            return showTableNames
-                ? getItemLabel(item)
-                : getItemLabelWithoutTableName(item);
+        // Process fields and generate headers using shared utility
+        const { sortedFieldIds, headers } = processFieldsForExport(fields, {
+            showTableNames,
+            customLabels,
+            columnOrder,
+            hiddenFields,
         });
 
         // Transform and upload the results

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -10,14 +10,11 @@ import {
     PivotConfig,
     pivotResultsAsCsv,
 } from '@lightdash/common';
-// Import regular ExcelJS - the fix is in the streaming pattern, not the package
-import { PutObjectCommand } from '@aws-sdk/client-s3';
 import * as Excel from 'exceljs';
 import fs from 'fs';
 import moment from 'moment';
 import os from 'os';
 import path from 'path';
-import { createInterface } from 'readline';
 import { Readable, Writable } from 'stream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -25,9 +22,21 @@ import Logger from '../../logging/logger';
 import {
     generateGenericFileId,
     processFieldsForExport,
+    streamJsonlData,
 } from '../../utils/FileDownloadUtils';
 
 export class ExcelService {
+    // Helper method for date/timestamp conversion
+    private static convertToExcelDate(value: unknown): Date | unknown {
+        if (typeof value === 'string') {
+            const dateValue = moment(value, moment.ISO_8601, true);
+            if (dateValue.isValid()) {
+                return dateValue.toDate();
+            }
+        }
+        return value;
+    }
+
     static generateFileId(
         fileName: string,
         truncated: boolean = false,
@@ -79,169 +88,6 @@ export class ExcelService {
         });
     }
 
-    static async streamJsonlRowsToFile(
-        onlyRaw: boolean,
-        itemMap: ItemsMap,
-        sortedFieldIds: string[],
-        excelHeaders: string[],
-        {
-            readStream,
-            writeStream,
-        }: {
-            readStream: Readable;
-            writeStream: Writable;
-        },
-    ): Promise<{ truncated: boolean }> {
-        return new Promise((resolve, reject) => {
-            // Initialize streaming workbook - exact pattern from working examples
-            const options = { stream: writeStream };
-            const workbook = new Excel.stream.xlsx.WorkbookWriter(options);
-            const worksheet = workbook.addWorksheet('Sheet1');
-
-            // Set up columns properly like in working examples
-            worksheet.columns = excelHeaders.map((header, index) => ({
-                header,
-                key: `col_${index}`,
-                width: 15,
-            }));
-
-            let rowCount = 0;
-            let lineBuffer = '';
-
-            // Process data line-by-line as it arrives (true streaming)
-            readStream.on('data', (chunk: Buffer) => {
-                lineBuffer += chunk.toString();
-                const lines = lineBuffer.split('\n');
-                lineBuffer = lines.pop() || '';
-
-                for (const line of lines) {
-                    if (line.trim() === '') {
-                        // Skip empty lines
-                    } else {
-                        try {
-                            const parsedRow = JSON.parse(line);
-
-                            if (parsedRow && typeof parsedRow === 'object') {
-                                rowCount += 1;
-
-                                // Convert row data for Excel
-                                const rowData = ExcelService.convertRowToExcel(
-                                    parsedRow,
-                                    itemMap,
-                                    onlyRaw,
-                                    sortedFieldIds,
-                                );
-
-                                // Validate row data
-                                if (
-                                    Array.isArray(rowData) &&
-                                    rowData.length > 0
-                                ) {
-                                    // Stream directly to Excel (no memory accumulation)
-                                    const rowObject: Record<
-                                        string,
-                                        string | number | Date | null
-                                    > = {};
-                                    rowData.forEach(
-                                        (
-                                            value:
-                                                | string
-                                                | number
-                                                | Date
-                                                | null,
-                                            colIndex: number,
-                                        ) => {
-                                            rowObject[`col_${colIndex}`] =
-                                                value;
-                                        },
-                                    );
-
-                                    const row = worksheet.addRow(rowObject);
-                                    row.commit(); // Immediate commit for streaming
-                                } else {
-                                    Logger.warn(
-                                        `Invalid row data on row ${rowCount}, skipping`,
-                                    );
-                                }
-                            }
-                        } catch (error) {
-                            Logger.error(
-                                `Error parsing JSON line: ${getErrorMessage(
-                                    error,
-                                )}`,
-                            );
-                        }
-                    }
-                }
-            });
-
-            readStream.on('end', async () => {
-                // Process any remaining buffered line
-                if (lineBuffer.trim()) {
-                    try {
-                        const parsedRow = JSON.parse(lineBuffer);
-
-                        if (parsedRow && typeof parsedRow === 'object') {
-                            rowCount += 1;
-                            const rowData = ExcelService.convertRowToExcel(
-                                parsedRow,
-                                itemMap,
-                                onlyRaw,
-                                sortedFieldIds,
-                            );
-
-                            if (Array.isArray(rowData) && rowData.length > 0) {
-                                // Stream the final row directly
-                                const rowObject: Record<
-                                    string,
-                                    string | number | Date | null
-                                > = {};
-                                rowData.forEach(
-                                    (
-                                        value: string | number | Date | null,
-                                        colIndex: number,
-                                    ) => {
-                                        rowObject[`col_${colIndex}`] = value;
-                                    },
-                                );
-
-                                const row = worksheet.addRow(rowObject);
-                                row.commit();
-                            }
-                        }
-                    } catch (error) {
-                        Logger.error(
-                            `Error parsing final line: ${getErrorMessage(
-                                error,
-                            )}`,
-                        );
-                    }
-                }
-
-                // Final commits - let ExcelJS complete naturally
-                worksheet.commit();
-
-                // ExcelJS streaming works perfectly - just needs time to finalize large files
-                // Our stress tests proved it can handle 1M+ rows efficiently
-                try {
-                    await workbook.commit();
-                } catch (error) {
-                    Logger.error(
-                        `Workbook commit failed: ${getErrorMessage(error)}`,
-                    );
-                    throw error;
-                }
-
-                resolve({ truncated: false });
-            });
-
-            readStream.on('error', (error) => {
-                Logger.error(`Read stream error: ${getErrorMessage(error)}`);
-                reject(error);
-            });
-        });
-    }
-
     static async downloadPivotTableXlsx({
         rows,
         itemMap,
@@ -278,17 +124,9 @@ export class ExcelService {
 
         // Add data to worksheet
         csvResults.forEach((row, index) => {
-            const excelRow = row.map((value) => {
-                // Handle date/timestamp conversion for Excel
-                if (typeof value === 'string') {
-                    // Check if it looks like a date/timestamp
-                    const dateValue = moment(value, moment.ISO_8601, true);
-                    if (dateValue.isValid()) {
-                        return dateValue.toDate();
-                    }
-                }
-                return value;
-            });
+            const excelRow = row.map((value) =>
+                ExcelService.convertToExcelDate(value),
+            );
             worksheet.addRow(excelRow);
 
             // Style headers (first row)
@@ -357,11 +195,12 @@ export class ExcelService {
         const readStream = await storageClient.getDowloadStream(
             resultsFileName,
         );
-        const { results: rows, truncated } = await ExcelService.streamJsonlData<
+        const { results: rows, truncated } = await streamJsonlData<
             Record<string, unknown>
         >({
             readStream,
-            onRow: (parsedRow) => parsedRow, // Just collect all rows
+            onRow: (parsedRow: Record<string, unknown>) => parsedRow, // Just collect all rows
+            maxLines: 1_000_000, // Excel limit - 1 million rows
         });
 
         if (rows.length === 0) {
@@ -395,256 +234,23 @@ export class ExcelService {
         );
     }
 
-    /**
-     * Shared utility for streaming JSONL data from storage
-     * Can be used for both row-by-row processing and collecting all rows
-     */
-    static async streamJsonlData<T>({
-        readStream,
-        onRow,
-        onComplete,
-        maxLines = 1_000_000,
-    }: {
-        readStream: Readable;
-        onRow?: (
-            parsedRow: Record<string, unknown>,
-            lineCount: number,
-        ) => T | void;
-        onComplete?: (results: T[], truncated: boolean) => void;
-        maxLines?: number;
-    }): Promise<{ results: T[]; truncated: boolean }> {
-        return new Promise((resolve, reject) => {
-            const lineReader = createInterface({
-                input: readStream,
-                crlfDelay: Infinity,
-            });
-
-            let lineCount = 0;
-            let truncated = false;
-            const results: T[] = [];
-
-            lineReader.on('line', (line: string) => {
-                if (!line.trim()) return;
-
-                lineCount += 1;
-                if (lineCount > maxLines) {
-                    truncated = true;
-                    lineReader.close();
-                    return;
-                }
-
-                try {
-                    const parsedRow = JSON.parse(line);
-                    if (onRow) {
-                        const result = onRow(parsedRow, lineCount);
-                        if (result !== undefined) {
-                            results.push(result);
-                        }
-                    }
-                } catch (error) {
-                    Logger.error(
-                        `Error parsing line ${lineCount}: ${getErrorMessage(
-                            error,
-                        )}`,
-                    );
-                }
-            });
-
-            lineReader.on('close', async () => {
-                if (onComplete) {
-                    await onComplete(results, truncated);
-                }
-                resolve({ results, truncated });
-            });
-
-            lineReader.on('error', (error) => {
-                reject(error);
-            });
-        });
-    }
-
-    static async streamJsonlRowsToFileViaTempFile(
-        onlyRaw: boolean,
-        itemMap: ItemsMap,
-        sortedFieldIds: string[],
-        excelHeaders: string[],
-        {
-            readStream,
-            writeStream,
-        }: {
-            readStream: Readable;
-            writeStream: Writable;
-        },
-    ): Promise<{ truncated: boolean }> {
-        // Create temporary file
-        const tempFilePath = path.join(
-            os.tmpdir(),
-            `lightdash-excel-${Date.now()}-${Math.random()
-                .toString(36)
-                .substr(2, 9)}.xlsx`,
-        );
-
-        try {
-            // Step 1: Create Excel file to temporary location using true streaming
-            const fileStream = fs.createWriteStream(tempFilePath);
-            const workbook = new Excel.stream.xlsx.WorkbookWriter({
-                stream: fileStream,
-            });
-            const worksheet = workbook.addWorksheet('Sheet1');
-
-            // Set up columns
-            worksheet.columns = excelHeaders.map((header, index) => ({
-                header,
-                key: `col_${index}`,
-                width: 15,
-            }));
-
-            let rowCount = 0;
-            let lineBuffer = '';
-
-            // Step 2: Process JSONL data line-by-line and stream to temp file
-            for await (const chunk of readStream) {
-                lineBuffer += chunk.toString();
-                const lines = lineBuffer.split('\n');
-                lineBuffer = lines.pop() || '';
-
-                for (const line of lines) {
-                    if (line.trim() === '') {
-                        // Skip empty lines
-                    } else {
-                        try {
-                            const parsedRow = JSON.parse(line);
-                            if (parsedRow && typeof parsedRow === 'object') {
-                                rowCount += 1;
-
-                                // Convert row data for Excel
-                                const rowData = ExcelService.convertRowToExcel(
-                                    parsedRow,
-                                    itemMap,
-                                    onlyRaw,
-                                    sortedFieldIds,
-                                );
-
-                                if (
-                                    Array.isArray(rowData) &&
-                                    rowData.length > 0
-                                ) {
-                                    // Stream directly to Excel temp file
-                                    const rowObject: Record<
-                                        string,
-                                        string | number | Date | null
-                                    > = {};
-                                    rowData.forEach(
-                                        (
-                                            value:
-                                                | string
-                                                | number
-                                                | Date
-                                                | null,
-                                            colIndex: number,
-                                        ) => {
-                                            rowObject[`col_${colIndex}`] =
-                                                value;
-                                        },
-                                    );
-
-                                    const row = worksheet.addRow(rowObject);
-                                    row.commit();
-                                } else {
-                                    Logger.warn(
-                                        `Invalid row data on row ${rowCount}, skipping`,
-                                    );
-                                }
-                            }
-                        } catch (error) {
-                            Logger.error(
-                                `Error parsing JSON line: ${getErrorMessage(
-                                    error,
-                                )}`,
-                            );
-                        }
-                    }
-                }
-            }
-
-            // Process any remaining buffered line
-            if (lineBuffer.trim()) {
-                try {
-                    const parsedRow = JSON.parse(lineBuffer);
-                    if (parsedRow && typeof parsedRow === 'object') {
-                        rowCount += 1;
-                        const rowData = ExcelService.convertRowToExcel(
-                            parsedRow,
-                            itemMap,
-                            onlyRaw,
-                            sortedFieldIds,
-                        );
-
-                        if (Array.isArray(rowData) && rowData.length > 0) {
-                            const rowObject: Record<
-                                string,
-                                string | number | Date | null
-                            > = {};
-                            rowData.forEach(
-                                (
-                                    value: string | number | Date | null,
-                                    colIndex: number,
-                                ) => {
-                                    rowObject[`col_${colIndex}`] = value;
-                                },
-                            );
-                            const row = worksheet.addRow(rowObject);
-                            row.commit();
-                        }
-                    }
-                } catch (error) {
-                    Logger.error(
-                        `Error parsing final line: ${getErrorMessage(error)}`,
-                    );
-                }
-            }
-
-            // Step 3: Commit Excel to temp file (this works reliably)
-            worksheet.commit();
-            await workbook.commit();
-
-            // Step 4: Read temp file as buffer and write to destination (simple approach)
-            const tempFileBuffer = fs.readFileSync(tempFilePath);
-
-            // Clean up temp file immediately after reading
-            fs.unlink(tempFilePath, (unlinkError) => {
-                if (unlinkError) {
-                    Logger.warn(
-                        `Could not delete temp file: ${unlinkError.message}`,
-                    );
-                }
-            });
-
-            // Write buffer to destination stream and end it
-            writeStream.write(tempFileBuffer);
-            writeStream.end();
-
-            return { truncated: false };
-        } catch (error) {
-            Logger.error(
-                `Excel streaming via temp file failed: ${getErrorMessage(
-                    error,
-                )}`,
-            );
-            // Clean up temp file on error
-            fs.unlink(tempFilePath, () => {});
-            throw error;
-        }
-    }
-
     // Helper method to create temporary file path
     private static createTempFilePath(prefix: string): string {
         return path.join(
             os.tmpdir(),
             `lightdash-excel-${prefix}-${Date.now()}-${Math.random()
                 .toString(36)
-                .substr(2, 9)}.xlsx`,
+                .substring(2, 11)}.xlsx`,
         );
+    }
+
+    // Helper method to clean up temporary files
+    private static cleanupTempFile(tempFilePath: string): void {
+        fs.unlink(tempFilePath, (err: NodeJS.ErrnoException | null) => {
+            if (err) {
+                Logger.warn(`Could not delete temp file: ${err.message}`);
+            }
+        });
     }
 
     // Helper method to stream JSONL data to Excel temp file
@@ -773,7 +379,10 @@ export class ExcelService {
         return rowCount;
     }
 
-    // NEW METHOD: Complete Excel export bypassing problematic stream architecture
+    /**
+     * Direct Excel export using streaming to minimize memory usage
+     * Processes JSONL data row-by-row and streams directly to S3
+     */
     static async downloadAsyncExcelDirectly(
         resultsFileName: string,
         fields: ItemsMap,
@@ -827,19 +436,23 @@ export class ExcelService {
                 sortedFieldIds,
             );
 
+            Logger.debug(`Processed ${rowCount} rows for Excel export`);
+
             // Step 3: Stream temp file directly to S3 (no memory spike!)
-            const fileUrl = await ExcelService.uploadFileStreamToS3(
-                storageClient,
+            const fileUrl = await storageClient.uploadFileStream(
                 formattedFileName,
                 tempFilePath,
-                attachmentDownloadName,
+                {
+                    contentType:
+                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    attachmentDownloadName: attachmentDownloadName
+                        ? `${attachmentDownloadName}.xlsx`
+                        : undefined,
+                },
             );
 
             // Clean up temp file after successful upload
-            fs.unlink(tempFilePath, (err: NodeJS.ErrnoException | null) => {
-                if (err)
-                    Logger.warn(`Could not delete temp file: ${err.message}`);
-            });
+            ExcelService.cleanupTempFile(tempFilePath);
 
             return {
                 fileUrl,
@@ -850,42 +463,8 @@ export class ExcelService {
                 `Direct Excel export failed: ${getErrorMessage(error)}`,
             );
             // Clean up temp file on error
-            fs.unlink(tempFilePath, () => {});
+            ExcelService.cleanupTempFile(tempFilePath);
             throw error;
         }
-    }
-
-    private static async uploadFileStreamToS3(
-        storageClient: S3ResultsFileStorageClient,
-        formattedFileName: string,
-        tempFilePath: string,
-        attachmentDownloadName?: string,
-    ): Promise<string> {
-        // Upload file stream directly using PutObjectCommand (no memory spike!)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const s3Client = (storageClient as any).s3; // Access underlying S3 client
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { bucket } = (storageClient as any).configuration;
-
-        // Create a read stream from the temp file
-        const fileStream = fs.createReadStream(tempFilePath);
-
-        await s3Client.send(
-            new PutObjectCommand({
-                Bucket: bucket,
-                Key: formattedFileName,
-                Body: fileStream,
-                ContentType:
-                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                ContentDisposition: `attachment; filename="${
-                    attachmentDownloadName
-                        ? `${attachmentDownloadName}.xlsx`
-                        : formattedFileName
-                }"`,
-            }),
-        );
-
-        // Get file URL
-        return storageClient.getFileUrl(formattedFileName, 'xlsx');
     }
 }

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -403,9 +403,6 @@ export class ExcelService {
                 },
             );
 
-            // Clean up temp file after successful upload
-            ExcelService.cleanupTempFile(tempFilePath);
-
             return {
                 fileUrl,
                 truncated,
@@ -414,9 +411,10 @@ export class ExcelService {
             Logger.error(
                 `Direct Excel export failed: ${getErrorMessage(error)}`,
             );
-            // Clean up temp file on error
-            ExcelService.cleanupTempFile(tempFilePath);
             throw error;
+        } finally {
+            // Always clean up temp file, regardless of success or failure
+            ExcelService.cleanupTempFile(tempFilePath);
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: potential memory leak & heap overflow, as we were re-using a static method meant for pivot table export for non-pivot one. For both CSV and XLSX.

### Description:
- Rethink the streaming approach
- Eliminate manual handling of the stream
- Use proper streaming for non-pivot CSV tables
- Use proper streaming for non-pivot XLSX tables, bridging with a temp file, otherwise the automatic pipeline cannot evenly handle the backpressure between reading JSONL, generating XLSX and streaming upload to s3.

### Result:
Supports millions of rows for CSV and at least 1 million for XLSX, no matter the amount of columns (to an extend with current `--max-old-space-size=1024`).