### PR TITLE
feat: Save generated viz from agent chat

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -8,6 +8,7 @@ import {
     AiConversationMessage,
     AiDuplicateSlackPromptError,
     AiMetricQuery,
+    AiVizMetadata,
     AiWebAppPrompt,
     AnyType,
     ApiAiAgentThreadCreateRequest,
@@ -915,6 +916,19 @@ export class AiAgentService {
             );
         }
 
+        const metadata = {
+            title:
+                'title' in message.vizConfigOutput &&
+                typeof message.vizConfigOutput.title === 'string'
+                    ? message.vizConfigOutput.title
+                    : null,
+            description:
+                'description' in message.vizConfigOutput &&
+                typeof message.vizConfigOutput.description === 'string'
+                    ? message.vizConfigOutput.description
+                    : null,
+        } satisfies AiVizMetadata;
+
         let vizConfig: AiAgentVizConfig;
         if (isVerticalBarMetricChartConfig(message.vizConfigOutput)) {
             vizConfig = {
@@ -963,6 +977,7 @@ export class AiAgentService {
                 return {
                     type: AiChartType.VERTICAL_BAR_CHART,
                     query,
+                    metadata,
                 };
             }
             case 'time_series_chart': {
@@ -979,6 +994,7 @@ export class AiAgentService {
                 return {
                     type: AiChartType.TIME_SERIES_CHART,
                     query,
+                    metadata,
                 };
             }
             case 'csv':
@@ -995,6 +1011,7 @@ export class AiAgentService {
                 return {
                     type: AiChartType.CSV,
                     query,
+                    metadata,
                 };
             default:
                 return assertUnreachable(vizConfig, 'Invalid viz config');

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5090,11 +5090,38 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiVizMetadata: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAiAgentThreadMessageVizQuery: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                metadata: { ref: 'AiVizMetadata', required: true },
                 query: {
                     ref: 'ApiExecuteAsyncMetricQueryResults',
                     required: true,
@@ -11752,7 +11779,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11762,7 +11789,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11772,7 +11799,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11785,7 +11812,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5675,8 +5675,25 @@
                     }
                 ]
             },
+            "AiVizMetadata": {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["description", "title"],
+                "type": "object"
+            },
             "ApiAiAgentThreadMessageVizQuery": {
                 "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/AiVizMetadata"
+                    },
                     "query": {
                         "$ref": "#/components/schemas/ApiExecuteAsyncMetricQueryResults"
                     },
@@ -5684,7 +5701,7 @@
                         "$ref": "#/components/schemas/AiChartType"
                     }
                 },
-                "required": ["query", "type"],
+                "required": ["metadata", "query", "type"],
                 "type": "object"
             },
             "ApiAiAgentThreadMessageVizQueryResponse": {
@@ -12557,22 +12574,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -18478,7 +18495,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1754.0",
+        "version": "0.1758.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/Ai/schemas.ts
+++ b/packages/common/src/ee/Ai/schemas.ts
@@ -260,6 +260,12 @@ export const SortFieldSchema = z.object({
         ),
 });
 
+export const VisualizationMetadataSchema = z.object({
+    title: z.string().describe('A descriptive title for the chart'),
+    description: z
+        .string()
+        .describe('A descriptive summary or explanation for the chart.'),
+});
 // export const CompactOrAliasSchema = z
 //     .nativeEnum(Compact)
 //     .or(z.enum(CompactAlias));
@@ -376,106 +382,101 @@ export const aiFindFieldsToolSchema = z.object({
         ),
 });
 
