### PR TITLE
chore: add persistent volume for postgres in `docker-compose.dev.mini.yml`

### DIFF
--- a/docker/docker-compose.dev.mini.yml
+++ b/docker/docker-compose.dev.mini.yml
@@ -1,6 +1,7 @@
 version: '3.8'
+
 volumes:
-    node_modules:
+    postgres_data:
 
 services:
     minio:
@@ -18,6 +19,8 @@ services:
         restart: always
         environment:
             POSTGRES_PASSWORD: password
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
         ports:
             - '5432:5432'
 


### PR DESCRIPTION
This PR replaces the `node_modules` volume (which is not required anymore) with a `postgres_data` volume in the development Docker Compose configuration. The new volume is properly mounted to the PostgreSQL container at `/var/lib/postgresql/data`, ensuring data persistence between container restarts.