### PR TITLE
fix: perform getCatalog requests in batches

### DIFF
--- a/packages/warehouses/src/utils/processPromisesInBatches.ts
+++ b/packages/warehouses/src/utils/processPromisesInBatches.ts
@@ -1,0 +1,19 @@
+export async function processPromisesInBatches<T, R>(
+    items: Array<T>,
+    batchSize: number,
+    fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+    let results: R[] = [];
+    /* eslint-disable no-await-in-loop */
+    for (let start = 0; start < items.length; start += batchSize) {
+        const end = Math.min(start + batchSize, items.length);
+        const slicedResults = await Promise.all(
+            items.slice(start, end).map(fn),
+        );
+        results = [...results, ...slicedResults];
+    }
+    /* eslint-enable no-await-in-loop */
+    return results;
+}
+
+export const DEFAULT_BATCH_SIZE = 100;

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -28,6 +28,10 @@ import {
 import { pipeline, Transform, Writable } from 'stream';
 import * as Util from 'util';
 import { WarehouseCatalog } from '../types';
+import {
+    DEFAULT_BATCH_SIZE,
+    processPromisesInBatches,
+} from '../utils/processPromisesInBatches';
 import WarehouseBaseClient from './WarehouseBaseClient';
 
 const assertIsSnowflakeLoggingLevel = (
@@ -583,12 +587,12 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             table: string;
         }[],
     ) {
-        const tablesMetadataPromises = config.map(
-            ({ database, schema, table }) =>
+        const tablesMetadata = await processPromisesInBatches(
+            config,
+            DEFAULT_BATCH_SIZE,
+            async ({ database, schema, table }) =>
                 this.runTableCatalogQuery(database, schema, table),
         );
-
-        const tablesMetadata = await Promise.all(tablesMetadataPromises);
 
         return tablesMetadata.reduce<WarehouseCatalog>((acc, tableMetadata) => {
             if (tableMetadata) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Performs catalog requests in batches instead of using `Promise.all`

Internal thread: https://lightdash.slack.com/archives/C03MCQ08UKS/p1749567281085269

test-frontend
test-backend
test-cli