-export const timeSeriesMetricVizConfigSchema = z.object({
-    title: z
-        .string()
-        .describe(
-            'The title of the chart. If not provided the chart will have no title.',
-        )
-        .nullable(),
-    exploreName: z
-        .string()
-        .describe(
-            'The name of the explore containing the metrics and dimensions used for the chart.',
-        ),
-    xDimension: z
-        .string()
-        .describe(
-            'The field id of the time dimension to be displayed on the x-axis.',
-        ),
-    yMetrics: z
-        .array(z.string())
-        .min(1)
-        .describe(
-            'At least one metric is required. The field ids of the metrics to be displayed on the y-axis. If there are multiple metrics there will be one line per metric',
-        ),
-    sorts: z
-        .array(SortFieldSchema)
-        .describe(
-            'Sort configuration for the query, it can use a combination of metrics and dimensions.',
-        ),
-    breakdownByDimension: z
-        .string()
-        .nullable()
-        .describe(
-            'The field id of the dimension used to split the metrics into series for each dimension value. For example if you wanted to split a metric into multiple series based on City you would use the City dimension field id here. If this is not provided then the metric will be displayed as a single series.',
-        ),
-    lineType: z
-        .union([z.literal('line'), z.literal('area')])
-        .describe(
-            'default line. The type of line to display. If area then the area under the line will be filled in.',
-        ),
-});
+export const timeSeriesMetricVizConfigSchema =
+    VisualizationMetadataSchema.extend({
+        exploreName: z
+            .string()
+            .describe(
+                'The name of the explore containing the metrics and dimensions used for the chart.',
+            ),
+        xDimension: z
+            .string()
+            .describe(
+                'The field id of the time dimension to be displayed on the x-axis.',
+            ),
+        yMetrics: z
+            .array(z.string())
+            .min(1)
+            .describe(
+                'At least one metric is required. The field ids of the metrics to be displayed on the y-axis. If there are multiple metrics there will be one line per metric',
+            ),
+        sorts: z
+            .array(SortFieldSchema)
+            .describe(
+                'Sort configuration for the query, it can use a combination of metrics and dimensions.',
+            ),
+        breakdownByDimension: z
+            .string()
+            .nullable()
+            .describe(
+                'The field id of the dimension used to split the metrics into series for each dimension value. For example if you wanted to split a metric into multiple series based on City you would use the City dimension field id here. If this is not provided then the metric will be displayed as a single series.',
+            ),
+        lineType: z
+            .union([z.literal('line'), z.literal('area')])
+            .describe(
+                'default line. The type of line to display. If area then the area under the line will be filled in.',
+            ),
+    });
 
 export type TimeSeriesMetricVizConfigSchemaType = z.infer<
     typeof timeSeriesMetricVizConfigSchema
 >;
 
