### PR TITLE
chore: enable MinIO browser in development environment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -87,6 +87,7 @@ INTERNAL_LIGHTDASH_HOST=http://lightdash-dev:3000
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 MINIO_DEFAULT_BUCKETS=default,results
+MINIO_BROWSER=on
 
 # S3 Configuration
 S3_ENDPOINT=http://minio:9000

--- a/docker/docker-compose.dev.mini.yml
+++ b/docker/docker-compose.dev.mini.yml
@@ -1,7 +1,6 @@
-version: '3.8'
-
 volumes:
     postgres_data:
+    minio_data:
 
 services:
     minio:
@@ -13,16 +12,19 @@ services:
             - MINIO_ROOT_USER=${MINIO_ROOT_USER}
             - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
             - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS}
+            - MINIO_BROWSER=${MINIO_BROWSER:-off}
+        volumes:
+            - minio_data:/bitnami/minio/data
 
     db-dev:
         image: pgvector/pgvector:pg16
         restart: always
         environment:
             POSTGRES_PASSWORD: password
-        volumes:
-            - postgres_data:/var/lib/postgresql/data
         ports:
             - '5432:5432'
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
 
     headless-browser:
         image: ghcr.io/browserless/chromium:v2.24.3

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
             - MINIO_ROOT_USER=${MINIO_ROOT_USER}
             - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
             - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS}
+            - MINIO_BROWSER=${MINIO_BROWSER:-off}
 
     lightdash-dev:
         build:


### PR DESCRIPTION
Enable MinIO browser in development environment by adding `MINIO_BROWSER=on` to `.env.development` and passing this environment variable to MinIO containers in Docker Compose files. Also added persistent storage for MinIO by creating a new volume `minio_data` in the mini development setup.