### PR TITLE
fix: allow schema validation errors for jwts again

### DIFF
--- a/packages/backend/src/auth/lightdashJwt.ts
+++ b/packages/backend/src/auth/lightdashJwt.ts
@@ -61,14 +61,14 @@ export function decodeLightdashJwt(
                     errorIdentifier = decodedToken.content.dashboardSlug;
                 }
             }
-            // FIXME: This needs to be cleaned up. Need to verify current behavior
+            // FIXME: This is legacy behavior where we simply log Zod schema validation errors.
             if (e instanceof z.ZodError) {
                 const zodErrors = e.issues
                     .map((issue) => issue.message)
                     .join(', ');
 
                 Logger.error(
-                    `Invalid embed token ${errorIdentifier}: ${zodErrors}`,
+                    `Token schema validation error: ${errorIdentifier}: ${zodErrors}`,
                 );
             } else {
                 Logger.error(
@@ -78,13 +78,6 @@ export function decodeLightdashJwt(
                 );
             }
             Sentry.captureException(e);
-            if (e instanceof z.ZodError) {
-                const zodErrors = e.issues
-                    .map((issue) => issue.message)
-                    .join(', ');
-                throw new ParameterError(`Invalid embed token: ${zodErrors}`);
-            }
-            throw e;
         }
         return decodedToken;
     } catch (e) {
@@ -96,7 +89,9 @@ export function decodeLightdashJwt(
         }
         if (e instanceof z.ZodError) {
             const zodErrors = e.issues.map((issue) => issue.message).join(', ');
-            throw new ParameterError(`Invalid embed token: ${zodErrors}`);
+            throw new ParameterError(
+                `Token schema validation error: ${zodErrors}`,
+            );
         }
         throw e;
     }

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -51,10 +51,7 @@ export type ApiEmbedDashboardResponse = {
     status: 'ok';
     results: Dashboard & {
         // declare type as TSOA doesn't understand zod type InteractivityOptions
-        dashboardFiltersInteractivity?: {
-            enabled: boolean | FilterInteractivityValues;
-            allowedFilters?: string[];
-        };
+        dashboardFiltersInteractivity?: CreateEmbedJwt['content']['dashboardFiltersInteractivity'];
         canExportCsv?: boolean;
         canExportImages?: boolean;
     };

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -39,7 +39,8 @@ export const FilterInteractivityValuesSchema = z.enum([
 
 export const DashboardFilterInteractivityOptionsSchema = z.object({
     enabled: z.union([z.boolean(), FilterInteractivityValuesSchema]),
-    allowedFilters: z.array(z.string()).optional(),
+    // Nullish because we have python clients that serialize None to null
+    allowedFilters: z.array(z.string()).nullish(),
 });
 
 export type DashboardFilterInteractivityOptions = z.infer<
@@ -101,7 +102,7 @@ type CommonEmbedJwtContent = {
     isPreview?: boolean;
     dashboardFiltersInteractivity?: {
         enabled: FilterInteractivityValues | boolean;
-        allowedFilters?: string[];
+        allowedFilters?: string[] | null;
     };
     canExportCsv?: boolean;
     canExportImages?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR improves JWT token validation for embedded dashboards by:

1. Updating the schema to properly handle `null` values for `allowedFilters` in dashboard filter interactivity options, which is needed for Python clients that serialize `None` to `null`.

2. Enhancing error handling in `decodeLightdashJwt` to log schema validation errors instead of throwing exceptions, reverting back to previous behavior. 

3. Improving error messages to be more specific about token schema validation errors.

4. Adding tests to verify that `null` values for `allowedFilters` are properly handled and that invalid payload structures are logged without throwing exceptions.