-export const verticalBarMetricVizConfigSchema = z.object({
-    exploreName: z
-        .string()
-        .describe(
-            'The name of the explore containing the metrics and dimensions used for the chart.',
-        ),
-    xDimension: z
-        .string()
-        .describe(
-            'The field id of the dimension to be displayed on the x-axis.',
-        ),
-    yMetrics: z
-        .array(z.string())
-        .min(1)
-        .describe(
-            'At least one metric is required. The field ids of the metrics to be displayed on the y-axis. The height of the bars',
-        ),
-    sorts: z
-        .array(SortFieldSchema)
-        .describe(
-            'Sort configuration for the query, it can use a combination of metrics and dimensions.',
-        ),
-    breakdownByDimension: z
-        .string()
-        .nullable()
-        .describe(
-            'The field id of the dimension used to split the metrics into groups along the x-axis. If stacking is false then this will create multiple bars around each x value, if stacking is true then this will create multiple bars for each metric stacked on top of each other',
-        ),
-    stackBars: z
-        .boolean()
-        .nullable()
-        .describe(
-            'If using breakdownByDimension then this will stack the bars on top of each other instead of side by side.',
-        ),
-    xAxisType: z
-        .union([z.literal('category'), z.literal('time')])
-        .describe(
-            'The x-axis type can be categorical for string value or time if the dimension is a date or timestamp.',
-        ),
-    xAxisLabel: z
-        .string()
-        .nullable()
-        .describe('A helpful label to explain the x-axis'),
-    yAxisLabel: z
-        .string()
-        .nullable()
-        .describe('A helpful label to explain the y-axis'),
-    title: z.string().nullable().describe('a descriptive title for the chart'),
-});
+export const verticalBarMetricVizConfigSchema =
+    VisualizationMetadataSchema.extend({
+        exploreName: z
+            .string()
+            .describe(
+                'The name of the explore containing the metrics and dimensions used for the chart.',
+            ),
+        xDimension: z
+            .string()
+            .describe(
+                'The field id of the dimension to be displayed on the x-axis.',
+            ),
+        yMetrics: z
+            .array(z.string())
+            .min(1)
+            .describe(
+                'At least one metric is required. The field ids of the metrics to be displayed on the y-axis. The height of the bars',
+            ),
+        sorts: z
+            .array(SortFieldSchema)
+            .describe(
+                'Sort configuration for the query, it can use a combination of metrics and dimensions.',
+            ),
+        breakdownByDimension: z
+            .string()
+            .nullable()
+            .describe(
+                'The field id of the dimension used to split the metrics into groups along the x-axis. If stacking is false then this will create multiple bars around each x value, if stacking is true then this will create multiple bars for each metric stacked on top of each other',
+            ),
+        stackBars: z
+            .boolean()
+            .nullable()
+            .describe(
+                'If using breakdownByDimension then this will stack the bars on top of each other instead of side by side.',
+            ),
+        xAxisType: z
+            .union([z.literal('category'), z.literal('time')])
+            .describe(
+                'The x-axis type can be categorical for string value or time if the dimension is a date or timestamp.',
+            ),
+        xAxisLabel: z
+            .string()
+            .nullable()
+            .describe('A helpful label to explain the x-axis'),
+        yAxisLabel: z
+            .string()
+            .nullable()
+            .describe('A helpful label to explain the y-axis'),
+    });
 
 export type VerticalBarMetricVizConfigSchemaType = z.infer<
     typeof verticalBarMetricVizConfigSchema
 >;
 
