### PR TITLE
fix: remove zod schema to unblock tsoa generate

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -673,26 +673,20 @@ export class AiAgentModel {
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
                     toolCalls: toolCalls
-                        .filter((tc) => isToolName(tc.tool_name))
+                        .filter(
+                            (
+                                tc,
+                            ): tc is DbAiAgentToolCall & {
+                                tool_name: ToolName;
+                            } => isToolName(tc.tool_name),
+                        )
                         .map((tc) => ({
                             uuid: tc.ai_agent_tool_call_uuid,
                             promptUuid: tc.ai_prompt_uuid,
                             toolCallId: tc.tool_call_id,
                             createdAt: tc.created_at,
-                            // TODO: handle this typing better
-                            ...(isFindFieldsToolArgs(tc.tool_args) &&
-                            tc.tool_name === 'findFields'
-                                ? {
-                                      toolName: 'findFields',
-                                      toolArgs: tc.tool_args,
-                                  }
-                                : {
-                                      toolName: tc.tool_name as Exclude<
-                                          ToolName,
-                                          'findFields'
-                                      >,
-                                      toolArgs: tc.tool_args,
-                                  }),
+                            toolName: tc.tool_name,
+                            toolArgs: tc.tool_args,
                         })),
                 });
             }
@@ -843,26 +837,20 @@ export class AiAgentModel {
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
                     toolCalls: toolCalls
-                        .filter((tc) => isToolName(tc.tool_name))
+                        .filter(
+                            (
+                                tc,
+                            ): tc is DbAiAgentToolCall & {
+                                tool_name: ToolName;
+                            } => isToolName(tc.tool_name),
+                        )
                         .map((tc) => ({
                             uuid: tc.ai_agent_tool_call_uuid,
                             promptUuid: tc.ai_prompt_uuid,
                             toolCallId: tc.tool_call_id,
                             createdAt: tc.created_at,
-                            // TODO: handle this typing better
-                            ...(isFindFieldsToolArgs(tc.tool_args) &&
-                            tc.tool_name === 'findFields'
-                                ? {
-                                      toolName: 'findFields',
-                                      toolArgs: tc.tool_args,
-                                  }
-                                : {
-                                      toolName: tc.tool_name as Exclude<
-                                          ToolName,
-                                          'findFields'
-                                      >,
-                                      toolArgs: tc.tool_args,
-                                  }),
+                            toolName: tc.tool_name,
+                            toolArgs: tc.tool_args,
                         })),
                 } satisfies AiAgentMessageAssistant;
             default:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4719,18 +4719,73 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiAgentToolCall: {
+    BaseAiAgentToolCall: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
-                toolArgs: { dataType: 'object', required: true },
-                toolName: { dataType: 'string', required: true },
                 toolCallId: { dataType: 'string', required: true },
                 promptUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Exclude_ToolName.findFields_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['generateBarVizConfig'] },
+                { dataType: 'enum', enums: ['generateCsv'] },
+                { dataType: 'enum', enums: ['generateQueryFilters'] },
+                { dataType: 'enum', enums: ['generateTimeSeriesVizConfig'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentToolCall: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'BaseAiAgentToolCall' },
+                {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                toolArgs: {
+                                    dataType: 'object',
+                                    required: true,
+                                },
+                                toolName: {
+                                    dataType: 'enum',
+                                    enums: ['findFields'],
+                                    required: true,
+                                },
+                            },
+                        },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                toolArgs: {
+                                    dataType: 'object',
+                                    required: true,
+                                },
+                                toolName: {
+                                    ref: 'Exclude_ToolName.findFields_',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
             validators: {},
         },
     },
@@ -4777,14 +4832,7 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                createdAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
+                createdAt: { dataType: 'string', required: true },
                 message: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5313,18 +5313,11 @@
                 ],
                 "type": "object"
             },
