### PR TITLE
fix: make serviceAccountModel optional in OrganizationService

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -244,6 +244,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             slackAuthenticationModel: ({ database }) =>
                 new CommercialSlackAuthenticationModel({ database }),
+            serviceAccountModel: ({ database }) =>
+                new ServiceAccountModel({ database }),
             featureFlagModel: ({ database }) =>
                 new CommercialFeatureFlagModel({ database, lightdashConfig }),
         },

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -4,6 +4,7 @@ import { AppArguments } from '../App';
 import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import LicenseClient from './clients/License/LicenseClient';
@@ -182,6 +183,26 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     contentModel: models.getContentModel(),
                     encryptionUtil: utils.getEncryptionUtil(),
                     userModel: models.getUserModel(),
+                }),
+            organizationService: ({ models, context, repository }) =>
+                new OrganizationService({
+                    lightdashConfig: context.lightdashConfig,
+                    analytics: context.lightdashAnalytics,
+                    organizationModel: models.getOrganizationModel(),
+                    projectModel: models.getProjectModel(),
+                    onboardingModel: models.getOnboardingModel(),
+                    inviteLinkModel: models.getInviteLinkModel(),
+                    organizationMemberProfileModel:
+                        models.getOrganizationMemberProfileModel(),
+                    userModel: models.getUserModel(),
+                    organizationAllowedEmailDomainsModel:
+                        models.getOrganizationAllowedEmailDomainsModel(),
+                    groupsModel: models.getGroupsModel(),
+                    personalAccessTokenModel:
+                        models.getPersonalAccessTokenModel(),
+                    emailModel: models.getEmailModel(),
+                    projectService: repository.getProjectService(),
+                    serviceAccountModel: models.getServiceAccountModel(),
                 }),
             asyncQueryService: ({
                 models,

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -1,6 +1,5 @@
 import { Knex } from 'knex';
 import { LightdashConfig } from '../config/parseConfig';
-import { ServiceAccountModel } from '../ee/models/ServiceAccountModel';
 import { type UtilRepository } from '../utils/UtilRepository';
 import { AnalyticsModel } from './AnalyticsModel';
 import { CatalogModel } from './CatalogModel/CatalogModel';
@@ -516,16 +515,6 @@ export class ModelRepository
         );
     }
 
-    public getServiceAccountModel(): ServiceAccountModel {
-        return this.getModel(
-            'serviceAccountModel',
-            () =>
-                new ServiceAccountModel({
-                    database: this.database,
-                }),
-        );
-    }
-
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
     }
@@ -543,6 +532,10 @@ export class ModelRepository
             'tagsModel',
             () => new TagsModel({ database: this.database }),
         );
+    }
+
+    public getServiceAccountModel<ModelImplT>(): ModelImplT {
+        return this.getModel('serviceAccountModel');
     }
 
     public getSpotlightTableConfigModel(): SpotlightTableConfigModel {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -72,7 +72,7 @@ type OrganizationServiceArguments = {
     personalAccessTokenModel: PersonalAccessTokenModel;
     emailModel: EmailModel;
     projectService: ProjectService; // For compiling project on new setup
-    serviceAccountModel: ServiceAccountModel; // For creating service account on new setup
+    serviceAccountModel?: ServiceAccountModel; // For creating service account on new setup
 };
 
 export class OrganizationService extends BaseService {
@@ -102,7 +102,7 @@ export class OrganizationService extends BaseService {
 
     private readonly projectService: ProjectService;
 
-    private readonly serviceAccountModel: ServiceAccountModel;
+    private readonly serviceAccountModel?: ServiceAccountModel;
 
     constructor({
         lightdashConfig,
@@ -918,7 +918,7 @@ export class OrganizationService extends BaseService {
                 );
             }
 
-            if (setup.serviceAccount) {
+            if (setup.serviceAccount && this.serviceAccountModel) {
                 this.logger.debug(`Initial setup: creating service account`);
                 await this.serviceAccountModel.save(
                     sessionUser,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -411,7 +411,6 @@ export class ServiceRepository
                         this.models.getPersonalAccessTokenModel(),
                     emailModel: this.models.getEmailModel(),
                     projectService: this.getProjectService(),
-                    serviceAccountModel: this.models.getServiceAccountModel(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

I think this is a better approach than https://github.com/lightdash/lightdash/pull/15450

Another option would be to create a separate EE service for the initialize environment, which is where this serviceAccountModel is used. 

Another option, is not move serviceAccountModel to non ee (along with the migration!) since this might be something that we use a lot in the future. 
### Description:
Makes the `serviceAccountModel` parameter optional in the `OrganizationService` to support the open-source version of Lightdash. This change allows the service to function properly without requiring service account functionality, which is an enterprise feature.

The PR adds the `organizationService` to the enterprise app arguments and updates the service to handle cases where the service account model is not provided.