### PR TITLE
fix: content-disposition header in s3Client

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -17,6 +17,7 @@ import { ReadStream } from 'fs';
 import { PassThrough, Readable } from 'stream';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import { createContentDispositionHeader } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 
 type S3ClientArguments = {
     lightdashConfig: LightdashConfig;
@@ -75,7 +76,7 @@ export class S3Client {
                 Body: file,
                 ContentType: contentType,
                 ACL: 'private',
-                ContentDisposition: `attachment; filename="${fileId}"`,
+                ContentDisposition: createContentDispositionHeader(fileId),
             },
         });
         try {
@@ -174,7 +175,7 @@ export class S3Client {
                 Body: buffer,
                 ContentType: `application/jsonl`,
                 ACL: 'private',
-                ContentDisposition: `attachment; filename="${fileId}"`,
+                ContentDisposition: createContentDispositionHeader(fileId),
             },
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15521

### Description:
Uses `createContentDispositionHeader` function in S3 client to set the `content-disposition` header when uploading files to S3.

**Steps to reproduce**
1. Create a chart with name: "美しいチャート"
2. Create scheduled delivery of type CSV
3. Click send now

**Before**
![image](https://github.com/user-attachments/assets/dad408fb-bc32-43e5-85ca-8e427df21fec)

**After**
![image](https://github.com/user-attachments/assets/e16b2618-abb7-43a5-a189-aeee51983c49)
![image](https://github.com/user-attachments/assets/4a26504a-b78b-4ee8-ba67-1bd8789dbed3)
