### PR TITLE
fix: validate undefined filter groups

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -242,20 +242,22 @@ export const isMetricFilterTarget = (
 export const getFilterRules = (filters: Filters): FilterRule[] => {
     const rules: FilterRule[] = [];
     const flattenFilterGroup = (filterGroup: FilterGroup): FilterRule[] => {
-        const groupRules: FilterRule[] = [];
-
-        (isAndFilterGroup(filterGroup)
+        // Explicitly checking for undefined filter groups (and || or), saved filter group somehow was undefined when saving
+        const groupItems: FilterGroupItem[] | undefined = isAndFilterGroup(
+            filterGroup,
+        )
             ? filterGroup.and
-            : filterGroup.or
-        ).forEach((item) => {
+            : filterGroup.or;
+
+        return (groupItems || []).flatMap((item) => {
             if (isFilterGroup(item)) {
-                rules.push(...flattenFilterGroup(item));
-            } else {
-                rules.push(item);
+                return flattenFilterGroup(item);
             }
+
+            return [item];
         });
-        return groupRules;
     };
+
     if (filters.dimensions) {
         rules.push(...flattenFilterGroup(filters.dimensions));
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/15501

### Description:
Fix filter rule flattening logic to handle undefined filter groups. The previous implementation wasn't correctly accumulating filter rules from nested groups and didn't handle the case where a filter group could be undefined. This change refactors the `flattenFilterGroup` function to use `flatMap` for cleaner code and adds explicit handling for undefined filter groups.

Root cause for the filters to have been saved incorrectly hasn't been found, but this fixes the validation problems