### PR TITLE
feat: add prefixes for PATs and ServiceAccount tokens

### DIFF
--- a/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
+++ b/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
@@ -1,6 +1,7 @@
 import {
     ApiCreateScimServiceAccountRequest,
     ApiErrorPayload,
+    AuthTokenPrefix,
     ScimErrorPayload,
     ServiceAccount,
     ServiceAccountScope,
@@ -81,7 +82,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
                 organizationUuid: req.user?.organizationUuid as string,
                 scopes: SCIM_SCOPES,
             },
-            prefix: 'scim_',
+            prefix: AuthTokenPrefix.SCIM,
         });
         this.setStatus(201);
         return {
@@ -168,7 +169,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
                 user: req.user!,
                 tokenUuid,
                 update: body,
-                prefix: 'scim_',
+                prefix: AuthTokenPrefix.SCIM,
             }),
         };
     }

--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -1,6 +1,7 @@
 import {
     ApiCreateServiceAccountRequest,
     ApiErrorPayload,
+    AuthTokenPrefix,
     ServiceAccount,
     ServiceAccountScope,
 } from '@lightdash/common';
@@ -76,7 +77,7 @@ export class ServiceAccountsController extends BaseController {
                 ...body,
                 organizationUuid: req.user?.organizationUuid as string,
             },
