### PR TITLE
fix: register refresh strategies in SchedulerApp

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -656,6 +656,8 @@ export default class App {
                 userService,
             }),
         );
+
+        // Refresh strategies also need to be registered on SchedulerApp
         if (googlePassportStrategy) {
             passport.use(googlePassportStrategy);
             refresh.use(googlePassportStrategy);

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -3,12 +3,15 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
+import refresh from 'passport-oauth2-refresh';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import {
     ClientProviderMap,
     ClientRepository,
 } from './clients/ClientRepository';
 import { LightdashConfig } from './config/parseConfig';
+import { googlePassportStrategy } from './controllers/authentication';
+import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
 import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import PrometheusMetrics from './prometheus';
@@ -153,6 +156,14 @@ export default class SchedulerApp {
     }
 
     public async start() {
+        // Load refresh strategies, required when running scheduler in production mode
+        if (googlePassportStrategy) {
+            refresh.use(googlePassportStrategy);
+        }
+        if (snowflakePassportStrategy) {
+            refresh.use('snowflake', snowflakePassportStrategy);
+        }
+
         this.prometheusMetrics.start();
         this.prometheusMetrics.monitorDatabase(this.database);
         // @ts-ignore


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

Before
![Screenshot from 2025-07-01 11-50-50](https://github.com/user-attachments/assets/5b83a4cf-57ac-4336-aab6-e955db1f2194)


After

![Screenshot from 2025-07-01 11-51-02](https://github.com/user-attachments/assets/78e1d076-dd85-4415-bd55-ce166169116a)


### Description:
Register OAuth refresh strategies in the SchedulerApp to ensure proper authentication token refreshing when running the scheduler in production mode. This adds the necessary configuration for Google and Snowflake OAuth strategies to work correctly in the scheduler context, similar to how they're already registered in the main App.