### PR TITLE
fix: add null checks to apiError properties in ApiErrorDisplay

### DIFF
--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -179,8 +179,11 @@ const useToaster = () => {
             },
         ) => {
             const title: ReactNode | undefined = props.title ?? 'Error';
-            const subtitle: ReactNode = (
+
+            const subtitle: ReactNode = props.apiError ? (
                 <ApiErrorDisplay apiError={props.apiError} />
+            ) : (
+                ''
             );
 
             showToast({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

I hit the edge case where the apiError is undefined, added null checks for apiError properties in ApiErrorDisplay component to prevent potential runtime errors when accessing properties of undefined objects.
