### PR TITLE
feat: SI and IEC byte formats

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1709,7 +1709,22 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Compact: {
         dataType: 'refEnum',
-        enums: ['thousands', 'millions', 'billions', 'trillions'],
+        enums: [
+            'thousands',
+            'millions',
+            'billions',
+            'trillions',
+            'kilobytes',
+            'megabytes',
+            'gigabytes',
+            'terabytes',
+            'petabytes',
+            'kibibytes',
+            'mebibytes',
+            'gibibytes',
+            'tebibytes',
+            'pebibytes',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CompactOrAlias: {
@@ -1729,6 +1744,26 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: ['billion'] },
                         { dataType: 'enum', enums: ['T'] },
                         { dataType: 'enum', enums: ['trillion'] },
+                        { dataType: 'enum', enums: ['KB'] },
+                        { dataType: 'enum', enums: ['kilobyte'] },
+                        { dataType: 'enum', enums: ['MB'] },
+                        { dataType: 'enum', enums: ['megabyte'] },
+                        { dataType: 'enum', enums: ['GB'] },
+                        { dataType: 'enum', enums: ['gigabyte'] },
+                        { dataType: 'enum', enums: ['TB'] },
+                        { dataType: 'enum', enums: ['terabyte'] },
+                        { dataType: 'enum', enums: ['PB'] },
+                        { dataType: 'enum', enums: ['petabyte'] },
+                        { dataType: 'enum', enums: ['KiB'] },
+                        { dataType: 'enum', enums: ['kibibyte'] },
+                        { dataType: 'enum', enums: ['MiB'] },
+                        { dataType: 'enum', enums: ['mebibyte'] },
+                        { dataType: 'enum', enums: ['GiB'] },
+                        { dataType: 'enum', enums: ['gibibyte'] },
+                        { dataType: 'enum', enums: ['TiB'] },
+                        { dataType: 'enum', enums: ['tebibytes'] },
+                        { dataType: 'enum', enums: ['PiB'] },
+                        { dataType: 'enum', enums: ['pebibytes'] },
                     ],
                 },
             ],
@@ -1973,6 +2008,8 @@ const models: TsoaRoute.Models = {
             'id',
             'date',
             'timestamp',
+            'bytes_si',
+            'bytes_iec',
             'custom',
         ],
     },
@@ -11587,7 +11624,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11597,7 +11634,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11607,7 +11644,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11620,7 +11657,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -15949,6 +15986,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        limit: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                                { dataType: 'undefined' },
+                            ],
+                        },
                         dateZoom: { ref: 'DateZoom' },
                         dashboardSorts: {
                             dataType: 'array',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1757,7 +1757,22 @@
                 "type": "object"
             },
             "Compact": {
-                "enum": ["thousands", "millions", "billions", "trillions"],
+                "enum": [
+                    "thousands",
+                    "millions",
+                    "billions",
+                    "trillions",
+                    "kilobytes",
+                    "megabytes",
+                    "gigabytes",
+                    "terabytes",
+                    "petabytes",
+                    "kibibytes",
+                    "mebibytes",
+                    "gibibytes",
+                    "tebibytes",
+                    "pebibytes"
+                ],
                 "type": "string"
             },
             "CompactOrAlias": {
@@ -1775,7 +1790,27 @@
                             "B",
                             "billion",
                             "T",
-                            "trillion"
+                            "trillion",
+                            "KB",
+                            "kilobyte",
+                            "MB",
+                            "megabyte",
+                            "GB",
+                            "gigabyte",
+                            "TB",
+                            "terabyte",
+                            "PB",
+                            "petabyte",
+                            "KiB",
+                            "kibibyte",
+                            "MiB",
+                            "mebibyte",
+                            "GiB",
+                            "gibibyte",
+                            "TiB",
+                            "tebibytes",
+                            "PiB",
+                            "pebibytes"
                         ]
                     }
                 ]
@@ -2105,6 +2140,8 @@
                     "id",
                     "date",
                     "timestamp",
