### PR TITLE
feat: add --skip-copy-content option to preview and start-preview commands

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -14,12 +14,17 @@ import {
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
+    getRequestMethod,
     KnexPaginateArgs,
+    LightdashRequestMethodHeader,
     OrganizationMemberProfileUpdate,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
     UpdateOrganization,
     UUID,
+    type ApiCreateProjectResults,
+    type ApiSuccess,
+    type CreateProject,
 } from '@lightdash/common';
 import {
     Body,
@@ -490,6 +495,31 @@ export class OrganizationController extends BaseController {
             results: await this.services
                 .getOrganizationService()
                 .setActiveColorPalette(req.user!, colorPaletteUuid),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/projects')
+    @OperationId('CreateProject')
+    async createProject(
+        @Request() req: express.Request,
+        @Body() body: CreateProject,
+    ): Promise<ApiSuccess<ApiCreateProjectResults>> {
+        const results = await this.services
+            .getProjectService()
+            .createWithoutCompile(
+                req.user!,
+                body,
+                getRequestMethod(req.header(LightdashRequestMethodHeader)),
+            );
+
+        return {
+            status: 'ok',
+            results,
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13075,6 +13075,427 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateProjectResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                hasContentCopy: { dataType: 'boolean', required: true },
+                project: { ref: 'Project', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ApiCreateProjectResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ApiCreateProjectResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    type: { ref: 'ProjectType', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dbtConnection: { ref: 'DbtProjectConfig', required: true },
+                    warehouseConnection: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'WarehouseCredentials' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    upstreamProjectUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dbtVersion: { ref: 'DbtVersionOption', required: true },
+                    semanticLayerConnection: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'SemanticLayerConnection' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                ref: 'Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__',
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SshTunnelConfiguration: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sshTunnelPrivateKey: { dataType: 'string' },
+                sshTunnelPublicKey: { dataType: 'string' },
+                sshTunnelUser: { dataType: 'string' },
+                sshTunnelPort: { dataType: 'double' },
+                sshTunnelHost: { dataType: 'string' },
+                useSshTunnel: { dataType: 'boolean' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateRedshiftCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SshTunnelConfiguration' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        timeoutSeconds: { dataType: 'double' },
+                        startOfWeek: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'WeekDay' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        ra3Node: { dataType: 'boolean' },
+                        sslmode: { dataType: 'string' },
+                        keepalivesIdle: { dataType: 'double' },
+                        threads: { dataType: 'double' },
+                        schema: { dataType: 'string', required: true },
+                        dbname: { dataType: 'string', required: true },
+                        port: { dataType: 'double', required: true },
+                        requireUserCredentials: { dataType: 'boolean' },
+                        password: { dataType: 'string', required: true },
+                        user: { dataType: 'string', required: true },
+                        host: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'WarehouseTypes.REDSHIFT',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateBigqueryCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                executionProject: { dataType: 'string' },
+                startOfWeek: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'WeekDay' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                maximumBytesBilled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                location: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                retries: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                requireUserCredentials: { dataType: 'boolean' },
+                keyfileContents: {
+                    ref: 'Record_string.string_',
+                    required: true,
+                },
+                authenticationType: { ref: 'BigqueryAuthenticationType' },
+                priority: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['interactive'] },
+                        { dataType: 'enum', enums: ['batch'] },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                timeoutSeconds: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                threads: { dataType: 'double' },
+                dataset: { dataType: 'string', required: true },
+                project: { dataType: 'string', required: true },
+                type: { ref: 'WarehouseTypes.BIGQUERY', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SslConfiguration: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                sslrootcert: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                sslrootcertFileName: { dataType: 'string' },
+                sslkey: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                sslkeyFileName: { dataType: 'string' },
+                sslcert: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                sslcertFileName: { dataType: 'string' },
+                sslmode: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreatePostgresCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SshTunnelConfiguration' },
+                { ref: 'SslConfiguration' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        timeoutSeconds: { dataType: 'double' },
+                        startOfWeek: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'WeekDay' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        role: { dataType: 'string' },
+                        searchPath: { dataType: 'string' },
+                        keepalivesIdle: { dataType: 'double' },
+                        threads: { dataType: 'double' },
+                        schema: { dataType: 'string', required: true },
+                        dbname: { dataType: 'string', required: true },
+                        port: { dataType: 'double', required: true },
+                        requireUserCredentials: { dataType: 'boolean' },
+                        password: { dataType: 'string', required: true },
+                        user: { dataType: 'string', required: true },
+                        host: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'WarehouseTypes.POSTGRES',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateSnowflakeCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                override: { dataType: 'boolean' },
+                quotedIdentifiersIgnoreCase: { dataType: 'boolean' },
+                startOfWeek: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'WeekDay' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                accessUrl: { dataType: 'string' },
+                queryTag: { dataType: 'string' },
+                clientSessionKeepAlive: { dataType: 'boolean' },
+                threads: { dataType: 'double' },
+                schema: { dataType: 'string', required: true },
+                warehouse: { dataType: 'string', required: true },
+                database: { dataType: 'string', required: true },
+                role: { dataType: 'string' },
+                token: { dataType: 'string' },
+                authenticationType: { ref: 'SnowflakeAuthenticationType' },
+                privateKeyPass: { dataType: 'string' },
+                privateKey: { dataType: 'string' },
+                requireUserCredentials: { dataType: 'boolean' },
+                password: { dataType: 'string' },
+                user: { dataType: 'string', required: true },
+                account: { dataType: 'string', required: true },
+                type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateDatabricksCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                compute: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            httpPath: { dataType: 'string', required: true },
+                            name: { dataType: 'string', required: true },
+                        },
+                    },
+                },
+                startOfWeek: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'WeekDay' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                requireUserCredentials: { dataType: 'boolean' },
+                personalAccessToken: { dataType: 'string', required: true },
+                httpPath: { dataType: 'string', required: true },
+                serverHostName: { dataType: 'string', required: true },
+                database: { dataType: 'string', required: true },
+                catalog: { dataType: 'string' },
+                type: { ref: 'WarehouseTypes.DATABRICKS', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateTrinoCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                startOfWeek: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'WeekDay' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                http_scheme: { dataType: 'string', required: true },
+                schema: { dataType: 'string', required: true },
+                dbname: { dataType: 'string', required: true },
+                port: { dataType: 'double', required: true },
+                requireUserCredentials: { dataType: 'boolean' },
+                password: { dataType: 'string', required: true },
+                user: { dataType: 'string', required: true },
+                host: { dataType: 'string', required: true },
+                type: { ref: 'WarehouseTypes.TRINO', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateWarehouseCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'CreateRedshiftCredentials' },
+                { ref: 'CreateBigqueryCredentials' },
+                { ref: 'CreatePostgresCredentials' },
+                { ref: 'CreateSnowflakeCredentials' },
+                { ref: 'CreateDatabricksCredentials' },
+                { ref: 'CreateTrinoCredentials' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateProjectTableConfiguration: {
+        dataType: 'refEnum',
+        enums: ['prod', 'all'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateProject: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_',
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        copyContent: { dataType: 'boolean' },
+                        tableConfiguration: {
+                            ref: 'CreateProjectTableConfiguration',
+                        },
+                        copyWarehouseConnectionFromUpstreamProject: {
+                            dataType: 'boolean',
+                        },
+                        warehouseConnection: {
+                            ref: 'CreateWarehouseCredentials',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     NotificationBase: {
         dataType: 'refAlias',
         type: {
@@ -29591,6 +30012,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'setActiveColorPalette',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_createProject: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateProject',
+        },
+    };
+    app.post(
+        '/api/v1/org/projects',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.createProject,
+        ),
+
+        async function OrganizationController_createProject(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_createProject,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createProject',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13933,6 +13933,562 @@
                 "required": ["uuid"],
                 "type": "object"
             },
+            "ApiCreateProjectResults": {
+                "properties": {
+                    "hasContentCopy": {
+                        "type": "boolean"
+                    },
+                    "project": {
+                        "$ref": "#/components/schemas/Project"
+                    }
+                },
+                "required": ["hasContentCopy", "project"],
+                "type": "object"
+            },
+            "ApiSuccess_ApiCreateProjectResults_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiCreateProjectResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ProjectType"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string"
+                    },
+                    "dbtConnection": {
+                        "$ref": "#/components/schemas/DbtProjectConfig"
+                    },
+                    "warehouseConnection": {
+                        "$ref": "#/components/schemas/WarehouseCredentials"
+                    },
+                    "upstreamProjectUuid": {
+                        "type": "string"
+                    },
+                    "dbtVersion": {
+                        "$ref": "#/components/schemas/DbtVersionOption"
+                    },
+                    "semanticLayerConnection": {
+                        "$ref": "#/components/schemas/SemanticLayerConnection"
+                    }
+                },
+                "required": ["name", "type", "dbtConnection", "dbtVersion"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_": {
+                "$ref": "#/components/schemas/Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "SshTunnelConfiguration": {
+                "properties": {
+                    "sshTunnelPrivateKey": {
+                        "type": "string"
+                    },
+                    "sshTunnelPublicKey": {
+                        "type": "string"
+                    },
+                    "sshTunnelUser": {
+                        "type": "string"
+                    },
+                    "sshTunnelPort": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "sshTunnelHost": {
+                        "type": "string"
+                    },
+                    "useSshTunnel": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "CreateRedshiftCredentials": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SshTunnelConfiguration"
+                    },
+                    {
+                        "properties": {
+                            "timeoutSeconds": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "startOfWeek": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/WeekDay"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "ra3Node": {
+                                "type": "boolean"
+                            },
+                            "sslmode": {
+                                "type": "string"
+                            },
+                            "keepalivesIdle": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "threads": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "schema": {
+                                "type": "string"
+                            },
+                            "dbname": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "requireUserCredentials": {
+                                "type": "boolean"
+                            },
+                            "password": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            },
+                            "host": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+                            }
+                        },
+                        "required": [
+                            "schema",
+                            "dbname",
+                            "port",
+                            "password",
+                            "user",
+                            "host",
+                            "type"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "CreateBigqueryCredentials": {
+                "properties": {
+                    "executionProject": {
+                        "type": "string"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "maximumBytesBilled": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "retries": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
+                    },
+                    "keyfileContents": {
+                        "$ref": "#/components/schemas/Record_string.string_"
+                    },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/BigqueryAuthenticationType"
+                    },
+                    "priority": {
+                        "type": "string",
+                        "enum": ["interactive", "batch"]
+                    },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "dataset": {
+                        "type": "string"
+                    },
+                    "project": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
+                    }
+                },
+                "required": ["keyfileContents", "dataset", "project", "type"],
+                "type": "object"
+            },
+            "SslConfiguration": {
+                "properties": {
+                    "sslrootcert": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sslrootcertFileName": {
+                        "type": "string"
+                    },
+                    "sslkey": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sslkeyFileName": {
+                        "type": "string"
+                    },
+                    "sslcert": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sslcertFileName": {
+                        "type": "string"
+                    },
+                    "sslmode": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "CreatePostgresCredentials": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SshTunnelConfiguration"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SslConfiguration"
+                    },
+                    {
+                        "properties": {
+                            "timeoutSeconds": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "startOfWeek": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/WeekDay"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "role": {
+                                "type": "string"
+                            },
+                            "searchPath": {
+                                "type": "string"
+                            },
+                            "keepalivesIdle": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "threads": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "schema": {
+                                "type": "string"
+                            },
+                            "dbname": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "requireUserCredentials": {
+                                "type": "boolean"
+                            },
+                            "password": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            },
+                            "host": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
+                            }
+                        },
+                        "required": [
+                            "schema",
+                            "dbname",
+                            "port",
+                            "password",
+                            "user",
+                            "host",
+                            "type"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "CreateSnowflakeCredentials": {
+                "properties": {
+                    "override": {
+                        "type": "boolean"
+                    },
+                    "quotedIdentifiersIgnoreCase": {
+                        "type": "boolean"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "accessUrl": {
+                        "type": "string"
+                    },
+                    "queryTag": {
+                        "type": "string"
+                    },
+                    "clientSessionKeepAlive": {
+                        "type": "boolean"
+                    },
+                    "threads": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "warehouse": {
+                        "type": "string"
+                    },
+                    "database": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string"
+                    },
+                    "token": {
+                        "type": "string"
+                    },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/SnowflakeAuthenticationType"
+                    },
+                    "privateKeyPass": {
+                        "type": "string"
+                    },
+                    "privateKey": {
+                        "type": "string"
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "type": "string"
+                    },
+                    "account": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
+                    }
+                },
+                "required": [
+                    "schema",
+                    "warehouse",
+                    "database",
+                    "user",
+                    "account",
+                    "type"
+                ],
+                "type": "object"
+            },
+            "CreateDatabricksCredentials": {
+                "properties": {
+                    "compute": {
+                        "items": {
+                            "properties": {
+                                "httpPath": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["httpPath", "name"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
+                    },
+                    "personalAccessToken": {
+                        "type": "string"
+                    },
+                    "httpPath": {
+                        "type": "string"
+                    },
+                    "serverHostName": {
+                        "type": "string"
+                    },
+                    "database": {
+                        "type": "string"
+                    },
+                    "catalog": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.DATABRICKS"
+                    }
+                },
+                "required": [
+                    "personalAccessToken",
+                    "httpPath",
+                    "serverHostName",
+                    "database",
+                    "type"
+                ],
+                "type": "object"
+            },
+            "CreateTrinoCredentials": {
+                "properties": {
+                    "startOfWeek": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/WeekDay"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "http_scheme": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "dbname": {
+                        "type": "string"
+                    },
+                    "port": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "type": "string"
+                    },
+                    "host": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.TRINO"
+                    }
+                },
+                "required": [
+                    "http_scheme",
+                    "schema",
+                    "dbname",
+                    "port",
+                    "password",
+                    "user",
+                    "host",
+                    "type"
+                ],
+                "type": "object"
+            },
+            "CreateWarehouseCredentials": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/CreateRedshiftCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreateBigqueryCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreatePostgresCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreateSnowflakeCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreateDatabricksCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreateTrinoCredentials"
+                    }
+                ]
+            },
+            "CreateProjectTableConfiguration": {
+                "enum": ["prod", "all"],
+                "type": "string"
+            },
+            "CreateProject": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_"
+                    },
+                    {
+                        "properties": {
+                            "copyContent": {
+                                "type": "boolean"
+                            },
+                            "tableConfiguration": {
+                                "$ref": "#/components/schemas/CreateProjectTableConfiguration"
+                            },
+                            "copyWarehouseConnectionFromUpstreamProject": {
+                                "type": "boolean"
+                            },
+                            "warehouseConnection": {
+                                "$ref": "#/components/schemas/CreateWarehouseCredentials"
+                            }
+                        },
+                        "required": ["warehouseConnection"],
+                        "type": "object"
+                    }
+                ]
+            },
             "NotificationBase": {
                 "properties": {
                     "url": {
@@ -17922,7 +18478,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1752.2",
+        "version": "0.1754.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -24106,6 +24662,44 @@
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
+            },
+            "post": {
+                "operationId": "CreateProject",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ApiCreateProjectResults_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateProject"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/org/users": {

--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -35,28 +35,6 @@ organizationRouter.post(
             .catch(next),
 );
 
-organizationRouter.post(
-    '/projects',
-    allowApiKeyAuthentication,
-    isAuthenticated,
-    unauthorisedInDemo,
-    async (req, res, next) =>
-        req.services
-            .getProjectService()
-            .createWithoutCompile(
-                req.user!,
-                req.body,
-                getRequestMethod(req.header(LightdashRequestMethodHeader)),
-            )
-            .then((results) => {
-                res.json({
-                    status: 'ok',
-                    results,
-                });
-            })
-            .catch(next),
-);
-
 organizationRouter.delete(
     '/projects/:projectUuid',
     allowApiKeyAuthentication,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -935,13 +935,16 @@ export class ProjectService extends BaseService {
                     data.upstreamProjectUuid,
                     projectUuid,
                 );
-                await this.copyContentOnPreview(
-                    data.upstreamProjectUuid,
-                    projectUuid,
-                    user,
-                );
 
-                hasContentCopy = true;
+                if (data.copyContent ?? true) {
+                    await this.copyContentOnPreview(
+                        data.upstreamProjectUuid,
+                        projectUuid,
+                        user,
+                    );
+
+                    hasContentCopy = true;
+                }
             } catch (e) {
                 Sentry.captureException(e);
                 this.logger.error(`Unable to copy content on preview ${e}`);

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -73,6 +73,7 @@ type CreateProjectOptions = {
     startOfWeek?: number;
     upstreamProjectUuid?: string;
     tableConfiguration?: CreateProjectTableConfiguration;
+    copyContent?: boolean;
 };
 export const createProject = async (
     options: CreateProjectOptions,
@@ -140,6 +141,7 @@ export const createProject = async (
         upstreamProjectUuid: options.upstreamProjectUuid,
         dbtVersion: dbtVersion.versionOption,
         tableConfiguration: options.tableConfiguration,
+        copyContent: options.copyContent,
     };
 
     return lightdashApi<ApiCreateProjectResults>({

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -31,6 +31,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     startOfWeek?: number;
     ignoreErrors: boolean;
     tableConfiguration: CreateProjectTableConfiguration;
+    skipCopyContent?: boolean;
 };
 
 type StopPreviewHandlerOptions = {
@@ -147,6 +148,12 @@ export const previewHandler = async (
                 `\n\nDeveloper preview will be deployed without any copied content!\nPlease set a project to copy content from by running 'lightdash config set-project'.\n`,
             ),
         );
+    } else if (options.skipCopyContent) {
+        console.error(
+            styles.warning(
+                `\n\nDeveloper preview will be deployed without any copied content!\n`,
+            ),
+        );
     } else {
         console.error(
             `\n${styles.success('✔')}   Copying charts and dashboards from "${
@@ -161,6 +168,7 @@ export const previewHandler = async (
             name,
             type: ProjectType.PREVIEW,
             upstreamProjectUuid: config.context?.project,
+            copyContent: !options.skipCopyContent,
         });
 
         project = results?.project;
@@ -341,6 +349,12 @@ export const startPreviewHandler = async (
                     `\n\nDeveloper preview will be deployed without any copied content!\nPlease set a project to copy content from by running 'lightdash config set-project'.\n`,
                 ),
             );
+        } else if (options.skipCopyContent) {
+            console.error(
+                styles.warning(
+                    `\n\nDeveloper preview will be deployed without any copied content!\n`,
+                ),
+            );
         } else {
             console.error(
                 `\n${styles.success(
@@ -358,6 +372,7 @@ export const startPreviewHandler = async (
             name: projectName,
             type: ProjectType.PREVIEW,
             upstreamProjectUuid: config.context?.project,
+            copyContent: !options.skipCopyContent,
         });
 
         const project = results?.project;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -416,6 +416,11 @@ program
         `If set to 'prod' it will copy the table configuration from prod project`,
         'all',
     )
+    .option(
+        '--skip-copy-content',
+        'Skip copying content from the source project',
+        false,
+    )
     .action(previewHandler);
 
 program
@@ -493,6 +498,11 @@ program
         '--table-configuration <prod|all>',
         `If set to 'prod' it will copy the table configuration from prod project`,
         'all',
+    )
+    .option(
+        '--skip-copy-content',
+        'Skip copying content from the source project',
+        false,
     )
     .action(startPreviewHandler);
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1119,6 +1119,7 @@ export type CreateProject = Omit<
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;
     tableConfiguration?: CreateProjectTableConfiguration;
+    copyContent?: boolean;
 };
 
 export type UpdateProject = Omit<

--- a/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
+++ b/packages/e2e/cypress/e2e/api/organizationPermissions.cy.ts
@@ -1,4 +1,12 @@
-import { MetricQuery, SEED_PROJECT } from '@lightdash/common';
+import {
+    DbtProjectType,
+    DbtVersionOptionLatest,
+    MetricQuery,
+    ProjectType,
+    SEED_PROJECT,
+    type CreateProject,
+} from '@lightdash/common';
+import warehouseConnections from '../../support/warehouses';
 
 const apiUrl = '/api/v1';
 
@@ -223,7 +231,7 @@ describe('Lightdash API tests for organization on different roles', () => {
         'member',
     ].forEach((role) => {
         describe(`org user with '${role}' role`, () => {
-            let email;
+            let email: Element | undefined;
 
             before(() => {
                 cy.loginWithPermissions(role, []).then((e) => {
@@ -312,7 +320,7 @@ describe('lightdash API tests for project creation permissions', () => {
         },
     ].forEach(({ role, canCreatePreview, canCreateProject }) => {
         describe(`org user with '${role}' role`, () => {
-            let email;
+            let email: Element | undefined;
 
             before(() => {
                 cy.loginWithPermissions(role, []).then((e) => {
@@ -327,14 +335,22 @@ describe('lightdash API tests for project creation permissions', () => {
             it('should get a parameter error when sending POST to project with DEFAULT and an UPSTREAM', () => {
                 const endpoint = `${apiUrl}/org/projects/`;
 
+                const body: CreateProject = {
+                    type: ProjectType.DEFAULT,
+                    upstreamProjectUuid: 'uuid',
+                    dbtConnection: {
+                        type: DbtProjectType.NONE,
+                    },
+                    dbtVersion: DbtVersionOptionLatest.LATEST,
+                    warehouseConnection: warehouseConnections.postgresSQL,
+                    name: 'testProject',
+                };
+
                 cy.request({
                     url: endpoint,
                     headers: { 'Content-type': 'application/json' },
                     method: 'POST',
-                    body: {
-                        type: 'DEFAULT',
-                        upstreamProjectUuid: 'uuid',
-                    },
+                    body,
                     failOnStatusCode: false,
                 }).then((resp) => {
                     expect(resp.status).to.eq(400);
@@ -345,13 +361,21 @@ describe('lightdash API tests for project creation permissions', () => {
                 it('Should get a forbidden error (403) from POST project', () => {
                     const endpoint = `${apiUrl}/org/projects/`;
 
+                    const body: CreateProject = {
+                        type: ProjectType.DEFAULT,
+                        dbtConnection: {
+                            type: DbtProjectType.NONE,
+                        },
+                        dbtVersion: DbtVersionOptionLatest.LATEST,
+                        warehouseConnection: warehouseConnections.postgresSQL,
+                        name: 'testProject',
+                    };
+
                     cy.request({
                         url: endpoint,
                         headers: { 'Content-type': 'application/json' },
                         method: 'POST',
-                        body: {
-                            type: 'DEFAULT',
-                        },
+                        body,
                         failOnStatusCode: false,
                     }).then((resp) => {
                         expect(resp.status).to.eq(403);
@@ -363,13 +387,21 @@ describe('lightdash API tests for project creation permissions', () => {
                 it('Should get a forbidden error (403) from POST preview project', () => {
                     const endpoint = `${apiUrl}/org/projects/`;
 
+                    const body: CreateProject = {
+                        type: ProjectType.PREVIEW,
+                        dbtConnection: {
+                            type: DbtProjectType.NONE,
+                        },
+                        dbtVersion: DbtVersionOptionLatest.LATEST,
+                        warehouseConnection: warehouseConnections.postgresSQL,
+                        name: 'testPreviewProject',
+                    };
+
                     cy.request({
                         url: endpoint,
                         headers: { 'Content-type': 'application/json' },
                         method: 'POST',
-                        body: {
-                            type: 'PREVIEW',
-                        },
+                        body,
                         failOnStatusCode: false,
                     }).then((resp) => {
                         expect(resp.status).to.eq(403);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15514

### Description:
Moved project creation endpoint to `OrganizationsController` so it uses TSOA.

The CLI has been updated with a `--skip-copy-content` option for the `preview` and `start-preview` commands, giving users more control over the project creation process.

**Tests to perform**
- Run `lightdash <preview|start-preview>` with and without `--skip-copy-content`
- All other project creation sources should work as they have been, project creation via UI should still copy content

**`start-preview` without `--skip-copy-content`**
![image](https://github.com/user-attachments/assets/a8a48d6b-78a8-46e4-bbff-200f17373bd6)
**`start-preview` with `--skip-copy-content`**
![image](https://github.com/user-attachments/assets/2e92f4d7-9892-4227-9cea-449d247174b0)
**`preview` without `--skip-copy-content`**
![image](https://github.com/user-attachments/assets/951ccb8c-3f3e-4742-bec0-6bba700a2ec7)
**`preview` with `--skip-copy-content`**
![image](https://github.com/user-attachments/assets/514ac8fd-8c18-4013-a9ab-4ff2c3dd875f)
