### PR TITLE
chore: add Nix flake for development environment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -322,7 +322,6 @@ eg. on MacOS you can follow this instructions:
 # 2 Install nvm (https://github.com/nvm-sh/nvm#troubleshooting-on-macos) and other required dependencies
 brew update
 brew install nvm
-brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman python-setuptools
 
 # 3 Install specified node version using NVM (https://github.com/nvm-sh/nvm)
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,17 @@ credentials.json
 packages/backend/target/
 venv/
 .venv/
+.venvs/
 dbt_modules/
 logs/
+
+# direnv
 /.envrc
+.direnv/
+
+# nix flakes
+flake.nix
+flake.lock
 
 # dangerfile
 dangerfile.development.ts

--- a/dockerfile
+++ b/dockerfile
@@ -23,9 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     unzip \
     git \
-    libcairo2-dev \
-    libpango1.0-dev \
-    librsvg2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -242,9 +239,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     git \
     build-essential \
-    libcairo2-dev \
-    libpango1.0-dev \
-    librsvg2-dev \
     dumb-init \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -23,9 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     unzip \
     git \
-    libcairo2-dev \
-    libpango1.0-dev \
-    librsvg2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -242,9 +239,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     git \
     build-essential \
-    libcairo2-dev \
-    libpango1.0-dev \
-    librsvg2-dev \
     dumb-init \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,239 @@
