### PR TITLE
chore: extract warehouse sql builder methods

### DIFF
--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -3,7 +3,10 @@ import { type QueryExecutionContext } from './analytics';
 import { type AnyType } from './any';
 import { type SupportedDbtAdapter } from './dbt';
 import { type DimensionType, type Metric } from './field';
-import { type CreateWarehouseCredentials } from './projects';
+import {
+    type CreateWarehouseCredentials,
+    type WarehouseTypes,
+} from './projects';
 import type { WarehouseQueryMetadata } from './queryHistory';
 
 export type RunQueryTags = {
@@ -67,7 +70,17 @@ export type WarehouseExecuteAsyncQuery = {
     durationMs: number;
 };
 
-export interface WarehouseClient {
+export interface WarehouseSqlBuilder {
+    type: WarehouseTypes;
+    getStartOfWeek: () => WeekDay | null | undefined;
+    getAdapterType: () => SupportedDbtAdapter;
+    getStringQuoteChar: () => string;
+    getEscapeStringQuoteChar: () => string;
+    getMetricSql: (sql: string, metric: Metric) => string;
+    concatString: (...args: string[]) => string;
+}
+
+export interface WarehouseClient extends Omit<WarehouseSqlBuilder, 'type'> {
     credentials: CreateWarehouseCredentials;
     getCatalog: (
         config: {
@@ -111,18 +124,6 @@ export interface WarehouseClient {
     ): Promise<WarehouseResults>;
 
     test(): Promise<void>;
-
-    getStartOfWeek(): WeekDay | null | undefined;
-
-    getAdapterType(): SupportedDbtAdapter;
-
-    getStringQuoteChar(): string;
-
-    getEscapeStringQuoteChar(): string;
-
-    getMetricSql(sql: string, metric: Metric): string;
-
-    concatString(...args: string[]): string;
 
     getAllTables(
         schema?: string,

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
@@ -1,0 +1,42 @@
+import {
+    Metric,
+    SupportedDbtAdapter,
+    WarehouseSqlBuilder,
+    WarehouseTypes,
+    WeekDay,
+} from '@lightdash/common';
+import { getDefaultMetricSql } from '../utils/sql';
+
+export default abstract class WarehouseBaseSqlBuilder
+    implements WarehouseSqlBuilder
+{
+    abstract readonly type: WarehouseTypes;
+
+    protected startOfWeek: WeekDay | null | undefined;
+
+    constructor(startOfWeek?: WeekDay | null) {
+        this.startOfWeek = startOfWeek;
+    }
+
+    getStartOfWeek(): WeekDay | null | undefined {
+        return this.startOfWeek;
+    }
+
+    abstract getAdapterType(): SupportedDbtAdapter;
+
+    getStringQuoteChar(): string {
+        return "'";
+    }
+
+    getEscapeStringQuoteChar(): string {
+        return '\\';
+    }
+
+    getMetricSql(sql: string, metric: Metric): string {
+        return getDefaultMetricSql(sql, metric.type);
+    }
+
+    concatString(...args: string[]): string {
+        return `CONCAT(${args.join(', ')})`;
+    }
+}


### PR DESCRIPTION
This separates all the sql building logic of warehouses from the query execution.

Benefit is that you can use the sql building functions without needing a set of valid/fake credentials.

Questions:
- [ ] Should we mark the usage of sql building functions on the warehouse client (e.g. `warehouseClient.startOfWeek()`) as deprecated and suggest users use the `warehouseSqlBuilder` directly instead?

