### PR TITLE
fix: auto-complete user setup when tracking is disabled

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -99,7 +99,29 @@ const UserCompletionModal: FC = () => {
         setFieldValue('enableEmailDomainAccess', true);
     }, [canEnableEmailDomainAccess, setFieldValue]);
 
-    if (!user.data || user.data.isSetupComplete) {
+    useEffect(() => {
+        // Tracking is disabled, we complete the user tracking with default values
+        if (
+            health.data?.rudder.writeKey === undefined &&
+            !isLoading &&
+            user.data &&
+            !user.data.isSetupComplete
+        ) {
+            mutate({
+                organizationName: user.data.organizationName,
+                jobTitle: 'Other',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: false,
+                isTrackingAnonymized: true,
+            });
+        }
+    }, [health.data?.rudder.writeKey, isLoading, mutate, user.data]);
+
+    if (
+        !user.data ||
+        user.data.isSetupComplete ||
+        health.data?.rudder.writeKey === undefined
+    ) {
         return null;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

Remove UI when `RUDDERSTACK_ANALYTICS_DISABLED=true`

![image](https://github.com/user-attachments/assets/e74780e2-883c-431e-9c57-d806f4f85486)

### Description:
Auto-complete user setup when tracking is disabled. When Rudder tracking is not configured (writeKey is undefined), the user completion modal will automatically submit with default values instead of showing the modal to the user.