### PR TITLE
fix: render filters based on metric query instead of ai_prompt.filtersOutput

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -252,8 +252,10 @@ export const AiChartVisualization: FC<Props> = ({
 
                                 {message.filtersOutput && (
                                     <AgentVisualizationFilters
-                                        // TODO: fix this using schema
-                                        filters={message.filtersOutput}
+                                        filters={
+                                            queryExecutionHandle.data.query
+                                                .metricQuery.filters
+                                        }
                                     />
                                 )}
                             </ErrorBoundary>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Render filters based on metric query instead of ai_prompt.filtersOutput. This ensures that changes to AI Tool schema don't affect the filters UI
