### PR TITLE
refactor: extract sort SQL generation into private method

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
@@ -395,6 +395,11 @@ export class MetricQueryBuilder {
         };
     }
 
+    private getLimitSQL() {
+        const { limit } = this.args.compiledMetricQuery;
+        return limit !== undefined ? `LIMIT ${limit}` : undefined;
+    }
+
     /**
      * Compiles a database query based on the provided metric query, explores, user attributes, and warehouse-specific configurations.
      *
@@ -649,7 +654,7 @@ export class MetricQueryBuilder {
             Logger.error('Error during metric inflation detection', e);
         }
 
-        const sqlLimit = `LIMIT ${limit}`;
+        const sqlLimit = this.getLimitSQL();
         const { sqlOrderBy, requiresQueryInCTE } = this.getSortSQL();
         if (
             compiledMetricQuery.compiledTableCalculations.length > 0 ||
@@ -704,7 +709,9 @@ export class MetricQueryBuilder {
             const cte = `WITH ${ctes.join(',\n')}`;
 
             return {
-                query: [cte, finalQuery, sqlOrderBy, sqlLimit].join('\n'),
+                query: [cte, finalQuery, sqlOrderBy, sqlLimit]
+                    .filter((l) => l !== undefined)
+                    .join('\n'),
                 fields,
                 warnings,
             };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored the query builder by extracting sort SQL generation into a dedicated method `getSortSQL()`. This improves code organization by separating the sorting logic from the main query compilation process, making the code more maintainable and easier to understand.

The new method returns both the SQL ORDER BY clause and a flag indicating whether the query requires wrapping in a Common Table Expression (CTE), which is needed for certain sorting operations like month names and day of week names.