### PR TITLE
refactor: move warning detection to private method

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
@@ -13,6 +13,7 @@ import {
     FilterOperator,
     IntrinsicUserAttributes,
     JoinModelRequiredFilterRule,
+    JoinRelationship,
     MetricType,
     SupportedDbtAdapter,
     TimeFrames,
@@ -327,6 +328,8 @@ export const EXPLORE: Explore = {
             sqlOn: '${table1.shared} = ${table2.shared}',
             compiledSqlOn: '("table1".shared) = ("table2".shared)',
             type: undefined,
+            tablesReferences: ['table1', 'table2'],
+            relationship: JoinRelationship.MANY_TO_ONE,
         },
     ],
     tables: {
@@ -336,6 +339,7 @@ export const EXPLORE: Explore = {
             database: 'database',
             schema: 'schema',
             sqlTable: '"db"."schema"."table1"',
+            primaryKey: ['dim1'],
             dimensions: {
                 dim1: {
                     type: DimensionType.NUMBER,
@@ -408,6 +412,7 @@ export const EXPLORE: Explore = {
             database: 'database',
             schema: 'schema',
             sqlTable: '"db"."schema"."table2"',
+            primaryKey: ['dim2'],
             dimensions: {
                 dim2: {
                     type: DimensionType.NUMBER,
@@ -444,6 +449,18 @@ export const EXPLORE: Explore = {
                     label: 'metric2',
                     sql: '${TABLE}.number_column',
                     compiledSql: 'MAX("table2".number_column)',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                metric3: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    name: 'metric3',
+                    label: 'metric3',
+                    sql: '${TABLE}.number_column',
+                    compiledSql: 'SUM("table2".number_column)',
                     tablesReferences: ['table2'],
                     hidden: false,
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added metric inflation warnings for custom bin dimensions with CTEs. This PR enhances the query builder to detect potential metric inflation issues when using custom bin dimensions across joined tables.

The changes include:
- Refactored warning generation into a separate method for better code organization
- Added primary key information to tables in the mock explore
- Added relationship information to joins
- Added a new test case that verifies warnings are generated when metrics could be inflated due to join relationships
- Added a new metric3 to the mock data to support testing

The test confirms that the query builder correctly generates both the CTE for the custom bin dimension and the appropriate warning when metrics might be inflated across joins.