### PR TITLE
feat: add OpenAI base URL configuration option

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -14,6 +14,7 @@ export const aiCopilotConfigSchema = z
                 .object({
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_OPENAI_MODEL_NAME),
+                    baseUrl: z.string().optional(),
                 })
                 .optional(),
             azure: z

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -877,6 +877,7 @@ export const parseConfig = (): LightdashConfig => {
                       modelName:
                           process.env.OPENAI_MODEL_NAME ||
                           DEFAULT_OPENAI_MODEL_NAME,
+                      baseUrl: process.env.OPENAI_BASE_URL,
                   }
                 : undefined,
             anthropic: process.env.ANTHROPIC_API_KEY

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -251,6 +251,10 @@ export const streamAgentResponse = async ({
                 chunking: 'line',
             }),
             toolCallStreaming: true,
+            onError: (error) => {
+                Logger.error(error);
+                Sentry.captureException(error);
+            },
         });
         return result;
     } catch (error) {

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -9,6 +9,9 @@ export const getOpenaiGptmodel = (
     const openai = createOpenAI({
         apiKey: config.apiKey,
         compatibility: 'strict',
+        ...(config.baseUrl
+            ? { baseURL: config.baseUrl, compatibility: 'compatible' }
+            : {}),
     });
 
     const model = openai(config.modelName, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15548

### Description:

Added support for custom OpenAI base URL in AI Copilot configuration. This allows users to specify an alternative OpenAI API endpoint through the `OPENAI_BASE_URL` environment variable. The implementation includes schema validation for the new `baseUrl` parameter and updates the OpenAI client configuration to use the custom endpoint when provided.
