### PR TITLE
feat: add Slack OAuth integration

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -122,6 +122,7 @@
         "passport-oauth2": "^1.8.0",
         "passport-oauth2-refresh": "^2.2.0",
         "passport-openidconnect": "^0.1.1",
+        "passport-slack-oauth2": "^1.2.0",
         "passport-strategy": "^1.0.0",
         "pdf-lib": "^1.17.1",
         "pg": "^8.11.3",

--- a/packages/backend/src/@types/passport-slack-oauth2.d.ts
+++ b/packages/backend/src/@types/passport-slack-oauth2.d.ts
@@ -1,0 +1,43 @@
+declare module 'passport-slack-oauth2' {
+    import { AnyType } from '@lightdash/common';
+    import { Strategy as PassportStrategy } from 'passport-strategy';
+    import express = require('express');
+
+    interface IStrategyOptions {
+        clientID: string;
+        clientSecret: string;
+        scope: string[];
+        callbackURL?: string;
+        state?: boolean;
+        passReqToCallback: true;
+    }
+
+    interface IVerifyOptions {
+        message: string;
+    }
+
+    interface SlackProfile {
+        user: { name: string; id: string };
+        team: { id: string };
+        provider: string;
+        id: string;
+        displayName: string;
+    }
+    interface VerifyFunction {
+        (
+            req: express.Request,
+            accessToken: string,
+            refreshToken: string,
+            profile: SlackProfile,
+            done: (
+                error: AnyType,
+                user?: AnyType,
+                options?: IVerifyOptions,
+            ) => void,
+        ): void;
+    }
+    export declare class Strategy extends PassportStrategy {
+        constructor(options: IStrategyOptions, verify: VerifyFunction);
+        constructor(verify: VerifyFunction);
+    }
+}

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -73,6 +73,7 @@ import PrometheusMetrics from './prometheus';
 import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
 import { InstanceConfigurationService } from './services/InstanceConfigurationService/InstanceConfigurationService';
