### PR TITLE
feat: service account authentication for API endpoints

### DIFF
--- a/examples/api/service-accounts.http
+++ b/examples/api/service-accounts.http
@@ -31,6 +31,11 @@ Authorization: Bearer 9649663ed1f1897221da9d8db09b961f
 GET http://localhost:8080/api/v1/org/projects
 Authorization: ApiKey 9034a7ef26151167617f9f9b412d5247
 
+### Also unauthorized, works for api tokens, but not for service accounts
+GET http://localhost:8080/api/v1/org/users
+Authorization: Bearer 3e3bd56d5f428cfdaaab961dfdac6aef
+#Authorization: ApiKey 9034a7ef26151167617f9f9b412d5247
+
 ### I can't use service account on an unauthorized endpoint (this endpoint does not have allowApiKeyAuthentication middleware)
 GET http://localhost:8080/api/v1/org/allowedEmailDomains
 Authorization: Bearer 3e3bd56d5f428cfdaaab961dfdac6aef

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -10,9 +10,13 @@ import {
     SessionServiceAccount,
     LightdashVersionHeader,
     SessionUser,
+    SessionLightdashUser,
     UnexpectedServerError,
     InvalidUser,
     ServiceAccount,
+    MemberAbility,
+    LightdashUser,
+    LightdashUserWithAbilityRules,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import flash from 'connect-flash';
@@ -29,6 +33,7 @@ import reDoc from 'redoc-express';
 import { URL } from 'url';
 import cors from 'cors';
 import { produce } from 'immer';
+import { AbilityBuilder } from '@casl/ability';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import {
     ClientProviderMap,
@@ -88,7 +93,7 @@ declare global {
             clients: ClientRepository;
         }
 
-        interface User extends SessionUser {}
+        interface User extends SessionLightdashUser, SessionServiceAccount {}
     }
 }
 

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -47,6 +47,18 @@ export const unauthorisedInDemo: RequestHandler = (req, res, next) => {
     }
 };
 
+export const allowServiceAccountAuthentication: RequestHandler = (
+    req,
+    res,
+    next,
+) => {
+    if (req.isAuthenticated()) {
+        next();
+        return;
+    }
+
+    authenticateServiceAccount(req, res, next);
+};
 /*
 This middleware is used to enable Api tokens and service accounts
 We first check service accounts (bearer header),

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -68,6 +68,7 @@ import express from 'express';
 import type { DbTagUpdate } from '../database/entities/tags';
 import {
     allowApiKeyAuthentication,
+    allowServiceAccountAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
 } from './authentication';
@@ -306,7 +307,11 @@ export class ProjectController extends BaseController {
     /**
      * List group access for projects
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowServiceAccountAuthentication,
+        allowApiKeyAuthentication,
+        isAuthenticated,
+    ])
     @SuccessResponse('200', 'Success')
     @Get('{projectUuid}/groupAccesses')
     @OperationId('GetProjectGroupAccesses')

--- a/packages/backend/src/models/DashboardModel/PersonalAccessTokenModel.ts
+++ b/packages/backend/src/models/DashboardModel/PersonalAccessTokenModel.ts
@@ -3,6 +3,7 @@ import {
     NotFoundError,
     PersonalAccessToken,
     PersonalAccessTokenWithToken,
+    SessionLightdashUser,
     SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
@@ -107,7 +108,7 @@ export class PersonalAccessTokenModel {
     Generates a new token and saves it
     */
     async create(
-        user: Pick<SessionUser, 'userId'>,
+        user: Pick<SessionLightdashUser, 'userId'>,
         data: CreatePersonalAccessToken,
     ): Promise<PersonalAccessTokenWithToken> {
         const token = crypto.randomBytes(16).toString('hex');
@@ -122,7 +123,7 @@ export class PersonalAccessTokenModel {
     it might be provided by the user, or generated automatically on this.create
     */
     async save(
-        user: Pick<SessionUser, 'userId'>,
+        user: Pick<SessionLightdashUser, 'userId'>,
         data: CreatePersonalAccessToken & { token: string },
     ): Promise<PersonalAccessTokenWithToken> {
         const tokenHash = PersonalAccessTokenModel._hash(data.token);

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -565,6 +565,7 @@ export class UserModel {
             userId: user.user_id,
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
+            accountType: 'user',
             ...lightdashUser,
         };
     }
@@ -727,6 +728,7 @@ export class UserModel {
             userId: user.user_id,
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
+            accountType: 'user',
         };
     }
 
@@ -770,6 +772,7 @@ export class UserModel {
             userId: user.user_id,
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
+            accountType: 'user',
         };
     }
 
@@ -809,13 +812,14 @@ export class UserModel {
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
             userId: user.user_id,
+            accountType: 'user',
         };
     }
 
     static lightdashUserFromSession(
         sessionUser: SessionUser,
     ): LightdashUserWithAbilityRules {
-        const { userId, ability, ...lightdashUser } = sessionUser;
+        const { ability, ...lightdashUser } = sessionUser;
         return lightdashUser;
     }
 
