### PR TITLE
fix: refetch when results are expired for explore charts

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1551,6 +1551,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
         readyQuery.data?.chart.projectUuid,
         readyQuery.data?.executeQueryResponse.queryUuid,
         readyQuery.data?.chart.name,
+        readyQuery.refetch,
     );
 
     const isLoading = useMemo(() => {

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1293,6 +1293,8 @@ const ExplorerProvider: FC<
         validQueryArgs?.projectUuid,
         // get last value from queryUuidHistory
         queryUuidHistory[queryUuidHistory.length - 1],
+        undefined,
+        query.refetch,
     );
     const getDownloadQueryUuid = useCallback(
         async (limit: number | null) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15585

### Description:
Added automatic query re-execution when expired cache results are detected:

**Implementation:**
- Added optional reExecuteQuery callback parameter to useInfiniteQueryResults hook
- Enhanced error handling in the results fetching logic to detect 406 "ExpiredError" responses
- When expired results are detected, automatically trigger a fresh query execution via the callback
- Maintain existing error handling behavior for other error types

**Notes:** This is difficult to test locally so here's what was done to test:
1. Enable cache
2. Set `CACHE_STALE_TIME_SECONDS` to some small value, I set 30s
3. Apply the following diff on `AsyncQueryService`
```diff
diff --git a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
index 8e0c8f73b..e2f16d593 100644
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -366,6 +366,8 @@ export class AsyncQueryService extends ProjectService {
             originalColumns,
         } = queryHistory;
 
+        console.log('RESULTS', resultsExpiresAt);
+
         if (status === QueryHistoryStatus.ERROR) {
             return {
                 status,
@@ -396,7 +398,7 @@ export class AsyncQueryService extends ProjectService {
                 `Result file not found for query ${queryUuid}`,
             );
         }
-        if (resultsExpiresAt < new Date()) {
+        if (resultsExpiresAt.getTime() - 10000 < new Date().getTime()) {
             // TODO: throw a specific error the FE will respond to
             throw new ExpiredError(
                 `Results expired for file ${resultsFileName} and project ${projectUuid}`,
```
4. Open a second terminal window (if you use docker, open inside the container) and run `watch -n1 date` - this will give you the current time - install watch if needed with `apt update` and `apt install watch`
5. Run a query, read the results expiration date from the logs, reload the page once is gets to less 10s from the expiry date (it should error with expired because of the applied diff)

**Before**
![before](https://github.com/user-attachments/assets/ac740092-be45-4cd1-a179-4eb2c39bd9e2)

**After**
![after](https://github.com/user-attachments/assets/18097ffd-3c17-40c9-86b6-f9162cd2175d)
