### PR TITLE
feat: show tool calls on how it's calculated & find fields schema

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -16,7 +16,10 @@ import {
     CreateSlackThread,
     CreateWebAppPrompt,
     CreateWebAppThread,
+    isFindFieldsToolArgs,
+    isToolName,
     SlackPrompt,
+    ToolName,
     UpdateSlackResponse,
     UpdateSlackResponseTs,
     UpdateWebAppResponse,
@@ -667,14 +670,28 @@ export class AiAgentModel {
                     filtersOutput: row.filters_output,
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
-                    toolCalls: toolCalls.map((toolCall) => ({
-                        uuid: toolCall.ai_agent_tool_call_uuid,
-                        promptUuid: toolCall.ai_prompt_uuid,
-                        toolCallId: toolCall.tool_call_id,
-                        toolName: toolCall.tool_name,
-                        toolArgs: toolCall.tool_args,
-                        createdAt: toolCall.created_at,
-                    })),
+                    toolCalls: toolCalls
+                        .filter((tc) => isToolName(tc.tool_name))
+                        .map((tc) => ({
+                            uuid: tc.ai_agent_tool_call_uuid,
+                            promptUuid: tc.ai_prompt_uuid,
+                            toolCallId: tc.tool_call_id,
+                            createdAt: tc.created_at,
+                            // TODO: handle this typing better
+                            ...(isFindFieldsToolArgs(tc.tool_args) &&
+                            tc.tool_name === 'findFields'
+                                ? {
+                                      toolName: 'findFields',
+                                      toolArgs: tc.tool_args,
+                                  }
+                                : {
+                                      toolName: tc.tool_name as Exclude<
+                                          ToolName,
+                                          'findFields'
+                                      >,
+                                      toolArgs: tc.tool_args,
+                                  }),
+                        })),
                 });
             }
 
@@ -823,14 +840,28 @@ export class AiAgentModel {
                     filtersOutput: row.filters_output,
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
-                    toolCalls: toolCalls.map((toolCall) => ({
-                        uuid: toolCall.ai_agent_tool_call_uuid,
-                        promptUuid: toolCall.ai_prompt_uuid,
-                        toolCallId: toolCall.tool_call_id,
-                        toolName: toolCall.tool_name,
-                        toolArgs: toolCall.tool_args,
-                        createdAt: toolCall.created_at,
-                    })),
+                    toolCalls: toolCalls
+                        .filter((tc) => isToolName(tc.tool_name))
+                        .map((tc) => ({
+                            uuid: tc.ai_agent_tool_call_uuid,
+                            promptUuid: tc.ai_prompt_uuid,
+                            toolCallId: tc.tool_call_id,
+                            createdAt: tc.created_at,
+                            // TODO: handle this typing better
+                            ...(isFindFieldsToolArgs(tc.tool_args) &&
+                            tc.tool_name === 'findFields'
+                                ? {
+                                      toolName: 'findFields',
+                                      toolArgs: tc.tool_args,
+                                  }
+                                : {
+                                      toolName: tc.tool_name as Exclude<
+                                          ToolName,
+                                          'findFields'
+                                      >,
+                                      toolArgs: tc.tool_args,
+                                  }),
+                        })),
                 } satisfies AiAgentMessageAssistant;
             default:
                 return assertUnreachable(role, `Unknown role ${role}`);

--- a/packages/common/src/ee/Ai/schemas.ts
+++ b/packages/common/src/ee/Ai/schemas.ts
@@ -500,3 +500,46 @@ export const csvFileVizConfigSchema = VisualizationMetadataSchema.extend({
 });
 
 export type CsvFileVizConfigSchemaType = z.infer<typeof csvFileVizConfigSchema>;