@@ -836,6 +840,10 @@ export class UserModel {
             throw new ParameterError("Password doesn't meet requirements");
         }
         const user = await this.findSessionUserByUUID(userUuid);
+        if (user.accountType === 'serviceAccount') {
+            throw new ForbiddenError('Service accounts cannot upsertPassword');
+        }
+
         await this.database(PasswordLoginTableName)
             .insert({
                 user_id: user.userId,
@@ -889,6 +897,7 @@ export class UserModel {
                 pat: this.lightdashConfig.auth.pat,
             },
         });
+
         return {
             user: {
                 ...mapDbUserDetailsToLightdashUser(
@@ -898,6 +907,7 @@ export class UserModel {
                 abilityRules: abilityBuilder.rules,
                 ability: abilityBuilder.build(),
                 userId: row.user_id,
+                accountType: 'user',
             },
             personalAccessToken:
                 PersonalAccessTokenModel.mapDbObjectToPersonalAccessToken(row),

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -891,6 +891,11 @@ export class CoderService extends BaseService {
         let parentSpaceUuid = closestAncestorSpaceUuid;
         let parentPath = closestAncestorSpace?.path ?? '';
         const newSpaces: Space[] = [];
+
+        if (user.accountType === 'serviceAccount') {
+            throw new ForbiddenError('Service accounts cannot create spaces');
+        }
+
         for await (const currentPath of remainingPath) {
             if (!parentPath) {
                 parentPath = currentPath;

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -345,6 +345,10 @@ describe('UserService', () => {
             );
         });
         test('should link openid with authenticated user', async () => {
+            if (authenticatedUser.accountType === 'serviceAccount') {
+                throw new Error('Service accounts cannot link identities');
+            }
+
             await userService.loginWithOpenId(
                 openIdUser,
                 authenticatedUser,
@@ -369,6 +373,10 @@ describe('UserService', () => {
             );
         });
         test('should link openid to an existing user that has another OIDC with the same email', async () => {
+            if (sessionUser.accountType === 'serviceAccount') {
+                throw new Error('Service accounts cannot link identities');
+            }
+
             const service = createUserService({
                 ...lightdashConfigMock,
                 auth: {
@@ -396,6 +404,10 @@ describe('UserService', () => {
             );
         });
         test('should link openid to an existing user that has the same verified email', async () => {
+            if (sessionUser.accountType === 'serviceAccount') {
+                throw new Error('Service accounts cannot link identities');
+            }
+
             const service = createUserService({
                 ...lightdashConfigMock,
                 auth: {

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -36,7 +36,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         : undefined;
     const headers = {
         'Content-Type': 'application/json',
-        Authorization: `ApiKey ${config.context.apiKey}`,
+        Authorization: `Bearer ${config.context.apiKey}`,
         [LightdashRequestMethodHeader]:
             process.env.CI === 'true'
                 ? RequestMethod.CLI_CI

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -1,6 +1,6 @@
 import { type ScimSchemaType, type ServiceAccount } from '..';
 
-export type SessionServiceAccount = {
+export type SessionScim = {
     organizationUuid: string;
 };
 

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -42,8 +42,16 @@ export interface LightdashUserWithAbilityRules extends LightdashUser {
     abilityRules: AbilityBuilder<MemberAbility>['rules'];
 }
 
-export interface SessionUser extends LightdashUserWithAbilityRules {
+export type SessionUser = SessionLightdashUser | SessionServiceAccount;
+
+export interface SessionLightdashUser extends LightdashUserWithAbilityRules {
     userId: number;
+    accountType: 'user';
+    ability: MemberAbility;
+}
+
+export interface SessionServiceAccount extends LightdashUserWithAbilityRules {
+    accountType: 'serviceAccount';
     ability: MemberAbility;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:
Adds support for service account authentication to additional endpoints by implementing the `allowServiceAccountAuthentication` middleware. This PR also introduces proper type differentiation between user accounts and service accounts with the `accountType` property, preventing service accounts from performing user-specific actions like creating organizations, spaces, passwords, or linking identities.

The changes include:
- Added a new middleware `allowServiceAccountAuthentication` to enable service account access to specific endpoints
- Updated the session user types to distinguish between regular users and service accounts
- Added proper authorization checks to prevent service accounts from performing unauthorized actions
- Updated the CLI to use Bearer token authentication instead of ApiKey
- Added an example API request to demonstrate service account authentication behavior

diff --git packages/backend/src/controllers/organizationController.ts packages/backend/src/controllers/organizationController.ts
index bf77efc593..afd923481b 100644
--- packages/backend/src/controllers/organizationController.ts
+++ packages/backend/src/controllers/organizationController.ts
@@ -163,7 +163,11 @@ export class OrganizationController extends BaseController {
      * Gets all projects of the current user's organization
      * @param req express request
      */
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Middlewares([
+        allowServiceAccountAuthentication,
+        allowApiKeyAuthentication,
+        isAuthenticated,
+    ])