### PR TITLE
feat: add tool call streaming for AI agents

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -224,6 +224,7 @@ export const streamAgentResponse = async ({
                 delayInMs: 20,
                 chunking: 'line',
             }),
+            toolCallStreaming: true,
         });
         return result;
     } catch (error) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../streaming/useAiAgentThreadStreamQuery';
 import { getOpenInExploreUrl } from '../../utils/getOpenInExploreUrl';
 import { isOptimisticMessageStub } from '../../utils/thinkingMessageStub';
+import AgentToolCalls from './AgentToolCalls/AgentToolCalls';
 import AgentVisualizationFilters from './AgentVisualizationFilters';
 import AgentVisualizationMetricsAndDimensions from './AgentVisualizationMetricsAndDimensions';
 import { AiChartVisualization } from './AiChartVisualization';
@@ -110,6 +111,7 @@ const AssistantBubbleContent: FC<{ message: AiAgentMessageAssistant }> = ({
 
     return (
         <>
+            <AgentToolCalls />
             <MDEditor.Markdown
                 source={messageContent}
                 style={{ backgroundColor: 'transparent' }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentToolCalls/AgentToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentToolCalls/AgentToolCalls.tsx
@@ -1,0 +1,64 @@
+import { Box, List, Text, ThemeIcon } from '@mantine-8/core';
+import { IconTool } from '@tabler/icons-react';
+import { useParams } from 'react-router';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { useAiAgentThreadStreamToolCalls } from '../../../streaming/useAiAgentThreadStreamQuery';
+
+// TODO :: should be based on schemas
+const TOOL_DISPLAY_MESSAGES = {
+    findFields: 'Finding relevant fields',
+    generateBarVizConfig: 'Generating a bar chart',
+    generateCsv: 'Generating CSV file',
+    generateQueryFilters: 'Applying filters to the query',
+    generateTimeSeriesVizConfig: 'Generating a line chart',
+} as const;
+
+const TOOL_NAMES = Object.keys(TOOL_DISPLAY_MESSAGES);
+
+const AgentToolCalls = () => {
+    const { threadUuid } = useParams();
+    const toolCalls = useAiAgentThreadStreamToolCalls(threadUuid!);
+    if (!toolCalls || toolCalls.length === 0) return null;
+
+    return (
+        <Box bg="gray.0" p="xs" mb="sm">
+            <List
+                spacing="xs"
+                size="xs"
+                icon={
+                    <ThemeIcon
+                        size={14}
+                        radius="xl"
+                        variant="light"
+                        color="gray"
+                    >
+                        <MantineIcon icon={IconTool} size={8} />
+                    </ThemeIcon>
+                }
+            >
+                {toolCalls
+                    .filter((toolCall) =>
+                        TOOL_NAMES.includes(toolCall.toolName),
+                    )
+                    .map((toolCall) => {
+                        const toolDescription =
+                            TOOL_DISPLAY_MESSAGES[
+                                toolCall.toolName as keyof typeof TOOL_DISPLAY_MESSAGES
+                            ];
+
+                        if (!toolDescription) return null;
+
+                        return (
+                            <List.Item key={toolCall.toolCallId}>
+                                <Text size="xs" c="dimmed">
+                                    {toolDescription}
+                                </Text>
+                            </List.Item>
+                        );
+                    })}
+            </List>
+        </Box>
+    );
+};
+
+export default AgentToolCalls;

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import { lightdashApiStream } from '../../../../api';
 import { useAiAgentThreadStreamAbortController } from './AiAgentThreadStreamAbortControllerContext';
 import {
+    addToolCall,
     type AiAgentThreadStreamDispatch,
     appendToMessage,
     setError,
@@ -73,6 +74,17 @@ export function useAiAgentThreadStreamMutation() {
                         await onFinish?.();
 
                         dispatch(stopStreaming({ threadUuid }));
+                    },
+                    onToolCallPart: (toolCall) => {
+                        if (abortController.signal.aborted) return;
+                        dispatch(
+                            addToolCall({
+                                threadUuid,
+                                toolCallId: toolCall.toolCallId,
+                                toolName: toolCall.toolName,
+                                args: toolCall.args,
+                            }),
+                        );
                     },
                     onErrorPart: (error) => {
                         if (abortController.signal.aborted) return;

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery.ts
@@ -15,3 +15,10 @@ export const useAiAgentThreadStreaming = (threadUuid: string) => {
         return threadStream?.isStreaming;
     });
 };
+
+export const useAiAgentThreadStreamToolCalls = (threadUuid: string) => {
+    return useSelector((state: AiAgentThreadStreamState) => {
+        const threadStream = state.threads[threadUuid];
+        return threadStream?.toolCalls ?? [];
+    });
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

Adds tool call streaming support for AI agents. This enhancement enables real-time visibility of tool calls as they happen during agent interactions.

The implementation includes:

- Enabling tool call streaming in the backend agent service
- Adding UI components to display active tool calls in the chat interface
- Creating Redux store actions and reducers to manage tool call streaming state
- Implementing handlers for tool call events, arguments, and results

This improves the user experience by providing transparency into what actions the AI agent is taking while processing requests.
