### PR TITLE
feat: Improve error UI/UX for explore results table

### DIFF
--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -30,7 +30,7 @@ describe('User attributes sql_filter', () => {
         // run query
         cy.get('button').contains('Run query').click();
 
-        cy.contains('Error running query');
+        cy.contains('Error loading results');
 
         cy.contains(
             // eslint-disable-next-line no-template-curly-in-string

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -61,6 +61,9 @@ export const ExplorerResults = memo(() => {
             return context.query.status;
         }
     });
+
+    const apiError = useExplorerContext((context) => context.query.error);
+
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,
     );
@@ -163,11 +166,13 @@ export const ExplorerResults = memo(() => {
     if (columns.length === 0) return <EmptyStateNoColumns />;
 
     if (isExploreLoading) return <EmptyStateExploreLoading />;
+
     return (
         <TrackSection name={SectionName.RESULTS_TABLE}>
             <Box px="xs" py="lg">
                 <Table
                     status={status}
+                    errorDetail={apiError?.error}
                     data={rows || []}
                     totalRowsCount={totalRows || 0}
                     isFetchingRows={isFetchingRows}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -1,9 +1,12 @@
-import { createStyles, keyframes, Loader, Text } from '@mantine/core';
-import { type FC } from 'react';
+import { type ApiErrorDetail } from '@lightdash/common';
+import { Anchor, createStyles, keyframes, Loader, Text } from '@mantine/core';
+import { IconTableOff } from '@tabler/icons-react';
+import { Fragment, type FC } from 'react';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import NoTableIcon from '../../../svgs/emptystate-no-table.svg?react';
 import { SectionName } from '../../../types/Events';
 import { EmptyState } from '../../common/EmptyState';
+import MantineIcon from '../../common/MantineIcon';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import { RefreshButton } from '../../RefreshButton';
 
@@ -215,9 +218,31 @@ export const ExploreLoadingState = () => (
     </EmptyState>
 );
 
-export const ExploreErrorState = () => (
+export const ExploreErrorState = ({
+    errorDetail,
+}: {
+    errorDetail?: ApiErrorDetail | null;
+}) => (
     <EmptyState
+        icon={<MantineIcon icon={IconTableOff} />}
         title="Error loading results"
-        description="There was an error loading the results"
-    ></EmptyState>
+        description={
+            <Fragment>
+                {errorDetail?.message ||
+                    'There was an error loading the results'}
+                {errorDetail?.data.documentationUrl && (
+                    <Fragment>
+                        <br />
+                        <Anchor
+                            href={errorDetail.data.documentationUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn how to resolve this in our documentation →
+                        </Anchor>
+                    </Fragment>
+                )}
+            </Fragment>
+        }
+    />
 );

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -1,3 +1,4 @@
+import { type ApiErrorDetail } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
 import { type ComponentProps, type FC } from 'react';
 import {
@@ -22,6 +23,7 @@ type Props = ComponentProps<typeof TableProvider> & {
     $shouldExpand?: boolean;
     $padding?: number;
     'data-testid'?: string;
+    errorDetail?: ApiErrorDetail | null;
 };
 
 const Table: FC<React.PropsWithChildren<Props>> = ({
@@ -35,6 +37,7 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
     minimal = false,
     showSubtotals = true,
     'data-testid': dataTestId,
+    errorDetail,
     ...rest
 }) => {
     const theme = useMantineTheme();
@@ -62,7 +65,9 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
                     showSubtotals={showSubtotals}
                 />
 
-                {status === 'error' && <ExploreErrorState />}
+                {status === 'error' && (
+                    <ExploreErrorState errorDetail={errorDetail} />
+                )}
                 {status === 'idle' && <IdleState />}
                 {status === 'success' && rest.data.length === 0 && (
                     <EmptyState />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Improves error handling in the Explorer Results view by displaying more detailed error information to users. 


![Screenshot 2025-06-23 at 11.24.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/c2f44a70-be96-44ce-8bbc-b0c13cce7df4.png)

This change aims to match the styles from Visualization errors and display more information that might be too tight or need to be persistent for a toast message (like including documentation links)

Also updates the error message text in the Cypress test from "Error running query" to "Error loading results" to match the new UI.
