### PR TITLE
fix: change paddings on a chat conversation container

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -44,7 +44,7 @@ const AiAgentThreadPage = () => {
     }
 
     return (
-        <Stack h="100%" justify="space-between" py="xl">
+        <Stack h="100%" justify="space-between" pb="md">
             <AgentChatDisplay
                 thread={thread}
                 agentName={agentQuery.data?.name ?? 'AI'}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/15446

### Description:
Changed the padding in the AgentThreadPage component from `py="xl"` to `pb="md"`, removing the top padding and reducing the bottom padding. This adjustment improves the layout of the AI agent thread page.