### PR TITLE
fix: apply chart limit to dashboard sql chart and fix remove comments and strip semi-colons when there's no limit

### DIFF
--- a/packages/backend/src/queryBuilder.ts
+++ b/packages/backend/src/queryBuilder.ts
@@ -471,8 +471,8 @@ export const applyLimitToSqlQuery = ({
     // do nothing if limit is undefined
     if (limit === undefined) {
         // strip any trailing semicolons and comments
-        let sql = sqlQuery.trim().replace(/;+$/g, '');
-        sql = removeComments(sql);
+        let sql = removeComments(sqlQuery);
+        sql = sql.trim().replace(/;+$/g, '');
         return sql.trim();
     }
     // get any existing outer limit and offset from the SQL query

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2545,7 +2545,7 @@ export class AsyncQueryService extends ProjectService {
             tileUuid,
             dashboardFilters,
             dashboardSorts,
-            limit,
+            limit: limit ?? savedChart.limit,
         });
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15414 

- Applies same limits as the chart view, previously it was just passing undefined
- Changes the order in which comments and semi-colons are stripped out from the sql since it was causing a semi-colon to remain if there was a comment after it

**Before**
```sql
WITH original_query AS (SELECT
"event_id" AS "event_id",
"timestamp_tz" AS "timestamp_tz",
"timestamp_ntz" AS "timestamp_ntz",
"timestamp_ltz" AS "timestamp_ltz",
"date" AS "date",
"event" AS "event"
FROM (
SELECT * FROM "postgres"."jaffle"."events";
) AS "sql_query"), group_by_query AS (SELECT "event", sum("event_id") AS "event_id_sum" FROM original_query group by "event")
SELECT * FROM group_by_query  LIMIT 500 
```

![image](https://github.com/user-attachments/assets/f9f48c20-f3b8-4089-b775-b2fa78a7f2d9)


**After**
```sql
WITH original_query AS (SELECT
"event_id" AS "event_id",
"timestamp_tz" AS "timestamp_tz",
"timestamp_ntz" AS "timestamp_ntz",
"timestamp_ltz" AS "timestamp_ltz",
"date" AS "date",
"event" AS "event"
FROM (
SELECT * FROM "postgres"."jaffle"."events" LIMIT 500
) AS "sql_query"), group_by_query AS (SELECT "event", sum("event_id") AS "event_id_sum" FROM original_query group by "event")
SELECT * FROM group_by_query  LIMIT 500 
```

![image](https://github.com/user-attachments/assets/8104fd80-8da0-4df1-8fc8-fe5133fee1e1)


test-frontend