+{
+  description = "Nix flake for Lightdash development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # This covers typical Linux and macOS architectures.
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config = { };
+          };
+
+          # Python version to use for venvs
+          python312 = pkgs.python312;
+
+          # Base directory for all DBT virtual environments
+          dbtVenvsBaseDir = ".venvs/dbt";
+          dbtAliasesDir = ".venvs/bin"; # Centralized location for all dbt aliases
+
+          # Define the dbt versions to set up automatically
+          # Using versions from dockerfile
+          dbtVersions = {
+            dbt1_4 = {
+              dbtCoreVersion = "1.4.9";
+              dbtAliasName = "dbt";
+              adapterVersions = {
+                postgres = "1.4.9";
+                redshift = "1.4.1";
+                snowflake = "1.4.5";
+                bigquery = "1.4.5";
+                databricks = "1.4.3";
+                trino = "1.4.2";
+              };
+            };
+            dbt1_5 = {
+              dbtCoreVersion = "1.5.0";
+              dbtAliasName = "dbt1.5";
+              adapterVersions = {
+                postgres = "1.5.11";
+                redshift = "1.5.12";
+                snowflake = "1.5.7";
+                bigquery = "1.5.9";
+                databricks = "1.5.7";
+                trino = "1.5.1";
+              };
+            };
+            dbt1_6 = {
+              dbtCoreVersion = "1.6.0";
+              dbtAliasName = "dbt1.6";
+              adapterVersions = {
+                postgres = "1.6.0";
+                redshift = "1.6.0";
+                snowflake = "1.6.0";
+                bigquery = "1.6.0";
+                databricks = "1.6.0";
+                trino = "1.6.0";
+              };
+            };
+            dbt1_7 = {
+              dbtCoreVersion = "1.7.0";
+              dbtAliasName = "dbt1.7";
+              adapterVersions = {
+                postgres = "1.7.0";
+                redshift = "1.7.0";
+                snowflake = "1.7.0";
+                bigquery = "1.7.0";
+                databricks = "1.7.0";
+                trino = "1.7.0";
+              };
+            };
+            dbt1_8 = {
+              dbtCoreVersion = "1.8.0";
+              dbtAliasName = "dbt1.8";
+              adapterVersions = {
+                postgres = "1.8.0";
+                redshift = "1.8.0";
+                snowflake = "1.8.0";
+                bigquery = "1.8.0";
+                databricks = "1.8.0";
+                trino = "1.8.0";
+              };
+            };
+            dbt1_9 = {
+              dbtCoreVersion = "1.9.0";
+              dbtAliasName = "dbt1.9";
+              adapterVersions = {
+                postgres = "1.9.0";
+                redshift = "1.9.0";
+                snowflake = "1.9.0";
+                bigquery = "1.9.0";
+                databricks = "1.9.0";
+                trino = "1.9.0";
+              };
+            };
+          };
+
+          # Helper function to create a dbt virtual environment and its alias
+          # Arguments are now a single attribute set for easier use with mapAttrsToList
+          mkDbtVenvSetup =
+            {
+              dbtCoreVersion,
+              dbtAliasName,
+              adapterVersions,
+            }:
+            ''
+              # Path to the venv, relative to project root
+              VENV_PATH="${dbtVenvsBaseDir}/${dbtCoreVersion}"
+              # Path to the dbt executable, relative to project root (for checks)
+              DBT_BIN_FROM_ROOT="$VENV_PATH/bin/dbt"
+              # Path to the alias file, relative to project root
+              ALIAS_PATH="${dbtAliasesDir}/${dbtAliasName}"
+              # Path to the dbt executable, relative to the alias's directory (for the symlink)
+              DBT_BIN_FOR_LINK="../dbt/${dbtCoreVersion}/bin/dbt"
+
+              # Ensure directories exist (these are relative to project root)
+              mkdir -p ${pkgs.lib.escapeShellArg dbtVenvsBaseDir}
+              mkdir -p ${pkgs.lib.escapeShellArg dbtAliasesDir}
+
+              if [ ! -d "$VENV_PATH" ]; then
+                echo "Setting up dbt ${dbtCoreVersion} virtual environment in $VENV_PATH..."
+                # Create the venv using the Nix-provided python
+                ${python312}/bin/python3 -m venv "$VENV_PATH" || { echo "Failed to create venv"; exit 1; }
+
+                # Activate for pip install (temporary activation for the script)
+                source "$VENV_PATH/bin/activate"
+
+                echo "Installing dbt-core==${dbtCoreVersion} and all adapters..."
+
+                # Install dbt-core first (required for 1.8+)
+                pip install "dbt-core==${dbtCoreVersion}" --disable-pip-version-check --no-warn-script-location || { echo "Failed to install dbt-core"; exit 1; }
+
+                # Install all adapters
+                pip install \
+                  "dbt-postgres~=${adapterVersions.postgres}" \
+                  "dbt-redshift~=${adapterVersions.redshift}" \
+                  "dbt-snowflake~=${adapterVersions.snowflake}" \
+                  "dbt-bigquery~=${adapterVersions.bigquery}" \
+                  "dbt-databricks~=${adapterVersions.databricks}" \
+                  "dbt-trino~=${adapterVersions.trino}" \
+                  "pytz" \
+                  "psycopg2-binary==2.9.6" \
+                  --disable-pip-version-check --no-warn-script-location || { echo "Failed to install adapters"; exit 1; }
+
+                deactivate # Deactivate after installation
+
+                echo "dbt ${dbtCoreVersion} venv setup complete with all adapters."
+              fi
+
+              # Create/update the symlink for the alias using the correct relative path
+              if [ -f "$DBT_BIN_FROM_ROOT" ]; then
+                ln -sf "$DBT_BIN_FOR_LINK" "$ALIAS_PATH"
+              else
+                echo "WARNING: dbt executable not found in $VENV_PATH. Alias '${dbtAliasName}' might not work."
+              fi
+            '';
+
+          # Programmatically generate the setup scripts for all defined dbt versions
+          dbtSetupScripts = pkgs.lib.concatStringsSep "\n\n" (
+            pkgs.lib.mapAttrsToList (name: versionInfo: mkDbtVenvSetup versionInfo) dbtVersions
+          );
+
+          # Programmatically generate the list of aliases for the help message
+          dbtAliasList = pkgs.lib.concatStringsSep ", " (
+            pkgs.lib.attrNames (
+              pkgs.lib.mapAttrs' (name: value: {
+                name = value.dbtAliasName;
+                value = null;
+              }) dbtVersions
+            )
+          );
+
+        in
+        {
+          default = pkgs.mkShell {
+            name = "lightdash-dev-shell";
+
+            # Essential build tools for native Node.js modules
+            nativeBuildInputs = with pkgs; [
+              gcc
+              gnumake
+              pkg-config
+              libpq
+              libpq.pg_config
+              openssl
+            ];
+
+            buildInputs = with pkgs; [
+              nodejs_22
+              pnpm
+
+              # for dbt
+              python312
+              postgresql
+
+              cloudflared
+
+              git-secrets
+            ];
+
+            # Environment setup
+            shellHook = ''
+              echo ""
+              echo "------------------------------------------------------"
+              echo "Entering Lightdash development shell for ${system}..."
+              echo "NODE: $(node --version)"
+              echo "PNPM: $(pnpm --version)"
+
+              # This single variable now expands to all the setup scripts
+              ${dbtSetupScripts}
+
+              # Add the alias directory to the PATH to make dbt commands directly available
+              export PATH="$PWD/${dbtAliasesDir}:$PATH"
+
+              echo "Available DBT commands: ${dbtAliasList}"
+              echo  "------------------------------------------------------"
+              echo  ""
+            '';
+          };
+        }
+      );
+    };
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -71,7 +71,7 @@
         "apache-arrow": "^16.1.0",
         "archiver": "^7.0.1",
         "bcrypt": "^5.1.1",
-        "canvas": "^2.11.2",
+        "canvas": "^3.1.2",
         "chokidar": "^4.0.2",
         "connect-flash": "^0.1.1",
         "connect-session-knex": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
       canvas:
-        specifier: ^2.11.2
-        version: 2.11.2(encoding@0.1.13)
+        specifier: ^3.1.2
+        version: 3.1.2
       chokidar:
         specifier: ^4.0.2
         version: 4.0.2
@@ -6565,6 +6565,10 @@ packages:
     resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
     engines: {node: '>=6'}
 