+
+// Derived types from schemas
+export type FindFieldsToolArgs = z.infer<typeof aiFindFieldsToolSchema>;
+
+// define tool names
+export const ToolNameSchema = z.enum([
+    'findFields',
+    'generateBarVizConfig',
+    'generateCsv',
+    'generateQueryFilters',
+    'generateTimeSeriesVizConfig',
+]);
+
+export type ToolName = z.infer<typeof ToolNameSchema>;
+
+export const isToolName = (toolName: string): toolName is ToolName =>
+    ToolNameSchema.safeParse(toolName).success;
+
+export const isFindFieldsToolArgs = (
+    toolArgs: unknown,
+): toolArgs is FindFieldsToolArgs =>
+    aiFindFieldsToolSchema.safeParse(toolArgs).success;
+
+// display messages schema
+export const ToolDisplayMessagesSchema = z.record(ToolNameSchema, z.string());
+
+export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
+    findFields: 'Finding relevant fields',
+    generateBarVizConfig: 'Generating a bar chart',
+    generateCsv: 'Generating CSV file',
+    generateQueryFilters: 'Applying filters to the query',
+    generateTimeSeriesVizConfig: 'Generating a line chart',
+});
+
+// after-tool-call messages
+export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
+    ToolDisplayMessagesSchema.parse({
+        findFields: 'Found relevant fields',
+        generateBarVizConfig: 'Generated a bar chart',
+        generateCsv: 'Generated CSV file',
+        generateQueryFilters: 'Applied filters to the query',
+        generateTimeSeriesVizConfig: 'Generated a line chart',
+    });

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -7,7 +7,9 @@ import type {
     CacheMetadata,
     ItemsMap,
     MetricQuery,
+    ToolName,
 } from '../..';
