### PR TITLE
feat: allow toggling default agent

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -438,6 +438,25 @@ export class AiAgentUserPreferencesController extends BaseController {
             results: undefined,
         };
     }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete()
+    @OperationId('deleteUserAgentPreferences')
+    async deleteUserAgentPreferences(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.getAiAgentService().deleteUserAgentPreferences(
+            req.user!,
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
 }
 
 @Route('/api/v1/projects/{projectUuid}/aiAgents')

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1345,6 +1345,18 @@ export class AiAgentModel {
             });
     }
 
+    async deleteUserAgentPreferences({
+        userUuid,
+        projectUuid,
+    }: {
+        userUuid: string;
+        projectUuid: string;
+    }): Promise<void> {
+        await this.database(AiAgentUserPreferencesTableName)
+            .where({ user_uuid: userUuid, project_uuid: projectUuid })
+            .delete();
+    }
+
     async createToolCall(data: {
         promptUuid: string;
         toolCallId: string;

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1949,4 +1949,31 @@ export class AiAgentService {
             defaultAgentUuid: body.defaultAgentUuid,
         });
     }
+
+    async deleteUserAgentPreferences(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const { organizationUuid, userUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const project = await this.projectService.getProject(projectUuid, user);
+        if (project.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError(
+                'Project does not belong to this organization',
+            );
+        }
+
+        await this.aiAgentModel.deleteUserAgentPreferences({
+            userUuid,
+            projectUuid,
+        });
+    }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11523,7 +11523,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11533,7 +11533,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11543,7 +11543,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11556,7 +11556,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -19918,6 +19918,68 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'setUserDefaultAgent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentUserPreferencesController_deleteUserAgentPreferences: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/aiAgents/preferences',
+        ...fetchMiddlewares<RequestHandler>(AiAgentUserPreferencesController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentUserPreferencesController.prototype
+                .deleteUserAgentPreferences,
+        ),
+
+        async function AiAgentUserPreferencesController_deleteUserAgentPreferences(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentUserPreferencesController_deleteUserAgentPreferences,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentUserPreferencesController>(
+                        AiAgentUserPreferencesController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteUserAgentPreferences',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12362,22 +12362,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17557,7 +17557,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1777.0",
+        "version": "0.1780.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton.tsx
@@ -7,6 +7,7 @@ import {
 import { IconStar } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
+    useDeleteUserAgentPreferences,
     useGetUserAgentPreferences,
     useUpdateUserAgentPreferences,
 } from '../../hooks/useUserAgentPreferences';
@@ -29,22 +30,31 @@ export const DefaultAgentButton: React.FC<Props> = ({
     const { mutateAsync: setDefaultAgentUuid } = useUpdateUserAgentPreferences(
         projectUuid!,
     );
+    const { mutateAsync: deleteUserPreferences } =
+        useDeleteUserAgentPreferences(projectUuid!);
 
     const isDefault = userAgentPreferences?.defaultAgentUuid === agentUuid;
 
     return (
-        <Tooltip label={isDefault ? 'Default agent' : 'Set as default agent'}>
+        <Tooltip
+            label={
+                isDefault ? 'Remove as default agent' : 'Set as default agent'
+            }
+        >
             <ActionIcon
                 className={styles.button}
                 radius="md"
                 variant="subtle"
                 color="gray"
-                onClick={() => {
-                    void setDefaultAgentUuid({
-                        defaultAgentUuid: agentUuid,
-                    });
+                onClick={async () => {
+                    if (isDefault) {
+                        await deleteUserPreferences();
+                    } else {
+                        await setDefaultAgentUuid({
+                            defaultAgentUuid: agentUuid,
+                        });
+                    }
                 }}
-                disabled={isDefault}
                 size={size}
                 {...props}
             >

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
@@ -1,6 +1,7 @@
 import {
     type ApiError,
     type ApiGetUserAgentPreferencesResponse,
+    type ApiSuccessEmpty,
     type ApiUpdateUserAgentPreferences,
     type ApiUpdateUserAgentPreferencesResponse,
 } from '@lightdash/common';
@@ -54,17 +55,96 @@ export const useUpdateUserAgentPreferences = (projectUuid: string) => {
     return useMutation<
         ApiUpdateUserAgentPreferencesResponse['results'],
         ApiError,
-        ApiUpdateUserAgentPreferences
+        ApiUpdateUserAgentPreferences,
+        { previousData: unknown }
     >({
         mutationFn: (data) => updateUserAgentPreferences(projectUuid, data),
+        onMutate: async (data) => {
+            await queryClient.cancelQueries({
+                queryKey: [USER_AGENT_PREFERENCES, projectUuid],
+            });
+
+            const previousData = queryClient.getQueryData([
+                USER_AGENT_PREFERENCES,
+                projectUuid,
+            ]);
+
+            queryClient.setQueryData(
+                [USER_AGENT_PREFERENCES, projectUuid],
+                data,
+            );
+
+            return { previousData };
+        },
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: [USER_AGENT_PREFERENCES, projectUuid],
             });
         },
-        onError: ({ error }) => {
+        onError: ({ error }, _variables, context) => {
+            if (context?.previousData) {
+                queryClient.setQueryData(
+                    [USER_AGENT_PREFERENCES, projectUuid],
+                    context.previousData,
+                );
+            }
             showToastApiError({
                 title: 'Failed to set agent as default',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const deleteUserAgentPreferences = (projectUuid: string) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/projects/${projectUuid}/aiAgents/preferences`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useDeleteUserAgentPreferences = (projectUuid: string) => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        void,
+        { previousData: unknown }
+    >({
+        mutationFn: () => deleteUserAgentPreferences(projectUuid),
+        onMutate: async () => {
+            await queryClient.cancelQueries({
+                queryKey: [USER_AGENT_PREFERENCES, projectUuid],
+            });
+
+            const previousData = queryClient.getQueryData([
+                USER_AGENT_PREFERENCES,
+                projectUuid,
+            ]);
+
+            queryClient.setQueryData(
+                [USER_AGENT_PREFERENCES, projectUuid],
+                null,
+            );
+
+            return { previousData };
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: [USER_AGENT_PREFERENCES, projectUuid],
+            });
+        },
+        onError: ({ error }, _variables, context) => {
+            if (context?.previousData !== undefined) {
+                queryClient.setQueryData(
+                    [USER_AGENT_PREFERENCES, projectUuid],
+                    context.previousData,
+                );
+            }
+            showToastApiError({
+                title: 'Failed to remove agent preferences',
                 apiError: error,
             });
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR makes the default agent setting nullable, allowing users to unset their default agent. Previously, once a default agent was set, users couldn't remove it. Now:

1. The `default_agent_uuid` field in the database schema is modified to accept null values
2. A new migration is added to support this change
3. The DefaultAgentButton component is updated to toggle between setting and unsetting the default agent
4. API types are updated to support null values for default agent UUID
