### PR TITLE
feat: use filename*=UTF-8 for content-disposition & utils tests

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
@@ -5,7 +5,7 @@ import { getErrorMessage, WarehouseResults } from '@lightdash/common';
 import fs from 'fs';
 import { PassThrough, Readable, Writable } from 'stream';
 import Logger from '../../logging/logger';
-import { sanitizeGenericFileName } from '../../utils/FileDownloadUtils';
+import { createContentDispositionHeader } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import {
     S3CacheClient,
     type S3CacheClientArguments,
@@ -47,9 +47,9 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
                 Key: fileName,
                 Body: passThrough,
                 ContentType: opts.contentType,
-                ContentDisposition: `attachment; filename="${
-                    attachmentDownloadName || fileName
-                }"`,
+                ContentDisposition: createContentDispositionHeader(
+                    attachmentDownloadName || fileName,
+                ),
             },
         });
 
@@ -171,9 +171,7 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
                 contentType: config.contentType,
             },
             attachmentDownloadName
-                ? `${sanitizeGenericFileName(attachmentDownloadName)}.${
-                      config.extension
-                  }`
+                ? `${attachmentDownloadName}.${config.extension}`
                 : undefined,
         );
 
@@ -216,9 +214,9 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
                 Key: fileName,
                 Body: fileStream,
                 ContentType: options.contentType,
-                ContentDisposition: `attachment; filename="${
-                    options.attachmentDownloadName || fileName
-                }"`,
+                ContentDisposition: createContentDispositionHeader(
+                    options.attachmentDownloadName || fileName,
+                ),
             },
         });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -89,7 +89,7 @@ import { measureTime } from '../../logging/measureTime';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type { SavedSqlModel } from '../../models/SavedSqlModel';
 import { wrapSentryTransaction } from '../../utils';
-import { processFieldsForExport } from '../../utils/FileDownloadUtils';
+import { processFieldsForExport } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import {
     QueryBuilder,
     ReferenceMap,

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -233,27 +233,27 @@ $4.00,value_4,2020-03-16
             `csv-payment-${timestamp}.csv`,
         );
         expect(CsvService.generateFileId('MyTable', false, time)).toEqual(
-            `csv-mytable-${timestamp}.csv`,
+            `csv-MyTable-${timestamp}.csv`,
         );
         expect(CsvService.generateFileId('my table', false, time)).toEqual(
-            `csv-my_table-${timestamp}.csv`,
+            `csv-my table-${timestamp}.csv`,
         );
         expect(CsvService.generateFileId('table!', false, time)).toEqual(
-            `csv-table_-${timestamp}.csv`,
+            `csv-table!-${timestamp}.csv`,
         );
         expect(
             CsvService.generateFileId('this is a chart title', false, time),
-        ).toEqual(`csv-this_is_a_chart_title-${timestamp}.csv`);
+        ).toEqual(`csv-this is a chart title-${timestamp}.csv`);
         expect(
             CsvService.generateFileId(
                 'another table (for testing)',
                 false,
                 time,
             ),
-        ).toEqual(`csv-another_table_for_testing_-${timestamp}.csv`);
+        ).toEqual(`csv-another table (for testing)-${timestamp}.csv`);
         expect(
             CsvService.generateFileId('weird chars *!"()_-', false, time),
-        ).toEqual(`csv-weird_chars_-${timestamp}.csv`);
+        ).toEqual(`csv-weird chars _!_()_--${timestamp}.csv`);
 
         // Test without time
         expect(CsvService.generateFileId('payment')).toContain(`csv-payment-`);
@@ -278,12 +278,12 @@ $4.00,value_4,2020-03-16
 
         const validNames = [
             `csv-payment-${timestamp}.csv`,
-            `csv-mytable-${timestamp}.csv`,
-            `csv-my_table-${timestamp}.csv`,
-            `csv-table_-${timestamp}.csv`,
-            `csv-this_is_a_chart_title-${timestamp}.csv`,
-            `csv-another_table_for_testing_-${timestamp}.csv`,
-            `csv-weird_chars_-${timestamp}.csv`,
+            `csv-MyTable-${timestamp}.csv`,
+            `csv-my table-${timestamp}.csv`,
+            `csv-table!-${timestamp}.csv`,
+            `csv-this is a chart title-${timestamp}.csv`,
+            `csv-another table (for testing)-${timestamp}.csv`,
+            `csv-weird chars _!_()_--${timestamp}.csv`,
             `csv-incomplete_results-payment-${timestamp}.csv`,
         ];
 
