### PR TITLE
feat: hydate req.account in jwt middleware

### DIFF
--- a/packages/backend/src/auth/lightdashJwt.ts
+++ b/packages/backend/src/auth/lightdashJwt.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import {
     CreateEmbedJwt,
-    EmbedJwt,
     EmbedJwtSchema,
     ForbiddenError,
     getErrorMessage,
@@ -45,7 +44,7 @@ export function encodeLightdashJwt(
 export function decodeLightdashJwt(
     token: string,
     encodedSecret: string | Buffer,
-): EmbedJwt {
+): CreateEmbedJwt {
     try {
         const encryptionUtil = new EncryptionUtil({ lightdashConfig });
         const secret = encryptionUtil.decrypt(
@@ -53,7 +52,7 @@ export function decodeLightdashJwt(
                 ? encodedSecret
                 : Buffer.from(encodedSecret),
         );
-        const decodedToken = verify(token, secret) as EmbedJwt;
+        const decodedToken = verify(token, secret) as CreateEmbedJwt;
 
         // Alert if the token is not in the expected format so we can inform the org before enforcing validation
         try {

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -5,6 +5,7 @@ import {
     ApiCalculateTotalResponse,
     ApiErrorPayload,
     ApiSuccessEmpty,
+    assertEmbeddedAuth,
     CacheMetadata,
     CreateEmbed,
     CreateEmbedJwt,
@@ -16,8 +17,6 @@ import {
     EmbedUrl,
     Explore,
     FieldValueSearchResult,
-    FilterInteractivityValues,
-    ForbiddenError,
     Item,
     MetricQueryResponse,
     SavedChart,
@@ -176,9 +175,9 @@ export class EmbedController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiEmbedDashboardResponse> {
         this.setStatus(200);
-        if (!req.account) {
-            throw new ForbiddenError('Account is missing');
-        }
+
+        assertEmbeddedAuth(req.account);
+
         return {
             status: 'ok',
             results: await this.getEmbedService().getDashboard(
@@ -197,9 +196,9 @@ export class EmbedController extends BaseController {
         @Body() body: SavedChartsInfoForDashboardAvailableFilters,
     ): Promise<ApiEmbedDashboardAvailableFiltersResponse> {
         this.setStatus(200);
-        if (!req.account) {
-            throw new ForbiddenError('Account is missing');
-        }
+
+        assertEmbeddedAuth(req.account);
+
         return {
             status: 'ok',
             results:
@@ -226,9 +225,9 @@ export class EmbedController extends BaseController {
         },
     ): Promise<ApiEmbedChartAndResultsResponse> {
         this.setStatus(200);
-        if (!req.account) {
-            throw new ForbiddenError('Account is missing');
-        }
+
+        assertEmbeddedAuth(req.account);
+
         return {
             status: 'ok',
             results: await this.getEmbedService().getChartAndResults(
@@ -256,9 +255,9 @@ export class EmbedController extends BaseController {
         },
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
-        if (!req.account) {
-            throw new ForbiddenError('Account is missing');
-        }
+
+        assertEmbeddedAuth(req.account);
+
         return {
             status: 'ok',
             results: await this.getEmbedService().calculateTotalFromSavedChart(
@@ -292,9 +291,7 @@ export class EmbedController extends BaseController {
         this.setStatus(200);
         const { search, limit, filters, forceRefresh } = body;
 
-        if (!req.account) {
-            throw new ForbiddenError('Account is missing');
-        }
+        assertEmbeddedAuth(req.account);
 
         const results = await this.getEmbedService().searchFilterValues({
             account: req.account,

--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -15,7 +15,17 @@ export class EmbedModel {
         const [embed] = await this.database('embedding')
             .select()
             .leftJoin('users', 'embedding.created_by', 'users.user_uuid')
-            .where('project_uuid', projectUuid);
+            .leftJoin(
+                'projects',
+                'projects.project_uuid',
+                'embedding.project_uuid',
+            )
+            .leftJoin(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where('embedding.project_uuid', projectUuid);
 
         if (!embed) {
             throw new NotFoundError(
@@ -41,7 +51,8 @@ export class EmbedModel {
         return {
             projectUuid: embed.project_uuid,
             organization: {
-                organizationUuid: embed.user_organization_uuid,
+                organizationUuid: embed.organization_uuid,
+                name: embed.organization_name,
             },
             encodedSecret: embed.encoded_secret,
             dashboardUuids: validDashboardUuids,

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/hydrateEmbeddedAccount.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/hydrateEmbeddedAccount.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    applyEmbeddedAbility,
+    CreateEmbedJwt,
+    Embed,
+    ExternalAccount,
+    MemberAbility,
+    Organization,
+} from '@lightdash/common';
+
+function getExternalId(
+    decodedToken: CreateEmbedJwt,
+    embedToken: string,
+    organization: Pick<Organization, 'organizationUuid' | 'name'>,
+): string {
+    return (
+        decodedToken.user?.externalId ||
+        `anonymous-jwt::${organization.organizationUuid}_${embedToken}`
+    );
+}
+
+/**
+ * Builds CASL abilities for the embedded user based on JWT content
+ */
+function buildEmbedAbilities(
+    embedJwt: CreateEmbedJwt,
+    dashboardUuid: string,
+    organization: Embed['organization'],
+): MemberAbility {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    applyEmbeddedAbility(embedJwt, dashboardUuid, organization, builder);
+
+    return builder.build();
+}
+
+export function hydrateEmbeddedAccount(
+    organization: Embed['organization'],
+    embedJwt: CreateEmbedJwt,
+    rawToken: string,
+    dashboardUuid: string,
+): ExternalAccount {
+    const abilities: MemberAbility = buildEmbedAbilities(
+        embedJwt,
+        dashboardUuid,
+        organization,
+    );
+
+    return {
+        authentication: {
+            type: 'jwt',
+            data: embedJwt,
+            source: rawToken,
+        },
+        organization,
+        // Create the fields we're able to set from the JWT
+        user: {
+            id: getExternalId(embedJwt, rawToken, organization),
+            type: 'external',
+            ability: abilities,
+            abilityRules: abilities.rules,
+            email: embedJwt.user?.email,
+            isActive: true,
+        },
+    };
+}

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/index.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/index.ts
@@ -1,0 +1,1 @@
+export { jwtAuthMiddleware } from './jwtAuthMiddleware';

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -77,7 +77,6 @@ export const mapDbUserDetailsToLightdashUser = (
 ): LightdashUser => ({
     userUuid: user.user_uuid,
     userId: user.user_id,
-    type: 'lightdash',
     email: user.email,
     firstName: user.first_name,
     lastName: user.last_name,

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -16,6 +16,7 @@ type UserAbilityBuilderArgs = {
     permissionsConfig: OrganizationMemberAbilitiesArgs['permissionsConfig'];
 };
 
+export * from './scopeAbility';
 export * from './serviceAccountAbility';
 
 export const getUserAbilityBuilder = ({

--- a/packages/common/src/authorization/scopeAbility.test.ts
+++ b/packages/common/src/authorization/scopeAbility.test.ts
@@ -1,0 +1,472 @@
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
+import { type CreateEmbedJwt } from '../ee';
+import { applyEmbeddedAbility } from './scopeAbility';
+import { type MemberAbility } from './types';
+
+const createEmbedJwt = (overrides?: {
+    content?: Partial<CreateEmbedJwt['content']>;
+    exp?: number;
+    iat?: number;
+    userAttributes?: { [key: string]: string };
+    user?: CreateEmbedJwt['user'];
+}): CreateEmbedJwt => {
+    const baseContent = {
+        type: 'dashboard',
+        projectUuid: 'project-uuid-1',
+        dashboardUuid: 'dashboard-uuid-1',
+        canExportCsv: false,
+        canExportImages: false,
+        canExportPagePdf: false,
+        canDateZoom: false,
+    };
+
+    const { content: contentOverrides, ...otherOverrides } = overrides || {};
+
+    return {
+        content: {
+            ...baseContent,
+            ...contentOverrides,
+        } as CreateEmbedJwt['content'],
+        exp: Date.now() / 1000 + 3600, // 1 hour from now
+        ...otherOverrides,
+    };
+};
+const organization = {
+    organizationUuid: 'organization-uuid-1',
+    name: 'Organization 1',
+};
+
+const defineAbilityForEmbedUser = (
+    embedUser: CreateEmbedJwt,
+    dashboardUuid: string,
+): MemberAbility => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    applyEmbeddedAbility(embedUser, dashboardUuid, organization, builder);
+    return builder.build();
+};
+
+describe('Embedded dashboard abilities', () => {
+    const dashboardUuid = 'dashboard-uuid-1';
+    const projectUuid = 'project-uuid-1';
+
+    describe('Base abilities', () => {
+        it('should allow viewing the specified dashboard', () => {
+            const embedUser = createEmbedJwt();
+            const ability = defineAbilityForEmbedUser(embedUser, dashboardUuid);
+
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', {
+                        dashboardUuid,
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ),
+            ).toBe(true);
+        });
+
+        it('should not allow viewing private saved charts', () => {
+            const embedUser = createEmbedJwt();
+            const ability = defineAbilityForEmbedUser(embedUser, dashboardUuid);
+
+            expect(
+                ability.can(
+                    'view',
+                    subject('SavedChart', {
+                        projectUuid,
+                        isPrivate: true,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('should not allow viewing saved charts from different projects', () => {
+            const embedUser = createEmbedJwt();
+            const ability = defineAbilityForEmbedUser(embedUser, dashboardUuid);
+
+            expect(
+                ability.can(
+                    'view',
+                    subject('SavedChart', {
+                        projectUuid: 'different-project-uuid',
+                        isPrivate: false,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('should handle missing optional properties gracefully', () => {
+            const embedUser: CreateEmbedJwt = {
+                content: {
+                    type: 'dashboard',
+                    projectUuid: 'project-uuid-1',
+                    dashboardUuid: 'dashboard-uuid-1',
+                },
+                exp: Date.now() / 1000 + 3600,
+            };
+            const ability = defineAbilityForEmbedUser(embedUser, dashboardUuid);
+
+            // Base abilities should still work
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', {
+                        dashboardUuid,
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ),
+            ).toBe(true);
+
+            // Export abilities should default to false
+            expect(
+                ability.can(
+                    'export',
+                    subject('Dashboard', {
+                        type: 'csv',
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'export',
+                    subject('Dashboard', {
+                        type: 'pdf',
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'export',
+                    subject('Dashboard', {
+                        type: 'images',
+                        organizationUuid: organization.organizationUuid,
+                    }),
+                ),
+            ).toBe(false);
+
+            // Date zoom should default to false
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', { canDateZoom: true }),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('Export abilities', () => {
+        describe('CSV export', () => {
+            it('should allow CSV export when canExportCsv is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportCsv: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'csv',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow CSV export when canExportCsv is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportCsv: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'csv',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+
+        describe('PDF export', () => {
+            it('should allow PDF export when canExportPagePdf is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportPagePdf: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'pdf',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow PDF export when canExportPagePdf is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportPagePdf: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'pdf',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+
+        describe('Images export', () => {
+            it('should allow images export when canExportImages is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportImages: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'images',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow images export when canExportImages is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportImages: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'images',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+
+        describe('Multiple export formats', () => {
+            it('should allow all export formats when all are enabled', () => {
+                const embedUser = createEmbedJwt({
+                    content: {
+                        canExportCsv: true,
+                        canExportPagePdf: true,
+                        canExportImages: true,
+                    },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'csv',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'pdf',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'images',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should allow only CSV and PDF when images is disabled', () => {
+                const embedUser = createEmbedJwt({
+                    content: {
+                        canExportCsv: true,
+                        canExportPagePdf: true,
+                        canExportImages: false,
+                    },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'csv',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'pdf',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'images',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should not allow any exports when all are disabled', () => {
+                const embedUser = createEmbedJwt({
+                    content: {
+                        canExportCsv: false,
+                        canExportPagePdf: false,
+                        canExportImages: false,
+                    },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'csv',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'pdf',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+                expect(
+                    ability.can(
+                        'export',
+                        subject('Dashboard', {
+                            type: 'images',
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+    });
+
+    describe('Dashboard abilities', () => {
+        describe('Date zoom', () => {
+            it('should allow date zoom when canDateZoom is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canDateZoom: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', {
+                            dateZoom: true,
+                            organizationUuid: organization.organizationUuid,
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow date zoom when canDateZoom is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canDateZoom: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', { dateZoom: true }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle undefined canDateZoom as false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canDateZoom: undefined },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Dashboard', { canDateZoom: true }),
+                    ),
+                ).toBe(false);
+            });
+        });
+    });
+});

--- a/packages/common/src/authorization/scopeAbility.ts
+++ b/packages/common/src/authorization/scopeAbility.ts
@@ -1,0 +1,93 @@
+import { type AbilityBuilder } from '@casl/ability';
+import { flow } from 'lodash';
+import { type CreateEmbedJwt, type Embed } from '../ee';
+import type { MemberAbility } from './types';
+
+type EmbeddedAbilityBuilderPayload = {
+    embedUser: CreateEmbedJwt;
+    dashboardUuid: string;
+    organization: Embed['organization'];
+    builder: Pick<AbilityBuilder<MemberAbility>, 'can'>;
+};
+
+type EmbeddedAbilityBuilder = (
+    options: EmbeddedAbilityBuilderPayload,
+) => EmbeddedAbilityBuilderPayload;
+
+const addBaseAbilities: EmbeddedAbilityBuilder = ({
+    embedUser,
+    dashboardUuid,
+    organization,
+    builder,
+}) => {
+    const { can } = builder;
+    can('view', 'Dashboard', {
+        dashboardUuid,
+        organizationUuid: organization.organizationUuid,
+    });
+    return { embedUser, dashboardUuid, organization, builder };
+};
+
+const exportAbilities: EmbeddedAbilityBuilder = ({
+    embedUser,
+    dashboardUuid,
+    organization,
+    builder,
+}) => {
+    const { content } = embedUser;
+    const { can } = builder;
+
+    if (content.canExportCsv) {
+        can('export', 'Dashboard', {
+            organizationUuid: organization.organizationUuid,
+            type: 'csv',
+        });
+    }
+
+    if (content.canExportPagePdf) {
+        can('export', 'Dashboard', {
+            organizationUuid: organization.organizationUuid,
+            type: 'pdf',
+        });
+    }
+
+    if (content.canExportImages) {
+        can('export', 'Dashboard', {
+            organizationUuid: organization.organizationUuid,
+            type: 'images',
+        });
+    }
+
+    return { embedUser, dashboardUuid, organization, builder };
+};
+
+const dashboardAbilities: EmbeddedAbilityBuilder = ({
+    embedUser,
+    dashboardUuid,
+    organization,
+    builder,
+}) => {
+    const { content } = embedUser;
+    const { can } = builder;
+
+    can('view', 'Dashboard', {
+        dateZoom: content.canDateZoom ?? false,
+        organizationUuid: organization.organizationUuid,
+    });
+    return { embedUser, dashboardUuid, organization, builder };
+};
+
+const applyAbilities = flow(
+    addBaseAbilities,
+    exportAbilities,
+    dashboardAbilities,
+);
+
+export function applyEmbeddedAbility(
+    embedUser: CreateEmbedJwt,
+    dashboardUuid: string,
+    organization: Embed['organization'],
+    builder: AbilityBuilder<MemberAbility>,
+) {
+    applyAbilities({ embedUser, dashboardUuid, organization, builder });
+}

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -2,12 +2,13 @@ import { type Ability, type ForcedSubject } from '@casl/ability';
 import { type OrganizationMemberProfile } from '../types/organizationMemberProfile';
 
 export type AbilityAction =
-    | 'manage'
-    | 'update'
-    | 'view'
     | 'create'
     | 'delete'
-    | 'promote';
+    | 'export'
+    | 'manage'
+    | 'promote'
+    | 'update'
+    | 'view';
 
 interface Project {
     organizationUuid: string;
@@ -19,37 +20,37 @@ interface Organization {
 }
 
 export type CaslSubjectNames =
-    | 'Project'
-    | 'Organization'
-    | 'OrganizationMemberProfile'
+    | 'AiAgent'
+    | 'AiAgentThread'
+    | 'Analytics'
+    | 'ChangeCsvResults'
+    | 'CompileProject'
+    | 'ContentAsCode'
+    | 'CustomSql'
     | 'Dashboard'
-    | 'Space'
-    | 'SavedChart'
+    | 'DashboardComments'
+    | 'Explore'
+    | 'ExportCsv'
+    | 'Group'
     | 'InviteLink'
     | 'Job'
-    | 'SqlRunner'
-    | 'Analytics'
-    | 'Explore'
-    | 'UnderlyingData'
-    | 'ExportCsv'
     | 'JobStatus'
-    | 'PinnedItems'
-    | 'Validation'
-    | 'Group'
-    | 'ChangeCsvResults'
-    | 'ScheduledDeliveries'
-    | 'DashboardComments'
-    | 'CustomSql'
-    | 'CompileProject'
-    | 'SemanticViewer'
-    | 'VirtualView'
-    | 'Tags'
-    | 'PersonalAccessToken'
     | 'MetricsTree'
+    | 'Organization'
+    | 'OrganizationMemberProfile'
+    | 'PersonalAccessToken'
+    | 'PinnedItems'
+    | 'Project'
+    | 'SavedChart'
+    | 'ScheduledDeliveries'
+    | 'SemanticViewer'
+    | 'Space'
     | 'SpotlightTableConfig'
-    | 'ContentAsCode'
-    | 'AiAgent'
-    | 'AiAgentThread';
+    | 'SqlRunner'
+    | 'Tags'
+    | 'UnderlyingData'
+    | 'Validation'
+    | 'VirtualView';
 
 export type Subject =
     | CaslSubjectNames

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -5,7 +5,7 @@ import assertUnreachable from '../../utils/assertUnreachable';
 
 export type Embed = {
     projectUuid: string;
-    organization: Pick<Organization, 'organizationUuid'>;
+    organization: Pick<Organization, 'organizationUuid' | 'name'>;
     encodedSecret: string;
     dashboardUuids: string[];
     allowAllDashboards: boolean;
@@ -97,8 +97,7 @@ export const EmbedJwtSchema = z
 export type EmbedJwt = z.infer<typeof EmbedJwtSchema>;
 
 // Note: we can't extend zod types since tsoa doesn't support it
-
-export type CommonEmbedJwtContent = {
+type CommonEmbedJwtContent = {
     type: 'dashboard';
     projectUuid?: string;
     isPreview?: boolean;

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -1,6 +1,11 @@
 import { type CreateEmbedJwt } from '../ee';
+import { ForbiddenError } from './errors';
 import { type Organization } from './organization';
-import { type SessionUser } from './user';
+import {
+    type AccountUser,
+    type ExternalUser,
+    type LightdashSessionUser,
+} from './user';
 
 type AccountAuthType =
     | 'session'
@@ -30,16 +35,19 @@ export enum AuthTokenPrefix {
 type EmbeddedAccountAuth = LightdashAuth<{
     type: 'jwt';
     data: CreateEmbedJwt;
+    /* The serialized token */
     source: string;
 }>;
 
 type LightdashUserAccountAuth = LightdashAuth<{
     type: 'session';
+    /* The serialized cookie */
     source: string;
 }>;
 
 type ServiceAccountAuth = LightdashAuth<{
     type: 'service-account';
+    /* The service account token */
     source: string;
 }>;
 
@@ -48,19 +56,46 @@ type LightdashAccountAuth =
     | LightdashUserAccountAuth
     | ServiceAccountAuth;
 
+type AccountOrganization = Pick<Organization, 'organizationUuid' | 'name'>;
+
+type ILightdashAccount = {
+    organization: AccountOrganization;
+    authentication: LightdashAccountAuth;
+    user: AccountUser;
+};
+
+type LightdashAccount<T extends ILightdashAccount> = {} & T;
+
+export type ExternalAccount = LightdashAccount<{
+    organization: AccountOrganization;
+    authentication: EmbeddedAccountAuth;
+    user: ExternalUser;
+}>;
+
+export type SessionAccount = LightdashAccount<{
+    organization: AccountOrganization;
+    authentication: LightdashUserAccountAuth;
+    user: LightdashSessionUser;
+}>;
+
 /**
  * The account object is used to store the account information for the user.
  * It's meant to be agnostic of the authentication method.
  */
-export type Account = {
-    organization: Pick<Organization, 'organizationUuid'>;
-    authentication: LightdashAccountAuth;
-    user: SessionUser;
-};
+export type Account = SessionAccount | ExternalAccount;
 
-export function getEmbeddedAuth(account: Account): EmbeddedAccountAuth {
-    if (account.authentication.type !== 'jwt') {
-        throw new Error('Account is not an embedded account');
+export function assertEmbeddedAuth(
+    account: Account | undefined,
+): asserts account is ExternalAccount {
+    if (account?.authentication.type !== 'jwt') {
+        throw new ForbiddenError('Account is not an embedded account');
     }
-    return account.authentication;
+}
+
+export function assertSessionAuth(
+    account: Account | undefined,
+): asserts account is SessionAccount {
+    if (account?.authentication.type !== 'session') {
+        throw new ForbiddenError('Account is not a session account');
+    }
 }

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -2,24 +2,50 @@ import { type AbilityBuilder } from '@casl/ability';
 import { type MemberAbility } from '../authorization/types';
 import { type AnyType } from './any';
 import { type OpenIdIdentityIssuerType } from './openIdIdentity';
+import { type Organization } from './organization';
 import { type OrganizationMemberRole } from './organizationMemberProfile';
 
-export type BaseUser = {
+export type AccountUser = {
+    id: string;
+    email: string | undefined;
+    /* Whether the user can login */
+    isActive: boolean;
+    abilityRules: AbilityBuilder<MemberAbility>['rules'];
+    ability: MemberAbility;
+    type: 'lightdash' | 'external';
+};
+
+export interface LightdashUser {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
     organizationUuid?: string;
     organizationName?: string;
     organizationCreatedAt?: Date;
+    userId: number;
     role?: OrganizationMemberRole;
+    isTrackingAnonymized: boolean;
+    isMarketingOptedIn: boolean;
+    isSetupComplete: boolean;
+    email: string | undefined;
     /* Whether the user can login */
     isActive: boolean;
-};
+    createdAt: Date;
+    updatedAt: Date;
+    /* Whether the user doesn't have an authentication method (password or openId) */
+    isPending?: boolean;
+}
 
-export interface LightdashUser extends BaseUser {
+export interface LightdashSessionUser extends AccountUser {
+    type: 'lightdash';
+    // The current effective primary key for users. It duplicates user.id.
     userUuid: string;
+    // The old sequential primary key for users
     userId: number;
-    type?: 'lightdash';
-    email: string | undefined;
     firstName: string;
     lastName: string;
+    organization: Pick<Organization, 'organizationUuid' | 'name'>;
+    role?: OrganizationMemberRole;
     isTrackingAnonymized: boolean;
     isMarketingOptedIn: boolean;
     isSetupComplete: boolean;
@@ -29,13 +55,11 @@ export interface LightdashUser extends BaseUser {
     isPending?: boolean;
 }
 
-export type ExternalUser = BaseUser &
-    Partial<LightdashUser> & {
-        externalId: string;
-        type: 'external';
-    };
+export interface ExternalUser extends AccountUser {
+    type: 'external';
+}
 
-export type LightdashUserWithOrg = Required<LightdashUser | ExternalUser>;
+export type LightdashUserWithOrg = Required<LightdashUser>;
 
 export const isUserWithOrg = (
     user: LightdashUser,

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -12,7 +12,7 @@ describe('Space', () => {
         cy.login();
     });
 
-    it('I can create a private space with private content', () => {
+    const createPrivateSpace = () => {
         const timestamp = new Date().toISOString();
 
         // Create private space
@@ -25,7 +25,7 @@ describe('Space', () => {
         // Create new chart
         cy.get('.tabler-icon-plus').click();
         cy.contains('Create new chart').click();
-        cy.contains('Orders').click();
+        cy.contains(/^Orders$/).click();
         cy.contains('Total order amount').click();
         cy.contains('Status').click();
         cy.contains('Save chart').click();
@@ -73,9 +73,11 @@ describe('Space', () => {
         cy.contains('All').click();
         cy.contains(`Private dashboard ${timestamp}`);
         cy.contains(`Private chart ${timestamp}`);
-    });
+    };
 
     it('Another non-admin user cannot see private content', () => {
+        createPrivateSpace();
+
         // We assume the previous test has been run and the private space has been created
         // If this is causing issues, try reusing the `createPrivateChart` from spacePermissions.cy.ts
         cy.request({

--- a/packages/frontend/src/testing/__mocks__/api/userResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/userResponse.mock.ts
@@ -1,6 +1,6 @@
 import {
-    OrganizationMemberRole,
     type LightdashUserWithAbilityRules,
+    OrganizationMemberRole,
 } from '@lightdash/common';
 
 export function mockUserResponse(
@@ -9,7 +9,6 @@ export function mockUserResponse(
     return {
         userUuid: 'b264d83a-9000-426a-85ec-3f9c20f368ce',
         userId: 1,
-        type: 'lightdash',
         email: 'demo@lightdash.com',
         firstName: 'David',
         lastName: 'Attenborough',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15580

### Description:
Refactors the JWT authentication middleware to improve embedded dashboard functionality. This PR:

- Introduces a new `hydrateEmbeddedAccount` utility to properly populate user session data and abilities
- Adds CASL ability rules for embedded users with proper scoping
- Replaces `EmbedJwt` with `CreateEmbedJwt` type in relevant places due to zod and tsoa not being on friendly terms
- Enhances the embed model to include organization name
- Extracts dashboard UUID resolution logic to a dedicated method
- Adds comprehensive test coverage for embedded user abilities
- Slight refactor to CASL verbs and subjects so their sorted for easier reading

This change improves the security model for embedded dashboards by properly scoping user permissions based on the JWT token contents.