+  canvas@3.1.2:
+    resolution: {integrity: sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==}
+    engines: {node: ^18.12.0 || >= 20.9.0}
+
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
@@ -6668,6 +6672,9 @@ packages:
   chokidar@4.0.2:
     resolution: {integrity: sha512-/b57FK+bblSU+dfewfFe0rT1YjVDfOmeLQwCAuC+vwvgLkXboATqqmy+Ipux6JrF6L5joe5CBnFOw+gLWH6yKg==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -7325,6 +7332,10 @@ packages:
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
     engines: {node: '>= 0.4'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.3:
     resolution: {integrity: sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==}
@@ -8008,6 +8019,10 @@ packages:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
@@ -8500,6 +8515,9 @@ packages:
   git-config-path@1.0.1:
     resolution: {integrity: sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==}
     engines: {node: '>=0.10.0'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -10429,6 +10447,9 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -10525,6 +10546,9 @@ packages:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
@@ -11304,6 +11328,11 @@ packages:
   preact@10.26.6:
     resolution: {integrity: sha512-5SRRBinwpwkaD+OqlBDeITlRgvd8I8QlxHJw9AxSdMNV6O+LodN9nUyYGpSF7sadHjs6RzeFShMexC6DbtWr9g==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   precinct@12.1.2:
     resolution: {integrity: sha512-x2qVN3oSOp3D05ihCd8XdkIPuEQsyte7PSxzLqiRgktu79S5Dr1I75/S+zAup8/0cwjoiJTQztE9h0/sWp9bJQ==}
     engines: {node: '>=18'}
@@ -11574,6 +11603,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-ace@9.5.0:
     resolution: {integrity: sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==}
@@ -12393,6 +12426,9 @@ packages:
   simple-get@3.1.1:
     resolution: {integrity: sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==}
 
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-git@3.16.0:
     resolution: {integrity: sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==}
 
@@ -12694,6 +12730,10 @@ packages:
     resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -12799,6 +12839,9 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  tar-fs@2.1.3:
+    resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
 
   tar-mini@0.2.0:
     resolution: {integrity: sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==}
@@ -21131,6 +21174,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
+
+  canvas@3.1.2:
+    dependencies:
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
 
   canvg@3.0.11:
     dependencies:
@@ -21242,6 +21291,8 @@ snapshots:
   chokidar@4.0.2:
     dependencies:
       readdirp: 4.0.2
+
+  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -21966,6 +22017,7 @@ snapshots:
   decompress-response@4.2.1:
     dependencies:
       mimic-response: 2.1.0
+    optional: true
 
   decompress-response@6.0.0:
     dependencies:
@@ -21997,6 +22049,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
       which-typed-array: 1.1.15
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.3: {}
 
@@ -22900,6 +22954,8 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expand-template@2.0.3: {}
+
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
@@ -23520,6 +23576,8 @@ snapshots:
       extend-shallow: 2.0.1
       fs-exists-sync: 0.1.0
       homedir-polyfill: 1.0.3
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -26041,7 +26099,8 @@ snapshots:
 
   mimic-response@1.0.1: {}
 
-  mimic-response@2.1.0: {}
+  mimic-response@2.1.0:
+    optional: true
 
   mimic-response@3.1.0: {}
 
@@ -26109,6 +26168,8 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
     dependencies:
@@ -26191,7 +26252,8 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nan@2.18.0: {}
+  nan@2.18.0:
+    optional: true
 
   nano-css@5.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -26209,6 +26271,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@3.3.8: {}
+
+  napi-build-utils@2.0.0: {}
 
   natural-compare-lite@1.4.0: {}
 
@@ -27001,6 +27065,21 @@ snapshots:
 
   preact@10.26.6: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.74.0
+      pump: 3.0.0
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.3
+      tunnel-agent: 0.6.0
+
   precinct@12.1.2:
     dependencies:
       '@dependents/detective-less': 5.0.0
@@ -27312,6 +27391,13 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-ace@9.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -28365,6 +28451,13 @@ snapshots:
       decompress-response: 4.2.1
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-git@3.16.0:
     dependencies:
@@ -28759,6 +28852,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strnum@1.0.5: {}
@@ -28856,6 +28951,13 @@ snapshots:
       wordwrapjs: 5.1.0
 
   tapable@2.2.1: {}
+
+  tar-fs@2.1.3:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
 
   tar-mini@0.2.0: {}
 


### PR DESCRIPTION
### Description:
This PR removes unnecessary Cairo, Pango, and librsvg dependencies from our Docker images and development environment. It also:

1. Upgrades the canvas package from v2.11.2 to v3.1.2, which no longer requires these native dependencies
2. Adds support for Nix development environment via a new flake.nix file
3. Updates .gitignore to include Nix and direnv related files
4. Adds automatic setup of multiple dbt versions in the Nix environment

This change will make our development environment setup simpler and more consistent across platforms.