### PR TITLE
feat: Link saved charts to ai prompts

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -320,6 +320,34 @@ export class AiAgentController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
+    @Patch(
+        '/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/savedQuery',
+    )
+    @OperationId('updateAgentThreadMessageSavedQuery')
+    async updateAgentThreadMessageSavedQuery(
+        @Request() req: express.Request,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() messageUuid: string,
+        @Body() body: { savedQueryUuid: string | null },
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+
+        await this.getAiAgentService().updateMessageSavedQuery(req.user!, {
+            savedQueryUuid: body.savedQueryUuid,
+            agentUuid,
+            threadUuid,
+            messageUuid,
+        });
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
     @Get('/projects/{projectUuid}/conversations')
     @OperationId('getAiAgentConversations')
     async getAiAgentConversations(

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -69,6 +69,7 @@ export type DbAiPrompt = {
     filters_output: object | null;
     human_score: number | null;
     metric_query: object | null;
+    saved_query_uuid: string | null;
 };
 
 export type AiPromptTable = Knex.CompositeTableType<
@@ -85,6 +86,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'filters_output'
             | 'human_score'
             | 'metric_query'
+            | 'saved_query_uuid'
         > & {
             responded_at: Knex.Raw;
         }

--- a/packages/backend/src/ee/database/migrations/20250625151529_add_saved_chart_uuid_to_prompt.ts
+++ b/packages/backend/src/ee/database/migrations/20250625151529_add_saved_chart_uuid_to_prompt.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const AiPromptTable = `ai_prompt`;
+const SavedQueriesTable = `saved_queries`;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiPromptTable, (table) => {
+        table
+            .uuid('saved_query_uuid')
+            .references('saved_query_uuid')
+            .inTable(SavedQueriesTable)
+            .nullable()
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiPromptTable, (table) => {
+        table.dropColumn('saved_query_uuid');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -594,6 +594,7 @@ export class AiAgentModel {
                     | 'viz_config_output'
                     | 'metric_query'
                     | 'human_score'
+                    | 'saved_query_uuid'
                 > &
                     Pick<DbUser, 'user_uuid'> &
                     Pick<DbAiThread, 'ai_thread_uuid'> &
@@ -611,6 +612,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.viz_config_output`,
                 `${AiPromptTableName}.metric_query`,
                 `${AiPromptTableName}.human_score`,
+                `${AiPromptTableName}.saved_query_uuid`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
@@ -687,6 +689,7 @@ export class AiAgentModel {
                             toolName: tc.tool_name,
                             toolArgs: tc.tool_args,
                         })),
+                    savedQueryUuid: row.saved_query_uuid,
                 });
             }
 
@@ -745,6 +748,7 @@ export class AiAgentModel {
                     | 'viz_config_output'
                     | 'metric_query'
                     | 'human_score'
+                    | 'saved_query_uuid'
                 > &
                     Pick<DbUser, 'user_uuid'> &
                     Pick<DbAiThread, 'ai_thread_uuid'> &
@@ -762,6 +766,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.viz_config_output`,
                 `${AiPromptTableName}.metric_query`,
                 `${AiPromptTableName}.human_score`,
+                `${AiPromptTableName}.saved_query_uuid`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
@@ -851,6 +856,7 @@ export class AiAgentModel {
                             toolName: tc.tool_name,
                             toolArgs: tc.tool_args,
                         })),
+                    savedQueryUuid: row.saved_query_uuid,
                 } satisfies AiAgentMessageAssistant;
             default:
                 return assertUnreachable(role, `Unknown role ${role}`);
@@ -1137,6 +1143,19 @@ export class AiAgentModel {
             })
             .where({
                 ai_prompt_uuid: data.promptUuid,
+            });
+    }
+
+    async updateMessageSavedQuery(data: {
+        messageUuid: string;
+        savedQueryUuid: string | null;
+    }): Promise<void> {
+        await this.database(AiPromptTableName)
+            .update({
+                saved_query_uuid: data.savedQueryUuid,
+            })
+            .where({
+                ai_prompt_uuid: data.messageUuid,
             });
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4740,6 +4740,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                savedQueryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 toolCalls: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'AiAgentToolCall' },
@@ -11586,7 +11594,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11596,7 +11604,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11606,7 +11614,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11619,7 +11627,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -19664,6 +19672,94 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updatePromptFeedback',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updateAgentThreadMessageSavedQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                savedQueryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/messages/:messageUuid/savedQuery',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updateAgentThreadMessageSavedQuery,
+        ),
+
+        async function AiAgentController_updateAgentThreadMessageSavedQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updateAgentThreadMessageSavedQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateAgentThreadMessageSavedQuery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5348,6 +5348,10 @@
             },
             "AiAgentMessageAssistant": {
                 "properties": {
+                    "savedQueryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "toolCalls": {
                         "items": {
                             "$ref": "#/components/schemas/AiAgentToolCall"
@@ -5394,6 +5398,7 @@
                     }
                 },
                 "required": [
+                    "savedQueryUuid",
                     "toolCalls",
                     "humanScore",
                     "metricQuery",
@@ -12441,22 +12446,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17636,7 +17641,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1769.0",
+        "version": "0.1769.6",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -121,6 +121,7 @@ export type AiAgentMessageAssistant = {
     humanScore: number | null;
 
     toolCalls: AiAgentToolCall[];
+    savedQueryUuid: string | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -69,7 +69,7 @@ type FormValues = z.infer<typeof saveToSpaceOrDashboardSchema>;
 type Props = {
     projectUuid?: string;
     savedData: CreateSavedChartVersion;
-    onConfirm: (savedData: CreateSavedChartVersion) => void;
+    onConfirm: (savedData: SavedChart) => void;
     onClose: () => void;
     dashboardInfoFromSavedData?: {
         dashboardUuid: string | null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -188,6 +188,7 @@ export const AiChartVisualization: FC<Props> = ({
 
                         {activeTab === 'chart' && (
                             <AiChartQuickOptions
+                                message={message}
                                 projectUuid={projectUuid}
                                 saveChartOptions={{
                                     name: queryExecutionHandle.data.metadata
@@ -195,10 +196,6 @@ export const AiChartVisualization: FC<Props> = ({
                                     description:
                                         queryExecutionHandle.data.metadata
                                             .description,
-                                }}
-                                message={{
-                                    threadUuid: message.threadUuid,
-                                    uuid: message.uuid,
                                 }}
                             />
                         )}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -219,6 +219,7 @@ const createOptimisticMessages = (
             metricQuery: null,
             humanScore: null,
             toolCalls: [],
+            savedQueryUuid: null,
         },
     ];
 };
@@ -483,6 +484,52 @@ export const useUpdatePromptFeedbackMutation = (
             showToastApiError({
                 title: 'Failed to submit feedback',
                 apiError: error,
+            });
+        },
+    });
+};
+
+const savePromptQuery = async ({
+    agentUuid,
+    threadUuid,
+    messageUuid,
+    savedQueryUuid,
+}: {
+    agentUuid: string;
+    threadUuid: string;
+    messageUuid: string;
+    savedQueryUuid: string | null;
+}) =>
+    lightdashApi<ApiSuccessEmpty>({
+        url: `/aiAgents/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/savedQuery`,
+        method: `PATCH`,
+        body: JSON.stringify({
+            savedQueryUuid,
+        }),
+    });
+
+export const useSavePromptQuery = (
+    agentUuid: string,
+    threadUuid: string,
+    messageUuid: string,
+) => {
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiSuccessEmpty,
+        ApiError,
+        { savedQueryUuid: string | null }
+    >({
+        mutationFn: ({ savedQueryUuid }) =>
+            savePromptQuery({
+                agentUuid,
+                threadUuid,
+                messageUuid,
+                savedQueryUuid,
+            }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
             });
         },
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15552, #15452

### Description:

Added the ability to associate saved charts with AI agent messages. When a user saves a chart from an AI agent response, the saved chart UUID is now stored in the database and linked to the message. 
This way, users can see which charts have been saved and provides a direct link to view the saved chart.

#### TODO
- [ ] Refresh message on saved chart, so we instantly switch the `save chart` with the `view chart` button
- [ ] Thoroughly testing