### PR TITLE
chore: add init claude context

### DIFF
--- a/.claude/commands/cs-bugs.md
+++ b/.claude/commands/cs-bugs.md
@@ -1,0 +1,1 @@
+Get all open customer support bugs from the customer support milestone (184)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Lightdash is an open-source business intelligence tool (Looker alternative) that connects to dbt projects to enable self-service analytics. It's a TypeScript monorepo built with modern web technologies.
+
+## Architecture
+
+**Monorepo Structure** (pnpm workspaces):
+- `packages/common/` - Shared utilities, types, and business logic
+- `packages/backend/` - Node.js/Express API server with database layer
+- `packages/frontend/` - React web application with Vite build system
+- `packages/warehouses/` - Data warehouse client adapters (BigQuery, Snowflake, Postgres, etc.)
+- `packages/cli/` - Command-line interface for dbt project management
+- `packages/e2e/` - Cypress end-to-end tests
+
+**Key Technologies:**
+- Backend: Express.js, Knex.js ORM, PostgreSQL, TSOA (OpenAPI generation)
+- Frontend: React 19, Mantine v8 UI, Emotion styling, TanStack Query
+- Build: pnpm workspaces, TypeScript project references, Vite
+
+## Common Development Commands
+
+**Development:**
+```bash
+pnpm dev                    # Start full development environment
+pnpm backend-dev           # Backend only
+pnpm frontend-dev          # Frontend only
+```
+
+**Code Quality:**
+```bash
+pnpm lint                  # Lint all packages
+pnpm fix-lint             # Auto-fix linting issues
+pnpm format               # Check code formatting
+pnpm fix-format           # Auto-format code
+```
+
+**Testing:**
+```bash
+pnpm test                 # Run all tests
+pnpm backend-test         # Backend tests only
+pnpm frontend-test        # Frontend tests only
+pnpm e2e-run             # E2E tests with Cypress
+```
+
+**Build:**
+```bash
+pnpm build               # Build all packages
+pnpm start               # Start production server
+```
+
+**API Generation:**
+```bash
+pnpm generate-api        # Generate OpenAPI specs from TSOA controllers
+```
+
+## Development Workflow
+
+1. **Package Management**: Use `pnpm` (v9.15.5+) - never use npm or yarn
+2. **TypeScript**: All packages use TypeScript with project references for type checking
+3. **Linting**: ESLint with Airbnb config, enforces `no-floating-promises`
+4. **Pre-commit**: Husky + lint-staged runs linting/formatting on staged files
+5. **Database**: Uses Knex.js for migrations and query building
+6. **API**: TSOA generates OpenAPI specs from TypeScript controllers
+7. **Authentication**: CASL-based authorization with multiple auth providers
+
+## Package-Specific Notes
+
+**Backend (`packages/backend/`):**
+- Express.js with session-based authentication
+- Database migrations in `src/database/migrations/`
+- Controllers use TSOA decorators for API generation
+- Background jobs with node-cron scheduler
+
+**Frontend (`packages/frontend/`):**
+- Vite for fast development and builds
+- Mantine v8 component library with custom theming
+- Monaco Editor for SQL editing
+- TanStack Query for server state management
+
+**Common (`packages/common/`):**
+- Shared types and utilities used across packages
+- Authorization logic with CASL
+- Published as `@lightdash/common`
+
+## TypeScript Project References
+
+**Important**: After SDK build changes, packages use TypeScript project references for proper IDE support:
+- All packages have `"composite": true` enabled
+- Frontend and backend reference common package via `"references"` in tsconfig.json
+- Common package builds to multiple targets: ESM (`dist/esm`), CJS (`dist/cjs`), Types (`dist/types`)
+- Web workers importing from common should use built ESM paths: `@lightdash/common/dist/esm/[module]`
+
+## Key Configuration Files
+
+- `/tsconfig.json` - TypeScript project references
+- `/pnpm-workspace.yaml` - Workspace configuration
+- `/.eslintrc.js` - Global linting rules
+- `/package.json` - Root scripts and dependency management
+- `.env.development.local` - Local development environment variables
+
+## Testing Memories
+
+- Use puppeteer mcp to interact with the frontend web app
+- Test user login is demo@lightdash.com and 'demo_password!'
+- Use ./scripts/reset-db.sh to reset the database, run migrations, and seed the database with dev data 
+
+## Current Project Status
+
+- Customer support issues are on milestone 184
+
+## Issue Management
+
+- bugs use the label 🐛 bug
+
+## Code Style Memories
+
+- Never use duck typing, don't have parameters that can have different types, make types intentional
+
+## Development Troubleshooting
+
+- If there are issues running dbt, make sure there is a python3 venv in the root of the repo, which has dbt-core and dbt-postgres installed

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -1,0 +1,162 @@
+# CLAUDE.md - CLI Package
+
+This file provides guidance to Claude Code when working with the Lightdash CLI package.
+
+## Package Overview
+
+The Lightdash CLI (`@lightdash/cli`) is a command-line interface for managing dbt projects and integrating with Lightdash. It provides tools for compiling, validating, deploying, and previewing dbt models.
+
+## Architecture
+
+**Core Components:**
+- `src/index.ts` - Main CLI entry point with Commander.js
+- `src/handlers/` - Command handlers for each CLI operation
+- `src/dbt/` - dbt integration utilities and warehouse targets
+- `src/warehouse/` - Warehouse client management
+- `src/config.ts` - Configuration management
+- `src/globalState.ts` - CLI state management
+
+**Key Dependencies:**
+- `commander` - CLI framework
+- `inquirer` - Interactive prompts
+- `execa` - Process execution for dbt commands
+- `chalk` - Terminal styling
+- `ora` - Loading spinners
+- `js-yaml` - YAML parsing for dbt configs
+
+## Development Commands
+
+**Build:**
+```bash
+pnpm cli-build           # Build CLI package
+pnpm build               # Build with TypeScript
+```
+
+**Testing:**
+```bash
+pnpm test                # Run Jest tests
+pnpm cli-test            # CLI-specific tests
+```
+
+**Code Quality:**
+```bash
+pnpm lint                # Lint CLI code
+pnpm fix-lint            # Auto-fix lint issues
+pnpm format              # Check formatting
+pnpm fix-format          # Auto-format code
+```
+
+## Development Workflow
+
+**Local Development:**
+1. Build the CLI: `pnpm cli-build`
+2. Run commands via Node.js: `node ./packages/cli/dist/index.js [command]`
+3. Test with example projects in `/examples/`
+
+**Common Development Commands:**
+```bash
+# Login to Lightdash instance
+node ./packages/cli/dist/index.js login http://localhost:3000
+
+# Compile dbt project
+node ./packages/cli/dist/index.js compile --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
+
+# Generate Lightdash config
+node ./packages/cli/dist/index.js generate --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
+
+# Preview changes
+node ./packages/cli/dist/index.js preview --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
+```
+
+## Command Structure
+
+**Main Commands:**
+- `login` - Authenticate with Lightdash instance
+- `compile` - Compile dbt models and generate Lightdash config
+- `generate` - Generate Lightdash YAML files
+- `validate` - Validate dbt project structure
+- `deploy` - Deploy project to Lightdash
+- `preview` - Preview changes before deployment
+- `dbt [command]` - Proxy dbt commands
+
+**Handler Pattern:**
+Each command has a corresponding handler in `src/handlers/` that:
+1. Validates input parameters
+2. Loads project configuration
+3. Executes the operation
+4. Provides user feedback via spinners/logs
+
+## Configuration
+
+**Key Config Files:**
+- `lightdash.yml` - Project configuration
+- `profiles.yml` - dbt profiles (warehouse connections)
+- `.lightdash/` - Local CLI state and auth tokens
+
+**Environment Variables:**
+- `LIGHTDASH_API_KEY` - API authentication
+- `DBT_PROJECT_DIR` - Default dbt project directory
+- `DBT_PROFILES_DIR` - Default dbt profiles directory
+
+## dbt Integration & Warehouse Support
+
+**Core Dependency:**
+Deploying or compiling a Lightdash project requires metadata from a dbt project. All this metadata is available in the `target/manifest.json` file produced by dbt. This manifest file is the starting point for everything Lightdash needs to understand the dbt project structure, models, and transformations.
+
+**dbt Execution Strategy:**
+- **Default behavior**: The Lightdash CLI usually runs dbt under the hood, passing through flags to ensure the manifest is up-to-date
+- **Skip compilation**: Users can use `--skip-dbt-compile` flag to skip any dbt calls when they want to manage dbt compilation themselves
+- This is useful when users have their own dbt workflow or when the manifest is already current
+
+**Supported Warehouses:**
+- BigQuery (`src/dbt/targets/Bigquery/`)
+- Snowflake (`src/dbt/targets/snowflake.ts`)
+- Postgres (`src/dbt/targets/postgres.ts`)
+- Redshift (`src/dbt/targets/redshift.ts`)
+- Databricks (`src/dbt/targets/databricks.ts`)
+- Trino (`src/dbt/targets/trino.ts`)
+
+**dbt Integration Details:**
+- Executes dbt commands via `execa`
+- Parses `target/manifest.json` for model metadata
+- Validates dbt project structure
+- Supports multiple dbt versions
+- Handles dbt compilation lifecycle
+
+## Testing
+
+**Test Structure:**
+- Unit tests for core utilities
+- Integration tests for dbt operations
+- Mock data for warehouse connections
+
+**Test Commands:**
+```bash
+jest                     # Run all tests
+jest --watch            # Watch mode
+jest src/dbt/models.test.ts  # Specific test file
+```
+
+## Publishing
+
+**Release Process:**
+```bash
+pnpm cli-build          # Build package
+pnpm release            # Publish to npm (with --no-git-checks)
+```
+
+**Binary Distribution:**
+- Main binary: `dist/index.js`
+- Package name: `@lightdash/cli`
+- Global install: `npm i -g @lightdash/cli`
+
+## Common Issues
+
+**dbt Version Compatibility:**
+- To test different dbt versions, modify `execa` calls to use `dbt${VERSION}` (e.g., `dbt1.8`)
+- Version detection in `src/handlers/dbt/getDbtVersion.ts`
+
+**Authentication:**
+- Tokens stored in `~/.lightdash/`
+- Login required before most operations
+- API key can be set via environment variable


### PR DESCRIPTION
Some quick initial context for claude - let's improve it over time

- Adds a root claude.md for project level context
- Adds a CLI claude.md that's pulled in for changes to `/packages/cli` files
- Adds a claude command to fetch open customer suppport issues