### PR TITLE
feat: New  ai-agents redirect route

### DIFF
--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -6,6 +6,7 @@ import { getMantine8ThemeOverride } from '../mantine8Theme';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 import AgentPage from './pages/AiAgents/AgentPage';
+import AgentsRedirect from './pages/AiAgents/AgentsRedirect';
 import AgentsWelcome from './pages/AiAgents/AgentsWelcome';
 import AiAgentThreadPage from './pages/AiAgents/AgentThreadPage';
 import AiAgentNewThreadPage from './pages/AiAgents/AiAgentNewThreadPage';
@@ -68,6 +69,14 @@ const COMMERCIAL_AI_ROUTES: RouteObject[] = [
 ];
 
 const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
+    {
+        path: '/ai-agents/',
+        element: (
+            <PrivateRoute>
+                <AgentsRedirect />
+            </PrivateRoute>
+        ),
+    },
     {
         path: '/projects/:projectUuid/ai-agents',
         element: (

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRedirect.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRedirect.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { Navigate } from 'react-router';
+import PageSpinner from '../../../components/PageSpinner';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useDefaultProject } from '../../../hooks/useProjects';
+import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+
+/**
+ * Page used to facilitate linking users to ai agents.
+ * This page will redirect them to their default project ai-agents welcome page.
+ */
+const AgentsRedirect = () => {
+    const { data, isLoading } = useDefaultProject();
+    const { showToastInfo } = useToaster();
+    const canViewAiAgents = useAiAgentPermission({
+        action: 'view',
+        projectUuid: data?.projectUuid,
+    });
+
+    useEffect(() => {
+        if (!canViewAiAgents) {
+            showToastInfo({
+                subtitle: 'You are not allowed to access this view',
+            });
+        }
+    }, [canViewAiAgents, showToastInfo]);
+
+    if (isLoading) {
+        return <PageSpinner />;
+    }
+
+    if (canViewAiAgents && data) {
+        return (
+            <Navigate to={`/projects/${data.projectUuid}/ai-agents`} replace />
+        );
+    }
+
+    return <Navigate to={`/projects/`} />;
+};
+
+export default AgentsRedirect;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This change makes it easier to create direct links to the AI Agents feature without requiring a specific project UUID in the URL.

Added a redirect page for AI Agents to improve navigation. This change makes it easier to create direct links to the AI Agents without the need of knowing project uuid.
When users access `/ai-agents/`, they will now be automatically redirected to their default project's AI agents page if they have the necessary permissions. If they lack permissions, they'll be redirected to the projects page with a toast