-            "AiAgentToolCall": {
+            "BaseAiAgentToolCall": {
                 "properties": {
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
-                    },
-                    "toolArgs": {
-                        "additionalProperties": true,
-                        "type": "object"
-                    },
-                    "toolName": {
-                        "type": "string"
                     },
                     "toolCallId": {
                         "type": "string"
@@ -5336,15 +5329,57 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "createdAt",
-                    "toolArgs",
-                    "toolName",
-                    "toolCallId",
-                    "promptUuid",
-                    "uuid"
-                ],
+                "required": ["createdAt", "toolCallId", "promptUuid", "uuid"],
                 "type": "object"
+            },
+            "Exclude_ToolName.findFields_": {
+                "type": "string",
+                "enum": [
+                    "generateBarVizConfig",
+                    "generateCsv",
+                    "generateQueryFilters",
+                    "generateTimeSeriesVizConfig"
+                ],
+                "description": "Exclude from T those types that are assignable to U"
+            },
+            "AiAgentToolCall": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/BaseAiAgentToolCall"
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "toolArgs": {
+                                        "additionalProperties": true,
+                                        "type": "object"
+                                    },
+                                    "toolName": {
+                                        "type": "string",
+                                        "enum": ["findFields"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["toolArgs", "toolName"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "toolArgs": {
+                                        "additionalProperties": true,
+                                        "type": "object"
+                                    },
+                                    "toolName": {
+                                        "$ref": "#/components/schemas/Exclude_ToolName.findFields_"
+                                    }
+                                },
+                                "required": ["toolArgs", "toolName"],
+                                "type": "object"
+                            }
+                        ]
+                    }
+                ]
             },
             "AiAgentMessageAssistant": {
                 "properties": {
@@ -5375,8 +5410,7 @@
                         "nullable": true
                     },
                     "createdAt": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "message": {
                         "type": "string",
@@ -17624,7 +17658,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1760.3",
+        "version": "0.1764.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -9,7 +9,6 @@ import type {
     MetricQuery,
     ToolName,
 } from '../..';
-import { type FindFieldsToolArgs } from '../Ai/schemas';
 
 /**
  * Supported AI visualization chart types
@@ -260,23 +259,13 @@ export type ApiUpdateUserAgentPreferences = AiAgentUserPreferences;
 
 export type ApiUpdateUserAgentPreferencesResponse = ApiSuccessEmpty;
 
-// Base tool call structure
-export type BaseAiAgentToolCall = {
+export type AiAgentToolCall = {
     uuid: string;
     promptUuid: string;
     toolCallId: string;
     createdAt: Date;
+    toolName: ToolName;
+    // TODO: Add specific types for other tools as schemas are created
+    // TODO: Check that generate-api works with zod infer schemas
+    toolArgs: object;
 };
-
-// Discriminated union for different tool types
-export type AiAgentToolCall = BaseAiAgentToolCall &
-    (
-        | {
-              toolName: 'findFields';
-              toolArgs: FindFieldsToolArgs;
-          }
-        | {
-              toolName: Exclude<ToolName, 'findFields'>;
-              toolArgs: object; // TODO: Add specific types for other tools as schemas are created
-          }
-    );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -1,6 +1,7 @@
 import {
     type AiAgentToolCall,
     assertUnreachable,
+    isFindFieldsToolArgs,
     TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL,
 } from '@lightdash/common';
 import { Badge, Group, Stack, Text, Timeline } from '@mantine-8/core';
@@ -42,6 +43,9 @@ const getToolDescription = (toolCall: AiAgentToolCall) => {
 
     switch (toolName) {
         case 'findFields':
+            if (!isFindFieldsToolArgs(toolCall.toolArgs)) {
+                return null;
+            }
             const fields = toolCall.toolArgs.embeddingSearchQueries || [];
             const exploreName = toolCall.toolArgs.exploreName;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Unblocked `pnpm generate-api` command by removing zod schema infer on `AiAgentToolCall`.`toolArgs`

error was

```
There was a problem resolving type of 'FindFieldsToolArgs'.
There was a problem resolving type of 'AiAgentToolCall'.
There was a problem resolving type of 'AiAgentMessageAssistant'.
There was a problem resolving type of 'AiAgentMessage<AiAgentUser>'.
There was a problem resolving type of 'AiAgentThread'.
There was a problem resolving type of 'ApiAiAgentThreadResponse'.
Generate routes error.
 GenerateMetadataError: No matching model found for referenced type aiFindFieldsToolSchema.
```