### PR TITLE
fix: only show agent tool calls during streaming

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -108,7 +108,7 @@ const AssistantBubbleContent: FC<{ message: AiAgentMessageAssistant }> = ({
 
     return (
         <>
-            <AgentToolCalls />
+            {isStreaming ? <AgentToolCalls /> : null}
             <MDEditor.Markdown
                 source={messageContent}
                 style={{ backgroundColor: 'transparent' }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Only show agent tool calls when streaming is active in the Agent. This prevents tool calls from being displayed when they're no longer relevant in non-streaming contexts.
