### PR TITLE
feat(backend): add streaming support for AI agent thread responses

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -28,6 +28,8 @@ import {
     QueryExecutionContext,
     SlackPrompt,
     UnexpectedServerError,
+    UpdateSlackResponse,
+    UpdateWebAppResponse,
     type SessionUser,
 } from '@lightdash/common';
 import { MessageElement } from '@slack/web-api/dist/response/ConversationsHistoryResponse';
@@ -44,7 +46,7 @@ import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagServic
 import { ProjectService } from '../../services/ProjectService/ProjectService';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { CommercialSchedulerClient } from '../scheduler/SchedulerClient';
-import { runAgent } from './ai/agents/agent';
+import { generateAgentResponse, streamAgentResponse } from './ai/agents/agent';
 import { generateEmbeddingsNameAndDescription } from './ai/embeds/embed';
 import { getModel } from './ai/models';
 import { getChatHistoryFromThreadMessages } from './ai/prompts/conversationHistory';
@@ -726,16 +728,87 @@ export class AiAgentService {
             const chatHistoryMessages =
                 getChatHistoryFromThreadMessages(threadMessages);
 
-            const response = await this.generateExploreResult(
+            const response = await this.generateOrStreamAgentResponse(
                 user,
                 chatHistoryMessages,
-                prompt,
+                {
+                    prompt,
+                    stream: false,
+                },
             );
 
             await this.aiAgentModel.updateWebAppResponse({
                 promptUuid,
                 response,
             });
+        } catch (e) {
+            Logger.error('Failed to generate agent thread response:', e);
+            throw new Error('Failed to generate agent thread response');
+        }
+    }
+
+    async streamAgentThreadResponse(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+        },
+    ): Promise<ReturnType<typeof streamAgentResponse>> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const thread = await this.aiAgentModel.findThread(threadUuid);
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        const { organizationUuid, projectUuid } = thread;
+
+        if (thread.organizationUuid !== user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const threadMessages = await this.aiAgentModel.getThreadMessages(
+            organizationUuid,
+            projectUuid,
+            threadUuid,
+        );
+
+        if (threadMessages.length === 0) {
+            throw new Error(
+                `No messages found in thread: ${threadUuid}. ${agentUuid}`,
+            );
+        }
+
+        const prompt = await this.aiAgentModel.findWebAppPrompt(
+            threadMessages[threadMessages.length - 1].ai_prompt_uuid,
+        );
+
+        if (!prompt) {
+            throw new NotFoundError(
+                `Prompt not found: ${
+                    threadMessages[threadMessages.length - 1].ai_prompt_uuid
+                }`,
+            );
+        }
+
+        try {
+            const chatHistoryMessages =
+                getChatHistoryFromThreadMessages(threadMessages);
+
+            const response = await this.generateOrStreamAgentResponse(
+                user,
+                chatHistoryMessages,
+                {
+                    prompt,
+                    stream: true,
+                },
+            );
+            return response;
         } catch (e) {
             Logger.error('Failed to generate agent thread response:', e);
             throw new Error('Failed to generate agent thread response');
@@ -1207,11 +1280,47 @@ export class AiAgentService {
         };
     }
 
-    async generateExploreResult(
+    async generateOrStreamAgentResponse(
         user: SessionUser,
         messageHistory: CoreMessage[],
-        slackOrWebAppPrompt: SlackPrompt | AiWebAppPrompt,
-    ): Promise<string> {
+        options: {
+            prompt: AiWebAppPrompt;
+            stream: true;
+        },
+    ): Promise<ReturnType<typeof streamAgentResponse>>;
+    async generateOrStreamAgentResponse(
+        user: SessionUser,
+        messageHistory: CoreMessage[],
+        options: {
+            prompt: AiWebAppPrompt;
+            stream: false;
+        },
+    ): Promise<string>;
+    async generateOrStreamAgentResponse(
+        user: SessionUser,
+        messageHistory: CoreMessage[],
+        options: {
+            prompt: SlackPrompt;
+            stream: false;
+        },
+    ): Promise<string>;
+    async generateOrStreamAgentResponse(
+        user: SessionUser,
+        messageHistory: CoreMessage[],
+        options:
+            | {
+                  prompt: AiWebAppPrompt;
+                  stream: true;
+              }
+            | {
+                  prompt: SlackPrompt;
+                  stream: false;
+              }
+            | {
+                  prompt: AiWebAppPrompt;
+                  stream: false;
+              },
+    ): Promise<string | ReturnType<typeof streamAgentResponse>> {
         if (!user.organizationUuid) {
             throw new Error('Organization not found');
         }
@@ -1220,17 +1329,18 @@ export class AiAgentService {
             throw new Error('AI Copilot is not enabled');
         }
 
-        const { projectUuid } = slackOrWebAppPrompt;
+        const { prompt, stream } = options;
+        const { projectUuid } = prompt;
 
         const agentSettings =
-            'slackChannelId' in slackOrWebAppPrompt
+            'slackChannelId' in prompt
                 ? await this.aiAgentModel.getAgentBySlackChannelId({
                       organizationUuid: user.organizationUuid,
-                      slackChannelId: slackOrWebAppPrompt.slackChannelId,
+                      slackChannelId: prompt.slackChannelId,
                   })
                 : await this.aiAgentModel.getAgent({
-                      organizationUuid: slackOrWebAppPrompt.organizationUuid,
-                      agentUuid: slackOrWebAppPrompt.agentUuid!,
+                      organizationUuid: prompt.organizationUuid,
+                      agentUuid: prompt.agentUuid!,
                   });
 
         const {
@@ -1242,7 +1352,7 @@ export class AiAgentService {
             sendFile,
         } = this.getAiAgentDependencies(
             user,
-            slackOrWebAppPrompt,
+            prompt,
             agentSettings?.tags ?? null,
         );
 
@@ -1254,27 +1364,38 @@ export class AiAgentService {
 
         const model = getModel(this.lightdashConfig.ai.copilot);
 
-        return runAgent({
-            args: {
-                model,
-                agentName: agentSettings.name,
-                instruction: agentSettings.instruction,
-                messageHistory,
-                aiAgentExploreSummaries,
-                promptUuid: slackOrWebAppPrompt.promptUuid,
-                maxLimit: this.lightdashConfig.query.maxLimit,
-            },
-            dependencies: {
-                getExplore,
-                searchFields,
-                runMiniMetricQuery,
-                getPrompt,
-                sendFile,
-                // avoid binding
-                updateProgress: (args) => updateProgress(args),
-                updatePrompt: (args) =>
-                    this.aiAgentModel.updateModelResponse(args),
-            },
+        const args = {
+            model,
+            agentName: agentSettings.name,
+            instruction: agentSettings.instruction,
+            messageHistory,
+            aiAgentExploreSummaries,
+            promptUuid: prompt.promptUuid,
+            maxLimit: this.lightdashConfig.query.maxLimit,
+        };
+
+        const dependencies = {
+            getExplore,
+            searchFields,
+            runMiniMetricQuery,
+            getPrompt,
+            sendFile,
+            // avoid binding
+            updateProgress: (progress: string) => updateProgress(progress),
+            updatePrompt: (
+                update: UpdateSlackResponse | UpdateWebAppResponse,
+            ) => this.aiAgentModel.updateModelResponse(update),
+        };
+
+        if (stream) {
+            return streamAgentResponse({
+                args,
+                dependencies,
+            });
+        }
+        return generateAgentResponse({
+            args,
+            dependencies,
         });
     }
 
@@ -1461,10 +1582,13 @@ export class AiAgentService {
             const chatHistoryMessages =
                 getChatHistoryFromThreadMessages(threadMessages);
 
-            response = await this.generateExploreResult(
+            response = await this.generateOrStreamAgentResponse(
                 user,
                 chatHistoryMessages,
-                slackPrompt,
+                {
+                    prompt: slackPrompt,
+                    stream: false,
+                },
             );
         } catch (e) {
             await this.slackClient.postMessage({
@@ -1716,10 +1840,13 @@ export class AiAgentService {
             throw new Error('Prompt not found');
         }
 
-        const response = await this.generateExploreResult(
+        const response = await this.generateOrStreamAgentResponse(
             user,
             [{ role: 'user', content: question }],
-            webAppPrompt,
+            {
+                prompt: webAppPrompt,
+                stream: false,
+            },
         );
 
         await this.aiAgentModel.updateWebAppResponse({

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -1,9 +1,20 @@
 import { AnyType } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
-import { CoreMessage, generateObject, generateText, NoSuchToolError } from 'ai';
+import {
+    CoreMessage,
+    generateObject,
+    generateText,
+    NoSuchToolError,
+    streamText,
+} from 'ai';
 import type { ZodType } from 'zod';
 
-import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
+import { ServerResponse } from 'http';
+import type {
+    AiAgentArgs,
+    AiAgentDependencies,
+    AiStreamAgentResponseArgs,
+} from '../types/aiAgent';
 
 import { getFindFields } from '../tools/findFields';
 import { getGenerateBarVizConfig } from '../tools/generateBarVizConfig';
@@ -16,13 +27,17 @@ import Logger from '../../../../logging/logger';
 import { getExploreInformationPrompt } from '../prompts/exploreInformation';
 import { getSystemPrompt } from '../prompts/system';
 
-export const runAgent = async ({
-    args,
-    dependencies,
-}: {
-    args: AiAgentArgs;
-    dependencies: AiAgentDependencies;
-}): Promise<string> => {
+const defaultAgentOptions = {
+    toolChoice: 'auto',
+    maxSteps: 10,
+    maxRetries: 3,
+    temperature: 0.2,
+} as const;
+
+const getAgentTools = (
+    args: AiAgentArgs,
+    dependencies: AiAgentDependencies,
+) => {
     const findFields = getFindFields({
         getExplore: dependencies.getExplore,
         searchFields: dependencies.searchFields,
@@ -75,26 +90,36 @@ export const runAgent = async ({
         getOneLineResult,
     };
 
-    const messages: CoreMessage[] = [
-        getSystemPrompt({
-            agentName: args.agentName,
-            instructions: args.instruction || undefined,
-        }),
-        getExploreInformationPrompt({
-            exploreInformation: args.aiAgentExploreSummaries,
-        }),
-        ...args.messageHistory,
-    ];
+    return tools;
+};
+
+const getAgentMessages = (args: AiAgentArgs) => [
+    getSystemPrompt({
+        agentName: args.agentName,
+        instructions: args.instruction || undefined,
+    }),
+    getExploreInformationPrompt({
+        exploreInformation: args.aiAgentExploreSummaries,
+    }),
+    ...args.messageHistory,
+];
+
+export const generateAgentResponse = async ({
+    args,
+    dependencies,
+}: {
+    args: AiAgentArgs;
+    dependencies: AiAgentDependencies;
+}): Promise<string> => {
+    const messages = getAgentMessages(args);
+    const tools = getAgentTools(args, dependencies);
 
     try {
         const result = await generateText({
+            ...defaultAgentOptions,
             model: args.model,
             tools,
-            toolChoice: 'auto',
             messages,
-            maxSteps: 10,
-            maxRetries: 3,
-            temperature: 0.2,
             experimental_repairToolCall: async ({
                 messages: conversationHistory,
                 error,
@@ -131,6 +156,72 @@ export const runAgent = async ({
             },
         });
         return result.text;
+    } catch (error) {
+        Logger.error(error);
+        Sentry.captureException(error);
+        throw error;
+    }
+};
+
+export const streamAgentResponse = async ({
+    args,
+    dependencies,
+}: {
+    args: AiStreamAgentResponseArgs;
+    dependencies: AiAgentDependencies;
+}) => {
+    const messages = getAgentMessages(args);
+    const tools = getAgentTools(args, dependencies);
+
+    try {
+        const result = streamText({
+            ...defaultAgentOptions,
+            model: args.model,
+            tools,
+            messages,
+            experimental_repairToolCall: async ({
+                messages: conversationHistory,
+                error,
+                toolCall,
+                parameterSchema,
+            }) => {
+                if (NoSuchToolError.isInstance(error)) {
+                    return null;
+                }
+
+                const tool = tools[toolCall.toolName as keyof typeof tools];
+
+                // TODO: extract this as separate agent
+                const { object: repairedArgs } = await generateObject({
+                    model: args.model,
+                    schema: tool.parameters as ZodType<AnyType>,
+                    messages: [
+                        ...conversationHistory,
+                        {
+                            role: 'system',
+                            content: [
+                                `The model tried to call the tool "${toolCall.toolName}"` +
+                                    ` with the following arguments:`,
+                                JSON.stringify(toolCall.args),
+                                `The tool accepts the following schema:`,
+                                JSON.stringify(parameterSchema(toolCall)),
+                                'Please fix the arguments.',
+                            ].join('\n'),
+                        },
+                    ],
+                });
+
+                return { ...toolCall, args: JSON.stringify(repairedArgs) };
+            },
+            onFinish: ({ text }) => {
+                void dependencies.updatePrompt({
+                    response: text,
+                    promptUuid: args.promptUuid,
+                });
+            },
+        });
+        await result.consumeStream();
+        return result;
     } catch (error) {
         Logger.error(error);
         Sentry.captureException(error);

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -1,4 +1,5 @@
 import { CoreMessage, LanguageModelV1 } from 'ai';
+import { ServerResponse } from 'http';
 import {
     GetExploreFn,
     GetPromptFn,
@@ -19,6 +20,7 @@ export type AiAgentArgs = {
     aiAgentExploreSummaries: AiAgentExploreSummary[];
     maxLimit: number;
 };
+
 export type AiAgentDependencies = {
     getExplore: GetExploreFn;
     searchFields: SearchFieldsFn | undefined;
@@ -28,3 +30,7 @@ export type AiAgentDependencies = {
     updatePrompt: UpdatePromptFn;
     updateProgress: UpdateProgressFn;
 };
+
+export type AiGenerateAgentResponseArgs = AiAgentArgs;
+
+export type AiStreamAgentResponseArgs = AiAgentArgs;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -7,6 +7,7 @@ import {
     ItemsMap,
     SlackPrompt,
     UpdateSlackResponse,
+    UpdateWebAppResponse,
 } from '@lightdash/common';
 import { PostSlackFile } from '../../../../clients/Slack/SlackClient';
 
@@ -32,4 +33,6 @@ export type RunMiniMetricQueryFn = (metricQuery: AiMetricQuery) => Promise<{
 
 export type SendFileFn = (args: PostSlackFile) => Promise<void>;
 
-export type UpdatePromptFn = (prompt: UpdateSlackResponse) => Promise<void>;
+export type UpdatePromptFn = (
+    prompt: UpdateWebAppResponse | UpdateSlackResponse,
+) => Promise<void>;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1227,7 +1227,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ConditionalOperator: {
+    FilterOperator: {
         dataType: 'refEnum',
         enums: [
             'isNull',
@@ -1252,14 +1252,14 @@ const models: TsoaRoute.Models = {
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'FilterRule_ConditionalOperator.DashboardFieldTarget.AnyType.AnyType_': {
+    'FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_': {
         dataType: 'refObject',
         properties: {
             values: {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
             },
-            operator: { ref: 'ConditionalOperator', required: true },
+            operator: { ref: 'FilterOperator', required: true },
             id: { dataType: 'string', required: true },
             target: { ref: 'DashboardFieldTarget', required: true },
             settings: { ref: 'AnyType' },
@@ -1297,7 +1297,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'FilterRule_ConditionalOperator.DashboardFieldTarget.AnyType.AnyType_',
+                    ref: 'FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -1889,7 +1889,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
             },
-            operator: { ref: 'ConditionalOperator', required: true },
+            operator: { ref: 'FilterOperator', required: true },
             id: { dataType: 'string', required: true },
             target: { ref: 'FieldTarget', required: true },
             settings: { ref: 'AnyType' },
@@ -2074,7 +2074,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
             },
-            operator: { ref: 'ConditionalOperator', required: true },
+            operator: { ref: 'FilterOperator', required: true },
             id: { dataType: 'string', required: true },
             target: {
                 dataType: 'nestedObjectLiteral',
@@ -3021,7 +3021,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ConditionalRule_ConditionalOperator.number-or-string_': {
+    'BaseFilterRule_FilterOperator.number-or-string_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -3036,7 +3036,7 @@ const models: TsoaRoute.Models = {
                         ],
                     },
                 },
-                operator: { ref: 'ConditionalOperator', required: true },
+                operator: { ref: 'FilterOperator', required: true },
                 id: { dataType: 'string', required: true },
             },
             validators: {},
@@ -3048,9 +3048,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'intersection',
             subSchemas: [
-                {
-                    ref: 'ConditionalRule_ConditionalOperator.number-or-string_',
-                },
+                { ref: 'BaseFilterRule_FilterOperator.number-or-string_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -3077,9 +3075,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'intersection',
             subSchemas: [
-                {
-                    ref: 'ConditionalRule_ConditionalOperator.number-or-string_',
-                },
+                { ref: 'BaseFilterRule_FilterOperator.number-or-string_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -3108,7 +3104,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ConditionalFormattingWithConditionalOperator: {
+    ConditionalFormattingWithFilterOperator: {
         dataType: 'refAlias',
         type: {
             dataType: 'union',
@@ -3131,7 +3127,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: {
                         dataType: 'refAlias',
-                        ref: 'ConditionalFormattingWithConditionalOperator',
+                        ref: 'ConditionalFormattingWithFilterOperator',
                     },
                     required: true,
                 },
@@ -3455,7 +3451,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
             },
-            operator: { ref: 'ConditionalOperator', required: true },
+            operator: { ref: 'FilterOperator', required: true },
             id: { dataType: 'string', required: true },
             target: { ref: 'JoinModelRequiredFilterTarget', required: true },
             settings: { ref: 'AnyType' },
@@ -5250,20 +5246,6 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        rows: {
-                            dataType: 'union',
-                            subSchemas: [
-                                {
-                                    dataType: 'array',
-                                    array: {
-                                        dataType: 'refAlias',
-                                        ref: 'Record_string.AnyType_',
-                                    },
-                                },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
                         prompt: { ref: 'AiWebAppPrompt', required: true },
                     },
                     required: true,
@@ -11438,11 +11420,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'FilterRule_ConditionalOperator.DashboardFieldTarget.any.any_': {
+    'FilterRule_FilterOperator.DashboardFieldTarget.any.any_': {
         dataType: 'refObject',
         properties: {
             values: { dataType: 'array', array: { dataType: 'any' } },
-            operator: { ref: 'ConditionalOperator', required: true },
+            operator: { ref: 'FilterOperator', required: true },
             id: { dataType: 'string', required: true },
             target: { ref: 'DashboardFieldTarget', required: true },
             settings: { dataType: 'any' },
@@ -11452,13 +11434,13 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_': {
+    'DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_': {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'FilterRule_ConditionalOperator.DashboardFieldTarget.any.any_',
+                    ref: 'FilterRule_FilterOperator.DashboardFieldTarget.any.any_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -11491,7 +11473,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: {
                         dataType: 'refAlias',
-                        ref: 'DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_',
+                        ref: 'DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_',
                     },
                     required: true,
                 },
@@ -11499,7 +11481,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: {
                         dataType: 'refAlias',
-                        ref: 'DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_',
+                        ref: 'DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_',
                     },
                     required: true,
                 },
@@ -11545,7 +11527,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                operator: { ref: 'ConditionalOperator', required: true },
+                operator: { ref: 'FilterOperator', required: true },
                 values: {
                     dataType: 'union',
                     subSchemas: [
@@ -19855,6 +19837,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_streamAgentThreadResponse: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/stream',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.streamAgentThreadResponse,
+        ),
+
+        async function AiAgentController_streamAgentThreadResponse(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_streamAgentThreadResponse,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'streamAgentThreadResponse',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1210,7 +1210,7 @@
                 "required": ["tableName", "fieldId"],
                 "type": "object"
             },
-            "ConditionalOperator": {
+            "FilterOperator": {
                 "enum": [
                     "isNull",
                     "notNull",
@@ -1234,7 +1234,7 @@
                 ],
                 "type": "string"
             },
-            "FilterRule_ConditionalOperator.DashboardFieldTarget.AnyType.AnyType_": {
+            "FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_": {
                 "properties": {
                     "values": {
                         "items": {
@@ -1243,7 +1243,7 @@
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -1287,7 +1287,7 @@
             "DashboardFilterRule": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/FilterRule_ConditionalOperator.DashboardFieldTarget.AnyType.AnyType_"
+                        "$ref": "#/components/schemas/FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_"
                     },
                     {
                         "properties": {
@@ -2008,7 +2008,7 @@
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -2210,7 +2210,7 @@
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -3244,7 +3244,7 @@
                 "type": "object",
                 "description": "Construct a type with a set of properties K of type T"
             },
-            "ConditionalRule_ConditionalOperator.number-or-string_": {
+            "BaseFilterRule_FilterOperator.number-or-string_": {
                 "properties": {
                     "values": {
                         "items": {
@@ -3261,7 +3261,7 @@
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -3273,7 +3273,7 @@
             "ConditionalFormattingWithValues_number-or-string_": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/ConditionalRule_ConditionalOperator.number-or-string_"
+                        "$ref": "#/components/schemas/BaseFilterRule_FilterOperator.number-or-string_"
                     },
                     {
                         "properties": {
@@ -3300,7 +3300,7 @@
             "ConditionalFormattingWithCompareTarget_number-or-string_": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/ConditionalRule_ConditionalOperator.number-or-string_"
+                        "$ref": "#/components/schemas/BaseFilterRule_FilterOperator.number-or-string_"
                     },
                     {
                         "properties": {
@@ -3332,7 +3332,7 @@
                     }
                 ]
             },
-            "ConditionalFormattingWithConditionalOperator": {
+            "ConditionalFormattingWithFilterOperator": {
                 "anyOf": [
                     {
                         "$ref": "#/components/schemas/ConditionalFormattingWithValues_number-or-string_"
@@ -3346,7 +3346,7 @@
                 "properties": {
                     "rules": {
                         "items": {
-                            "$ref": "#/components/schemas/ConditionalFormattingWithConditionalOperator"
+                            "$ref": "#/components/schemas/ConditionalFormattingWithFilterOperator"
                         },
                         "type": "array"
                     },
@@ -3695,7 +3695,7 @@
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -5900,12 +5900,6 @@
                 "properties": {
                     "results": {
                         "properties": {
-                            "rows": {
-                                "items": {
-                                    "$ref": "#/components/schemas/Record_string.AnyType_"
-                                },
-                                "type": "array"
-                            },
                             "prompt": {
                                 "$ref": "#/components/schemas/AiWebAppPrompt"
                             }
@@ -12306,14 +12300,14 @@
                     }
                 ]
             },
-            "FilterRule_ConditionalOperator.DashboardFieldTarget.any.any_": {
+            "FilterRule_FilterOperator.DashboardFieldTarget.any.any_": {
                 "properties": {
                     "values": {
                         "items": {},
                         "type": "array"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "id": {
                         "type": "string"
@@ -12333,10 +12327,10 @@
                 "type": "object",
                 "additionalProperties": true
             },
-            "DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_": {
+            "DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/FilterRule_ConditionalOperator.DashboardFieldTarget.any.any_"
+                        "$ref": "#/components/schemas/FilterRule_FilterOperator.DashboardFieldTarget.any.any_"
                     },
                     {
                         "properties": {
@@ -12358,13 +12352,13 @@
                 "properties": {
                     "metrics": {
                         "items": {
-                            "$ref": "#/components/schemas/DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_"
+                            "$ref": "#/components/schemas/DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_"
                         },
                         "type": "array"
                     },
                     "tableCalculations": {
                         "items": {
-                            "$ref": "#/components/schemas/DashboardFilterRule_ConditionalOperator.DashboardFieldTarget.any.any_"
+                            "$ref": "#/components/schemas/DashboardFilterRule_FilterOperator.DashboardFieldTarget.any.any_"
                         },
                         "type": "array"
                     }
@@ -12393,7 +12387,7 @@
                         "type": "boolean"
                     },
                     "operator": {
-                        "$ref": "#/components/schemas/ConditionalOperator"
+                        "$ref": "#/components/schemas/FilterOperator"
                     },
                     "values": {
                         "items": {},
@@ -17833,7 +17827,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1732.0",
+        "version": "0.1734.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/Ai/types.ts
+++ b/packages/common/src/ee/Ai/types.ts
@@ -1,4 +1,3 @@
-import type { AnyType } from '../../types/any';
 import { type TraceTaskBase } from '../../types/scheduler';
 
 export type AiThread = {
@@ -155,7 +154,6 @@ export type ApiAiConversationResponse = {
     status: 'ok';
     results: {
         prompt: AiWebAppPrompt;
-        rows: Record<string, AnyType>[] | undefined;
     };
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

This PR adds streaming support for AI agent responses. It introduces a new endpoint `/api/v1/aiAgents/:agentUuid/threads/:threadUuid/stream` that streams the AI agent's response to the client instead of waiting for the complete response before sending it.
