### PR TITLE
fix: do not invalidate on human score change

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -479,12 +479,6 @@ export const useUpdatePromptFeedbackMutation = (
                 },
             );
         },
-        onSuccess: () => {
-            // Invalidate relevant queries to refresh the data
-            void queryClient.invalidateQueries({
-                queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
-            });
-        },
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to submit feedback',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Removed the `onSuccess` callback from the `useUpdatePromptFeedbackMutation` hook that was invalidating queries. This eliminates the automatic refresh of thread data after submitting feedback.

