### PR TITLE
refactor: replace dayjs with date-fns in useTimeAgo hook

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -52,7 +52,7 @@ import { AiChartVisualization } from './AiChartVisualization';
 export const UserBubble: FC<{ message: AiAgentMessageUser<AiAgentUser> }> = ({
     message,
 }) => {
-    const timeAgo = useTimeAgo(new Date(message.createdAt));
+    const timeAgo = useTimeAgo(message.createdAt);
     const name = message.user.name;
     const app = useApp();
     const showUserName = app.user?.data?.userUuid !== message.user.uuid;

--- a/packages/frontend/src/hooks/useTimeAgo.ts
+++ b/packages/frontend/src/hooks/useTimeAgo.ts
@@ -1,17 +1,33 @@
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import { useEffect, useState } from 'react';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useInterval } from 'react-use';
 
-dayjs.extend(relativeTime);
+export const useTimeAgo = (
+    dateOrString: Date | string,
+    interval: number = 10000,
+) => {
+    const parsed = useMemo(() => {
+        return typeof dateOrString === 'string'
+            ? parseISO(dateOrString)
+            : dateOrString;
+    }, [dateOrString]);
 
-export const useTimeAgo = (timeStamp: Date, interval: number = 10000) => {
-    const [timeAgo, setTimeAgo] = useState<string>(dayjs(timeStamp).fromNow());
+    const getTimeAgo = useCallback(() => {
+        return formatDistanceToNowStrict(parsed, {
+            addSuffix: true,
+            roundingMethod: 'floor',
+        });
+    }, [parsed]);
+
+    const [timeAgo, setTimeAgo] = useState<string>(getTimeAgo());
+
     useInterval(() => {
-        setTimeAgo(dayjs(timeStamp).fromNow());
+        setTimeAgo(getTimeAgo());
     }, interval);
+
     useEffect(() => {
-        setTimeAgo(dayjs(timeStamp).fromNow());
-    }, [timeStamp]);
+        setTimeAgo(getTimeAgo());
+    }, [parsed, getTimeAgo]);
+
     return timeAgo;
 };


### PR DESCRIPTION
Refactored the `useTimeAgo` hook to use `date-fns` instead of `dayjs` for time formatting. The hook now accepts both Date objects and ISO string dates, automatically parsing strings when needed. This improves consistency in time display and fixes a bug in the `UserBubble` component where dates weren't being properly parsed.