### PR TITLE
fix: don't override labels or hide columns in results table download

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -1,8 +1,4 @@
 import { subject } from '@casl/ability';
-import {
-    getCustomLabelsFromTableConfig,
-    getHiddenTableFields,
-} from '@lightdash/common';
 import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -54,19 +50,9 @@ const ResultsCard: FC = memo(() => {
         (context) => context.actions.getDownloadQueryUuid,
     );
 
-    const unsavedChartVersion = useExplorerContext(
-        (context) => context.state.unsavedChartVersion,
-    );
-
     const savedChart = useExplorerContext(
         (context) => context.state.savedChart,
     );
-
-    const customLabels = getCustomLabelsFromTableConfig(
-        unsavedChartVersion.chartConfig.config,
-    );
-
-    const hiddenFields = getHiddenTableFields(unsavedChartVersion.chartConfig);
 
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
 
@@ -151,8 +137,8 @@ const ResultsCard: FC = memo(() => {
                                         }
                                         getGsheetLink={getGsheetLink}
                                         columnOrder={columnOrder}
-                                        customLabels={customLabels}
-                                        hiddenFields={hiddenFields}
+                                        customLabels={undefined} // for results table download, don't override labels
+                                        hiddenFields={undefined} // for results table download, don't hide columns
                                         chartName={savedChart?.name}
                                         showTableNames
                                     />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Removes custom labels and hidden fields from the ResultsCard component when downloading results. This ensures that the downloaded data maintains the original column names and includes all columns, rather than using customized labels or hiding certain fields.