### PR TITLE
fix: remove 100 row limit in validator table

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -397,8 +397,7 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                     ) : !!data?.length ? (
                         <>
                             <ValidatorTable
-                                // Hard limit to 100 rows, otherwise it breaks the UI
-                                data={data.slice(0, 100)} // TODO add pagination
+                                data={data}
                                 projectUuid={projectUuid}
                                 onSelectValidationError={(validationError) => {
                                     if (
@@ -410,12 +409,6 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                                     }
                                 }}
                             />
-                            {data.length > 100 && (
-                                <Text p="md" c="gray.7">
-                                    Showing only 100 of {data.length} validation
-                                    errors.
-                                </Text>
-                            )}
                         </>
                     ) : (
                         <Group position="center" spacing="xs" p="md">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #15380


I initially added a hard limit in the FE because the UI was a bit slow to load (also, there were some bugs on that page that made it worse, but they are fixed now). But now the customer wants to display all errors, and adding pagination is a bigger piece of work.

I tested again (with 1000 results) , and it seems better, it should work better on prod, without dev mode/scan.

[Screencast from 2025-06-30 09-44-53.webm](https://github.com/user-attachments/assets/95ef03bc-3d3c-45c4-b2bf-53bc9fe590e4)

### Description:
Removed the 100-row limit in the SettingsValidator component. Previously, the validator table was artificially limited to display only the first 100 validation errors, with a note indicating the total count. This change allows the table to display all validation errors without truncation.