### PR TITLE
fix: improve chat UI and time formatting

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatBubbles.tsx
@@ -82,7 +82,6 @@ export const UserBubble: FC<{ message: AiAgentMessageUser<AiAgentUser> }> = ({
                 color="white"
                 style={{
                     overflow: 'unset',
-                    borderStartEndRadius: '0px',
                 }}
             >
                 <MDEditor.Markdown

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -137,12 +137,6 @@ export const AgentChatInput = ({
                         borderBottomRightRadius: rem(12),
                     }}
                 >
-                    {!disabled && (
-                        <Text size="xs" c="dimmed">
-                            Agent can make mistakes. Please double-check
-                            responses.
-                        </Text>
-                    )}
                     {disabled && disabledReason && (
                         <Text
                             size="xs"

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -167,6 +167,7 @@ const AgentPage = () => {
                                 >
                                     Threads
                                 </Title>
+
                                 <Button
                                     size="compact-xs"
                                     variant="dark"
@@ -178,6 +179,11 @@ const AgentPage = () => {
                                     }
                                     component={Link}
                                     to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
+                                    style={{
+                                        visibility: threadUuid
+                                            ? 'visible'
+                                            : 'hidden',
+                                    }}
                                 >
                                     New thread
                                 </Button>

--- a/packages/frontend/src/hooks/useTimeAgo.ts
+++ b/packages/frontend/src/hooks/useTimeAgo.ts
@@ -1,4 +1,4 @@
-import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { formatDistanceToNow, parseISO } from 'date-fns';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useInterval } from 'react-use';
 
@@ -13,10 +13,11 @@ export const useTimeAgo = (
     }, [dateOrString]);
 
     const getTimeAgo = useCallback(() => {
-        return formatDistanceToNowStrict(parsed, {
+        const timeAgo = formatDistanceToNow(parsed, {
             addSuffix: true,
-            roundingMethod: 'floor',
         });
+
+        return timeAgo;
     }, [parsed]);
 
     const [timeAgo, setTimeAgo] = useState<string>(getTimeAgo());


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR makes three UI improvements:

1. Removes the `borderStartEndRadius: '0px'` style from the UserBubble component, allowing for consistent border radius styling.
2. Hides the "New thread" button when user's already on "New Thread" screen
3. Improves the time ago formatting by switching from `formatDistanceToNowStrict` to `formatDistanceToNow`, which provides more natural relative time descriptions (e.g., "about 2 hours ago" instead of "2 hours ago").