@@ -291,8 +291,8 @@ $4.00,value_4,2020-03-16
             `without_prefix-${timestamp}.csv`,
             `csv-without_suffix-${timestamp}`,
             `csv-no_timestamp.csv`,
-            `csv-with space-${timestamp}.csv`,
-            `csv-UPPERCASED-${timestamp}.csv`,
+            `csv-file/invalid-${timestamp}.csv`,
+            `csv-file\\invalid-${timestamp}.csv`,
         ];
         validNames.forEach((name) => {
             expect(name + CsvService.isValidCsvFileId(name)).toEqual(

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -279,7 +279,9 @@ export class CsvService extends BaseService {
     }
 
     static isValidCsvFileId(fileId: string): boolean {
-        return /^csv-(incomplete_results-)?[a-z0-9_]+-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.csv$/.test(
+        // Updated regex to allow Unicode characters, spaces, mixed case, and common punctuation
+        // This matches our new sanitizeGenericFileName approach
+        return /^csv-(incomplete_results-)?[^/\\:*?"<>|]+-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.csv$/.test(
             fileId,
         );
     }

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -84,7 +84,7 @@ import {
     isRowValueTimestamp,
     sanitizeGenericFileName,
     streamJsonlData,
-} from '../../utils/FileDownloadUtils';
+} from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { BaseService } from '../BaseService';
 import { ProjectService } from '../ProjectService/ProjectService';
 

--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -628,9 +628,9 @@ describe('ExcelService', () => {
             const fileName = 'test-results';
             const fileId = ExcelService.generateFileId(fileName);
 
-            // Format is: xlsx-test_results-YYYY-MM-DD-HH-mm-ss-SSSS.xlsx
+            // Format is: xlsx-test-results-YYYY-MM-DD-HH-mm-ss-SSSS.xlsx
             expect(fileId).toMatch(
-                /^xlsx-test_results-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.xlsx$/,
+                /^xlsx-test-results-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.xlsx$/,
             );
         });
 
@@ -638,9 +638,9 @@ describe('ExcelService', () => {
             const fileName = 'test-results';
             const fileId = ExcelService.generateFileId(fileName, true);
 
-            // Format is: xlsx-incomplete_results-test_results-YYYY-MM-DD-HH-mm-ss-SSSS.xlsx
+            // Format is: xlsx-incomplete_results-test-results-YYYY-MM-DD-HH-mm-ss-SSSS.xlsx
             expect(fileId).toMatch(
-                /^xlsx-incomplete_results-test_results-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.xlsx$/,
+                /^xlsx-incomplete_results-test-results-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.xlsx$/,
             );
         });
     });

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -24,7 +24,7 @@ import {
     generateGenericFileId,
     processFieldsForExport,
     streamJsonlData,
-} from '../../utils/FileDownloadUtils';
+} from '../../utils/FileDownloadUtils/FileDownloadUtils';
 
 export class ExcelService {
     private static readonly EXCEL_ROW_LIMIT = 1_000_000;

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
@@ -1,0 +1,232 @@
+import {
+    createContentDispositionHeader,
+    sanitizeGenericFileName,
+} from './FileDownloadUtils';
+
+describe('FileDownloadUtils', () => {
+    describe('sanitizeGenericFileName', () => {
+        // Test cases as data arrays for faster execution
+        const preserveTestCases = [
+            ['美しいチャート', '美しいチャート', 'Japanese characters'],
+            ['Données français', 'Données français', 'French characters'],
+            ['Sales Report 2024', 'Sales Report 2024', 'spaces'],
+            ['MyReport', 'MyReport', 'mixed case'],
+            [
+                'Sales-Report_Final',
+                'Sales-Report_Final',
+                'hyphens and underscores',
+            ],
+            ['Data (2024)', 'Data (2024)', 'parentheses'],
+            ['Report.v1', 'Report.v1', 'dots'],
+            ['Report123', 'Report123', 'numbers'],
+            ['Sales Report 📊 2024', 'Sales Report 📊 2024', 'emoji'],
+        ];
+
+        const unsafeCharTestCases = [
+            ['Q1/Q2 Report', 'Q1_Q2 Report', 'forward slash'],
+            ['Data\\Export', 'Data_Export', 'backslash'],
+            ['Report: Summary', 'Report_ Summary', 'colon'],
+            ['Data*Export', 'Data_Export', 'asterisk'],
+            ['What?', 'What_', 'question mark'],
+            ['The "Best" Report', 'The _Best_ Report', 'quotes'],
+            ['Data<Export>', 'Data_Export_', 'angle brackets'],
+            ['Data|Export', 'Data_Export', 'pipe'],
+        ];
+
+        const controlCharTestCases = [
+            ['Report\x00Test', 'ReportTest', 'null character'],
+            ['Report\tTest', 'ReportTest', 'tab character'],
+            ['Report\nTest', 'ReportTest', 'newline'],
+            ['Report\r\nTest', 'ReportTest', 'CRLF'],
+            ['Report\x7FTest', 'ReportTest', 'DEL character'],
+        ];
+
+        const trimTestCases = [
+            ['   Report', 'Report', 'leading spaces'],
+            ['Report   ', 'Report', 'trailing spaces'],
+            ['...Report', 'Report', 'leading dots'],
+            ['Report...', 'Report', 'trailing dots'],
+            [' . Report . ', 'Report', 'mixed leading/trailing'],
+        ];
+
+        it.each(preserveTestCases)(
+            'should preserve %s (%s)',
+            (input, expected) => {
+                expect(sanitizeGenericFileName(input)).toBe(expected);
+            },
+        );
+
+        it.each(unsafeCharTestCases)(
+            'should replace %s (%s)',
+            (input, expected) => {
+                expect(sanitizeGenericFileName(input)).toBe(expected);
+            },
+        );
+
+        it.each(controlCharTestCases)(
+            'should remove %s (%s)',
+            (input, expected) => {
+                expect(sanitizeGenericFileName(input)).toBe(expected);
+            },
+        );
+
+        it.each(trimTestCases)('should trim %s (%s)', (input, expected) => {
+            expect(sanitizeGenericFileName(input)).toBe(expected);
+        });
+
+        it('handles multiple scenarios in batch', () => {
+            // Group related assertions to reduce test overhead
+            expect(
+                sanitizeGenericFileName('Report: Q1/Q2 Analysis "Data"'),
+            ).toBe('Report_ Q1_Q2 Analysis _Data_');
+            expect(sanitizeGenericFileName('Data___Export')).toBe(
+                'Data_Export',
+            );
+            expect(sanitizeGenericFileName('Data//\\\\Export')).toBe(
+                'Data_Export',
+            );
+            expect(sanitizeGenericFileName('')).toBe('download');
+            expect(sanitizeGenericFileName('//\\\\')).toBe('_');
+            expect(sanitizeGenericFileName('***')).toBe('_');
+            expect(sanitizeGenericFileName('   ...')).toBe('download');
+        });
+
+        it('handles real-world complex examples', () => {
+            expect(sanitizeGenericFileName('美しいチャート: Q1/Q2 分析')).toBe(
+                '美しいチャート_ Q1_Q2 分析',
+            );
+            expect(
+                sanitizeGenericFileName('Données "françaises": Q1\\Q2'),
+            ).toBe('Données _françaises_ Q1_Q2');
+            expect(
+                sanitizeGenericFileName('Johnson & Johnson: Q1 Report (Final)'),
+            ).toBe('Johnson & Johnson_ Q1 Report (Final)');
+
+            // Test very long filename
+            const longName = 'a'.repeat(300);
+            expect(sanitizeGenericFileName(longName)).toBe(longName);
+        });
+    });
+
+    describe('createContentDispositionHeader', () => {
+        const unicodeTestCases = [
+            [
+                '美しいチャート.csv',
+                '.csv',
+                '%E7%BE%8E%E3%81%97%E3%81%84%E3%83%81%E3%83%A3%E3%83%BC%E3%83%88.csv',
+                'Japanese',
+            ],
+            [
+                'Report 美しい.csv',
+                'Report .csv',
+                'Report%20%E7%BE%8E%E3%81%97%E3%81%84.csv',
+                'mixed ASCII/Unicode',
+            ],
+            ['données.csv', 'donnes.csv', 'donn%C3%A9es.csv', 'French'],
+            ['Sales 📊.csv', 'Sales .csv', 'Sales%20%F0%9F%93%8A.csv', 'emoji'],
+        ];
+
+        it('handles basic functionality', () => {
+            expect(createContentDispositionHeader('report.csv')).toBe(
+                'attachment; filename="report.csv"; filename*=UTF-8\'\'report.csv',
+            );
+
+            expect(createContentDispositionHeader('report: data.csv')).toBe(
+                'attachment; filename="report_ data.csv"; filename*=UTF-8\'\'report_%20data.csv',
+            );
+        });
+
+        it.each(unicodeTestCases)(
+            'handles %s (%s)',
+            (input, expectedFallback, expectedEncoded) => {
+                const result = createContentDispositionHeader(input);
+                expect(result).toContain(`filename="${expectedFallback}"`);
+                expect(result).toContain(`filename*=UTF-8''${expectedEncoded}`);
+            },
+        );
+
+        it('handles ASCII fallback scenarios', () => {
+            const result1 =
+                createContentDispositionHeader('美しいチャート Report.csv');
+            expect(result1).toContain('filename=" Report.csv"'); // Japanese removed
+            expect(result1).toContain(
+                "filename*=UTF-8''%E7%BE%8E%E3%81%97%E3%81%84%E3%83%81%E3%83%A3%E3%83%BC%E3%83%88%20Report.csv",
+            );
+
+            const result2 =
+                createContentDispositionHeader('美しいチャート.csv');
+            expect(result2).toContain('filename=".csv"'); // Only extension remains
+        });
+
+        it('handles sanitization and encoding together', () => {
+            const result1 = createContentDispositionHeader('美しい: Q1/Q2.csv');
+            expect(result1).toContain('filename="_ Q1_Q2.csv"');
+            expect(result1).toContain(
+                "filename*=UTF-8''%E7%BE%8E%E3%81%97%E3%81%84_%20Q1_Q2.csv",
+            );
+
+            const result2 = createContentDispositionHeader(
+                'Données "françaises": Q1\\Q2 📊.xlsx',
+            );
+            expect(result2).toContain(
+                'filename="Donnes _franaises_ Q1_Q2 .xlsx"',
+            );
+            expect(result2).toContain(
+                "filename*=UTF-8''Donn%C3%A9es%20_fran%C3%A7aises_%20Q1_Q2%20%F0%9F%93%8A.xlsx",
+            );
+        });
+
+        it('handles edge cases and RFC 5987 compliance', () => {
+            // Edge cases
+            expect(createContentDispositionHeader('')).toBe(
+                'attachment; filename="download"; filename*=UTF-8\'\'download',
+            );
+            expect(createContentDispositionHeader('//\\\\')).toBe(
+                'attachment; filename="_"; filename*=UTF-8\'\'_',
+            );
+
+            // RFC 5987 format compliance
+            const result = createContentDispositionHeader('test.csv');
+            expect(result).toMatch(
+                /^attachment; filename="[^"]*"; filename\*=UTF-8''[^;]*$/,
+            );
+
+            // Proper encoding
+            expect(createContentDispositionHeader('test file.csv')).toContain(
+                "filename*=UTF-8''test%20file.csv",
+            );
+            expect(createContentDispositionHeader('test&file.csv')).toContain(
+                "filename*=UTF-8''test%26file.csv",
+            );
+        });
+    });
+
+    describe('integration between functions', () => {
+        it('should work together for complex filenames', () => {
+            const originalFilename =
+                '美しいチャート: "Q1/Q2" Analysis (Final).xlsx';
+
+            // Test sanitization
+            const sanitized = sanitizeGenericFileName(originalFilename);
+            expect(sanitized).toBe(
+                '美しいチャート_ _Q1_Q2_ Analysis (Final).xlsx',
+            );
+
+            // Test full header creation
+            const header = createContentDispositionHeader(originalFilename);
+            expect(header).toContain(
+                'filename="_ _Q1_Q2_ Analysis (Final).xlsx"',
+            ); // ASCII fallback
+            expect(header).toContain(
+                "filename*=UTF-8''%E7%BE%8E%E3%81%97%E3%81%84%E3%83%81%E3%83%A3%E3%83%BC%E3%83%88_%20_Q1_Q2_%20Analysis%20(Final).xlsx",
+            );
+        });
+
+        it('should handle edge case where sanitization results in empty string', () => {
+            const header = createContentDispositionHeader('///\\\\\\');
+            expect(header).toBe(
+                'attachment; filename="_"; filename*=UTF-8\'\'_',
+            );
+        });
+    });
+});

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.test.ts
@@ -118,12 +118,12 @@ describe('FileDownloadUtils', () => {
             ],
             [
                 'Report 美しい.csv',
-                'Report .csv',
+                'Report.csv',
                 'Report%20%E7%BE%8E%E3%81%97%E3%81%84.csv',
                 'mixed ASCII/Unicode',
             ],
             ['données.csv', 'donnes.csv', 'donn%C3%A9es.csv', 'French'],
-            ['Sales 📊.csv', 'Sales .csv', 'Sales%20%F0%9F%93%8A.csv', 'emoji'],
+            ['Sales 📊.csv', 'Sales.csv', 'Sales%20%F0%9F%93%8A.csv', 'emoji'],
         ];
 
         it('handles basic functionality', () => {
@@ -148,7 +148,7 @@ describe('FileDownloadUtils', () => {
         it('handles ASCII fallback scenarios', () => {
             const result1 =
                 createContentDispositionHeader('美しいチャート Report.csv');
-            expect(result1).toContain('filename=" Report.csv"'); // Japanese removed
+            expect(result1).toContain('filename="Report.csv"'); // Japanese removed, space normalized
             expect(result1).toContain(
                 "filename*=UTF-8''%E7%BE%8E%E3%81%97%E3%81%84%E3%83%81%E3%83%A3%E3%83%BC%E3%83%88%20Report.csv",
             );
@@ -169,7 +169,7 @@ describe('FileDownloadUtils', () => {
                 'Données "françaises": Q1\\Q2 📊.xlsx',
             );
             expect(result2).toContain(
-                'filename="Donnes _franaises_ Q1_Q2 .xlsx"',
+                'filename="Donnes _franaises_ Q1_Q2.xlsx"',
             );
             expect(result2).toContain(
                 "filename*=UTF-8''Donn%C3%A9es%20_fran%C3%A7aises_%20Q1_Q2%20%F0%9F%93%8A.xlsx",

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
@@ -48,8 +48,14 @@ export function createContentDispositionHeader(filename: string): string {
     // First sanitize the filename using our standard sanitization
     const sanitizedFilename = sanitizeGenericFileName(filename);
 
-    // Create ASCII fallback by removing non-ASCII characters
-    const asciiFallback = sanitizedFilename.replace(/[^\u0000-\u007F]/g, ''); // eslint-disable-line no-control-regex
+    // Create ASCII fallback by removing non-ASCII characters and normalizing spaces
+    const asciiFallback =
+        sanitizedFilename
+            .replace(/[^\u0000-\u007F]/g, '') // eslint-disable-line no-control-regex
+            .replace(/\s+/g, ' ') // normalize multiple spaces to single space
+            .replace(/\s+\./g, '.') // remove spaces before file extensions
+            .trim() || // remove leading/trailing spaces
+        'download'; // fallback if empty
 
     // RFC 5987 encoding: encode the filename and prepend with UTF-8''
     const encodedFilename = encodeURIComponent(sanitizedFilename);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15475

### Description:
We resolved the "Invalid character in header content" issue for Japanese users by implementing RFC 5987-compliant Content-Disposition headers that properly encode Unicode filenames. The solution replaces aggressive ASCII-only sanitization with smart character handling that preserves Unicode characters (like Japanese text) while safely removing only filesystem-unsafe characters, then creates dual-format headers with both an ASCII fallback (`filename="fallback.csv"`) and a properly URL-encoded Unicode version (`filename*=UTF-8''%E7%BE%8E%E3%81%97%E3%81%84.csv`) to ensure browser compatibility.

<img width="585" alt="Screenshot 2025-06-23 at 15 15 16" src="https://github.com/user-attachments/assets/f15d858b-15fa-47c7-acc8-850f34e67368" />
