### PR TITLE
fix: allow users to get slack installation on commercial

### DIFF
--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -24,10 +24,6 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
 
-        if (user.ability.cannot('view', 'Organization')) {
-            throw new ForbiddenError();
-        }
-
         const installation =
             await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                 organizationUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15115

### Description:

Removes unnecessary permission check in `CommercialSlackIntegrationService`.

Extends work done on: https://github.com/lightdash/lightdash/pull/15379 , but includes Commercial-related code

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/b85b09a3-c2d0-4d1f-af54-8085bf270ba6.png)