+import { slackPassportStrategy } from './controllers/authentication/strategies/slackStrategy';
 
 // We need to override this interface to have our user typing
 declare global {
@@ -699,6 +700,9 @@ export default class App {
         if (snowflakePassportStrategy) {
             passport.use('snowflake', snowflakePassportStrategy);
             refresh.use('snowflake', snowflakePassportStrategy);
+        }
+        if (slackPassportStrategy) {
+            passport.use('slack', slackPassportStrategy);
         }
 
         passport.serializeUser((user, done) => {

--- a/packages/backend/src/clients/Slack/SlackOptions.ts
+++ b/packages/backend/src/clients/Slack/SlackOptions.ts
@@ -8,12 +8,7 @@ export const slackOptions = {
     stateSecret: lightdashConfig.slack?.stateSecret || '',
     scopes: slackRequiredScopes,
 
-    // Slack only allow https on redirections
-    // When testing locally on http://localhost:3000, replace again https:// with http:// after redirection happens
-    redirectUri: `${lightdashConfig.siteUrl.replace(
-        'http://',
-        'https://',
-    )}/api/v1/slack/oauth_redirect`,
+    redirectUri: `${lightdashConfig.siteUrl}/api/v1/slack/oauth_redirect`,
     installerOptions: {
         directInstall: true,
         // The default value for redirectUriPath is ‘/slack/oauth_redirect’, but we override it to match the existing redirect route in the Slack app manifest files.

--- a/packages/backend/src/controllers/authentication/strategies/slackStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/slackStrategy.ts
@@ -1,0 +1,69 @@
+/// <reference path="../../../@types/passport-slack-oauth2.d.ts" />
+import {
+    ForbiddenError,
+    getErrorMessage,
+    OpenIdIdentityIssuerType,
+    OpenIdUser,
+    UnexpectedDatabaseError,
+} from '@lightdash/common';
+import { Strategy as SlackStrategy } from 'passport-slack-oauth2';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+
+export const slackPassportStrategy = !(
+    lightdashConfig.slack?.clientId && lightdashConfig.slack?.clientSecret
+)
+    ? undefined
+    : new SlackStrategy(
+          {
+              scope: ['openid', 'identity.basic'],
+              clientID: lightdashConfig.slack.clientId,
+              clientSecret: lightdashConfig.slack.clientSecret,
+              callbackURL: `${lightdashConfig.siteUrl}/api/v1/auth/slack/callback`,
+              state: true,
+              passReqToCallback: true,
+          },
+          async (req, accessToken, refreshToken, profile, done) => {
+              if (!req.user || req.user.email === undefined) {
+                  return done(new ForbiddenError('Invalid user'));
+              }
+
+              const openIdUser: OpenIdUser = {
+                  openId: {
+                      subject: profile.id,
+                      issuer: 'slack-oauth2',
+                      issuerType: OpenIdIdentityIssuerType.SLACK,
+                      email: req.user.email,
+                      firstName: profile.user.name.split(' ')[0],
+                      lastName: profile.user.name.split(' ')[1],
+                      groups: undefined,
+                      teamId: profile.team.id,
+                  },
+              };
+
+              try {
+                  // This might throw an error if the user is already linked to the identity
+                  await req.services
+                      .getUserService()
+                      .linkOpenIdIdentityToUser(req.user, openIdUser);
+                  return done(null);
+              } catch (e: unknown) {
+                  if (
+                      e &&
+                      typeof e === 'object' &&
+                      'code' in e &&
+                      e.code === '23505'
+                  ) {
+                      // Postgres duplicate key error code
+                      console.warn(
+                          `Trying to link open id to user ${req.user.userUuid} but user is already linked`,
+                      );
+                      return done(null); // Silent error if user is already linked to the identity
+                  }
+                  console.error(
+                      `Unable to link open id to user ${req.user.userUuid}`,
+                      e,
+                  );
+                  return done(new UnexpectedDatabaseError(getErrorMessage(e)));
+              }
+          },
+      );

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -2,7 +2,9 @@ import {
     ApiErrorPayload,
     ApiSlackChannelsResponse,
     ApiSlackCustomSettingsResponse,
+    ApiSuccessEmpty,
     ForbiddenError,
+    OpenIdIdentityIssuerType,
     SlackAppCustomSettings,
 } from '@lightdash/common';
 import {
@@ -90,6 +92,32 @@ export class SlackController extends BaseController {
                     organizationUuid,
                     body,
                 ),
+        };
+    }
+
+    /**
+     * Check if the user has an OpenID identity for Slack
+     * @param req express request
+     */
+    @Middlewares([isAuthenticated])
+    @Get('/is-authenticated')
+    @OperationId('IsSlackOpenIdLinked')
+    async isSlackOpenIdLinked(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+
+        // This will throw a 404 if not found
+        await req.services
+            .getUserService()
+            .isOpenIdLinked(
+                req.user?.userUuid!,
+                OpenIdIdentityIssuerType.SLACK,
+            );
+
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 }

--- a/packages/backend/src/database/entities/openIdIdentities.ts
+++ b/packages/backend/src/database/entities/openIdIdentities.ts
@@ -9,6 +9,7 @@ export type DbOpenIdIdentity = {
     created_at: Date;
     email: string;
     refresh_token?: string;
+    team_id?: string;
 };
 
 export const OpenIdIdentitiesTableName = 'openid_identities';

--- a/packages/backend/src/database/migrations/20250703090429_add_openid_team.ts
+++ b/packages/backend/src/database/migrations/20250703090429_add_openid_team.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('openid_identities', (table) => {
+        table.string('team_id').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('openid_identities', (table) => {
+        table.dropColumn('team_id');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6030,7 +6030,15 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OpenIdIdentityIssuerType: {
         dataType: 'refEnum',
-        enums: ['google', 'okta', 'oneLogin', 'azuread', 'oidc', 'snowflake'],
+        enums: [
+            'google',
+            'okta',
+            'oneLogin',
+            'azuread',
+            'oidc',
+            'snowflake',
+            'slack',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LocalIssuerTypes: {
@@ -11523,7 +11531,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11533,7 +11541,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11543,7 +11551,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11556,7 +11564,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -23827,6 +23835,60 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsSlackController_isSlackOpenIdLinked: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/slack/is-authenticated',
+        ...fetchMiddlewares<RequestHandler>(SlackController),
+        ...fetchMiddlewares<RequestHandler>(
+            SlackController.prototype.isSlackOpenIdLinked,
+        ),
+
+        async function SlackController_isSlackOpenIdLinked(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsSlackController_isSlackOpenIdLinked,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<SlackController>(
+                    SlackController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'isSlackOpenIdLinked',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6731,7 +6731,8 @@
                     "oneLogin",
                     "azuread",
                     "oidc",
-                    "snowflake"
+                    "snowflake",
+                    "slack"
                 ],
                 "type": "string"
             },
@@ -12362,22 +12363,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17553,7 +17554,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1782.0",
+        "version": "0.1784.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -20344,6 +20345,37 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/slack/is-authenticated": {
+            "get": {
+                "operationId": "IsSlackOpenIdLinked",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Check if the user has an OpenID identity for Slack",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v1/share/{nanoId}": {

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -137,6 +137,7 @@ export class OpenIdIdentityModel {
                 user_id: createIdentity.userId,
                 email: createIdentity.email,
                 refresh_token: createIdentity.refreshToken,
+                team_id: createIdentity.teamId,
             })
             .returning('*');
         return this.getIdentityByOpenId(identity.issuer, identity.subject);

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1046,4 +1046,23 @@ export class UserModel {
             .select('openid_identities.issuer_type');
         return rows.map((row) => row.issuer_type);
     }
+
+    async getOpenIdByIssuerType(
+        userUuid: string,
+        issuerType: OpenIdIdentityIssuerType,
+    ) {
+        const rows = await this.database(OpenIdIdentitiesTableName)
+            .leftJoin('users', 'openid_identities.user_id', 'users.user_id')
+            .where('users.user_uuid', userUuid)
+            .where('issuer_type', issuerType)
+            .select('*');
+
+        if (rows.length === 0) {
+            throw new NotFoundError('OpenID identity not found');
+        }
+        if (rows.length > 1) {
+            throw new Error('Multiple OpenID identities found');
+        }
+        return rows[0];
+    }
 }

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -166,6 +166,26 @@ apiV1Router.get(
     }),
 );
 
+// path to start the OAuth flow
+apiV1Router.get(
+    '/auth/slack',
+    (req, res, next) => {
+        // If the user is not already authenticated in Lightdash, force them to login on lightdash first
+        if (req.user?.userUuid) {
+            return next();
+        }
+        return res.redirect('/login?redirect=/api/v1/auth/slack');
+    },
+    passport.authenticate('slack'),
+);
+
+// OAuth callback url
+apiV1Router.get(
+    '/auth/slack/callback',
+    passport.authenticate('slack', { failureRedirect: '/login' }),
+    (req, res) => res.redirect('/'),
+);
+
 apiV1Router.get(lightdashConfig.auth.google.callbackPath, (req, res, next) => {
     passport.authenticate('google', {
         failureRedirect: getOidcRedirectURL(false)(req),

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -30,6 +30,7 @@ import {
     MissingConfigError,
     NotExistsError,
     NotFoundError,
+    NotImplementedError,
     OpenIdIdentityIssuerType,
     OpenIdIdentitySummary,
     OpenIdUser,
@@ -868,7 +869,7 @@ export class UserService extends BaseService {
         return this.userModel.findSessionUserByUUID(user.userUuid);
     }
 
-    private async linkOpenIdIdentityToUser(
+    async linkOpenIdIdentityToUser(
         sessionUser: SessionUser,
         openIdUser: OpenIdUser,
         refreshToken?: string,
@@ -880,6 +881,7 @@ export class UserService extends BaseService {
             email: openIdUser.openId.email,
             issuerType: openIdUser.openId.issuerType,
             refreshToken,
+            teamId: openIdUser.openId.teamId,
         });
         await this.tryVerifyUserEmail(sessionUser, openIdUser.openId.email);
         this.analytics.track({
@@ -1662,6 +1664,8 @@ export class UserService extends BaseService {
             case OpenIdIdentityIssuerType.GENERIC_OIDC:
             case OpenIdIdentityIssuerType.SNOWFLAKE:
                 return true;
+            case OpenIdIdentityIssuerType.SLACK:
+                return false;
             default:
                 assertUnreachable(
                     loginMethod,
@@ -1799,6 +1803,8 @@ export class UserService extends BaseService {
                 return this.lightdashConfig.auth.oidc.loginPath;
             case OpenIdIdentityIssuerType.SNOWFLAKE:
                 return this.lightdashConfig.auth.snowflake.loginPath;
+            case OpenIdIdentityIssuerType.SLACK:
+                throw new NotImplementedError('Slack login is not supported');
             default:
                 assertUnreachable(
                     issuer,
@@ -1914,5 +1920,17 @@ export class UserService extends BaseService {
             }
             throw new Error('No admin user found');
         }
+    }
+
+    async isOpenIdLinked(
+        userUuid: string,
+        issuerType: OpenIdIdentityIssuerType,
+    ): Promise<boolean> {
+        const openId = await this.userModel.getOpenIdByIssuerType(
+            userUuid,
+            issuerType,
+        );
+
+        return openId !== undefined;
     }
 }

--- a/packages/common/src/types/openIdIdentity.ts
+++ b/packages/common/src/types/openIdIdentity.ts
@@ -5,6 +5,7 @@ export enum OpenIdIdentityIssuerType {
     AZUREAD = 'azuread',
     GENERIC_OIDC = 'oidc',
     SNOWFLAKE = 'snowflake',
+    SLACK = 'slack',
 }
 
 export const isOpenIdIdentityIssuerType = (
@@ -21,6 +22,7 @@ export type CreateOpenIdIdentity = {
     userId: number;
     email: string;
     refreshToken?: string; // Used in google to access google drive files
+    teamId?: string;
 };
 
 export type UpdateOpenIdentity = Pick<

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -68,6 +68,7 @@ export interface OpenIdUser {
         firstName: string | undefined;
         lastName: string | undefined;
         groups?: string[] | undefined;
+        teamId?: string | undefined;
     };
 }
 

--- a/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
@@ -35,6 +35,8 @@ const isIssuerTypeAvailable = (
             return health.auth.oidc.enabled;
         case OpenIdIdentityIssuerType.SNOWFLAKE:
             return health.auth.snowflake.enabled;
+        case OpenIdIdentityIssuerType.SLACK:
+            return false;
         default:
             return assertUnreachable(
                 issuerType,

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -57,6 +57,8 @@ const Login: FC<{}> = () => {
             });
         }
     }, [flashMessages.data, showToastError]);
+    const queryParams = new URLSearchParams(location.search);
+    const redirectParam = queryParams.get('redirect');
 
     const [preCheckEmail, setPreCheckEmail] = useState<string>();
     const [isLoginOptionsLoadingDebounced, setIsLoginOptionsLoadingDebounced] =
@@ -64,6 +66,8 @@ const Login: FC<{}> = () => {
 
     const redirectUrl = location.state?.from
         ? `${location.state.from.pathname}${location.state.from.search}`
+        : redirectParam
+        ? redirectParam
         : '/';
 
     const form = useForm<LoginParams>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       passport-openidconnect:
         specifier: ^0.1.1
         version: 0.1.1
+      passport-slack-oauth2:
+        specifier: ^1.2.0
+        version: 1.2.0
       passport-strategy:
         specifier: ^1.0.0
         version: 1.0.0
@@ -6020,7 +6023,6 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
-    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -11069,6 +11071,9 @@ packages:
   passport-openidconnect@0.1.1:
     resolution: {integrity: sha512-r0QJiWEzwCg2MeCIXVP5G6YxVRqnEsZ2HpgKRthZ9AiQHJrgGUytXpsdcGF9BRwd3yMrEesb/uG/Yxb86rrY0g==}
     engines: {node: '>= 0.6.0'}
+
+  passport-slack-oauth2@1.2.0:
+    resolution: {integrity: sha512-SeQl8uPoi4ajhzgIvwQM7gW/6yPrKH0hPFjxcP/426SOZ0M9ZNDOfSa32q3NTw7KcwYOTjyWX/2xdJndQE7Rkg==}
 
   passport-strategy@1.0.0:
     resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
@@ -18072,7 +18077,7 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 22.13.1
+      '@types/node': 22.15.3
 
   '@slack/oauth@2.6.3':
     dependencies:
@@ -19927,7 +19932,7 @@ snapshots:
 
   '@types/through@0.0.30':
     dependencies:
-      '@types/node': 22.13.1
+      '@types/node': 22.15.3
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -26836,6 +26841,10 @@ snapshots:
     dependencies:
       oauth: 0.9.15
       passport-strategy: 1.0.0
+
+  passport-slack-oauth2@1.2.0:
+    dependencies:
+      passport-oauth2: 1.8.0
 
   passport-strategy@1.0.0: {}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### How to use with AI bot

- open a browser on `/api/v1/auth/slack` to start authentication
- poll `/api/v1/slack/is-authenticated` with user credentials until this returns 200 (returns 404 when not authenticated)
- openid_identities will contain a `user_id` and `slack id` (subject) 

### Changes required on slack apps. 

We need to add a new extra callback to the slack app, for this flow to work. 

Slack app > oauth & permissions > redirect URLs

https://api.slack.com/apps/A04EJP8LZPD/oauth

![image](https://github.com/user-attachments/assets/40cb6fc5-13e8-4ae0-925b-19850aa61d9f)


### Demo:

[Screencast from 2025-07-03 09-25-30.webm](https://github.com/user-attachments/assets/3d875dbf-af74-485b-8ca0-c33f9b263e1a)

On slack settings you can see who have logged in, and revoke access if we need to. 
https://lightdash.slack.com/marketplace/A04EJP8LZPD-lightdash-share-local?next_id=0&tab=settings

![image](https://github.com/user-attachments/assets/8958937b-6445-4924-a710-db3b12e63e4c)


Also added team to the database

![image](https://github.com/user-attachments/assets/7499dead-14d4-461c-8c5c-ab36f2d7574d)

In the future, we could pass the teamId they want to login into in the request, most likely, we will wrap the `auth` api request and pass an extra argument with the `team` to the slackstrategy ( not doing this now because that will depend on the UI,) 



### AI Description:
Add Slack OAuth integration to allow users to link their Lightdash accounts with Slack. This PR:

- Adds Slack OAuth2 authentication strategy
- Creates type definitions for the Slack passport strategy
- Implements API endpoints for checking if a user has linked their Slack account
- Adds necessary dependencies (`passport-slack-oauth2` and `@slack/oauth`)
- Registers the Slack strategy in the application
- Updates the OpenID identity issuer types to include Slack