### PR TITLE
feat: add service account token to CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,10 +41,12 @@
         "@types/node-fetch": "2.x",
         "@types/nunjucks": "^3.2.1",
         "@types/parse-node-version": "^1.0.0",
-        "@types/uuid": "^10.0.0"
+        "@types/uuid": "^10.0.0",
+        "ts-node": "^10.9.2"
     },
     "scripts": {
         "test": "jest",
+        "dev": "ts-node src/index.ts",
         "build": "tsc --build tsconfig.json",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "prettier --config .prettierrc.js --ignore-unknown --ignore-path ./../../.gitignore",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,6 +18,10 @@ export type Config = {
         serverUrl?: string;
         project?: string;
         projectName?: string;
+        /**
+         * This is an API token that is used to authenticate with the Lightdash API.
+         * It could be a personal access token or a service account token.
+         */
         apiKey?: string;
         proxyAuthorization?: string;
         previewProject?: string;
@@ -28,7 +32,7 @@ export type Config = {
     };
 };
 
-export const setConfig = async (config: Config) => {
+const setConfig = async (config: Config) => {
     await fs.mkdir(path.dirname(configFilePath), { recursive: true });
     await fs.writeFile(configFilePath, yaml.dump(config), 'utf8');
 };

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -4,14 +4,13 @@ import {
     ApiResponse,
     AuthorizationError,
     LightdashError,
-    LightdashRequestMethodHeader,
-    RequestMethod,
 } from '@lightdash/common';
 import fetch, { BodyInit } from 'node-fetch';
 import { URL } from 'url';
 import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
+import { buildRequestHeaders } from '../utils';
 
 const { version: VERSION } = require('../../../package.json');
 
@@ -31,18 +30,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             `Not logged in. Run 'lightdash login --help'`,
         );
     }
-    const proxyAuthorizationHeader = config.context.proxyAuthorization
-        ? { 'Proxy-Authorization': config.context.proxyAuthorization }
-        : undefined;
-    const headers = {
-        'Content-Type': 'application/json',
-        Authorization: `ApiKey ${config.context.apiKey}`,
-        [LightdashRequestMethodHeader]:
-            process.env.CI === 'true'
-                ? RequestMethod.CLI_CI
-                : RequestMethod.CLI,
-        ...proxyAuthorizationHeader,
-    };
+    const headers = buildRequestHeaders(config.context.apiKey);
     const fullUrl = new URL(url, config.context.serverUrl).href;
     GlobalState.debug(`> Making HTTP ${method} request to: ${fullUrl}`);
 

--- a/packages/cli/src/handlers/utils.ts
+++ b/packages/cli/src/handlers/utils.ts
@@ -1,0 +1,49 @@
+import {
+    AuthTokenPrefix,
+    LightdashRequestMethodHeader,
+    RequestMethod,
+} from '@lightdash/common';
+
+enum TokenType {
+    ApiKey = 'ApiKey',
+    Bearer = 'Bearer',
+}
+
+type RequestHeader = {
+    'Content-Type': 'application/json';
+    Authorization: string;
+    'Proxy-Authorization'?: string;
+    [LightdashRequestMethodHeader]: RequestMethod;
+};
+
+/**
+ * We initially used personal access tokens (PATs) for CLI authentication without any prefix.
+ * Service account tokens are launching with a prefix, so we'll check them first.
+ * We assume a missing prefix is a personal access token, although new PATs will be created with a prefix.
+ *
+ * See {@link AuthTokenPrefix} for the available token prefixes
+ */
+function getAuthHeader(token: string) {
+    const authType = token?.startsWith(AuthTokenPrefix.SERVICE_ACCOUNT)
+        ? TokenType.Bearer
+        : TokenType.ApiKey;
+    return `${authType} ${token}`;
+}
+
+export function buildRequestHeaders(token: string) {
+    const headers: RequestHeader = {
+        'Content-Type': 'application/json',
+        Authorization: getAuthHeader(token),
+        [LightdashRequestMethodHeader]:
+            process.env.CI === 'true'
+                ? RequestMethod.CLI_CI
+                : RequestMethod.CLI,
+    };
+
+    if (process.env.LIGHTDASH_PROXY_AUTHORIZATION) {
+        headers['Proxy-Authorization'] =
+            process.env.LIGHTDASH_PROXY_AUTHORIZATION;
+    }
+
+    return headers;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -173,11 +173,11 @@ ${styles.bold('Examples:')}
   ${styles.title('⚡')}️lightdash ${styles.bold(
             'login',
         )} https://custom.lightdash.domain --token 12345 ${styles.secondary(
-            '-- Logs in with a personal access token (useful for users that use SSO in the browser)',
+            '-- Logs in with an API access token (useful for users that use SSO in the browser)',
         )}
 `,
     )
-    .option('--token <token>', 'Login with a personal access token', undefined)
+    .option('--token <token>', 'Login with an API access token', undefined)
     .option('--verbose', undefined, false)
 
     .action(login);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,6 +598,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.15.3)(typescript@5.7.2)
 
   packages/common:
     dependencies:
@@ -16662,7 +16665,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19924,7 +19927,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -19941,7 +19944,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -21834,7 +21837,7 @@ snapshots:
       chalk: 2.4.2
       commander: 2.20.3
       core-js: 3.38.0
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-json-patch: 3.1.1
       get-stdin: 6.0.0
       http-proxy-agent: 5.0.0
@@ -26253,7 +26256,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -28363,7 +28366,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/15390

### Description:
I created a new branch for this based on the proper CASL PR from @rephus. 

Adds support for service account tokens in the CLI by updating the authentication mechanism to handle both personal access tokens (PATs) and service account tokens.

Key changes:
- Renamed `apiKey` to `apiToken` throughout the codebase to better reflect that it can be either a PAT or service account token
- Added token type detection based on prefixes to determine the correct authorization header format
- Created a utility function `buildRequestHeaders` to centralize header creation logic
- Added a `dev` script to the CLI package for easier local development with ts-node
- Updated login handler to properly process token authentication responses
