### PR TITLE
fix: running query breaking series axis configuration for cartesian charts

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -183,6 +183,7 @@ export const useGetReadyQueryResults = (data: QueryResultsProps | null) => {
     const result = useQuery<ApiExecuteAsyncMetricQueryResults, ApiError>({
         enabled: !!data,
         queryKey: ['create-query', data],
+        keepPreviousData: true, // needed to keep the last metric query which could break cartesian chart config
         queryFn: ({ signal }) => {
             return executeAsyncQuery(data, signal);
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15449

### Description:
Added `keepPreviousData: true` to the query configuration in `useGetReadyQueryResults` hook to preserve the last metric query data. This prevents potential breakage in cartesian chart configuration during data transitions.

https://github.com/user-attachments/assets/058cef68-884c-4cb2-9aa5-e6e3ccadb09b