-export const csvFileVizConfigSchema = z.object({
+export const csvFileVizConfigSchema = VisualizationMetadataSchema.extend({
     exploreName: z
         .string()
         .describe(

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -223,9 +223,15 @@ export type ApiAiAgentThreadMessageVizResponse = {
     results: ApiAiAgentThreadMessageViz;
 };
 
+export type AiVizMetadata = {
+    title: string | null;
+    description: string | null;
+};
+
 export type ApiAiAgentThreadMessageVizQuery = {
     type: AiChartType;
     query: ApiExecuteAsyncMetricQueryResults;
+    metadata: AiVizMetadata;
 };
 
 export type ApiAiAgentThreadMessageVizQueryResponse = {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -301,6 +301,7 @@ const VisualizationProvider: FC<
         colorPalette,
         getGroupColor,
         getSeriesColor,
+        chartConfig,
     };
 
     switch (chartConfig.type) {

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -1,5 +1,6 @@
 import {
     type ApiErrorDetail,
+    type ChartConfig,
     type ChartType,
     type ItemsMap,
     type MetricQuery,
@@ -41,6 +42,7 @@ type VisualizationContext = {
     getSeriesColor: (seriesLike: SeriesLike) => string;
     getGroupColor: (groupPrefix: string, groupName: string) => string;
     colorPalette: string[];
+    chartConfig: ChartConfig;
     apiErrorDetail?: ApiErrorDetail | null;
 };
 

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -97,7 +97,13 @@ const MantineModal: React.FC<MantineModalProps> = ({
                     })}
                     {...modalBodyProps}
                 >
-                    <Stack px="xl" py="md" spacing="md">
+                    <Stack
+                        spacing="md"
+                        {...{
+                            px: modalBodyProps?.px ?? 'xl',
+                            py: modalBodyProps?.py ?? 'md',
+                        }}
+                    >
                         {children}
                     </Stack>
                 </Modal.Body>

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -18,6 +18,7 @@ import {
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
+import { DEFAULT_CHART_METADATA, type ChartMetadata } from './types';
 
 type Props = {
     dashboardName: string | null;
@@ -25,6 +26,7 @@ type Props = {
     savedData: CreateSavedChartVersion;
     projectUuid?: string;
     onClose: () => void;
+    defaults?: ChartMetadata;
 };
 
 type SaveToDashboardFormValues = { name: string; description: string };
@@ -42,6 +44,7 @@ export const SaveToDashboard: FC<Props> = ({
     dashboardUuid,
     projectUuid,
     onClose,
+    defaults = DEFAULT_CHART_METADATA,
 }) => {
     const [dashboardInfoFromStorage, setDashboardInfoFromStorage] = useState({
         name: dashboardName,
@@ -86,8 +89,7 @@ export const SaveToDashboard: FC<Props> = ({
     const unsavedDashboardTiles = getUnsavedDashboardTiles();
     const form = useForm<FormValues>({
         initialValues: {
-            name: '',
-            description: '',
+            ...defaults,
         },
         validate: zodResolver(validationSchema),
     });

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -7,6 +7,7 @@ import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage
 import MantineIcon from '../../MantineIcon';
 import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
+import { type ChartMetadata } from './types';
 
 interface ChartCreateModalProps {
     savedData: CreateSavedChartVersion;
@@ -14,6 +15,7 @@ interface ChartCreateModalProps {
     onClose: () => void;
     defaultSpaceUuid?: string;
     onConfirm: (savedData: CreateSavedChartVersion) => void;
+    chartMetadata?: ChartMetadata;
 }
 
 enum SaveMode {
@@ -27,6 +29,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     onClose,
     defaultSpaceUuid,
     onConfirm,
+    chartMetadata,
 }) => {
     // Store it in the state to avoid losing the param when the user switches between tables
     const [spaceUuid] = useState(defaultSpaceUuid);
@@ -73,6 +76,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                     dashboardUuid={editingDashboardInfo.dashboardUuid}
                     savedData={savedData}
                     onClose={onClose}
+                    defaults={chartMetadata}
                 />
             )}
 
@@ -87,6 +91,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                         dashboardName: savedData.dashboardName ?? null,
                         dashboardUuid: savedData.dashboardUuid ?? null,
                     }}
+                    chartMetadata={chartMetadata}
                 />
             )}
         </Modal>

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/types.ts
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/types.ts
@@ -12,3 +12,13 @@ export const saveToSpaceSchema = z.object({
 });
 
 export type SaveToSpaceFormType = z.infer<typeof saveToSpaceSchema>;
+
+export type ChartMetadata = {
+    name: string;
+    description: string;
+};
+
+export const DEFAULT_CHART_METADATA = {
+    name: '',
+    description: '',
+} as const;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,0 +1,124 @@
+import { ActionIcon, Menu } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import {
+    IconChartBar,
+    IconDeviceFloppy,
+    IconDots,
+    IconExternalLink,
+} from '@tabler/icons-react';
+import { Fragment, useMemo } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { SaveToSpaceOrDashboard } from '../../../../../components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard';
+import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
+import { getOpenInExploreUrl } from '../../utils/getOpenInExploreUrl';
+
+type Props = {
+    projectUuid?: string;
+    saveChartOptions?: {
+        name: string | null;
+        description: string | null;
+    };
+};
+
+export const AiChartQuickOptions = ({
+    projectUuid,
+    saveChartOptions = { name: '', description: '' },
+}: Props) => {
+    const [opened, { open, close }] = useDisclosure(false);
+
+    const { visualizationConfig, columnOrder, resultsData, chartConfig } =
+        useVisualizationContext();
+    const metricQuery = resultsData?.metricQuery;
+    const type = chartConfig.type;
+    const vizConfig = visualizationConfig;
+
+    const isDisabled = !metricQuery || !type || !vizConfig;
+
+    const openInExploreUrl = useMemo(() => {
+        if (isDisabled) return '';
+        return getOpenInExploreUrl({
+            metricQuery,
+            projectUuid,
+            columnOrder,
+            chartConfig,
+            pivotColumns:
+                vizConfig &&
+                'breakdownByDimension' in vizConfig &&
+                typeof vizConfig.breakdownByDimension === 'string'
+                    ? [vizConfig.breakdownByDimension]
+                    : undefined,
+        });
+    }, [
+        isDisabled,
+        metricQuery,
+        projectUuid,
+        columnOrder,
+        chartConfig,
+        vizConfig,
+    ]);
+
+    if (!metricQuery) return null;
+
+    return (
+        <Fragment>
+            <Menu>
+                <Menu.Target>
+                    <ActionIcon size="sm" variant="subtle" color="gray">
+                        <MantineIcon icon={IconDots} size="lg" color="gray" />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <Menu.Label>Quick actions</Menu.Label>
+                    <Menu.Item
+                        onClick={() => open()}
+                        leftSection={<MantineIcon icon={IconDeviceFloppy} />}
+                    >
+                        Save
+                    </Menu.Item>
+                    <Menu.Item
+                        component={Link}
+                        to={openInExploreUrl}
+                        target="_blank"
+                        leftSection={<MantineIcon icon={IconExternalLink} />}
+                        disabled={isDisabled}
+                    >
+                        Explore from here
+                    </Menu.Item>
+                </Menu.Dropdown>
+            </Menu>
+            <MantineModal
+                opened={opened}
+                onClose={close}
+                title="Save chart"
+                icon={IconChartBar}
+                size="lg"
+                modalBodyProps={{
+                    px: 0,
+                    py: 0,
+                }}
+                modalRootProps={{
+                    closeOnClickOutside: false,
+                }}
+            >
+                <SaveToSpaceOrDashboard
+                    projectUuid={projectUuid}
+                    savedData={{
+                        metricQuery: metricQuery,
+                        tableName: metricQuery.exploreName,
+                        chartConfig,
+                        tableConfig: { columnOrder },
+                    }}
+                    onConfirm={close}
+                    onClose={close}
+                    chartMetadata={{
+                        name: saveChartOptions.name ?? '',
+                        description: saveChartOptions.description ?? '',
+                    }}
+                    redirectOnSuccess={false}
+                />
+            </MantineModal>
+        </Fragment>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -4,7 +4,7 @@ import {
     type AiAgentMessageAssistant,
     type ApiAiAgentThreadMessageVizQuery,
 } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
+import { Box, Group } from '@mantine-8/core';
 import { useMemo, useState, type FC } from 'react';
 import { SeriesContextMenu } from '../../../../../components/Explorer/VisualizationCard/SeriesContextMenu';
 import LightdashVisualization from '../../../../../components/LightdashVisualization';
@@ -19,10 +19,12 @@ import { useOrganization } from '../../../../../hooks/organization/useOrganizati
 import { useExplore } from '../../../../../hooks/useExplore';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { getChartConfigFromAiAgentVizConfig } from '../../utils/echarts';
+import { AiChartQuickOptions } from './AiChartQuickOptions';
 
 type Props = ApiAiAgentThreadMessageVizQuery & {
     vizConfig: AiAgentMessageAssistant['vizConfigOutput'];
     results: InfiniteQueryResults;
+    projectUuid: string;
 };
 
 export const AiChartVisualization: FC<Props> = ({
@@ -30,6 +32,8 @@ export const AiChartVisualization: FC<Props> = ({
     results,
     type,
     vizConfig,
+    projectUuid,
+    metadata,
 }) => {
     const { data: health } = useHealth();
     const { data: organization } = useOrganization();
@@ -97,6 +101,15 @@ export const AiChartVisualization: FC<Props> = ({
                         setEchartSeries(series);
                     }}
                 >
+                    <Group justify="flex-end" w="100%">
+                        <AiChartQuickOptions
+                            projectUuid={projectUuid}
+                            saveChartOptions={{
+                                name: metadata.title,
+                                description: metadata.description,
+                            }}
+                        />
+                    </Group>
                     <LightdashVisualization
                         className="sentry-block ph-no-capture"
                         data-testid="ai-visualization"

--- a/packages/frontend/src/ee/features/aiCopilot/utils/getOpenInExploreUrl.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/getOpenInExploreUrl.ts
@@ -1,39 +1,23 @@
-import type {
-    AiAgentMessageAssistant,
-    AiChartType,
-    AnyType,
-    MetricQuery,
-} from '@lightdash/common';
+import type { ChartConfig, MetricQuery } from '@lightdash/common';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../../hooks/useExplorerRoute';
-import { getChartConfigFromAiAgentVizConfig } from './echarts';
 
 export const getOpenInExploreUrl = ({
     metricQuery,
     projectUuid,
     columnOrder,
-    type,
     pivotColumns,
-    vizConfig,
-    rows,
+    chartConfig,
 }: {
     metricQuery: MetricQuery;
     projectUuid: string | undefined;
     columnOrder: string[];
-    type: AiChartType;
     pivotColumns?: string[];
-    vizConfig: AiAgentMessageAssistant['vizConfigOutput'];
-    rows: Record<string, unknown>[];
+    chartConfig: ChartConfig;
 }) => {
     return getExplorerUrlFromCreateSavedChartVersion(projectUuid, {
         tableName: metricQuery.exploreName,
         metricQuery,
-        chartConfig: getChartConfigFromAiAgentVizConfig({
-            type,
-            // TODO :: fix this using schema
-            config: vizConfig as AnyType,
-            metricQuery,
-            rows,
-        }),
+        chartConfig,
         tableConfig: {
             columnOrder,
         },

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -330,7 +330,9 @@ export const useUpdateMutation = (
     );
 };
 
-export const useCreateMutation = () => {
+export const useCreateMutation = ({
+    redirectOnSuccess = true,
+}: { redirectOnSuccess?: boolean } = {}) => {
     const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
@@ -343,16 +345,23 @@ export const useCreateMutation = () => {
         {
             mutationKey: ['saved_query_create', projectUuid],
             onSuccess: (data) => {
+                const navigateUrl = `/projects/${projectUuid}/saved/${data.uuid}/view`;
                 queryClient.setQueryData(['saved_query', data.uuid], data);
                 showToastSuccess({
                     title: `Success! Chart was saved.`,
+                    action: redirectOnSuccess
+                        ? undefined
+                        : {
+                              children: 'View chart',
+                              icon: IconArrowRight,
+                              onClick: () => navigate(navigateUrl),
+                          },
                 });
-                void navigate(
-                    `/projects/${projectUuid}/saved/${data.uuid}/view`,
-                    {
+                if (redirectOnSuccess) {
+                    void navigate(navigateUrl, {
                         replace: true,
-                    },
-                );
+                    });
+                }
             },
             onError: ({ error }) => {
                 showToastApiError({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15276

### Description:
Added the ability to save charts generated by AI Agents in chats.
This PR also adds a new `description` field to chart configuration schemas so agents can create them to simplify saving charts

#### TODO
- [x] Move `SaveVisualization` inside `AiChartVisualization` instead of top level assistant bubble
- [x] ~~Fix styles for tree when selecting spaces as saved location (because we are rendering inside a mantine 8 theme with styles)~~ Follow up PR including navigation improvements


<details><summary>Screenshots 📸</summary>

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/03c9f530-9cfa-40a5-8b2a-8b81f0eb6ff9.png)

Following video is not up to date with UI

[Screen Recording 2025-06-19 at 19.03.35.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/HorFj8gm8QUuuIDE2vgk/11aa34e4-a643-43b4-be0f-1fa81fb2e04f.mov" />](https://app.graphite.dev/media/video/HorFj8gm8QUuuIDE2vgk/11aa34e4-a643-43b4-be0f-1fa81fb2e04f.mov)

_pls ignore the amount of times I added this chart in the dashboard, I promise it was all testing and the tool only saves the chart once 😭_ 
</details>