### PR TITLE
feat: Improve Custom SQL queries permissions UX

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17833,7 +17833,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1734.2",
+        "version": "0.1735.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -16,6 +16,7 @@ import {
     createVirtualView as createVirtualViewObject,
     CreateWarehouseCredentials,
     type CustomDimension,
+    CustomSqlQueryForbiddenError,
     DashboardFilters,
     DEFAULT_RESULTS_PAGE_SIZE,
     Dimension,
@@ -1577,9 +1578,7 @@ export class AsyncQueryService extends ProjectService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -4,6 +4,7 @@ import {
     AnyType,
     ApiSqlQueryResults,
     applyDimensionOverrides,
+    CustomSqlQueryForbiddenError,
     DashboardFilters,
     DateGranularity,
     DimensionType,
@@ -1111,9 +1112,7 @@ This method can be memory intensive
                 }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         // If the user can't change the csv limit, default csvLimit to undefined
@@ -1184,9 +1183,7 @@ This method can be memory intensive
                 }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const baseAnalyticsProperties: DownloadCsv['properties'] = {

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    CustomSqlQueryForbiddenError,
     ForbiddenError,
     isCustomSqlDimension,
     SessionUser,
@@ -90,9 +91,7 @@ export class GdriveService extends BaseService {
                 }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const { organizationUuid } = await this.projectService.getProject(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -33,6 +33,7 @@ import {
     CreateVirtualViewPayload,
     CreateWarehouseCredentials,
     CustomFormatType,
+    CustomSqlQueryForbiddenError,
     DashboardAvailableFilters,
     DashboardBasicDetails,
     DashboardFilters,
@@ -1673,9 +1674,7 @@ export class ProjectService extends BaseService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const explore =
@@ -1771,9 +1770,7 @@ export class ProjectService extends BaseService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const queryTags: RunQueryTags = {
@@ -2086,9 +2083,7 @@ export class ProjectService extends BaseService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const queryTags: RunQueryTags = {
@@ -5231,9 +5226,7 @@ export class ProjectService extends BaseService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         const results = await this._calculateTotal(
@@ -5408,9 +5401,7 @@ export class ProjectService extends BaseService {
                 subject('CustomSql', { organizationUuid, projectUuid }),
             )
         ) {
-            throw new ForbiddenError(
-                'User cannot run queries with custom SQL dimensions',
-            );
+            throw new CustomSqlQueryForbiddenError();
         }
 
         // Reuse the _calculateTotal method by passing the explore, metricQuery, and organizationUuid

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -37,11 +37,12 @@ export const getDimensionFromId = (
     explore: Explore,
     adapterType: SupportedDbtAdapter,
     startOfWeek: WeekDay | null | undefined,
+    checkUnfilteredTables: boolean = true,
 ): CompiledDimension => {
     const dimensions = getDimensions(explore);
     const dimension = dimensions.find((d) => getItemId(d) === dimId);
 
-    if (dimension === undefined) {
+    if (!dimension) {
         const { baseDimensionId, newTimeFrame } = getDateDimension(dimId);
 
         if (baseDimensionId) {
@@ -50,6 +51,7 @@ export const getDimensionFromId = (
                 explore,
                 adapterType,
                 startOfWeek,
+                checkUnfilteredTables,
             );
             if (baseField && newTimeFrame)
                 return {
@@ -69,12 +71,14 @@ export const getDimensionFromId = (
         // it is possible that the explore is a joined table and is filtered by user_attributes
         // So we check if the dimension exists in the unfiltered tables
         if (
+            checkUnfilteredTables &&
             explore.unfilteredTables &&
             getDimensionFromId(
                 dimId,
                 { ...explore, tables: explore.unfilteredTables },
                 adapterType,
                 startOfWeek,
+                false,
             )
         ) {
             throw new AuthorizationError(

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -2,17 +2,26 @@
 import { type AnyType } from './any';
 import { type DbtLog } from './job';
 
+type LightdashErrorData = {
+    /**
+     * Optional URL linking to relevant documentation.
+     * Can be used to provide users with additional context/guidance about the error.
+     */
+    documentationUrl?: string;
+    [key: string]: AnyType;
+};
+
 type LightdashErrorParams = {
     message: string;
     name: string;
     statusCode: number;
-    data: { [key: string]: AnyType };
+    data: LightdashErrorData;
 };
 
 export class LightdashError extends Error {
     statusCode: number;
 
-    data: { [key: string]: AnyType };
+    data: LightdashErrorData;
 
     constructor({ message, name, statusCode, data }: LightdashErrorParams) {
         super(message);
@@ -521,6 +530,21 @@ export class AiAgentNotFoundError extends LightdashError {
             name: 'AiAgentNotFoundError',
             statusCode: 400,
             data: {},
+        });
+    }
+}
+
+export class CustomSqlQueryForbiddenError extends LightdashError {
+    constructor(
+        message: string = 'User cannot run queries with custom SQL dimensions',
+    ) {
+        super({
+            message,
+            name: 'CustomSqlQueryForbiddenError',
+            statusCode: 403,
+            data: {
+                documentationUrl: `https://docs.lightdash.com/references/custom-fields#custom-sql`,
+            },
         });
     }
 }

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -759,26 +759,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         chartWithDashboardFilters.metricQuery?.customDimensions;
 
     const { pathname: chartPathname, search: chartSearch } = useMemo(() => {
-        if (cannotUseCustomDimensions) {
-            const queryWithoutCustomDimensions = {
-                ...chartWithDashboardFilters,
-                metricQuery: {
-                    ...chartWithDashboardFilters.metricQuery,
-                    customDimensions: undefined,
-                },
-            };
-            return getExplorerUrlFromCreateSavedChartVersion(
-                chartWithDashboardFilters.projectUuid,
-                queryWithoutCustomDimensions,
-                true,
-            );
-        }
         return getExplorerUrlFromCreateSavedChartVersion(
             chartWithDashboardFilters.projectUuid,
             chartWithDashboardFilters,
             true,
         );
-    }, [chartWithDashboardFilters, cannotUseCustomDimensions]);
+    }, [chartWithDashboardFilters]);
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -154,6 +154,7 @@ const VisualizationCard: FC<{
                     unsavedChartVersion.pivotConfig?.columns
                 }
                 resultsData={resultsData}
+                apiErrorDetail={query.error?.error}
                 isLoading={isLoadingQueryResults}
                 columnOrder={unsavedChartVersion.tableConfig.columnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -3,6 +3,7 @@ import {
     ChartType,
     FeatureFlags,
     isDimension,
+    type ApiErrorDetail,
     type ChartConfig,
     type DashboardFilters,
     type ItemsMap,
@@ -68,6 +69,7 @@ export type VisualizationProviderProps = {
     tableCalculationsMetadata?: TableCalculationMetadata[];
     setEchartsRef?: (ref: RefObject<EChartsReact | null>) => void;
     computedSeries?: Series[];
+    apiErrorDetail?: ApiErrorDetail | null;
 };
 
 const VisualizationProvider: FC<
@@ -92,6 +94,7 @@ const VisualizationProvider: FC<
     tableCalculationsMetadata,
     setEchartsRef,
     computedSeries,
+    apiErrorDetail,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -287,6 +290,7 @@ const VisualizationProvider: FC<
         chartRef,
         resultsData: lastValidResultsData,
         isLoading,
+        apiErrorDetail,
         columnOrder,
         itemsMap,
         setStacking,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -1,4 +1,5 @@
 import {
+    type ApiErrorDetail,
     type ChartType,
     type ItemsMap,
     type MetricQuery,
@@ -40,6 +41,7 @@ type VisualizationContext = {
     getSeriesColor: (seriesLike: SeriesLike) => string;
     getGroupColor: (groupPrefix: string, groupName: string) => string;
     colorPalette: string[];
+    apiErrorDetail?: ApiErrorDetail | null;
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -1,5 +1,9 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { memo, type FC } from 'react';
+import { Anchor } from '@mantine/core';
+import { IconChartBarOff } from '@tabler/icons-react';
+import { Fragment, memo, type FC } from 'react';
+import { EmptyState } from '../common/EmptyState';
+import MantineIcon from '../common/MantineIcon';
 import CustomVisualization from '../CustomVisualization';
 import FunnelChart from '../FunnelChart';
 import SimpleChart from '../SimpleChart';
@@ -24,10 +28,40 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
         className,
         ...props
     }) => {
-        const { visualizationConfig, minimal } = useVisualizationContext();
+        const { visualizationConfig, minimal, apiErrorDetail } =
+            useVisualizationContext();
 
         if (!visualizationConfig) {
             return null;
+        }
+
+        if (apiErrorDetail) {
+            return (
+                <EmptyState
+                    icon={<MantineIcon icon={IconChartBarOff} />}
+                    title="Unable to load visualization"
+                    description={
+                        <Fragment>
+                            {apiErrorDetail.message}
+                            {apiErrorDetail.data.documentationUrl && (
+                                <Fragment>
+                                    <br />
+                                    <Anchor
+                                        href={
+                                            apiErrorDetail.data.documentationUrl
+                                        }
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Learn how to resolve this in our
+                                        documentation →
+                                    </Anchor>
+                                </Fragment>
+                            )}
+                        </Fragment>
+                    }
+                ></EmptyState>
+            );
         }
 
         switch (visualizationConfig.chartType) {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -175,10 +175,7 @@ export const executeQueryAndWaitForResults = async (
 };
 
 export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
-    const setErrorResponse = useQueryError({
-        forceToastOnForbidden: true,
-        forbiddenToastTitle: 'Error running query',
-    });
+    const setErrorResponse = useQueryError();
 
     const result = useQuery<ApiExecuteAsyncMetricQueryResults, ApiError>({
         enabled: !!data,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15169

### Description:
This PR introduces a new `CustomSqlQueryForbiddenError` error to display when users attempt to run queries with custom SQL dimensions without proper permissions.

To achieve that, this PR also includes:
- Includes new optional `documentationUrl` prop into Error data
- Adds a new error visualization in `LightdashVisualization` component that displays the error message and documentation link when a query fails
- Fixes a potential infinite recursion issue in `getDimensionFromId` by adding a flag to control checking of unfiltered tables
- Unified logic for `Edit chart` and `Explore from here` from `DashboardChartTile` by including Custom Dimensions. (I think that if we allow this for `Edit chart` then why not here? 🤔)

<details><summary>Screenshots 📷 </summary>

## Explore from here behavior

### Before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/dd2ce047-b17b-4079-8bf7-057bd951fe3e.png)

### After

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/bbadb792-5992-49a6-9874-e16b187e73f3.png)

</details>