-            prefix: '',
+            prefix: AuthTokenPrefix.SERVICE_ACCOUNT,
         });
         this.setStatus(201);
         return {

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -1,4 +1,5 @@
 import {
+    AuthTokenPrefix,
     CreateServiceAccount,
     ServiceAccount,
     ServiceAccountScope,
@@ -47,7 +48,7 @@ export class ServiceAccountModel {
     async create({
         user,
         data,
-        prefix = 'scim_',
+        prefix = AuthTokenPrefix.SCIM,
     }: {
         user: SessionUser;
         data: CreateServiceAccount;
@@ -102,7 +103,7 @@ export class ServiceAccountModel {
         serviceAccountUuid,
         rotatedByUserUuid,
         expiresAt,
-        prefix = 'scim_',
+        prefix = AuthTokenPrefix.SCIM,
     }: {
         serviceAccountUuid: string;
         rotatedByUserUuid: string;

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import {
-    CommercialFeatureFlags,
+    AuthTokenPrefix,
     CreateServiceAccount,
     ForbiddenError,
     NotFoundError,
@@ -15,10 +15,6 @@ import {
 
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../../config/parseConfig';
-import { EmailModel } from '../../../models/EmailModel';
-import { GroupsModel } from '../../../models/GroupsModel';
-import { OrganizationMemberProfileModel } from '../../../models/OrganizationMemberProfileModel';
-import { UserModel } from '../../../models/UserModel';
 import { BaseService } from '../../../services/BaseService';
 import {
     ScimAccessTokenAuthenticationEvent,
@@ -72,7 +68,7 @@ export class ServiceAccountService extends BaseService {
     async create({
         user,
         tokenDetails,
-        prefix = 'scim_',
+        prefix = AuthTokenPrefix.SCIM,
     }: {
         user: SessionUser;
         tokenDetails: CreateServiceAccount;
@@ -165,7 +161,7 @@ export class ServiceAccountService extends BaseService {
         user,
         tokenUuid,
         update,
-        prefix = 'scim_',
+        prefix = AuthTokenPrefix.SCIM,
     }: {
         user: SessionUser;
         tokenUuid: string;

--- a/packages/backend/src/models/DashboardModel/PersonalAccessTokenModel.ts
+++ b/packages/backend/src/models/DashboardModel/PersonalAccessTokenModel.ts
@@ -1,4 +1,5 @@
 import {
+    AuthTokenPrefix,
     CreatePersonalAccessToken,
     NotFoundError,
     PersonalAccessToken,
@@ -110,7 +111,9 @@ export class PersonalAccessTokenModel {
         user: Pick<SessionUser, 'userId'>,
         data: CreatePersonalAccessToken,
     ): Promise<PersonalAccessTokenWithToken> {
-        const token = crypto.randomBytes(16).toString('hex');
+        const token = `${AuthTokenPrefix.PERSONAL_ACCESS_TOKEN}${crypto
+            .randomBytes(16)
+            .toString('hex')}`;
         return this.save(user, {
             ...data,
             token,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,10 +41,12 @@
         "@types/node-fetch": "2.x",
         "@types/nunjucks": "^3.2.1",
         "@types/parse-node-version": "^1.0.0",
-        "@types/uuid": "^10.0.0"
+        "@types/uuid": "^10.0.0",
+        "ts-node": "^10.9.2"
     },
     "scripts": {
         "test": "jest",
+        "dev": "ts-node src/index.ts",
         "build": "tsc --build tsconfig.json",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "prettier --config .prettierrc.js --ignore-unknown --ignore-path ./../../.gitignore",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,6 +18,10 @@ export type Config = {
         serverUrl?: string;
         project?: string;
         projectName?: string;
+        /**
+         * This is an API token that is used to authenticate with the Lightdash API.
+         * It could be a personal access token or a service account token.
+         */
         apiKey?: string;
         proxyAuthorization?: string;
         previewProject?: string;
@@ -28,7 +32,7 @@ export type Config = {
     };
 };
 
-export const setConfig = async (config: Config) => {
+const setConfig = async (config: Config) => {
     await fs.mkdir(path.dirname(configFilePath), { recursive: true });
     await fs.writeFile(configFilePath, yaml.dump(config), 'utf8');
 };

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -4,14 +4,13 @@ import {
     ApiResponse,
     AuthorizationError,
     LightdashError,
-    LightdashRequestMethodHeader,
-    RequestMethod,
 } from '@lightdash/common';
 import fetch, { BodyInit } from 'node-fetch';
 import { URL } from 'url';
 import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
+import { buildRequestHeaders } from '../utils';
 
 const { version: VERSION } = require('../../../package.json');
 
@@ -31,18 +30,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             `Not logged in. Run 'lightdash login --help'`,
         );
     }
-    const proxyAuthorizationHeader = config.context.proxyAuthorization
-        ? { 'Proxy-Authorization': config.context.proxyAuthorization }
-        : undefined;
-    const headers = {
-        'Content-Type': 'application/json',
-        Authorization: `ApiKey ${config.context.apiKey}`,
-        [LightdashRequestMethodHeader]:
-            process.env.CI === 'true'
-                ? RequestMethod.CLI_CI
-                : RequestMethod.CLI,
-        ...proxyAuthorizationHeader,
-    };
+    const headers = buildRequestHeaders(config.context.apiKey);
     const fullUrl = new URL(url, config.context.serverUrl).href;
     GlobalState.debug(`> Making HTTP ${method} request to: ${fullUrl}`);
 

--- a/packages/cli/src/handlers/utils.ts
+++ b/packages/cli/src/handlers/utils.ts
@@ -1,0 +1,49 @@
+import {
+    AuthTokenPrefix,
+    LightdashRequestMethodHeader,
+    RequestMethod,
+} from '@lightdash/common';
+
+enum TokenType {
+    ApiKey = 'ApiKey',
+    Bearer = 'Bearer',
+}
+
+type RequestHeader = {
+    'Content-Type': 'application/json';
+    Authorization: string;
+    'Proxy-Authorization'?: string;
+    [LightdashRequestMethodHeader]: RequestMethod;
+};
+
+/**
+ * We initially used personal access tokens (PATs) for CLI authentication without any prefix.
+ * Service account tokens are launching with a prefix, so we'll check them first.
+ * We assume a missing prefix is a personal access token, although new PATs will be created with a prefix.
+ *
+ * See {@link AuthTokenPrefix} for the available token prefixes
+ */
+function getAuthHeader(token: string) {
+    const authType = token?.startsWith(AuthTokenPrefix.SERVICE_ACCOUNT)
+        ? TokenType.Bearer
+        : TokenType.ApiKey;
+    return `${authType} ${token}`;
+}
+
+export function buildRequestHeaders(token: string) {
+    const headers: RequestHeader = {
+        'Content-Type': 'application/json',
+        Authorization: getAuthHeader(token),
+        [LightdashRequestMethodHeader]:
+            process.env.CI === 'true'
+                ? RequestMethod.CLI_CI
+                : RequestMethod.CLI,
+    };
+
+    if (process.env.LIGHTDASH_PROXY_AUTHORIZATION) {
+        headers['Proxy-Authorization'] =
+            process.env.LIGHTDASH_PROXY_AUTHORIZATION;
+    }
+
+    return headers;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -173,11 +173,11 @@ ${styles.bold('Examples:')}
   ${styles.title('⚡')}️lightdash ${styles.bold(
             'login',
         )} https://custom.lightdash.domain --token 12345 ${styles.secondary(
-            '-- Logs in with a personal access token (useful for users that use SSO in the browser)',
+            '-- Logs in with an API access token (useful for users that use SSO in the browser)',
         )}
 `,
     )
-    .option('--token <token>', 'Login with a personal access token', undefined)
+    .option('--token <token>', 'Login with an API access token', undefined)
     .option('--verbose', undefined, false)
 
     .action(login);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -206,6 +206,7 @@ export * from './types/api/sort';
 export * from './types/api/spotlight';
 export * from './types/api/success';
 export * from './types/api/uuid';
+export * from './types/auth';
 export * from './types/bigQuerySSO';
 export * from './types/catalog';
 export * from './types/coder';

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -1,0 +1,8 @@
+/**
+ * Prefixes for the authorization tokens we store in the database
+ */
+export enum AuthTokenPrefix {
+    SCIM = 'scim_',
+    SERVICE_ACCOUNT = 'ldsvc_',
+    PERSONAL_ACCESS_TOKEN = 'ldpat_',
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,6 +598,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.15.3)(typescript@5.7.2)
 
   packages/common:
     dependencies:
@@ -16662,7 +16665,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19924,7 +19927,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -19941,7 +19944,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -21834,7 +21837,7 @@ snapshots:
       chalk: 2.4.2
       commander: 2.20.3
       core-js: 3.38.0
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-json-patch: 3.1.1
       get-stdin: 6.0.0
       http-proxy-agent: 5.0.0
@@ -26253,7 +26256,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -28363,7 +28366,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Adds prefixes to Service Account tokens and Personal Access tokens.

Introduces an `AuthTokenPrefix` enum to standardize token prefixes across the application. This replaces hardcoded string prefixes with the enum values for SCIM tokens (`scim_`), service account tokens (`ldsvc_`), and personal access tokens (`ldpat_`). 