### PR TITLE
feat: make s3 optional for snowflake

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -30,23 +30,6 @@ beforeEach(() => {
     };
 });
 
-describe('When S3 environment variables are not set', () => {
-    test('Should error when S3_ENDPOINT is not set', () => {
-        delete process.env.S3_ENDPOINT;
-        expect(() => parseConfig()).toThrowError(ParseError);
-    });
-
-    test('Should error when S3_BUCKET is not set', () => {
-        delete process.env.S3_BUCKET;
-        expect(() => parseConfig()).toThrowError(ParseError);
-    });
-
-    test('Should error when S3_REGION is not set', () => {
-        delete process.env.S3_REGION;
-        expect(() => parseConfig()).toThrowError(ParseError);
-    });
-});
-
 test('Should default results S3 config to S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -422,10 +422,7 @@ export const parseBaseS3Config = (): LightdashConfig['s3'] => {
     );
 
     if (!endpoint || !bucket || !region) {
-        console.error(
-            'ERROR: S3 is not configured. Missing S3_ENDPOINT, S3_BUCKET, S3_REGION, read docs for more info: https://docs.lightdash.com/self-host/customize-deployment/environment-variables',
-        );
-        throw new ParseError('Missing S3 configuration');
+        return undefined;
     }
 
     return {
@@ -441,6 +438,11 @@ export const parseBaseS3Config = (): LightdashConfig['s3'] => {
 
 export const parseResultsS3Config = (): LightdashConfig['results']['s3'] => {
     const baseS3Config = parseBaseS3Config();
+
+    if (!baseS3Config) {
+        return undefined;
+    }
+
     const {
         endpoint: baseEndpoint,
         bucket: baseBucket,
@@ -562,13 +564,13 @@ export type LightdashConfig = {
         overrideColorPalette?: string[];
         overrideColorPaletteName?: string;
     };
-    s3: S3Config;
+    s3?: S3Config;
     headlessBrowser: HeadlessBrowserConfig;
     results: {
         cacheEnabled: boolean;
         autocompleteEnabled: boolean;
         cacheStateTimeSeconds: number;
-        s3: Omit<S3Config, 'expirationTime'>;
+        s3?: Omit<S3Config, 'expirationTime'>;
     };
     slack?: SlackConfig;
     scheduler: {

--- a/packages/backend/src/ee/services/CommercialCacheService.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.ts
@@ -31,12 +31,16 @@ export class CommercialCacheService implements ICacheService {
         this.storageClient = storageClient;
     }
 
+    get isEnabled() {
+        return this.lightdashConfig.results.cacheEnabled;
+    }
+
     async findCachedResultsFile(
         projectUuid: string,
         cacheKey: string,
     ): Promise<CacheHitCacheResult | null> {
         // If caching is disabled, return null
-        if (!this.lightdashConfig.results.cacheEnabled) {
+        if (!this.isEnabled) {
             return null;
         }
 

--- a/packages/backend/src/services/CacheService/ICacheService.ts
+++ b/packages/backend/src/services/CacheService/ICacheService.ts
@@ -1,6 +1,7 @@
 import { CacheHitCacheResult } from './types';
 
 export interface ICacheService {
+    isEnabled: boolean;
     findCachedResultsFile: (
         projectUuid: string,
         cacheKey: string,

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
@@ -36,6 +36,15 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
+    getAsyncQueryResults: async () => ({
+        queryId: null,
+        queryMetadata: null,
+        totalRows: 0,
+        durationMs: 0,
+        fields: {},
+        pageCount: 0,
+        rows: [],
+    }),
     streamQuery(query, streamCallback) {
         streamCallback({
             fields: {},
@@ -114,6 +123,15 @@ export const bigqueryClientMock: WarehouseClient = {
                 },
             },
         },
+    }),
+    getAsyncQueryResults: async () => ({
+        queryId: null,
+        queryMetadata: null,
+        totalRows: 0,
+        durationMs: 0,
+        fields: {},
+        pageCount: 0,
+        rows: [],
     }),
     streamQuery(query, streamCallback) {
         streamCallback({

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -31,6 +31,15 @@ export const warehouseClientMock: WarehouseClient = {
             },
         },
     }),
+    getAsyncQueryResults: async () => ({
+        queryId: null,
+        queryMetadata: null,
+        totalRows: 0,
+        durationMs: 0,
+        fields: {},
+        pageCount: 0,
+        rows: [],
+    }),
     streamQuery: (_query, streamCallback) => {
         streamCallback({
             fields: {},

--- a/packages/common/src/types/queryHistory.ts
+++ b/packages/common/src/types/queryHistory.ts
@@ -4,7 +4,7 @@ import type { QueryExecutionContext } from './analytics';
 import type { ExecuteAsyncQueryRequestParams } from './api/paginatedQuery';
 import type { ItemsMap } from './field';
 import type { MetricQuery } from './metricQuery';
-import { WarehouseTypes } from './projects';
+import type { WarehouseTypes } from './projects';
 import type { GroupByColumn, SortBy, ValuesColumn } from './sqlRunner';
 
 export interface IWarehouseQueryMetadata {
@@ -18,12 +18,6 @@ export interface BigQueryWarehouseQueryMetadata
 }
 
 export type WarehouseQueryMetadata = BigQueryWarehouseQueryMetadata;
-
-export function isBigQueryWarehouseQueryMetadata(
-    metadata: WarehouseQueryMetadata | null,
-): metadata is BigQueryWarehouseQueryMetadata {
-    return !!metadata && metadata.type === WarehouseTypes.BIGQUERY;
-}
 
 export enum QueryHistoryStatus {
     PENDING = 'pending',

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -67,6 +67,22 @@ export type WarehouseExecuteAsyncQuery = {
     durationMs: number;
 };
 
+export type WarehouseGetAsyncQueryResultsArgs = WarehousePaginationArgs & {
+    sql: string;
+    queryId: string | null;
+    queryMetadata: WarehouseQueryMetadata | null;
+};
+
+export type WarehouseGetAsyncQueryResults<
+    TFormattedRow extends Record<string, unknown>,
+> = {
+    queryId: string | null;
+    fields: Record<string, { type: DimensionType }>;
+    pageCount: number;
+    totalRows: number;
+    rows: TFormattedRow[];
+};
+
 export interface WarehouseSqlBuilder {
     getStartOfWeek: () => WeekDay | null | undefined;
     getAdapterType: () => SupportedDbtAdapter;
@@ -87,6 +103,11 @@ export interface WarehouseClient extends WarehouseSqlBuilder {
         }[],
     ) => Promise<WarehouseCatalog>;
 
+    getAsyncQueryResults<TFormattedRow extends Record<string, unknown>>(
+        args: WarehouseGetAsyncQueryResultsArgs,
+        rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
+    ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>>;
+
     streamQuery(
         query: string,
         streamCallback: (data: WarehouseResults) => void,
@@ -99,7 +120,7 @@ export interface WarehouseClient extends WarehouseSqlBuilder {
 
     executeAsyncQuery(
         args: WarehouseExecuteAsyncQueryArgs,
-        resultsStreamCallback: (
+        resultsStreamCallback?: (
             rows: WarehouseResults['rows'],
             fields: WarehouseResults['fields'],
         ) => void,

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -70,6 +70,9 @@ const warehouseClientMock: WarehouseClient = {
     getCatalog() {
         throw new NotImplementedError('getCatalog not implemented');
     },
+    getAsyncQueryResults() {
+        throw new NotImplementedError('getAsyncQueryResults not implemented');
+    },
     getAdapterType() {
         throw new NotImplementedError('getCatalog not implemented');
     },

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -89,6 +89,15 @@ export const createTemporaryVirtualView = (
             maximumBytesBilled: 0,
         },
         getCatalog: async () => ({}),
+        getAsyncQueryResults: async () => ({
+            queryId: null,
+            queryMetadata: null,
+            totalRows: 0,
+            durationMs: 0,
+            fields: {},
+            pageCount: 0,
+            rows: [],
+        }),
         streamQuery: async () => {},
         executeAsyncQuery: async () => ({
             queryId: null,

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -3,6 +3,7 @@ import {
     CreateWarehouseCredentials,
     DimensionType,
     Metric,
+    NotImplementedError,
     PartitionColumn,
     SupportedDbtAdapter,
     WarehouseCatalog,
@@ -11,6 +12,8 @@ import {
     WeekDay,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
+    type WarehouseGetAsyncQueryResults,
+    type WarehouseGetAsyncQueryResultsArgs,
 } from '@lightdash/common';
 import { type WarehouseClient } from '../types';
 
@@ -46,6 +49,15 @@ export default abstract class WarehouseBaseClient<
     abstract getCatalog(
         config: { database: string; schema: string; table: string }[],
     ): Promise<WarehouseCatalog>;
+
+    async getAsyncQueryResults<TFormattedRow extends Record<string, unknown>>(
+        _args: WarehouseGetAsyncQueryResultsArgs,
+        _rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
+    ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>> {
+        throw new NotImplementedError(
+            `Paginated query results are not supported for warehouse type: ${this.getAdapterType()}`,
+        );
+    }
 
     abstract streamQuery(
         query: string,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15699

### Description:

- Makes S3 storage optional for queries running in snowflake warehouses

**Query code paths:**
- **Cache disabled:**
  - **S3 enabled:** No change, S3 results file is created and we paginate on top of the result file for all warehouses
  - **S3 disabled:**
    - **Snowflake:** Trigger async query in the warehouse and paginate results directly from there.
    - **Other warehouses:** Throws error when trying to paginate. Method not implemented.
- **Cache enabled:**
  - **S3 enabled:** No change, cache still works the same way using the results files.
  - **S3 disabled:** Errors for all warehouses. 

test-frontend