+import { type FindFieldsToolArgs } from '../Ai/schemas';
 
 /**
  * Supported AI visualization chart types
@@ -258,11 +260,23 @@ export type ApiUpdateUserAgentPreferences = AiAgentUserPreferences;
 
 export type ApiUpdateUserAgentPreferencesResponse = ApiSuccessEmpty;
 
-export type AiAgentToolCall = {
+// Base tool call structure
+export type BaseAiAgentToolCall = {
     uuid: string;
     promptUuid: string;
     toolCallId: string;
-    toolName: string;
-    toolArgs: object;
     createdAt: Date;
 };
+
+// Discriminated union for different tool types
+export type AiAgentToolCall = BaseAiAgentToolCall &
+    (
+        | {
+              toolName: 'findFields';
+              toolArgs: FindFieldsToolArgs;
+          }
+        | {
+              toolName: Exclude<ToolName, 'findFields'>;
+              toolArgs: object; // TODO: Add specific types for other tools as schemas are created
+          }
+    );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -1,9 +1,7 @@
 import {
-    AiChartType,
     type AiAgentMessageAssistant,
     type AiAgentMessageUser,
     type AiAgentUser,
-    type Filters,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -31,7 +29,6 @@ import { format, parseISO } from 'date-fns';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { useInfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import useApp from '../../../../../providers/App/useApp';
@@ -44,10 +41,8 @@ import {
     useAiAgentThreadStreamQuery,
 } from '../../streaming/useAiAgentThreadStreamQuery';
 import { isOptimisticMessageStub } from '../../utils/thinkingMessageStub';
-import AgentToolCalls from './AgentToolCalls/AgentToolCalls';
-import AgentVisualizationFilters from './AgentVisualizationFilters';
-import AgentVisualizationMetricsAndDimensions from './AgentVisualizationMetricsAndDimensions';
 import { AiChartVisualization } from './AiChartVisualization';
+import AgentToolCalls from './ToolCalls/AgentToolCalls';
 
 export const UserBubble: FC<{ message: AiAgentMessageUser<AiAgentUser> }> = ({
     message,
@@ -113,7 +108,7 @@ const AssistantBubbleContent: FC<{ message: AiAgentMessageAssistant }> = ({
 
     return (
         <>
-            {isStreaming ? <AgentToolCalls /> : null}
+            {isStreaming && <AgentToolCalls />}
             <MDEditor.Markdown
                 source={messageContent}
                 style={{ backgroundColor: 'transparent' }}
@@ -231,36 +226,12 @@ export const AssistantBubble: FC<{
                         </Stack>
                     ) : (
                         <AiChartVisualization
-                            metadata={queryExecutionHandle.data.metadata}
-                            query={queryExecutionHandle.data.query}
-                            vizConfig={vizConfig}
                             results={queryResults}
-                            type={queryExecutionHandle.data.type}
+                            message={message}
+                            queryExecutionHandle={queryExecutionHandle}
                             projectUuid={projectUuid}
                         />
                     )}
-                    <Stack gap="xs">
-                        <ErrorBoundary>
-                            {queryExecutionHandle.data &&
-                                queryExecutionHandle.data.type !==
-                                    AiChartType.CSV && (
-                                    <AgentVisualizationMetricsAndDimensions
-                                        metricQuery={metricQuery}
-                                        fieldsMap={
-                                            queryExecutionHandle.data.query
-                                                .fields
-                                        }
-                                    />
-                                )}
-
-                            {message.filtersOutput && (
-                                <AgentVisualizationFilters
-                                    // TODO: fix this using schema
-                                    filters={message.filtersOutput as Filters}
-                                />
-                            )}
-                        </ErrorBoundary>
-                    </Stack>
                 </Paper>
             )}
             <Group gap={0} display={isPreview ? 'none' : 'flex'}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -1,10 +1,13 @@
 import {
+    AiChartType,
     ChartType,
     ECHARTS_DEFAULT_COLORS,
     type AiAgentMessageAssistant,
     type ApiAiAgentThreadMessageVizQuery,
+    type ApiError,
 } from '@lightdash/common';
-import { Box, Group } from '@mantine-8/core';
+import { Box, Group, SegmentedControl, Stack } from '@mantine-8/core';
+import { type QueryObserverSuccessResult } from '@tanstack/react-query';
 import { useMemo, useState, type FC } from 'react';
 import { SeriesContextMenu } from '../../../../../components/Explorer/VisualizationCard/SeriesContextMenu';
 import LightdashVisualization from '../../../../../components/LightdashVisualization';
@@ -13,36 +16,45 @@ import { DrillDownModal } from '../../../../../components/MetricQueryData/DrillD
 import MetricQueryDataProvider from '../../../../../components/MetricQueryData/MetricQueryDataProvider';
 import UnderlyingDataModal from '../../../../../components/MetricQueryData/UnderlyingDataModal';
 import { type EchartSeriesClickEvent } from '../../../../../components/SimpleChart';
+import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { type EChartSeries } from '../../../../../hooks/echarts/useEchartsCartesianConfig';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useOrganization } from '../../../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { getChartConfigFromAiAgentVizConfig } from '../../utils/echarts';
+import AgentVisualizationFilters from './AgentVisualizationFilters';
+import AgentVisualizationMetricsAndDimensions from './AgentVisualizationMetricsAndDimensions';
 import { AiChartQuickOptions } from './AiChartQuickOptions';
+import { AiChartToolCalls } from './ToolCalls/AiChartToolCalls';
 
-type Props = ApiAiAgentThreadMessageVizQuery & {
-    vizConfig: AiAgentMessageAssistant['vizConfigOutput'];
+type Props = {
     results: InfiniteQueryResults;
+    queryExecutionHandle: QueryObserverSuccessResult<
+        ApiAiAgentThreadMessageVizQuery,
+        ApiError
+    >;
     projectUuid: string;
+    message: AiAgentMessageAssistant;
 };
 
 export const AiChartVisualization: FC<Props> = ({
-    query,
     results,
-    type,
-    vizConfig,
+    queryExecutionHandle,
     projectUuid,
-    metadata,
+    message,
 }) => {
     const { data: health } = useHealth();
     const { data: organization } = useOrganization();
-    const { metricQuery, fields } = query;
+    const { metricQuery, fields } = queryExecutionHandle.data.query;
     const tableName = metricQuery?.exploreName;
     const { data: explore } = useExplore(tableName);
     const [echartsClickEvent, setEchartsClickEvent] =
         useState<EchartSeriesClickEvent | null>(null);
     const [echartSeries, setEchartSeries] = useState<EChartSeries[]>([]);
+    const [activeTab, setActiveTab] = useState('chart');
+
+    const toolCalls = message.toolCalls;
 
     const resultsData = useMemo(
         () => ({
@@ -56,78 +68,143 @@ export const AiChartVisualization: FC<Props> = ({
     const chartConfig = useMemo(
         () =>
             getChartConfigFromAiAgentVizConfig({
-                config: vizConfig as any,
+                config: message.vizConfigOutput as any,
                 rows: results.rows,
-                type,
+                type: queryExecutionHandle.data.type,
                 metricQuery,
             }),
-        [vizConfig, results.rows, type, metricQuery],
+        [
+            message.vizConfigOutput,
+            results.rows,
+            queryExecutionHandle.data.type,
+            metricQuery,
+        ],
     );
 
     return (
-        <Box h="100%" mih={400}>
-            <MetricQueryDataProvider
-                metricQuery={metricQuery}
-                tableName={tableName}
-                explore={explore}
-                queryUuid={query.queryUuid}
-            >
-                <VisualizationProvider
-                    resultsData={resultsData}
-                    chartConfig={chartConfig}
-                    columnOrder={[
-                        ...metricQuery.dimensions,
-                        ...metricQuery.metrics,
+        <Stack gap="xs">
+            <Group>
+                <SegmentedControl
+                    value={activeTab}
+                    onChange={setActiveTab}
+                    data={[
+                        { label: 'Chart', value: 'chart' },
+                        { label: "How it's calculated", value: 'calculation' },
                     ]}
-                    pivotTableMaxColumnLimit={
-                        health?.pivotTable.maxColumnLimit ?? 60
-                    }
-                    initialPivotDimensions={
-                        // TODO :: fix this using schema
-                        vizConfig && 'breakdownByDimension' in vizConfig
-                            ? // TODO :: fix this using schema
-                              [vizConfig.breakdownByDimension as string]
-                            : undefined
-                    }
-                    colorPalette={
-                        organization?.chartColors ?? ECHARTS_DEFAULT_COLORS
-                    }
-                    isLoading={resultsData.isFetchingRows}
-                    onSeriesContextMenu={(
-                        e: EchartSeriesClickEvent,
-                        series: EChartSeries[],
-                    ) => {
-                        setEchartsClickEvent(e);
-                        setEchartSeries(series);
-                    }}
-                >
-                    <Group justify="flex-end" w="100%">
-                        <AiChartQuickOptions
-                            projectUuid={projectUuid}
-                            saveChartOptions={{
-                                name: metadata.title,
-                                description: metadata.description,
-                            }}
-                        />
-                    </Group>
-                    <LightdashVisualization
-                        className="sentry-block ph-no-capture"
-                        data-testid="ai-visualization"
-                    />
-                    {chartConfig.type === ChartType.CARTESIAN && (
-                        <SeriesContextMenu
-                            echartSeriesClickEvent={
-                                echartsClickEvent ?? undefined
-                            }
-                            dimensions={metricQuery.dimensions}
-                            series={echartSeries}
+                    size="xs"
+                    radius="md"
+                    color="gray"
+                />
+            </Group>
+
+            {activeTab === 'chart' ? (
+                <>
+                    <Box h="100%" mih={350}>
+                        <MetricQueryDataProvider
+                            metricQuery={metricQuery}
+                            tableName={tableName}
                             explore={explore}
-                        />
-                    )}
-                </VisualizationProvider>
-                <UnderlyingDataModal />
-                <DrillDownModal />
-            </MetricQueryDataProvider>
-        </Box>
+                            queryUuid={
+                                queryExecutionHandle.data.query.queryUuid
+                            }
+                        >
+                            <VisualizationProvider
+                                resultsData={resultsData}
+                                chartConfig={chartConfig}
+                                columnOrder={[
+                                    ...metricQuery.dimensions,
+                                    ...metricQuery.metrics,
+                                ]}
+                                pivotTableMaxColumnLimit={
+                                    health?.pivotTable.maxColumnLimit ?? 60
+                                }
+                                initialPivotDimensions={
+                                    // TODO :: fix this using schema
+                                    message.vizConfigOutput &&
+                                    'breakdownByDimension' in
+                                        message.vizConfigOutput
+                                        ? // TODO :: fix this using schema
+                                          [
+                                              message.vizConfigOutput
+                                                  .breakdownByDimension as string,
+                                          ]
+                                        : undefined
+                                }
+                                colorPalette={
+                                    organization?.chartColors ??
+                                    ECHARTS_DEFAULT_COLORS
+                                }
+                                isLoading={resultsData.isFetchingRows}
+                                onSeriesContextMenu={(
+                                    e: EchartSeriesClickEvent,
+                                    series: EChartSeries[],
+                                ) => {
+                                    setEchartsClickEvent(e);
+                                    setEchartSeries(series);
+                                }}
+                            >
+                                <Group justify="flex-end" w="100%">
+                                    <AiChartQuickOptions
+                                        projectUuid={projectUuid}
+                                        saveChartOptions={{
+                                            name: queryExecutionHandle.data
+                                                .metadata.title,
+                                            description:
+                                                queryExecutionHandle.data
+                                                    .metadata.description,
+                                        }}
+                                    />
+                                </Group>
+                                <LightdashVisualization
+                                    className="sentry-block ph-no-capture"
+                                    data-testid="ai-visualization"
+                                />
+                                {chartConfig.type === ChartType.CARTESIAN && (
+                                    <SeriesContextMenu
+                                        echartSeriesClickEvent={
+                                            echartsClickEvent ?? undefined
+                                        }
+                                        dimensions={metricQuery.dimensions}
+                                        series={echartSeries}
+                                        explore={explore}
+                                    />
+                                )}
+                            </VisualizationProvider>
+                            <UnderlyingDataModal />
+                            <DrillDownModal />
+                        </MetricQueryDataProvider>
+                    </Box>
+                    <Stack gap="xs">
+                        <ErrorBoundary>
+                            {queryExecutionHandle.data &&
+                                queryExecutionHandle.data.type !==
+                                    AiChartType.CSV && (
+                                    <AgentVisualizationMetricsAndDimensions
+                                        metricQuery={
+                                            queryExecutionHandle.data.query
+                                                .metricQuery
+                                        }
+                                        fieldsMap={
+                                            queryExecutionHandle.data.query
+                                                .fields
+                                        }
+                                    />
+                                )}
+
+                            {message.filtersOutput && (
+                                <AgentVisualizationFilters
+                                    // TODO: fix this using schema
+                                    filters={message.filtersOutput}
+                                />
+                            )}
+                        </ErrorBoundary>
+                    </Stack>
+                </>
+            ) : (
+                <Box mih={350} mt="sm">
+                    <AiChartToolCalls toolCalls={toolCalls} />
+                </Box>
+            )}
+        </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AgentToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AgentToolCalls.tsx
@@ -1,19 +1,9 @@
+import { TOOL_DISPLAY_MESSAGES, ToolNameSchema } from '@lightdash/common';
 import { Box, List, Text, ThemeIcon } from '@mantine-8/core';
 import { IconTool } from '@tabler/icons-react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { useAiAgentThreadStreamToolCalls } from '../../../streaming/useAiAgentThreadStreamQuery';
-
-// TODO :: should be based on schemas
-const TOOL_DISPLAY_MESSAGES = {
-    findFields: 'Finding relevant fields',
-    generateBarVizConfig: 'Generating a bar chart',
-    generateCsv: 'Generating CSV file',
-    generateQueryFilters: 'Applying filters to the query',
-    generateTimeSeriesVizConfig: 'Generating a line chart',
-} as const;
-
-const TOOL_NAMES = Object.keys(TOOL_DISPLAY_MESSAGES);
 
 const AgentToolCalls = () => {
     const { threadUuid } = useParams();
@@ -37,24 +27,28 @@ const AgentToolCalls = () => {
                 }
             >
                 {toolCalls
-                    .filter((toolCall) =>
-                        TOOL_NAMES.includes(toolCall.toolName),
+                    .filter(
+                        (toolCall) =>
+                            ToolNameSchema.safeParse(toolCall.toolName).success,
                     )
                     .map((toolCall) => {
-                        const toolDescription =
-                            TOOL_DISPLAY_MESSAGES[
-                                toolCall.toolName as keyof typeof TOOL_DISPLAY_MESSAGES
-                            ];
-
-                        if (!toolDescription) return null;
-
-                        return (
-                            <List.Item key={toolCall.toolCallId}>
-                                <Text size="xs" c="dimmed">
-                                    {toolDescription}
-                                </Text>
-                            </List.Item>
+                        const toolName = ToolNameSchema.safeParse(
+                            toolCall.toolName,
                         );
+                        if (toolName.success) {
+                            const toolDescription =
+                                TOOL_DISPLAY_MESSAGES[toolName.data];
+
+                            if (!toolDescription) return null;
+
+                            return (
+                                <List.Item key={toolCall.toolCallId}>
+                                    <Text size="xs" c="dimmed">
+                                        {toolDescription}
+                                    </Text>
+                                </List.Item>
+                            );
+                        }
                     })}
             </List>
         </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -1,0 +1,144 @@
+import {
+    type AiAgentToolCall,
+    assertUnreachable,
+    TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL,
+} from '@lightdash/common';
+import { Badge, Group, Stack, Text, Timeline } from '@mantine-8/core';
+import {
+    IconChartHistogram,
+    IconChartLine,
+    IconFileText,
+    IconFilter,
+    IconSearch,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+
+const getToolIcon = (toolName: string) => {
+    const iconMap = {
+        findFields: IconSearch,
+        generateBarVizConfig: IconChartHistogram,
+        generateTimeSeriesVizConfig: IconChartLine,
+        generateQueryFilters: IconFilter,
+        generateCsv: IconFileText,
+    } as const;
+
+    return iconMap[toolName as keyof typeof iconMap] || IconSparkles;
+};
+
+const getToolDescription = (toolCall: AiAgentToolCall) => {
+    const { toolName, toolArgs } = toolCall;
+
+    // Type guard to ensure toolArgs exists
+    if (!toolArgs) {
+        return (
+            <Text c="dimmed" size="sm">
+                {TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL[toolCall.toolName] ||
+                    `Executed ${toolCall.toolName}`}
+            </Text>
+        );
+    }
+
+    switch (toolName) {
+        case 'findFields':
+            const fields = toolCall.toolArgs.embeddingSearchQueries || [];
+            const exploreName = toolCall.toolArgs.exploreName;
+
+            return (
+                <>
+                    <Text c="dimmed" size="xs">
+                        Found {fields.length} relevant field
+                        {fields.length !== 1 ? 's' : ''} in{' '}
+                        <Text
+                            variant="link"
+                            component="span"
+                            inherit
+                            c="dark.6"
+                            fw={500}
+                        >
+                            {exploreName}
+                        </Text>{' '}
+                        table
+                    </Text>
+                    {fields.length > 0 && (
+                        <Text size="xs" mt={4} c="dimmed">
+                            <Group gap="xs">
+                                Fields:
+                                {fields.map((field) => (
+                                    <Badge
+                                        key={field.name}
+                                        color="gray"
+                                        variant="light"
+                                        size="xs"
+                                        radius="sm"
+                                        style={{
+                                            textTransform: 'none',
+                                            fontWeight: 400,
+                                        }}
+                                    >
+                                        {field.name}
+                                    </Badge>
+                                ))}
+                            </Group>
+                        </Text>
+                    )}
+                </>
+            );
+        case 'generateBarVizConfig':
+        case 'generateCsv':
+        case 'generateQueryFilters':
+        case 'generateTimeSeriesVizConfig':
+            return null;
+
+        default:
+            return assertUnreachable(toolName, `Unknown tool name ${toolName}`);
+    }
+};
+
+type AiChartToolCallsProps = {
+    toolCalls: AiAgentToolCall[] | undefined;
+};
+
+export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({ toolCalls }) => {
+    if (!toolCalls || toolCalls.length === 0) return null;
+
+    return (
+        <Stack>
+            <Timeline
+                active={toolCalls.length - 1}
+                bulletSize={20}
+                lineWidth={2}
+                color="indigo.6"
+            >
+                {toolCalls.map((toolCall) => {
+                    const IconComponent = getToolIcon(toolCall.toolName);
+
+                    return (
+                        <Timeline.Item
+                            key={toolCall.uuid}
+                            radius="md"
+                            bullet={
+                                <MantineIcon
+                                    icon={IconComponent}
+                                    size={12}
+                                    stroke={1.5}
+                                />
+                            }
+                            title={
+                                <Text fw={500} size="sm">
+                                    {TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL[
+                                        toolCall.toolName
+                                    ] || toolCall.toolName}
+                                </Text>
+                            }
+                            lineVariant={'solid'}
+                        >
+                            {getToolDescription(toolCall)}
+                        </Timeline.Item>
+                    );
+                })}
+            </Timeline>
+        </Stack>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15361

### Description:

Added a "How it's calculated" tab to AI-generated charts that shows the sequence of tool calls used to create the visualization. 

Key changes:
- Created typed schemas for AI tool calls with display messages
- Added a segmented control in the chart visualization to toggle between "Chart" and "How it's calculated" views
- Implemented a timeline component that shows the sequence of tool operations with appropriate icons
- Enhanced the display of field search results to show which fields were selected from which tables
- Moved tool call components to a dedicated folder structure

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/98e679b0-0381-4a31-bfec-6a3270e55d6e.png)

