### PR TITLE
fix: pass org name to ai feature flags

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -93,6 +93,7 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                 {
                     userUuid: user.userUuid,
                     organizationUuid: user.organizationUuid,
+                    organizationName: user.organizationName,
                 },
             );
         } else {
@@ -127,6 +128,7 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                 {
                     userUuid: user.userUuid,
                     organizationUuid: user.organizationUuid,
+                    organizationName: user.organizationName,
                 },
             ),
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Similar to: https://github.com/lightdash/lightdash/pull/15148


Added `organizationName` to the user context in `CommercialFeatureFlagModel` when tracking feature flag usage. This ensures that organization name data is properly passed along when tracking feature flag usage events.