+                    "bytes_si",
+                    "bytes_iec",
                     "custom"
                 ],
                 "type": "string"
@@ -12434,22 +12471,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -16692,8 +16729,7 @@
                             "limit": {
                                 "type": "number",
                                 "format": "double",
-                                "nullable": true,
-                                "description": "Limit override for query execution:\n- undefined: use saved chart's original limit\n- null: no limit (unlimited results)\n- number: apply specific limit"
+                                "nullable": true
                             },
                             "versionUuid": {
                                 "type": "string"
@@ -16754,6 +16790,11 @@
                     },
                     {
                         "properties": {
+                            "limit": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
                             "dateZoom": {
                                 "$ref": "#/components/schemas/DateZoom"
                             },
@@ -17795,7 +17836,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1725.0",
+        "version": "0.1728.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -14,6 +14,16 @@ export enum Compact {
     MILLIONS = 'millions',
     BILLIONS = 'billions',
     TRILLIONS = 'trillions',
+    KILOBYTES = 'kilobytes',
+    MEGABYTES = 'megabytes',
+    GIGABYTES = 'gigabytes',
+    TERABYTES = 'terabytes',
+    PETABYTES = 'petabytes',
+    KIBIBYTES = 'kibibytes',
+    MEBIBYTES = 'mebibytes',
+    GIBIBYTES = 'gibibytes',
+    TEBIBYTES = 'tebibytes',
+    PEBIBYTES = 'pebibytes',
 }
 
 const CompactAlias = [
@@ -25,6 +35,26 @@ const CompactAlias = [
     'billion',
     'T',
     'trillion',
+    'KB',
+    'kilobyte',
+    'MB',
+    'megabyte',
+    'GB',
+    'gigabyte',
+    'TB',
+    'terabyte',
+    'PB',
+    'petabyte',
+    'KiB',
+    'kibibyte',
+    'MiB',
+    'mebibyte',
+    'GiB',
+    'gibibyte',
+    'TiB',
+    'tebibytes',
+    'PiB',
+    'pebibytes',
 ] as const;
 
 export enum NumberSeparator {
@@ -77,6 +107,86 @@ export const CompactConfigMap: Record<Compact, CompactConfig> = {
         convertFn: (value: number) => value / 1000000000000,
         label: 'trillions (T)',
         suffix: 'T',
+    },
+    [Compact.KILOBYTES]: {
+        compact: Compact.KILOBYTES,
+        alias: ['KB', 'kilobyte'],
+        orderOfMagnitude: 3,
+        convertFn: (value: number) => value / 1000,
+        label: 'kilobytes (KB)',
+        suffix: 'KB',
+    },
+    [Compact.MEGABYTES]: {
+        compact: Compact.MEGABYTES,
+        alias: ['MB', 'megabyte'],
+        orderOfMagnitude: 6,
+        convertFn: (value: number) => value / 1000000,
+        label: 'megabytes (MB)',
+        suffix: 'MB',
+    },
+    [Compact.GIGABYTES]: {
+        compact: Compact.GIGABYTES,
+        alias: ['GB', 'gigabyte'],
+        orderOfMagnitude: 9,
+        convertFn: (value: number) => value / 1000000000,
+        label: 'gigabytes (GB)',
+        suffix: 'GB',
+    },
+    [Compact.TERABYTES]: {
+        compact: Compact.TERABYTES,
+        alias: ['TB', 'terabyte'],
+        orderOfMagnitude: 12,
+        convertFn: (value: number) => value / 1000000000000,
+        label: 'terabytes (TB)',
+        suffix: 'TB',
+    },
+    [Compact.PETABYTES]: {
+        compact: Compact.PETABYTES,
+        alias: ['PB', 'petabyte'],
+        orderOfMagnitude: 15,
+        convertFn: (value: number) => value / 1000000000000000,
+        label: 'petabytes (PB)',
+        suffix: 'PB',
+    },
+    [Compact.KIBIBYTES]: {
+        compact: Compact.KIBIBYTES,
+        alias: ['KiB', 'kibibyte'],
+        orderOfMagnitude: -1,
+        convertFn: (value: number) => value / 1024,
+        label: 'kibibytes (KiB)',
+        suffix: 'KiB',
+    },
+    [Compact.MEBIBYTES]: {
+        compact: Compact.MEBIBYTES,
+        alias: ['MiB', 'mebibyte'],
+        orderOfMagnitude: -1,
+        convertFn: (value: number) => value / 1048576,
+        label: 'mebibytes (MiB)',
+        suffix: 'MiB',
+    },
+    [Compact.GIBIBYTES]: {
+        compact: Compact.GIBIBYTES,
+        alias: ['GiB', 'gibibyte'],
+        orderOfMagnitude: -1,
+        convertFn: (value: number) => value / 1073741824,
+        label: 'gibibytes (GiB)',
+        suffix: 'GiB',
+    },
+    [Compact.TEBIBYTES]: {
+        compact: Compact.TEBIBYTES,
+        alias: ['TiB', 'tebibytes'],
+        orderOfMagnitude: -1,
+        convertFn: (value: number) => value / 1099511627776,
+        label: 'tebibytes (TiB)',
+        suffix: 'TiB',
+    },
+    [Compact.PEBIBYTES]: {
+        compact: Compact.PEBIBYTES,
+        alias: ['PiB', 'pebibytes'],
+        orderOfMagnitude: -1,
+        convertFn: (value: number) => value / 1125899906842624,
+        label: 'pebibytes (PiB)',
+        suffix: 'PiB',
     },
 };
 
@@ -188,6 +298,8 @@ export enum CustomFormatType {
     ID = 'id',
     DATE = 'date',
     TIMESTAMP = 'timestamp',
+    BYTES_SI = 'bytes_si',
+    BYTES_IEC = 'bytes_iec',
     CUSTOM = 'custom',
 }
 
@@ -569,3 +681,32 @@ export const isSummable = (item: Item | undefined) => {
     const isDatePart = isDimension(item) && item.timeInterval;
     return isNumbericType && !isPercent && !isDatePart;
 };
+
+const SIByteCompacts: Compact[] = [
+    Compact.KILOBYTES,
+    Compact.MEGABYTES,
+    Compact.GIGABYTES,
+    Compact.TERABYTES,
+    Compact.PETABYTES,
+];
+
+export const IECByteCompacts: Compact[] = [
+    Compact.KIBIBYTES,
+    Compact.MEBIBYTES,
+    Compact.GIBIBYTES,
+    Compact.TEBIBYTES,
+    Compact.PEBIBYTES,
+];
+
+export function getCompactOptionsForFormatType(
+    type: CustomFormatType,
+): Compact[] {
+    if (type === CustomFormatType.BYTES_IEC) return IECByteCompacts;
+    if (type === CustomFormatType.BYTES_SI) return SIByteCompacts;
+    return [
+        Compact.THOUSANDS,
+        Compact.MILLIONS,
+        Compact.BILLIONS,
+        Compact.TRILLIONS,
+    ];
+}


### PR DESCRIPTION
Closes: [15377](https://github.com/lightdash/lightdash/issues/15377)

### Description:
Support for compact byte formats:
- SI: KB, MB, GB, TB, PB
- IEC: KiB, MiB, GiB, TiB, PiB

Divides by multiples of 1000 or 1024 depending on the desired byte standard. Note that KiB, MiB, etc. which divide by 1024^n require special handling since standard formats are base 10.

**New Types**
![image](https://github.com/user-attachments/assets/87311db8-748a-442f-ba01-2bd4ec3e5148)

**New Compact Formats**
![image](https://github.com/user-attachments/assets/ebd82234-ca53-402b-abd6-e6df979f71b1)

**Example output: Formatted vs. raw value for KiB**
![image](https://github.com/user-attachments/assets/c4f74909-1644-4cde-ab3d-517291ec5043)

**Config menu also uses these values**
![image](https://github.com/user-attachments/assets/0a2454a0-17ea-4692-958e-ba9bd211101b)
