### PR TITLE
fix: wait for non-null charts' responses

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -778,7 +778,7 @@ export class UnfurlService extends BaseService {
                                 );
 
                                 const expectedPaginatedResponses =
-                                    chartTileUuids.length;
+                                    nonNullChartTileUuids.length;
                                 this.logger.info(
                                     `Dashboard screenshot: Expecting ${expectedPaginatedResponses} paginated responses`,
                                 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15102

### Description:

Fix a bug in the UnfurlService where the expected number of paginated responses for dashboard screenshots was incorrectly using `chartTileUuids` instead of `nonNullChartTileUuids`. This ensures that the service correctly tracks the expected number of responses when generating dashboard screenshots.

relevant logs that confirm this theory

> INFO ... Dashboard screenshot: 14 non-null chart tiles out of 16 total tiles
> INFO ... Dashboard screenshot: Expecting 16 paginated responses
> INFO ... Waiting for 16 paginated responses with timeout 2880000ms

☝️ should be waiting for 14