### PR TITLE
chore: add minimum_access_role to ai_agent table

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -1,3 +1,4 @@
+import { ProjectMemberRole } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const AiAgentTableName = 'ai_agent';
@@ -12,6 +13,7 @@ export type DbAiAgent = {
     tags: string[] | null;
     created_at: Date;
     updated_at: Date;
+    minimum_access_role: ProjectMemberRole | null;
 };
 
 export type AiAgentTable = Knex.CompositeTableType<

--- a/packages/backend/src/ee/database/migrations/20250516163327_add_ai_agent_uuid_to_ai_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20250516163327_add_ai_agent_uuid_to_ai_thread.ts
@@ -25,6 +25,7 @@ export async function up(knex: Knex): Promise<void> {
 
     for await (const mapping of slackMappings) {
         const [agent] = await knex(AIAgentTableName)
+            // @ts-expect-error minimum_access_role is not in the table at this point in time (see) /ee/database/migrations/20250702125236_add_role_level_access_to_agents.ts
             .insert({
                 project_uuid: mapping.project_uuid,
                 organization_uuid: mapping.organization_uuid,

--- a/packages/backend/src/ee/database/migrations/20250702125236_add_role_level_access_to_agents.ts
+++ b/packages/backend/src/ee/database/migrations/20250702125236_add_role_level_access_to_agents.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const AiAgentTableName = 'ai_agent';
+const ProjectMembershipRolesTableName = 'project_membership_roles';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(AiAgentTableName, 'minimum_access_role'))
+        return;
+
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table
+            .text('minimum_access_role')
+            .nullable()
+            .references('role')
+            .inTable(ProjectMembershipRolesTableName)
+            .onDelete('RESTRICT')
+            .defaultTo(null);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasColumn(AiAgentTableName, 'minimum_access_role')))
+        return;
+
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.dropForeign(['minimum_access_role']);
+        table.dropColumn('minimum_access_role');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -248,7 +248,10 @@ export class AiAgentModel {
                     organization_uuid: args.organizationUuid,
                     tags: args.tags,
                     description: null,
+                    // FIXME: add image_url from args
                     image_url: null,
+                    // TODO: add minimum_access_role
+                    minimum_access_role: null,
                 })
                 .returning('*');
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15385

### Description:

Add role-based access control to AI agents by introducing a `minimum_access_role` field to the `ai_agent` table. This allows restricting agent access based on a user's project role.

The changes include:
- Adding the `minimum_access_role` column to the `DbAiAgent` type
- Creating a new migration file to add the column with a foreign key reference to `project_membership_roles`
- Adding a TODO comment to incorporate the new field in agent creation
- Adding a TS-expect-error annotation to handle the field absence in previous migrations