### PR TITLE
feat: add service account creation during initial setup

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -264,16 +264,14 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
         return value as T;
     };
 
-    const parseApiExpiration = (): Date | null => {
-        const apiExpiration = process.env.LD_SETUP_API_KEY_EXPIRATION;
+    const parseApiExpiration = (envVariable: string): Date | null => {
+        const apiExpiration = process.env[envVariable];
         const apiExpirationDays = apiExpiration
             ? parseInt(apiExpiration, 10)
             : 30; // Convert to number, this might throw an error
         if (apiExpirationDays === 0) return null; // If 0, we return null, which means, no expiration
         if (Number.isNaN(apiExpirationDays)) {
-            throw new ParameterError(
-                'LD_SETUP_API_KEY_EXPIRATION must be a valid number',
-            );
+            throw new ParameterError(`${envVariable} must be a valid number`);
         }
         return new Date(Date.now() + 1000 * 60 * 60 * 24 * apiExpirationDays);
     };
@@ -305,7 +303,17 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
             apiKey: process.env.LD_SETUP_ADMIN_API_KEY
                 ? {
                       token: process.env.LD_SETUP_ADMIN_API_KEY,
-                      expirationTime: parseApiExpiration(),
+                      expirationTime: parseApiExpiration(
+                          'LD_SETUP_API_KEY_EXPIRATION',
+                      ),
+                  }
+                : undefined,
+            serviceAccount: process.env.LD_SETUP_SERVICE_ACCOUNT_TOKEN
+                ? {
+                      token: process.env.LD_SETUP_SERVICE_ACCOUNT_TOKEN,
+                      expirationTime: parseApiExpiration(
+                          'LD_SETUP_SERVICE_ACCOUNT_EXPIRATION',
+                      ),
                   }
                 : undefined,
             project: {
@@ -567,6 +575,10 @@ export type LightdashConfig = {
             defaultRole: OrganizationMemberRole;
         };
         apiKey?: {
+            token: string;
+            expirationTime: Date | null;
+        };
+        serviceAccount?: {
             token: string;
             expirationTime: Date | null;
         };

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -31,6 +31,7 @@ import {
     ParameterError,
     ProjectType,
     RequestMethod,
+    ServiceAccountScope,
     SessionUser,
     UnexpectedServerError,
     UpdateAllowedEmailDomains,
@@ -42,6 +43,7 @@ import {
 import { groupBy } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
 import { PersonalAccessTokenModel } from '../../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../../models/EmailModel';
 import { GroupsModel } from '../../models/GroupsModel';
@@ -70,6 +72,7 @@ type OrganizationServiceArguments = {
     personalAccessTokenModel: PersonalAccessTokenModel;
     emailModel: EmailModel;
     projectService: ProjectService; // For compiling project on new setup
+    serviceAccountModel: ServiceAccountModel; // For creating service account on new setup
 };
 
 export class OrganizationService extends BaseService {
@@ -99,6 +102,8 @@ export class OrganizationService extends BaseService {
 
     private readonly projectService: ProjectService;
 
+    private readonly serviceAccountModel: ServiceAccountModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -113,6 +118,7 @@ export class OrganizationService extends BaseService {
         personalAccessTokenModel,
         emailModel,
         projectService,
+        serviceAccountModel,
     }: OrganizationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -129,6 +135,7 @@ export class OrganizationService extends BaseService {
         this.personalAccessTokenModel = personalAccessTokenModel;
         this.emailModel = emailModel;
         this.projectService = projectService;
+        this.serviceAccountModel = serviceAccountModel;
     }
 
     async get(user: SessionUser): Promise<Organization> {
@@ -908,6 +915,25 @@ export class OrganizationService extends BaseService {
             } else {
                 this.logger.info(
                     `Initial setup: No whitelisted domain, skipping`,
+                );
+            }
+
+            if (setup.serviceAccount) {
+                this.logger.debug(`Initial setup: creating service account`);
+                await this.serviceAccountModel.save(
+                    sessionUser,
+                    {
+                        organizationUuid,
+                        expiresAt: setup.serviceAccount.expirationTime,
+                        description: 'Initial setup service account',
+                        scopes: [ServiceAccountScope.ORG_ADMIN],
+                    },
+                    setup.serviceAccount.token,
+                );
+                this.logger.info(`Initial setup: service account created`);
+            } else {
+                this.logger.info(
+                    `Initial setup: No service account token provided, skipping`,
                 );
             }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -411,6 +411,7 @@ export class ServiceRepository
                         this.models.getPersonalAccessTokenModel(),
                     emailModel: this.models.getEmailModel(),
                     projectService: this.getProjectService(),
+                    serviceAccountModel: this.models.getServiceAccountModel(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A


## How to test / how it works 

Create a new database, without users or orgs
Configure all ENV variables to trigger the initial setup .  https://docs.lightdash.com/self-host/customize-deployment/environment-variables#initialize-instance

add new service acocunt token 
```
export LD_SETUP_SERVICE_ACCOUNT_TOKEN='service_account_12345' 
export LD_SETUP_SERVICE_ACCOUNT_EXPIRATION='30' 
```
Start backend, new org/project/service account will be created

Now you can use that key to query the api allowed endpoints

![Screenshot from 2025-06-17 16-55-32](https://github.com/user-attachments/assets/3266bbb8-8d81-45e2-985a-4ecee2dc05e9)



### Description:
Adds support for creating a service account during initial setup by introducing new environment variables:
- `LD_SETUP_SERVICE_ACCOUNT_TOKEN`: Token for the service account
- `LD_SETUP_SERVICE_ACCOUNT_EXPIRATION`: Expiration time in days for the service account token

The PR refactors the `parseApiExpiration` function to be reusable for both admin API keys and service account tokens. It also modifies the `ServiceAccountModel` to allow saving a service account with a predefined token rather than only generating new ones.