### PR TITLE
feat: show sql instead of metric query

### DIFF
--- a/packages/common/src/ee/Ai/schemas.ts
+++ b/packages/common/src/ee/Ai/schemas.ts
@@ -567,7 +567,7 @@ export const generateQueryFiltersToolArgsSchemaTransformed = z.object({
 // GENERATE BAR VIZ CONFIG TOOL ARGS
 export const verticalBarMetricVizConfigToolArgsSchema = z.object({
     vizConfig: verticalBarMetricVizConfigSchema,
-    filters: filtersSchema,
+    filters: filtersSchema.nullable(),
 });
 export type VerticalBarMetricVizConfigToolArgs = z.infer<
     typeof verticalBarMetricVizConfigToolArgsSchema
@@ -586,7 +586,7 @@ export const verticalBarMetricVizConfigToolArgsSchemaTransformed = z.object({
 // GENERATE TIME SERIES VIZ CONFIG TOOL ARGS
 export const timeSeriesMetricVizConfigToolArgsSchema = z.object({
     vizConfig: timeSeriesMetricVizConfigSchema,
-    filters: filtersSchema,
+    filters: filtersSchema.nullable(),
 });
 export type TimeSeriesMetricVizConfigToolArgs = z.infer<
     typeof timeSeriesMetricVizConfigToolArgsSchema

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -23,6 +23,7 @@ import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { type EChartSeries } from '../../../../../hooks/echarts/useEchartsCartesianConfig';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useOrganization } from '../../../../../hooks/organization/useOrganization';
+import { useCompiledSqlFromMetricQuery } from '../../../../../hooks/useCompiledSql';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import useApp from '../../../../../providers/App/useApp';
@@ -79,6 +80,12 @@ export const AiChartVisualization: FC<Props> = ({
     );
 
     const toolCalls = message.toolCalls;
+
+    const { data: compiledSql } = useCompiledSqlFromMetricQuery({
+        tableName,
+        projectUuid,
+        metricQuery,
+    });
 
     const resultsData = useMemo(
         () => ({
@@ -232,7 +239,10 @@ export const AiChartVisualization: FC<Props> = ({
                                 <DrillDownModal />
                             </>
                         ) : activeTab === 'calculation' ? (
-                            <AiChartToolCalls toolCalls={toolCalls} />
+                            <AiChartToolCalls
+                                toolCalls={toolCalls}
+                                compiledSql={compiledSql}
+                            />
                         ) : (
                             assertUnreachable(activeTab, 'Invalid active tab')
                         )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartGenerationToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartGenerationToolCallDescription.tsx
@@ -1,8 +1,3 @@
-import type {
-    CsvFileVizConfigSchemaType,
-    TimeSeriesMetricVizConfigSchemaType,
-    VerticalBarMetricVizConfigSchemaType,
-} from '@lightdash/common';
 import { Badge, Button, Group, HoverCard, Stack, Text } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
 import { IconEye } from '@tabler/icons-react';
@@ -13,16 +8,13 @@ export const AiChartGenerationToolCallDescription = ({
     dimensions,
     metrics,
     breakdownByDimension,
-    metricQuery,
+    sql,
 }: {
     title: string;
     dimensions: string[];
     metrics: string[];
     breakdownByDimension?: string | null;
-    metricQuery:
-        | CsvFileVizConfigSchemaType
-        | TimeSeriesMetricVizConfigSchemaType
-        | VerticalBarMetricVizConfigSchemaType;
+    sql?: string | null;
 }) => {
     return (
         <Stack gap="xs">
@@ -89,43 +81,47 @@ export const AiChartGenerationToolCallDescription = ({
                 </Text>
             </Group>
 
-            <HoverCard
-                shadow="subtle"
-                radius="md"
-                position="bottom-start"
-                withinPortal
-            >
-                <HoverCard.Target>
-                    <Group justify="start">
-                        <Button
-                            size="compact-xs"
-                            variant="subtle"
-                            color="gray.6"
-                            leftSection={
-                                <MantineIcon
-                                    icon={IconEye}
-                                    size={12}
-                                    stroke={1.5}
-                                />
-                            }
+            {sql && (
+                <HoverCard
+                    shadow="subtle"
+                    radius="md"
+                    position="bottom-start"
+                    withinPortal
+                >
+                    <HoverCard.Target>
+                        <Group justify="start">
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                color="gray.6"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconEye}
+                                        size={12}
+                                        stroke={1.5}
+                                    />
+                                }
+                            >
+                                SQL
+                            </Button>
+                        </Group>
+                    </HoverCard.Target>
+                    <HoverCard.Dropdown p={0} maw={500}>
+                        <Prism
+                            language="sql"
+                            withLineNumbers
+                            noCopy
+                            styles={{
+                                lineContent: {
+                                    fontSize: 10,
+                                },
+                            }}
                         >
-                            See metric query
-                        </Button>
-                    </Group>
-                </HoverCard.Target>
-                <HoverCard.Dropdown p={0}>
-                    <Prism
-                        language="json"
-                        styles={{
-                            lineContent: {
-                                fontSize: 10,
-                            },
-                        }}
-                    >
-                        {JSON.stringify(metricQuery, null, 2)}
-                    </Prism>
-                </HoverCard.Dropdown>
-            </HoverCard>
+                            {sql}
+                        </Prism>
+                    </HoverCard.Dropdown>
+                </HoverCard>
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -1,5 +1,6 @@
 import {
     type AiAgentToolCall,
+    type ApiCompiledQueryResults,
     assertUnreachable,
     CsvFileVizConfigToolArgsSchemaTransformed,
     generateQueryFiltersToolArgsSchemaTransformed,
@@ -39,9 +40,10 @@ const getToolIcon = (toolName: string) => {
     return iconMap[toolName as keyof typeof iconMap] || IconSparkles;
 };
 
-const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
-    toolCall,
-}) => {
+const ToolCallDescription: FC<{
+    toolCall: AiAgentToolCall;
+    compiledSql: ApiCompiledQueryResults | undefined;
+}> = ({ toolCall, compiledSql }) => {
     const toolName = ToolNameSchema.parse(toolCall.toolName);
 
     switch (toolName) {
@@ -121,6 +123,7 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
                 verticalBarMetricVizConfigToolArgsSchemaTransformed.parse(
                     toolCall.toolArgs,
                 );
+
             return (
                 <AiChartGenerationToolCallDescription
                     title={barVizConfigToolArgs.vizConfig.title}
@@ -129,9 +132,7 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
                     breakdownByDimension={
                         barVizConfigToolArgs.vizConfig.breakdownByDimension
                     }
-                    // TODO: VizConfig is not a metric query, it's a viz config as the name suggests
-                    // We need to change the name of the field to something more appropriate
-                    metricQuery={barVizConfigToolArgs.vizConfig}
+                    sql={compiledSql}
                 />
             );
         case 'generateCsv':
@@ -150,9 +151,7 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
                         csvFileVizConfigToolArgs.vizConfig.dimensions ?? []
                     }
                     metrics={csvFileVizConfigToolArgs.vizConfig.metrics}
-                    // TODO: VizConfig is not a metric query, it's a viz config as the name suggests
-                    // We need to change the name of the field to something more appropriate
-                    metricQuery={csvFileVizConfigToolArgs.vizConfig}
+                    sql={compiledSql}
                 />
             );
         case 'generateTimeSeriesVizConfig':
@@ -163,6 +162,7 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
                 timeSeriesMetricVizConfigToolArgsSchemaTransformed.parse(
                     toolCall.toolArgs,
                 );
+
             return (
                 <AiChartGenerationToolCallDescription
                     title={timeSeriesToolCallArgs.vizConfig.title}
@@ -171,9 +171,7 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
                     breakdownByDimension={
                         timeSeriesToolCallArgs.vizConfig.breakdownByDimension
                     }
-                    // TODO: VizConfig is not a metric query, it's a viz config as the name suggests
-                    // We need to change the name of the field to something more appropriate
-                    metricQuery={timeSeriesToolCallArgs.vizConfig}
+                    sql={compiledSql}
                 />
             );
 
@@ -184,9 +182,13 @@ const ToolCallDescription: FC<{ toolCall: AiAgentToolCall }> = ({
 
 type AiChartToolCallsProps = {
     toolCalls: AiAgentToolCall[] | undefined;
+    compiledSql: ApiCompiledQueryResults | undefined;
 };
 
-export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({ toolCalls }) => {
+export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
+    toolCalls,
+    compiledSql,
+}) => {
     if (!toolCalls || toolCalls.length === 0) return null;
 
     return (
@@ -223,7 +225,10 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({ toolCalls }) => {
                             }
                             lineVariant={'solid'}
                         >
-                            <ToolCallDescription toolCall={toolCall} />
+                            <ToolCallDescription
+                                toolCall={toolCall}
+                                compiledSql={compiledSql}
+                            />
                         </Timeline.Item>
                     );
                 })}

--- a/packages/frontend/src/hooks/useCompiledSql.ts
+++ b/packages/frontend/src/hooks/useCompiledSql.ts
@@ -77,3 +77,19 @@ export const useCompiledSql = (
         ...queryOptions,
     });
 };
+
+export const useCompiledSqlFromMetricQuery = ({
+    tableName,
+    projectUuid,
+    metricQuery,
+}: {
+    tableName: string;
+    projectUuid: string;
+    metricQuery: MetricQuery;
+}) => {
+    return useQuery<ApiCompiledQueryResults, ApiError>({
+        queryKey: ['compiledQuery', tableName, metricQuery, projectUuid],
+        queryFn: () => getCompiledQuery(projectUuid!, tableName, metricQuery),
+        enabled: !!tableName && !!projectUuid && !!metricQuery,
+    });
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:


- Adding a `sql` field to the `VisualizationMetadataSchema` to store generated SQL queries
- Making filters nullable in chart generation tool args schemas (this was necessary for non-filtered queries!)
- Adding a SQL viewer with syntax highlighting that appears when clicking the "SQL" button **instead** of the metric query


<img width="606" alt="image" src="https://github.com/user-attachments/assets/2b5a9063-107f-4fca-93ac-324b31c0f6c7" />
