### PR TITLE
fix: chartName in language maps

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -56,7 +56,7 @@ type CoderServiceArguments = {
 const isAnyChartTile = (
     tile: DashboardTileAsCode | DashboardTile,
 ): tile is DashboardTile & {
-    properties: { chartSlug: string; hideTitle: boolean };
+    properties: { chartSlug: string; hideTitle: boolean; chartName?: string };
 } =>
     tile.type === DashboardTileTypes.SAVED_CHART ||
     tile.type === DashboardTileTypes.SQL_CHART;
@@ -273,6 +273,7 @@ export class CoderService extends BaseService {
                             title: tile.properties.title,
                             hideTitle: tile.properties.hideTitle,
                             chartSlug: tile.properties.chartSlug,
+                            chartName: tile.properties.chartName,
                         },
                     };
                 }

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -65,7 +65,7 @@ export type DashboardTileAsCode = Omit<DashboardTile, 'properties' | 'uuid'> & {
     properties:
         | Pick<
               DashboardChartTileProperties['properties'],
-              'title' | 'hideTitle' | 'chartSlug'
+              'title' | 'hideTitle' | 'chartSlug' | 'chartName'
           >
         | DashboardMarkdownTileProperties['properties']
         | DashboardLoomTileProperties['properties'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #13844

### Description:
Added support for `chartName` property in dashboard tiles. This property is now included in the type definitions for dashboard tiles and is properly handled in the `CoderService` when processing chart tiles.

**Steps to test**
1. Create chart
2. Add chart to dashboard
3. Run `lightdash download --language-map`
4. Check dashboard language map

**Before**
```yaml
dashboard:
  dashboard-with-dashboard-charts:
    name: Dashboard with dashboard charts
    tiles:
      - type: saved_chart
        properties:
          title: ''
          chartName: ''
```

**After**
```yaml
dashboard:
  dashboard-with-dashboard-charts:
    name: Dashboard with dashboard charts
    tiles:
      - type: saved_chart
        properties:
          title: ''
          chartName: '[Saved in dashboard] How much revenue do we have per payment method?'
```