### PR TITLE
feat(backend): streaming support for AI Agent thread responses

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -2,8 +2,12 @@ import {
     ApiAiAgentResponse,
     ApiAiAgentStartThreadResponse,
     ApiAiAgentSummaryResponse,
+    ApiAiAgentThreadCreateRequest,
+    ApiAiAgentThreadCreateResponse,
     ApiAiAgentThreadGenerateRequest,
     ApiAiAgentThreadGenerateResponse,
+    ApiAiAgentThreadMessageCreateRequest,
+    ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadResponse,
@@ -181,9 +185,51 @@ export class AiAgentController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads')
+    @OperationId('createAgentThread')
+    async createAgentThread(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Body() body: ApiAiAgentThreadCreateRequest,
+    ): Promise<ApiAiAgentThreadCreateResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().createAgentThread(
+                req.user!,
+                agentUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/messages')
+    @OperationId('createAgentThreadMessage')
+    async createAgentThreadMessage(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Body() body: ApiAiAgentThreadMessageCreateRequest,
+    ): Promise<ApiAiAgentThreadMessageCreateResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().createAgentThreadMessage(
+                req.user!,
+                agentUuid,
+                threadUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
     @Post('/{agentUuid}/generate')
     @OperationId('startAgentThread')
-    async createAgentThread(
+    async startAgentThread(
         @Request() req: express.Request,
         @Path() agentUuid: string,
         @Body() body: ApiAiAgentThreadGenerateRequest,
@@ -228,6 +274,30 @@ export class AiAgentController extends BaseController {
             status: 'ok',
             results: { jobId },
         };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/stream')
+    @OperationId('streamAgentThreadResponse')
+    async streamAgentThreadResponse(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+    ): Promise<void> {
+        const stream = await this.getAiAgentService().streamAgentThreadResponse(
+            req.user!,
+            {
+                agentUuid,
+                threadUuid,
+            },
+        );
+
+        /**
+         * @ref https://github.com/lukeautry/tsoa/issues/44#issuecomment-357784246
+         * Hack to get the response object from the request
+         */
+        stream.pipeDataStreamToResponse(req.res!);
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -479,7 +479,7 @@ export class AiAgentModel {
                     | 'created_at'
                     | 'created_from'
                 > &
-                    Pick<DbAiPrompt, 'prompt'> &
+                    Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> &
                     Pick<DbUser, 'user_uuid'> &
                     Pick<DbAiSlackThread, 'slack_user_id'> & {
                         user_name: string;
@@ -490,6 +490,7 @@ export class AiAgentModel {
                 `${AiThreadTableName}.created_at`,
                 `${AiThreadTableName}.created_from`,
                 `${AiPromptTableName}.prompt`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
                 this.database.raw(
                     `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
@@ -652,6 +653,30 @@ export class AiAgentModel {
         });
     }
 
+    async findThreadMessage(
+        role: 'user',
+        {
+            organizationUuid,
+            threadUuid,
+            messageUuid,
+        }: {
+            organizationUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+        },
+    ): Promise<AiAgentMessageUser<AiAgentUser>>;
+    async findThreadMessage(
+        role: 'assistant',
+        {
+            organizationUuid,
+            threadUuid,
+            messageUuid,
+        }: {
+            organizationUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+        },
+    ): Promise<AiAgentMessageAssistant>;
     async findThreadMessage(
         role: 'user' | 'assistant',
         {

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -1,9 +1,21 @@
 import { AnyType } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
-import { CoreMessage, generateObject, generateText, NoSuchToolError } from 'ai';
+import {
+    CoreMessage,
+    generateObject,
+    generateText,
+    NoSuchToolError,
+    smoothStream,
+    streamText,
+} from 'ai';
 import type { ZodType } from 'zod';
 
-import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
+import { ServerResponse } from 'http';
+import type {
+    AiAgentArgs,
+    AiAgentDependencies,
+    AiStreamAgentResponseArgs,
+} from '../types/aiAgent';
 
 import { getFindFields } from '../tools/findFields';
 import { getGenerateBarVizConfig } from '../tools/generateBarVizConfig';
@@ -16,13 +28,17 @@ import Logger from '../../../../logging/logger';
 import { getExploreInformationPrompt } from '../prompts/exploreInformation';
 import { getSystemPrompt } from '../prompts/system';
 
-export const runAgent = async ({
-    args,
-    dependencies,
-}: {
-    args: AiAgentArgs;
-    dependencies: AiAgentDependencies;
-}): Promise<string> => {
+const defaultAgentOptions = {
+    toolChoice: 'auto',
+    maxSteps: 10,
+    maxRetries: 3,
+    temperature: 0.2,
+} as const;
+
+const getAgentTools = (
+    args: AiAgentArgs,
+    dependencies: AiAgentDependencies,
+) => {
     const findFields = getFindFields({
         getExplore: dependencies.getExplore,
         searchFields: dependencies.searchFields,
@@ -75,26 +91,36 @@ export const runAgent = async ({
         getOneLineResult,
     };
 
-    const messages: CoreMessage[] = [
-        getSystemPrompt({
-            agentName: args.agentName,
-            instructions: args.instruction || undefined,
-        }),
-        getExploreInformationPrompt({
-            exploreInformation: args.aiAgentExploreSummaries,
-        }),
-        ...args.messageHistory,
-    ];
+    return tools;
+};
+
+const getAgentMessages = (args: AiAgentArgs) => [
+    getSystemPrompt({
+        agentName: args.agentName,
+        instructions: args.instruction || undefined,
+    }),
+    getExploreInformationPrompt({
+        exploreInformation: args.aiAgentExploreSummaries,
+    }),
+    ...args.messageHistory,
+];
+
+export const generateAgentResponse = async ({
+    args,
+    dependencies,
+}: {
+    args: AiAgentArgs;
+    dependencies: AiAgentDependencies;
+}): Promise<string> => {
+    const messages = getAgentMessages(args);
+    const tools = getAgentTools(args, dependencies);
 
     try {
         const result = await generateText({
+            ...defaultAgentOptions,
             model: args.model,
             tools,
-            toolChoice: 'auto',
             messages,
-            maxSteps: 10,
-            maxRetries: 3,
-            temperature: 0.2,
             experimental_repairToolCall: async ({
                 messages: conversationHistory,
                 error,
@@ -131,6 +157,75 @@ export const runAgent = async ({
             },
         });
         return result.text;
+    } catch (error) {
+        Logger.error(error);
+        Sentry.captureException(error);
+        throw error;
+    }
+};
+
+export const streamAgentResponse = async ({
+    args,
+    dependencies,
+}: {
+    args: AiStreamAgentResponseArgs;
+    dependencies: AiAgentDependencies;
+}) => {
+    const messages = getAgentMessages(args);
+    const tools = getAgentTools(args, dependencies);
+
+    try {
+        const result = streamText({
+            ...defaultAgentOptions,
+            model: args.model,
+            tools,
+            messages,
+            experimental_repairToolCall: async ({
+                messages: conversationHistory,
+                error,
+                toolCall,
+                parameterSchema,
+            }) => {
+                if (NoSuchToolError.isInstance(error)) {
+                    return null;
+                }
+
+                const tool = tools[toolCall.toolName as keyof typeof tools];
+
+                // TODO: extract this as separate agent
+                const { object: repairedArgs } = await generateObject({
+                    model: args.model,
+                    schema: tool.parameters as ZodType<AnyType>,
+                    messages: [
+                        ...conversationHistory,
+                        {
+                            role: 'system',
+                            content: [
+                                `The model tried to call the tool "${toolCall.toolName}"` +
+                                    ` with the following arguments:`,
+                                JSON.stringify(toolCall.args),
+                                `The tool accepts the following schema:`,
+                                JSON.stringify(parameterSchema(toolCall)),
+                                'Please fix the arguments.',
+                            ].join('\n'),
+                        },
+                    ],
+                });
+
+                return { ...toolCall, args: JSON.stringify(repairedArgs) };
+            },
+            onFinish: ({ text }) => {
+                void dependencies.updatePrompt({
+                    response: text,
+                    promptUuid: args.promptUuid,
+                });
+            },
+            experimental_transform: smoothStream({
+                delayInMs: 20,
+                chunking: 'line',
+            }),
+        });
+        return result;
     } catch (error) {
         Logger.error(error);
         Sentry.captureException(error);

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -19,6 +19,7 @@ export type AiAgentArgs = {
     aiAgentExploreSummaries: AiAgentExploreSummary[];
     maxLimit: number;
 };
+
 export type AiAgentDependencies = {
     getExplore: GetExploreFn;
     searchFields: SearchFieldsFn | undefined;
@@ -28,3 +29,7 @@ export type AiAgentDependencies = {
     updatePrompt: UpdatePromptFn;
     updateProgress: UpdateProgressFn;
 };
+
+export type AiGenerateAgentResponseArgs = AiAgentArgs;
+
+export type AiStreamAgentResponseArgs = AiAgentArgs;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -7,6 +7,7 @@ import {
     ItemsMap,
     SlackPrompt,
     UpdateSlackResponse,
+    UpdateWebAppResponse,
 } from '@lightdash/common';
 import { PostSlackFile } from '../../../../clients/Slack/SlackClient';
 
@@ -32,4 +33,6 @@ export type RunMiniMetricQueryFn = (metricQuery: AiMetricQuery) => Promise<{
 
 export type SendFileFn = (args: PostSlackFile) => Promise<void>;
 
-export type UpdatePromptFn = (prompt: UpdateSlackResponse) => Promise<void>;
+export type UpdatePromptFn = (
+    prompt: UpdateWebAppResponse | UpdateSlackResponse,
+) => Promise<void>;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4886,6 +4886,66 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentThreadSummary_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentThreadSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadCreateResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentThreadSummary_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadCreateRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { prompt: { dataType: 'string' } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentMessageUser_AiAgentUser__: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'AiAgentMessageUser_AiAgentUser_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadMessageCreateResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentMessageUser_AiAgentUser__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadMessageCreateRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAiAgentStartThreadResponse: {
         dataType: 'refAlias',
         type: {
@@ -5331,20 +5391,6 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        rows: {
-                            dataType: 'union',
-                            subSchemas: [
-                                {
-                                    dataType: 'array',
-                                    array: {
-                                        dataType: 'refAlias',
-                                        ref: 'Record_string.AnyType_',
-                                    },
-                                },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
                         prompt: { ref: 'AiWebAppPrompt', required: true },
                     },
                     required: true,
@@ -11755,7 +11801,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11765,7 +11811,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11775,7 +11821,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11788,7 +11834,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -19742,11 +19788,11 @@ export function RegisterRoutes(app: Router) {
             in: 'body',
             name: 'body',
             required: true,
-            ref: 'ApiAiAgentThreadGenerateRequest',
+            ref: 'ApiAiAgentThreadCreateRequest',
         },
     };
     app.post(
-        '/api/v1/aiAgents/:agentUuid/generate',
+        '/api/v1/aiAgents/:agentUuid/threads',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
             AiAgentController.prototype.createAgentThread,
@@ -19781,6 +19827,144 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'createAgentThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_createAgentThreadMessage: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadMessageCreateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/messages',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.createAgentThreadMessage,
+        ),
+
+        async function AiAgentController_createAgentThreadMessage(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_createAgentThreadMessage,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAgentThreadMessage',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_startAgentThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadGenerateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/generate',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.startAgentThread,
+        ),
+
+        async function AiAgentController_startAgentThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_startAgentThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'startAgentThread',
                     controller,
                     response,
                     next,
@@ -19853,6 +20037,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_streamAgentThreadResponse: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/stream',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.streamAgentThreadResponse,
+        ),
+
+        async function AiAgentController_streamAgentThreadResponse(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_streamAgentThreadResponse,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'streamAgentThreadResponse',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5462,6 +5462,57 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiSuccess_AiAgentThreadSummary_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentThreadSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadCreateResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentThreadSummary_"
+            },
+            "ApiAiAgentThreadCreateRequest": {
+                "properties": {
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentMessageUser_AiAgentUser__": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentMessageUser_AiAgentUser_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadMessageCreateResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentMessageUser_AiAgentUser__"
+            },
+            "ApiAiAgentThreadMessageCreateRequest": {
+                "properties": {
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["prompt"],
+                "type": "object"
+            },
             "ApiAiAgentStartThreadResponse": {
                 "properties": {
                     "results": {
@@ -5958,12 +6009,6 @@
                 "properties": {
                     "results": {
                         "properties": {
-                            "rows": {
-                                "items": {
-                                    "$ref": "#/components/schemas/Record_string.AnyType_"
-                                },
-                                "type": "array"
-                            },
                             "prompt": {
                                 "$ref": "#/components/schemas/AiWebAppPrompt"
                             }
@@ -12565,22 +12610,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART-or-DashboardTileTypes.SEMANTIC_VIEWER_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/common/src/ee/Ai/types.ts
+++ b/packages/common/src/ee/Ai/types.ts
@@ -1,4 +1,3 @@
-import type { AnyType } from '../../types/any';
 import { type TraceTaskBase } from '../../types/scheduler';
 
 export type AiThread = {
@@ -155,7 +154,6 @@ export type ApiAiConversationResponse = {
     status: 'ok';
     results: {
         prompt: AiWebAppPrompt;
-        rows: Record<string, AnyType>[] | undefined;
     };
 };
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -185,6 +185,20 @@ export type ApiAiAgentThreadResponse = {
     results: AiAgentThread;
 };
 
+export type ApiAiAgentThreadCreateRequest = {
+    prompt?: string;
+};
+
+export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
+
+export type ApiAiAgentThreadMessageCreateRequest = {
+    prompt: string;
+};
+
+export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
+    AiAgentMessageUser<AiAgentUser>
+>;
+
 export type ApiAiAgentThreadGenerateRequest = {
     prompt: string;
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -120,6 +120,8 @@ import { type UserWarehouseCredentials } from './types/userWarehouseCredentials'
 import { type ValidationResponse } from './types/validation';
 
 import type {
+    ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadResponse,
@@ -923,7 +925,9 @@ type ApiResults =
     | ApiAiAgentThreadMessageVizResponse['results']
     | ApiAiAgentThreadMessageVizQueryResponse['results']
     | ApiUpdateUserAgentPreferencesResponse['results']
-    | ApiGetUserAgentPreferencesResponse[`results`];
+    | ApiGetUserAgentPreferencesResponse[`results`]
+    | ApiAiAgentThreadCreateResponse['results']
+    | ApiAiAgentThreadMessageCreateResponse['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #15360

### Description:

This PR adds streaming support for AI agent responses and introduces new endpoints for thread management. Key changes include:

1. Added new endpoints:

   - `POST /{agentUuid}/threads` to create a new agent thread
   - `POST /{agentUuid}/threads/{threadUuid}/messages` to add messages to a thread
   - `POST /{agentUuid}/threads/{threadUuid}/stream` to stream agent responses

2. Refactored the agent response generation logic:

   - Split `runAgent` into `generateAgentResponse` and `streamAgentResponse`
   - Added streaming support using the AI library's `streamText` and `smoothStream`

3. Fixed a method name conflict by renaming `createAgentThread` to `startAgentThread`
