### PR TITLE
fix: bring back table wide conditional formatting

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -103,7 +103,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                     // Reset the config if the field type changes
                     // TODO: move to a helper function
                     const shouldReset =
-                        (isNumericItem(currentField) &&
+                        ((!currentField || isNumericItem(currentField)) &&
                             isStringDimension(newField)) ||
                         (isStringDimension(currentField) &&
                             isNumericItem(newField));
@@ -377,7 +377,8 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                             ConditionalFormattingConfigType
                                                 .Range
                                         ],
-                                        disabled: !isNumericItem(field),
+                                        disabled:
+                                            field && !isNumericItem(field),
                                     },
                                 ]}
                                 value={getConditionalFormattingConfigType(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14671](https://github.com/lightdash/lightdash/issues/14671)

This brings back the ability of using range conditional formatting to when there's no field selected - check comment below

### Description:

**Before**
![image](https://github.com/user-attachments/assets/198dbdcc-2a5a-40c9-9d91-6a6008757270)

**After**
![image](https://github.com/user-attachments/assets/04c3151c-2d50-43fe-9f7c-0210c043644c)

