### PR TITLE
fix: scroll-to-bottom behavior when loading charts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -178,7 +178,6 @@ export const AssistantBubble: FC<{
         useAiAgentThreadStreaming(message.threadUuid) &&
         isOptimisticMessageStub(message.message);
 
-    const metricQuery = queryExecutionHandle.data?.query.metricQuery;
     const vizConfig = message.vizConfigOutput;
 
     if (!projectUuid) throw new Error(`Project Uuid not found`);
@@ -195,11 +194,12 @@ export const AssistantBubble: FC<{
         >
             <AssistantBubbleContent message={message} />
 
-            {vizConfig && metricQuery && (
+            {vizConfig && (
                 <Paper
                     withBorder
                     radius="md"
                     p="md"
+                    h="500px"
                     shadow="none"
                     {...((queryExecutionHandle.isError ||
                         queryExecutionHandle.isLoading) && {
@@ -210,8 +210,12 @@ export const AssistantBubble: FC<{
                     })}
                 >
                     {isQueryLoading ? (
-                        <Center>
-                            <Loader type="dots" color="gray" />
+                        <Center h="100%">
+                            <Loader
+                                type="dots"
+                                color="gray"
+                                delayedMessage="Loading visualization..."
+                            />
                         </Center>
                     ) : isQueryError ? (
                         <Stack gap="xs" align="center">

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -49,7 +49,6 @@ export const AgentChatDisplay: FC<PropsWithChildren<AgentChatDisplayProps>> = ({
 
     return (
         <Flex
-            key={thread.uuid}
             ref={viewport}
             direction="column"
             h={height}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -171,7 +171,7 @@ export const AiChartVisualization: FC<Props> = ({
                     setEchartSeries(series);
                 }}
             >
-                <Stack gap="md" h="100%" mih={400}>
+                <Stack gap="md" h="100%">
                     <Group justify="space-between" align="start">
                         <SegmentedControl
                             style={{
@@ -204,7 +204,13 @@ export const AiChartVisualization: FC<Props> = ({
                         )}
                     </Group>
 
-                    <Box flex="1 0 0">
+                    <Box
+                        flex="1 0 0"
+                        style={{
+                            // Scrolling for tables
+                            overflow: 'auto',
+                        }}
+                    >
                         {activeTab === 'chart' ? (
                             <>
                                 <LightdashVisualization


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #15432

### Description:

Fixes scroll-to-bottom behavior when loading threads w/ charts

- Sets a fixed height for all visualizations
- Makes tables scrollable
- Removes the unnecessary metricQuery check for visualization rendering

Demo (throttled 4g):

[CleanShot 2025-07-01 at 17.41.52.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/SRLEqMEevAzoFwvhnfeq/851c7dec-fd83-46d3-8c8a-58752cbc5306.mp4" />](https://app.graphite.dev/media/video/SRLEqMEevAzoFwvhnfeq/851c7dec-fd83-46d3-8c8a-58752cbc5306.mp4)

