### PR TITLE
fix: Legend scroll arrows don't work when chart title is hidden on a dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -24,6 +24,7 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type ReactNode } from 'react';
+import { useDelayedHover } from '../../../hooks/useDelayedHover';
 import MantineIcon from '../../common/MantineIcon';
 import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/DeleteChartTileThatBelongsToDashboardModal';
 import ChartUpdateModal from '../TileForms/ChartUpdateModal';
@@ -85,6 +86,9 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         setIsDeletingChartThatBelongsToDashboard,
     ] = useState(false);
     const { hovered: containerHovered, ref: containerRef } = useHover();
+    const { isHovered: chartHovered, ...chartHoveredProps } = useDelayedHover({
+        delay: 500,
+    });
     const [titleHovered, setTitleHovered] = useState(false);
     const [isMenuOpen, toggleMenu] = useToggle([false, true]);
 
@@ -204,7 +208,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             {visibleHeaderElement}
                         </Group>
                     )}
-                    {(containerHovered && !titleHovered) ||
+                    {(containerHovered && !titleHovered && !chartHovered) ||
                     isMenuOpen ||
                     lockHeaderVisibility ? (
                         <>
@@ -316,7 +320,15 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 </Group>
             </HeaderContainer>
 
-            <ChartContainer className="non-draggable sentry-block ph-no-capture">
+            <ChartContainer
+                className="non-draggable sentry-block ph-no-capture"
+                onMouseEnter={
+                    hideTitle ? chartHoveredProps.handleMouseEnter : undefined
+                }
+                onMouseLeave={
+                    hideTitle ? chartHoveredProps.handleMouseLeave : undefined
+                }
+            >
                 {children}
             </ChartContainer>
 

--- a/packages/frontend/src/hooks/useDelayedHover.ts
+++ b/packages/frontend/src/hooks/useDelayedHover.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface UseDelayedHoverOptions {
+    delay?: number;
+}
+
+export const useDelayedHover = ({
+    delay = 300,
+}: UseDelayedHoverOptions = {}) => {
+    const [isHovered, setIsHovered] = useState(false);
+    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    const handleMouseEnter = () => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => {
+            setIsHovered(true);
+        }, delay);
+    };
+
+    const handleMouseLeave = () => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+        setIsHovered(false);
+    };
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, []);
+
+    return {
+        isHovered,
+        handleMouseEnter,
+        handleMouseLeave,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15654

### Description:
Added a new `useDelayedHover` hook that introduces a configurable delay before triggering hover state changes. This hook is used in the TileBase component to prevent the chart area from being blocked by the edit menu when hovering over the tile, while still allowing interaction with both chart and menu items.

[Screen Recording 2025-07-02 at 19.06.54.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/HorFj8gm8QUuuIDE2vgk/3c392a81-7393-444a-bc56-23a9abf5447d.mov" />](https://app.graphite.dev/media/video/HorFj8gm8QUuuIDE2vgk/3c392a81-7393-444a-bc56-23a9abf5447d.mov)

