### PR TITLE
feat: Introduce larger custom widths for scheduled deliveries + screenshot improvs

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -647,6 +647,13 @@ export class UnfurlService extends BaseService {
                     );
 
                     page = await browser.newPage({
+                        viewport:
+                            chartType === ChartType.BIG_NUMBER
+                                ? bigNumberViewport
+                                : {
+                                      ...viewport,
+                                      width: gridWidth ?? viewport.width,
+                                  },
                         extraHTTPHeaders: {
                             [LightdashRequestMethodHeader]:
                                 RequestMethod.HEADLESS_BROWSER,
@@ -671,15 +678,6 @@ export class UnfurlService extends BaseService {
                             sameSite: 'Strict',
                         },
                     ]);
-
-                    if (chartType === ChartType.BIG_NUMBER) {
-                        await page.setViewportSize(bigNumberViewport);
-                    } else {
-                        await page.setViewportSize({
-                            ...viewport,
-                            width: gridWidth ?? viewport.width,
-                        });
-                    }
 
                     page.on('requestfailed', (request) => {
                         this.logger.warn(
@@ -942,18 +940,19 @@ export class UnfurlService extends BaseService {
                     }
 
                     const fullPage = await page.locator(finalSelector);
+                    const fullPageSize = await fullPage?.boundingBox();
 
-                    if (chartType === ChartType.BIG_NUMBER) {
-                        await page.setViewportSize(bigNumberViewport);
-                    } else {
-                        const fullPageSize = await fullPage?.boundingBox();
-
+                    if (
+                        chartType !== ChartType.BIG_NUMBER &&
+                        fullPageSize?.height
+                    ) {
                         await page.setViewportSize({
                             width: gridWidth ?? viewport.width,
-                            height: fullPageSize?.height
-                                ? Math.round(fullPageSize.height)
-                                : viewport.height,
+                            height: Math.round(fullPageSize.height),
                         });
+                        // Viewport changes can trigger layout shifts - wait for things to settle
+                        // before taking the shot 📸
+                        await page.waitForTimeout(100);
                     }
 
                     if (

--- a/packages/frontend/src/features/scheduler/constants/index.ts
+++ b/packages/frontend/src/features/scheduler/constants/index.ts
@@ -15,4 +15,12 @@ export const CUSTOM_WIDTH_OPTIONS = [
         label: 'TV Screen (1600px)',
         value: '1600',
     },
+    {
+        label: 'Large Monitor (1920px)',
+        value: '1920',
+    },
+    {
+        label: 'Ultra-wide Monitor (2560px)',
+        value: '2560',
+    },
 ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Improve unfurl service by setting viewport dimensions during page creation rather than after, which prevents unnecessary layout shifts. 
I've added a small timeout after viewport changes to make sure everything is in place before taking screenshots.

I've also expanded the custom width options for scheduled deliveries to include larger monitor sizes (1920px and 2560px), giving users more flexibility for their exports.