### PR TITLE
feat: improve sql runner completion

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -19,6 +19,11 @@ import { LanguageIdEnum, setupLanguageFeatures } from 'monaco-sql-languages';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import '../../../styles/monaco.css';
+import { useDetectedTableFields } from '../hooks/useDetectedTableFields';
+import {
+    useTableFields,
+    type WarehouseTableFieldWithContext,
+} from '../hooks/useTableFields';
 import { useTables, type TablesBySchema } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql } from '../store/sqlRunnerSlice';
@@ -131,8 +136,9 @@ const registerCustomCompletionProvider = (
     language: string,
     quoteChar: string,
     tables: string[],
+    fields?: WarehouseTableFieldWithContext[],
 ) => {
-    monaco.languages.registerCompletionItemProvider(language, {
+    return monaco.languages.registerCompletionItemProvider(language, {
         provideCompletionItems: (model, position) => {
             const wordUntilPosition = model.getWordUntilPosition(position);
             const range = {
@@ -149,31 +155,61 @@ const registerCustomCompletionProvider = (
                 endColumn: position.column,
             });
 
-            const suggestions: languages.CompletionItem[] = tables.map(
-                (table) => {
-                    const parts = table.split('.');
-                    const typedParts = textUntilPosition.split('.');
-                    const insertParts = parts.slice(typedParts.length - 1);
+            const suggestions: languages.CompletionItem[] = [];
 
-                    // Check if the last typed part is already quoted
-                    const lastTypedPart = typedParts[typedParts.length - 1];
-                    const isLastPartQuoted =
-                        lastTypedPart.startsWith(`${quoteChar}`) &&
-                        !lastTypedPart.endsWith(`${quoteChar}`);
+            // Add field suggestions first (top priority)
+            if (fields && fields.length > 0) {
+                const fieldSuggestions = fields.map((field) => {
+                    // Check if field has table context information
+                    const hasTableContext =
+                        'table' in field && 'schema' in field;
+                    const tableContext = hasTableContext
+                        ? ` from ${field.schema}.${field.table}`
+                        : '';
 
-                    let insertText = insertParts.join('.');
-                    if (isLastPartQuoted) {
-                        // Remove the opening quote from the first part to insert
-                        insertText = insertText.replace(/^${quoteChar}/, '');
-                    }
                     return {
-                        label: table,
-                        kind: monaco.languages.CompletionItemKind.Class,
-                        insertText: insertText,
+                        label: `${field.name} (${field.type})${tableContext}`,
+                        kind: monaco.languages.CompletionItemKind.Field,
+                        insertText: `${quoteChar}${field.name}${quoteChar}`,
                         range,
+                        sortText: `0${field.name}`, // High priority with '0' prefix
+                        detail: `Column: ${field.type}${tableContext}`,
                     };
-                },
-            );
+                });
+                const setOfSuggestions = new Set(suggestions);
+                fieldSuggestions.forEach((suggestion) => {
+                    setOfSuggestions.add(suggestion);
+                });
+                suggestions.push(...Array.from(setOfSuggestions));
+            }
+
+            // Add table suggestions (lower priority)
+            const tableSuggestions = tables.map((table) => {
+                const parts = table.split('.');
+                const typedParts = textUntilPosition.split('.');
+                const insertParts = parts.slice(typedParts.length - 1);
+
+                // Check if the last typed part is already quoted
+                const lastTypedPart = typedParts[typedParts.length - 1];
+                const isLastPartQuoted =
+                    lastTypedPart.startsWith(`${quoteChar}`) &&
+                    !lastTypedPart.endsWith(`${quoteChar}`);
+
+                let insertText = insertParts.join('.');
+                if (isLastPartQuoted) {
+                    // Remove the opening quote from the first part to insert
+                    insertText = insertText.replace(/^${quoteChar}/, '');
+                }
+                return {
+                    label: table,
+                    kind: monaco.languages.CompletionItemKind.Class,
+                    insertText: insertText,
+                    range,
+                    sortText: `1${table}`, // Lower priority with '1' prefix
+                    detail: 'Table',
+                };
+            });
+            suggestions.push(...tableSuggestions);
 
             return { suggestions };
         },
@@ -214,6 +250,19 @@ export const SqlEditor: FC<{
     const { data: tablesData, isLoading: isTablesDataLoading } = useTables({
         projectUuid,
     });
+
+    const currentTable = useAppSelector((state) => state.sqlRunner.activeTable);
+    const currentSchema = useAppSelector(
+        (state) => state.sqlRunner.activeSchema,
+    );
+
+    const { data: tableFieldsData } = useTableFields({
+        projectUuid,
+        tableName: currentTable,
+        schema: currentSchema,
+        search: undefined,
+    });
+
     const transformedData:
         | { database: string; tablesBySchema: TablesBySchema }
         | undefined = useMemo(() => {
@@ -230,6 +279,15 @@ export const SqlEditor: FC<{
             tablesBySchema,
         };
     }, [tablesData]);
+
+    // Use React Query to fetch field data for all detected tables in SQL
+    const { data: detectedTablesFieldData } = useDetectedTableFields({
+        sql,
+        quoteChar,
+        projectUuid,
+        transformedData,
+    });
+
     const editorRef = useRef<Parameters<OnMount>['0'] | null>(null);
 
     const language = useMemo(
@@ -245,28 +303,14 @@ export const SqlEditor: FC<{
                 inherit: true,
                 ...LIGHTDASH_THEME,
             });
-
-            if (transformedData && quoteChar) {
-                const tablesList = generateTableCompletions(
-                    quoteChar,
-                    transformedData,
-                );
-                if (tablesList && tablesList.length > 0) {
-                    registerCustomCompletionProvider(
-                        monaco,
-                        language,
-                        quoteChar,
-                        tablesList,
-                    );
-                }
-            }
         },
-        [language, quoteChar, transformedData],
+        [language],
     );
 
     const monaco = useMonaco();
     const decorationsCollectionRef =
         useRef<editor.IEditorDecorationsCollection | null>(null); // Ref to store the decorations collection
+    const completionProviderRef = useRef<{ dispose: () => void } | null>(null); // Ref to store the completion provider
 
     const onMount: OnMount = useCallback(
         (editorObj, monacoObj) => {
@@ -287,6 +331,61 @@ export const SqlEditor: FC<{
         },
         [onSubmit],
     );
+
+    // Register completion provider reactively when data changes
+    useEffect(() => {
+        if (!monaco || !transformedData || !quoteChar) return;
+
+        // Dispose of the previous completion provider
+        if (completionProviderRef.current) {
+            completionProviderRef.current.dispose();
+            completionProviderRef.current = null;
+        }
+
+        const tablesList = generateTableCompletions(quoteChar, transformedData);
+
+        // Transform current table fields to include context and combine with detected table fields
+        const currentTableFieldsWithContext = (tableFieldsData || []).map(
+            (field) => ({
+                ...field,
+                table: currentTable || '',
+                schema: currentSchema || '',
+            }),
+        );
+
+        const allFieldsData = [
+            ...currentTableFieldsWithContext,
+            ...(detectedTablesFieldData || []),
+        ];
+
+        if (tablesList && tablesList.length > 0) {
+            const provider = registerCustomCompletionProvider(
+                monaco,
+                language,
+                quoteChar,
+                tablesList,
+                allFieldsData.length > 0 ? allFieldsData : undefined,
+            );
+            completionProviderRef.current = provider;
+        }
+
+        // Cleanup function to dispose provider on unmount
+        return () => {
+            if (completionProviderRef.current) {
+                completionProviderRef.current.dispose();
+                completionProviderRef.current = null;
+            }
+        };
+    }, [
+        monaco,
+        language,
+        quoteChar,
+        transformedData,
+        tableFieldsData,
+        detectedTablesFieldData,
+        currentTable,
+        currentSchema,
+    ]);
 
     useEffect(() => {
         // remove any existing decorations

--- a/packages/frontend/src/features/sqlRunner/hooks/useDetectedTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useDetectedTableFields.tsx
@@ -1,0 +1,157 @@
+import { useMemo } from 'react';
+import {
+    useMultipleTableFields,
+    type TableReference,
+} from './useMultipleTableFields';
+import { type TablesBySchema } from './useTables';
+
+const parseTableReferencesFromSQL = (
+    sql: string,
+    quoteChar: string,
+): Array<{
+    database?: string;
+    schema?: string;
+    table: string;
+    fullReference: string;
+}> => {
+    if (!sql) return [];
+
+    const tableReferences: Array<{
+        database?: string;
+        schema?: string;
+        table: string;
+        fullReference: string;
+    }> = [];
+
+    // Regex to match quoted identifiers in SQL
+    // This matches patterns like: "database"."schema"."table" or schema.table or just table
+    const quotedIdentifierRegex = new RegExp(
+        `\\${quoteChar}([^${quoteChar}]+)\\${quoteChar}(?:\\.\\${quoteChar}([^${quoteChar}]+)\\${quoteChar})?(?:\\.\\${quoteChar}([^${quoteChar}]+)\\${quoteChar})?`,
+        'gi',
+    );
+
+    // Also match unquoted identifiers (word.word.word pattern)
+    const unquotedIdentifierRegex =
+        /\b([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*){1,2})\b/g;
+
+    let match;
+
+    // Parse quoted identifiers
+    while ((match = quotedIdentifierRegex.exec(sql)) !== null) {
+        const parts = [match[1], match[2], match[3]].filter(Boolean);
+        const fullReference = match[0];
+
+        if (parts.length === 3) {
+            // database.schema.table
+            tableReferences.push({
+                database: parts[0],
+                schema: parts[1],
+                table: parts[2],
+                fullReference,
+            });
+        } else if (parts.length === 2) {
+            // schema.table
+            tableReferences.push({
+                schema: parts[0],
+                table: parts[1],
+                fullReference,
+            });
+        } else if (parts.length === 1) {
+            // just table
+            tableReferences.push({
+                table: parts[0],
+                fullReference,
+            });
+        }
+    }
+
+    // Parse unquoted identifiers
+    while ((match = unquotedIdentifierRegex.exec(sql)) !== null) {
+        const parts = match[1].split('.');
+        const fullReference = match[0];
+
+        if (parts.length === 3) {
+            // database.schema.table
+            tableReferences.push({
+                database: parts[0],
+                schema: parts[1],
+                table: parts[2],
+                fullReference,
+            });
+        } else if (parts.length === 2) {
+            // schema.table
+            tableReferences.push({
+                schema: parts[0],
+                table: parts[1],
+                fullReference,
+            });
+        }
+    }
+
+    // Remove duplicates based on fullReference
+    const uniqueReferences = tableReferences.filter(
+        (ref, index, self) =>
+            index ===
+            self.findIndex((r) => r.fullReference === ref.fullReference),
+    );
+
+    return uniqueReferences;
+};
+
+export const useDetectedTableFields = ({
+    sql,
+    quoteChar,
+    projectUuid,
+    transformedData,
+}: {
+    sql: string;
+    quoteChar: string;
+    projectUuid: string;
+    transformedData?: { database: string; tablesBySchema: TablesBySchema };
+}) => {
+    // Parse SQL to detect table references
+    const detectedTables = useMemo(() => {
+        if (!sql || !quoteChar) return [];
+        return parseTableReferencesFromSQL(sql, quoteChar);
+    }, [sql, quoteChar]);
+
+    // Filter and prepare table references for React Query
+    const tableReferences = useMemo((): TableReference[] => {
+        if (!transformedData || !projectUuid || detectedTables.length === 0) {
+            return [];
+        }
+
+        return detectedTables
+            .filter((tableRef) => {
+                // Only include tables that exist in our catalog
+                if (!tableRef.database || !tableRef.schema) {
+                    return false;
+                }
+
+                const matchesCurrentDatabase =
+                    tableRef.database === transformedData.database;
+                const schemaExists = transformedData.tablesBySchema?.some(
+                    (s) => s.schema === tableRef.schema,
+                );
+                const tableExists = transformedData.tablesBySchema
+                    ?.find((s) => s.schema === tableRef.schema)
+                    ?.tables.hasOwnProperty(tableRef.table);
+
+                return matchesCurrentDatabase && schemaExists && tableExists;
+            })
+            .map((tableRef) => ({
+                projectUuid,
+                tableName: tableRef.table,
+                schema: tableRef.schema!,
+            }));
+    }, [detectedTables, transformedData, projectUuid]);
+
+    // Use the new multi-table fields hook
+    const result = useMultipleTableFields(tableReferences);
+
+    return {
+        ...result,
+        detectedTableCount: detectedTables.length,
+        validTableCount: tableReferences.length,
+    };
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useMultipleTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useMultipleTableFields.tsx
@@ -1,0 +1,94 @@
+import { type ApiError, type WarehouseTableSchema } from '@lightdash/common';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import {
+    fetchTableFields,
+    type WarehouseTableFieldWithContext,
+} from './useTableFields';
+
+export type TableReference = {
+    projectUuid: string;
+    tableName: string;
+    schema: string;
+};
+
+export const useMultipleTableFields = (tableReferences: TableReference[]) => {
+    // Create queries for each unique table reference
+    const queries = useMemo(() => {
+        // Deduplicate table references based on projectUuid + schema + tableName
+        const uniqueReferences = tableReferences.filter(
+            (ref, index, self) =>
+                index ===
+                self.findIndex(
+                    (r) =>
+                        r.projectUuid === ref.projectUuid &&
+                        r.schema === ref.schema &&
+                        r.tableName === ref.tableName,
+                ),
+        );
+
+        return uniqueReferences.map((ref) => ({
+            queryKey: [
+                'sqlRunner',
+                'tables',
+                ref.tableName,
+                ref.projectUuid,
+                ref.schema,
+            ],
+            queryFn: () =>
+                fetchTableFields({
+                    projectUuid: ref.projectUuid,
+                    tableName: ref.tableName,
+                    schema: ref.schema,
+                }),
+            retry: false,
+            enabled: !!(ref.projectUuid && ref.tableName && ref.schema),
+            staleTime: 5 * 60 * 1000, // 5 minutes - keep data fresh but allow caching
+            meta: {
+                tableName: ref.tableName,
+                schema: ref.schema,
+                projectUuid: ref.projectUuid,
+            },
+        }));
+    }, [tableReferences]);
+
+    const results = useQueries({
+        queries,
+    });
+
+    const allFieldsWithContext =
+        useMemo((): WarehouseTableFieldWithContext[] => {
+            return results
+                .filter((result) => result.isSuccess && result.data)
+                .flatMap((result, index) => {
+                    const data = result.data as WarehouseTableSchema;
+                    // Get the corresponding query meta data
+                    const queryMeta = queries[index]?.meta;
+                    const table = queryMeta?.tableName || '';
+                    const schema = queryMeta?.schema || '';
+
+                    return Object.entries(
+                        data,
+                    ).map<WarehouseTableFieldWithContext>(([name, type]) => ({
+                        name,
+                        type,
+                        table,
+                        schema,
+                    }));
+                });
+        }, [results, queries]);
+
+    // Aggregate loading and error states
+    const isLoading = results.some((result) => result.isLoading);
+    const isError = results.some((result) => result.isError);
+    const errors = results
+        .filter((result) => result.isError)
+        .map((result) => result.error as ApiError);
+
+    return {
+        data: allFieldsWithContext,
+        isLoading,
+        isError,
+        errors,
+    };
+};

--- a/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
@@ -14,7 +14,7 @@ export type GetTableFieldsParams = {
     search: string | undefined;
 };
 
-const fetchTableFields = async ({
+export const fetchTableFields = async ({
     projectUuid,
     tableName,
     schema,
@@ -34,6 +34,11 @@ const fetchTableFields = async ({
 export type WarehouseTableField = {
     name: string;
     type: DimensionType;
+};
+
+export type WarehouseTableFieldWithContext = WarehouseTableField & {
+    table: string;
+    schema: string;
 };
 
 export const useTableFields = ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15437

### Description:

Enhanced SQL editor autocomplete with column suggestions. The editor now detects tables in the SQL query and provides intelligent field suggestions with type information alongside table suggestions.

Key improvements:
- Added column autocomplete with data types in the SQL editor
- Implemented detection of table references in SQL queries
- Created new hooks to fetch and manage field data for multiple tables
- Prioritized field suggestions over table suggestions in the autocomplete dropdown
- Added context information to show which table/schema a field belongs to

> [!IMPORTANT]
> we never had field suggestions 

To try it out: 

type `e` or `o` to get autocomplete of the orders and/or events table

then whenever you type another character you get the fields both tables have, filtered! 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/5dcdf126-f170-417d-8e7a-506bf5587109.png)
