### PR TITLE
feat: allow create projects without warehouse credentials

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -550,7 +550,7 @@ export type ProjectEvent = BaseTrack & {
         projectName: string;
         projectId: string;
         projectType: DbtProjectType;
-        warehouseConnectionType: WarehouseTypes;
+        warehouseConnectionType?: WarehouseTypes;
         organizationId: string;
         dbtConnectionType: DbtProjectType;
         isPreview: boolean;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1110,6 +1110,21 @@ export type CreateProject = Omit<
     copyContent?: boolean;
 };
 
+export type CreateProjectOptionalCredentials = Omit<
+    CreateProject,
+    'warehouseConnection'
+> & {
+    warehouseConnection?: CreateWarehouseCredentials;
+};
+
+export const hasWarehouseCredentials = (
+    createProject: CreateProjectOptionalCredentials,
+): createProject is CreateProjectOptionalCredentials & {
+    warehouseConnection: CreateWarehouseCredentials;
+} =>
+    !!createProject.warehouseConnection &&
+    Object.keys(createProject.warehouseConnection).length > 0;
+
 export type UpdateProject = Omit<
     Project,
     | 'projectUuid'

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -61,8 +61,8 @@ export type OrganizationProject = {
     type: ProjectType;
     createdByUserUuid: string | null;
     upstreamProjectUuid: string | null;
-    warehouseType: WarehouseTypes;
-    requireUserCredentials: boolean;
+    warehouseType?: WarehouseTypes;
+    requireUserCredentials?: boolean;
 };
 
 /**

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/utils.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/utils.tsx
@@ -61,11 +61,11 @@ export const WarehouseTypeLabels: WarehouseLabel[] = [
     },
 ];
 
-export const getWarehouseLabel = (key: SelectedWarehouse) => {
+export const getWarehouseLabel = (key?: SelectedWarehouse) => {
     return WarehouseTypeLabels.find((w) => w.key === key)?.label ?? null;
 };
 
-export const getWarehouseIcon = (key: SelectedWarehouse, size = 'md') => {
+export const getWarehouseIcon = (key?: SelectedWarehouse, size = 'md') => {
     const item = WarehouseTypeLabels.find((w) => w.key === key);
     if (!item) return null;
 

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -25,7 +25,7 @@ export const ProjectForm: FC<Props> = ({
 }) => {
     const { health } = useApp();
     const form = useFormContext();
-    const warehouse = form.values.warehouse?.type;
+    const warehouse = form.values.warehouse.type;
 
     return (
         <Stack spacing="xl">

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DbtProjectType,
     ProjectType,
+    WarehouseTypes,
     type CreateWarehouseCredentials,
     type Project,
 } from '@lightdash/common';
@@ -43,6 +44,9 @@ const UpdateProjectConnection: FC<{
     } = useUpdateMutation(projectUuid);
     const onProjectError = useOnProjectError();
 
+    const warehouseType: WarehouseTypes =
+        project.warehouseConnection?.type || WarehouseTypes.SNOWFLAKE;
+
     const isDisabled =
         project.type === ProjectType.PREVIEW ||
         isSaving ||
@@ -62,14 +66,13 @@ const UpdateProjectConnection: FC<{
                 ...project.dbtConnection,
             },
             warehouse: {
-                ...warehouseDefaultValues[project.warehouseConnection!.type],
+                ...warehouseDefaultValues[warehouseType],
                 ...project.warehouseConnection,
             } as CreateWarehouseCredentials,
             dbtVersion: project.dbtVersion,
         },
         validate: {
-            warehouse:
-                warehouseValueValidators[project.warehouseConnection!.type],
+            warehouse: warehouseValueValidators[warehouseType],
             dbt: dbtFormValidators,
         },
         validateInputOnBlur: true,
@@ -90,7 +93,7 @@ const UpdateProjectConnection: FC<{
             await mutateAsync({
                 name,
                 dbtConnection,
-                warehouseConnection: warehouseConnection!,
+                warehouseConnection: warehouseConnection,
                 dbtVersion,
             });
         }


### PR DESCRIPTION
Working towards https://github.com/lightdash/lightdash/issues/15347

This makes it possible to create a project without any warehouse credentials. This is only available on the "precompiled" endpoint, which expects a bunch of already constructed explorers.

The `Project` variable already had the warehouse credentials as optional and it appears to be well handled.

Changes:
- LightdashAnalytics - now warehouse type is optional so will be missing sometimes
- `OrganizationProject` had warehouse credentials as required but I've made it optional (only needed for user specific credentials flow in the UI)
- Added defaults to the `ProjectConnection` form in case there are no credentials.
