### PR TITLE
fix: export dashboard CSV without opening a new tab

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -1,4 +1,5 @@
 import {
+    formatDate,
     type ApiError,
     type ApiJobScheduledResponse,
     type CreateDashboard,
@@ -238,7 +239,17 @@ export const useExportCsvDashboard = () => {
                 pollJobStatus(job.jobId)
                     .then(async (details) => {
                         if (details?.url) {
-                            window.open(details.url, '_blank');
+                            const link = document.createElement('a');
+                            link.href = details.url;
+                            link.setAttribute(
+                                'download',
+                                `${data.dashboard.name}-${formatDate(
+                                    Date.now(),
+                                )}`,
+                            );
+                            document.body.appendChild(link);
+                            link.click();
+                            link.remove(); // Remove the link from the DOM
                             showToastSuccess({
                                 key: 'dashboard_export_toast',
                                 title: `Success! ${data.dashboard.name} was exported.`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15679 

Reproduction steps in the ticket.
Note: wasn't able to reproduce locally, perhaps because it doesn't block `localhost` urls.

### Description:
Enhanced the CSV export functionality for dashboards by implementing a direct download mechanism instead of opening in a new tab. The exported file is now automatically downloaded with a filename that includes the dashboard name and current date.

This improves the user experience by eliminating the need to manually save the file from a new browser tab and provides a more intuitive download flow.