### PR TITLE
fix: transform filters on tool call

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -1,4 +1,4 @@
-import { isSlackPrompt } from '@lightdash/common';
+import { filtersSchemaTransformed, isSlackPrompt } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     GetPromptFn,
@@ -40,6 +40,9 @@ Rules for generating the bar chart visualization:
         parameters: schema,
         execute: async ({ filters, vizConfig }) => {
             try {
+                // Transform filters to the correct format for the query and keep the original format for the tool call args
+                const transformedFilters =
+                    filtersSchemaTransformed.parse(filters);
                 await updateProgress(
                     '🔍 Running a query for your bar chart...',
                 );
@@ -50,7 +53,7 @@ Rules for generating the bar chart visualization:
                     await renderVerticalBarMetricChart({
                         runMetricQuery: runMiniMetricQuery,
                         vizConfig,
-                        filters: filters ?? undefined,
+                        filters: transformedFilters ?? undefined,
                     });
 
                 const file = await renderEcharts(chartOptions);

--- a/packages/backend/src/ee/services/ai/tools/generateCsv.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateCsv.ts
@@ -1,4 +1,4 @@
-import { isSlackPrompt } from '@lightdash/common';
+import { filtersSchemaTransformed, isSlackPrompt } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     GetPromptFn,
@@ -40,6 +40,9 @@ Rules for generating the CSV file:
         parameters: schema,
         execute: async ({ filters, vizConfig }) => {
             try {
+                // Transform filters to the correct format for the query and keep the original format for the tool call args
+                const transformedFilters =
+                    filtersSchemaTransformed.parse(filters);
                 await updateProgress(
                     '🔍 Running a query for your bar chart...',
                 );
@@ -51,7 +54,7 @@ Rules for generating the CSV file:
                 const { csv, metricQuery } = await renderCsvFile({
                     runMetricQuery: runMiniMetricQuery,
                     config: vizConfig,
-                    filters: filters ?? undefined,
+                    filters: transformedFilters ?? undefined,
                     maxLimit,
                 });
 

--- a/packages/backend/src/ee/services/ai/tools/generateQueryFilters.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateQueryFilters.ts
@@ -1,4 +1,5 @@
 import {
+    filtersSchemaTransformed,
     generateQueryFiltersToolSchema,
     getTotalFilterRules,
 } from '@lightdash/common';
@@ -36,20 +37,24 @@ Rules for generating filters:
         execute: async ({ exploreName, filters }) => {
             try {
                 const explore = await getExplore({ exploreName });
-                const filterRules = getTotalFilterRules(filters);
+
+                // Transform filters to the correct format for the query and keep the original format for the tool call args
+                const transformedFilters =
+                    filtersSchemaTransformed.parse(filters);
+                const filterRules = getTotalFilterRules(transformedFilters);
 
                 validateFilterRules(explore, filterRules);
 
                 await updatePrompt({
                     promptUuid,
-                    filtersOutput: filters,
+                    filtersOutput: transformedFilters,
                 });
 
                 return `Filters have been successfully generated.
 
 Filters:
 \`\`\`json
-${JSON.stringify(filters, null, 4)}
+${JSON.stringify(transformedFilters, null, 4)}
 \`\`\``;
             } catch (e) {
                 return toolErrorHandler(e, `Error generating filters.`);

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfigTool.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfigTool.ts
@@ -1,4 +1,4 @@
-import { isSlackPrompt } from '@lightdash/common';
+import { filtersSchemaTransformed, isSlackPrompt } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     GetPromptFn,
@@ -45,6 +45,9 @@ Rules for generating the time series chart visualization:
         parameters: schema,
         execute: async ({ filters, vizConfig }) => {
             try {
+                // Transform filters to the correct format for the query and keep the original format for the tool call args
+                const transformedFilters =
+                    filtersSchemaTransformed.parse(filters);
                 await updateProgress(
                     '🔍 Running a query for your line chart...',
                 );
@@ -57,7 +60,7 @@ Rules for generating the time series chart visualization:
                     await renderTimeseriesChart({
                         runMetricQuery: runMiniMetricQuery,
                         vizConfig,
-                        filters: filters ?? undefined,
+                        filters: transformedFilters ?? undefined,
                     });
 
                 const file = await renderEcharts(chartOptions);

--- a/packages/backend/src/ee/services/ai/tools/getOneLineResult.ts
+++ b/packages/backend/src/ee/services/ai/tools/getOneLineResult.ts
@@ -1,4 +1,7 @@
-import { lighterMetricQuerySchema } from '@lightdash/common';
+import {
+    lighterMetricQuerySchema,
+    lighterMetricQuerySchemaTransformed,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     GetPromptFn,
@@ -37,22 +40,17 @@ Rules for fetching the result:
         parameters: schema,
         execute: async (metricQuery) => {
             try {
+                const transformedMetricQuery =
+                    lighterMetricQuerySchemaTransformed.parse(metricQuery);
                 const prompt = await getPrompt();
 
                 await updatePrompt({
                     promptUuid: prompt.promptUuid,
-                    metricQuery,
+                    metricQuery: transformedMetricQuery,
                 });
 
                 await updateProgress('🔍 Fetching the results...');
-                const result = await runMiniMetricQuery({
-                    ...metricQuery,
-                    filters: {
-                        metrics: metricQuery.filters?.metrics ?? undefined,
-                        dimensions:
-                            metricQuery.filters?.dimensions ?? undefined,
-                    },
-                });
+                const result = await runMiniMetricQuery(transformedMetricQuery);
 
                 if (result.rows.length > 1) {
                     throw new Error(

--- a/packages/backend/src/ee/services/ai/visualizations/csvFile.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/csvFile.ts
@@ -3,6 +3,7 @@ import {
     AiMetricQuery,
     csvFileVizConfigSchema,
     filtersSchema,
+    filtersSchemaTransformed,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify/sync';
 import { z } from 'zod';
@@ -45,7 +46,7 @@ export const isCsvFileConfig = (config: unknown): config is CsvFileConfig =>
 export const metricQueryCsv = async (
     config: CsvFileConfig,
     maxLimit: number,
-    filters: z.infer<typeof filtersSchema> = {},
+    filters: z.infer<typeof filtersSchemaTransformed> = {},
 ): Promise<AiMetricQuery> => ({
     exploreName: config.exploreName,
     metrics: config.metrics,
@@ -60,7 +61,7 @@ type RenderCsvFileArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     config: CsvFileConfig;
-    filters: z.infer<typeof filtersSchema> | undefined;
+    filters: z.infer<typeof filtersSchemaTransformed> | undefined;
     maxLimit: number;
 };
 

--- a/packages/backend/src/ee/services/ai/visualizations/timeSeriesChart.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/timeSeriesChart.ts
@@ -2,6 +2,7 @@ import {
     AiChartType,
     AiMetricQuery,
     filtersSchema,
+    filtersSchemaTransformed,
     MetricQuery,
     timeSeriesMetricVizConfigSchema,
 } from '@lightdash/common';
@@ -43,7 +44,7 @@ export const isTimeSeriesMetricChartConfig = (
 
 export const metricQueryTimeSeriesChartMetric = (
     config: TimeSeriesMetricChartConfig,
-    filters: z.infer<typeof filtersSchema> = {},
+    filters: z.infer<typeof filtersSchemaTransformed> = {},
 ): AiMetricQuery => {
     const metrics = config.yMetrics;
     const dimensions = [
@@ -130,7 +131,7 @@ type RenderTimeseriesChartArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     vizConfig: TimeSeriesMetricChartConfig;
-    filters: z.infer<typeof filtersSchema> | undefined;
+    filters: z.infer<typeof filtersSchemaTransformed> | undefined;
 };
 
 export const renderTimeseriesChart = async ({

--- a/packages/backend/src/ee/services/ai/visualizations/verticalBarChart.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/verticalBarChart.ts
@@ -2,6 +2,7 @@ import {
     AiChartType,
     AiMetricQuery,
     filtersSchema,
+    filtersSchemaTransformed,
     MetricQuery,
     verticalBarMetricVizConfigSchema,
 } from '@lightdash/common';
@@ -45,7 +46,7 @@ export const isVerticalBarMetricChartConfig = (
 
 export const metricQueryVerticalBarChartMetric = (
     config: VerticalBarMetricChartConfig,
-    filters: z.infer<typeof filtersSchema> = {},
+    filters: z.infer<typeof filtersSchemaTransformed> = {},
 ): AiMetricQuery => {
     const metrics = config.yMetrics;
     const dimensions = [
@@ -132,7 +133,7 @@ type RenderVerticalBarMetricChartArgs = {
         metricQuery: AiMetricQuery,
     ) => ReturnType<InstanceType<typeof ProjectService>['runMetricQuery']>;
     vizConfig: VerticalBarMetricChartConfig;
-    filters: z.infer<typeof filtersSchema> | undefined;
+    filters: z.infer<typeof filtersSchemaTransformed> | undefined;
 };
 
 export const renderVerticalBarMetricChart = async ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15361

### Description:

This PR adds filter transformation to ensure proper format for queries while maintaining the original format for tool call arguments. It introduces a new `filtersSchemaTransformed` schema that properly transforms filter rules into the format expected by the query engine.

The changes apply this transformation in multiple visualization tools:
- Bar chart visualization
- CSV generation
- Query filters
- Time series visualization

This ensures consistent filter handling across all AI-powered visualization tools while maintaining backward compatibility with the existing API.