### PR TITLE
fix: return cache hit when there's cache valid within 10 min buffer

### DIFF
--- a/packages/backend/src/ee/services/CommercialCacheService.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.ts
@@ -10,6 +10,10 @@ type CacheServiceDependencies = {
     storageClient: S3ResultsFileStorageClient;
 };
 
+// Buffer time to ensure cache doesn't expire while being fetched
+// This prevents queries from expiring during pagination requests
+const DEFAULT_CACHE_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes in milliseconds
+
 export class CommercialCacheService implements ICacheService {
     private readonly queryHistoryModel: QueryHistoryModel;
 
@@ -43,7 +47,18 @@ export class CommercialCacheService implements ICacheService {
                 projectUuid,
             );
 
-        // Case 1: Valid cache exists
+        const staleTimeMilliseconds =
+            this.lightdashConfig.results.cacheStateTimeSeconds * 1000;
+
+        // If stale time is greater than quadruple default buffer, use default buffer
+        // Otherwise, use quarter of stale time
+        // This is to still allow any stale time to be used and keep a buffer for pagination requests
+        const expiryBuffer =
+            staleTimeMilliseconds > DEFAULT_CACHE_EXPIRY_BUFFER_MS * 4
+                ? DEFAULT_CACHE_EXPIRY_BUFFER_MS
+                : staleTimeMilliseconds / 4;
+
+        // Case 1: Valid cache exists with sufficient buffer time
         if (
             latestMatchingQuery &&
             latestMatchingQuery.resultsFileName &&
@@ -52,7 +67,8 @@ export class CommercialCacheService implements ICacheService {
             latestMatchingQuery.resultsExpiresAt &&
             latestMatchingQuery.resultsUpdatedAt &&
             latestMatchingQuery.totalRowCount !== null &&
-            latestMatchingQuery.resultsExpiresAt > new Date()
+            latestMatchingQuery.resultsExpiresAt >
+                new Date(Date.now() + expiryBuffer)
         ) {
             return {
                 cacheHit: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/15585

### Description:
Added a buffer time to prevent cache expiration during pagination requests. The PR introduces a 10-minute buffer when checking if a cache is valid, ensuring that results don't expire while being actively fetched or paginated through.

This change helps prevent scenarios where a user might start paginating through results, only to have the cache expire midway through their session.

**Cache Buffer Logic:**
We use a dynamic buffer system to prevent cache expiration during pagination:
- For cache stale times > 40 minutes: Use a fixed 10-minute buffer
- For cache stale times ≤ 40 minutes: Use 25% of the stale time as buffer

This approach ensures that even short cache times remain usable while maintaining a safety margin for pagination requests. Without this dynamic buffer, a fixed 10-minute buffer would make caches with expiry times under 10 minutes completely unusable.

**For cache times ≤ 40 minutes:**
Use 1/4 of stale time as buffer
10 min cache → 2.5 min buffer → 7.5 min usable (75% usable)
20 min cache → 5 min buffer → 15 min usable (75% usable)
30 min cache → 7.5 min buffer → 22.5 min usable (75% usable)
40 min cache → 10 min buffer → 30 min usable (75% usable)

**For cache times > 40 minutes:**
Use fixed 10-minute buffer
50 min cache → 10 min buffer → 40 min usable (80% usable)
60 min cache → 10 min buffer → 50 min usable (83% usable)