### PR TITLE
feat: add group access to ai agents

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -102,6 +102,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     userModel: models.getUserModel(),
                     aiAgentModel: models.getAiAgentModel(),
+                    groupsModel: models.getGroupsModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),
                     projectService: repository.getProjectService(),

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -44,6 +44,7 @@ import {
     DbAiWebAppPrompt,
 } from '../database/entities/ai';
 import {
+    AiAgentGroupAccessTableName,
     AiAgentInstructionVersionsTableName,
     AiAgentIntegrationTableName,
     AiAgentSlackIntegrationTableName,
@@ -73,7 +74,41 @@ export class AiAgentModel {
         agentUuid: string;
         projectUuid?: string;
     }): Promise<AiAgentSummary> {
-        const query = this.database(AiAgentTableName)
+        const integrations = this.database
+            .from(AiAgentIntegrationTableName)
+            .leftJoin(
+                AiAgentSlackIntegrationTableName,
+                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
+                `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
+            )
+            .select(
+                `${AiAgentIntegrationTableName}.ai_agent_uuid`,
+                `${AiAgentIntegrationTableName}.integration_type`,
+                `${AiAgentSlackIntegrationTableName}.slack_channel_id`,
+            )
+            .whereNotNull(`${AiAgentIntegrationTableName}.integration_type`)
+            .where(`${AiAgentIntegrationTableName}.ai_agent_uuid`, agentUuid);
+
+        const groupAccess = this.database
+            .from(AiAgentGroupAccessTableName)
+            .select('ai_agent_uuid', 'group_uuid')
+            .where(`${AiAgentGroupAccessTableName}.ai_agent_uuid`, agentUuid);
+
+        const latestInstruction = this.database
+            .from(AiAgentInstructionVersionsTableName)
+            .select(
+                'ai_agent_uuid',
+                this.database.raw('instruction'),
+                this.database.raw(
+                    'ROW_NUMBER() OVER (PARTITION BY ai_agent_uuid ORDER BY created_at DESC) as rn',
+                ),
+            );
+
+        const query = this.database
+            .with('integrations', integrations)
+            .with('latest_instruction', latestInstruction)
+            .with('group_access', groupAccess)
+            .from(AiAgentTableName)
             .select({
                 uuid: `${AiAgentTableName}.ai_agent_uuid`,
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
@@ -82,40 +117,34 @@ export class AiAgentModel {
                 tags: `${AiAgentTableName}.tags`,
                 integrations: this.database.raw(`
                     COALESCE(
-                        json_agg(
-                            CASE WHEN ${AiAgentIntegrationTableName}.integration_type IS NOT NULL
-                            THEN json_build_object(
-                                'type', ${AiAgentIntegrationTableName}.integration_type,
-                                'channelId', ${AiAgentSlackIntegrationTableName}.slack_channel_id
+                        (SELECT json_agg(
+                            json_build_object(
+                                'type', integration_type,
+                                'channelId', slack_channel_id
                             )
-                            ELSE NULL
-                            END
-                        ) FILTER (WHERE ${AiAgentIntegrationTableName}.integration_type IS NOT NULL),
+                        ) FROM integrations
+                         WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid),
                         '[]'::json
                     )
                 `),
                 updatedAt: `${AiAgentTableName}.updated_at`,
                 createdAt: `${AiAgentTableName}.created_at`,
                 instruction: this.database.raw(`
-                    (SELECT instruction FROM ${AiAgentInstructionVersionsTableName}
-                     WHERE ${AiAgentInstructionVersionsTableName}.ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid
-                     ORDER BY created_at DESC LIMIT 1)
-                    `),
+                    (SELECT instruction FROM latest_instruction 
+                     WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid AND rn = 1)
+                `),
                 imageUrl: `${AiAgentTableName}.image_url`,
+                groupAccess: this.database.raw(`
+                    COALESCE(
+                        (SELECT json_agg(group_uuid) 
+                         FROM group_access
+                         WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid),
+                        '[]'::json
+                    )
+                `),
             } satisfies Record<keyof AiAgent, unknown>)
-            .leftJoin(
-                AiAgentIntegrationTableName,
-                `${AiAgentTableName}.ai_agent_uuid`,
-                `${AiAgentIntegrationTableName}.ai_agent_uuid`,
-            )
-            .leftJoin(
-                AiAgentSlackIntegrationTableName,
-                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
-                `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
-            )
             .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
             .where(`${AiAgentTableName}.ai_agent_uuid`, agentUuid)
-            .groupBy(`${AiAgentTableName}.ai_agent_uuid`)
             .first<AiAgent | undefined>();
 
         if (projectUuid) {
@@ -140,7 +169,39 @@ export class AiAgentModel {
         organizationUuid: string;
         projectUuid?: string;
     }): Promise<AiAgentSummary[]> {
-        const query = this.database(AiAgentTableName)
+        const integrations = this.database
+            .from(AiAgentIntegrationTableName)
+            .leftJoin(
+                AiAgentSlackIntegrationTableName,
+                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
+                `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
+            )
+            .select(
+                `${AiAgentIntegrationTableName}.ai_agent_uuid`,
+                `${AiAgentIntegrationTableName}.integration_type`,
+                `${AiAgentSlackIntegrationTableName}.slack_channel_id`,
+            )
+            .whereNotNull(`${AiAgentIntegrationTableName}.integration_type`);
+
+        const groupAccess = this.database
+            .from(AiAgentGroupAccessTableName)
+            .select('ai_agent_uuid', 'group_uuid');
+
+        const latestInstruction = this.database
+            .from(AiAgentInstructionVersionsTableName)
+            .select(
+                'ai_agent_uuid',
+                this.database.raw('instruction'),
+                this.database.raw(
+                    'ROW_NUMBER() OVER (PARTITION BY ai_agent_uuid ORDER BY created_at DESC) as rn',
+                ),
+            );
+
+        const query = this.database
+            .with('integrations', integrations)
+            .with('latest_instruction', latestInstruction)
+            .with('group_access', groupAccess)
+            .from(AiAgentTableName)
             .select({
                 uuid: `${AiAgentTableName}.ai_agent_uuid`,
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
@@ -148,38 +209,33 @@ export class AiAgentModel {
                 name: `${AiAgentTableName}.name`,
                 tags: `${AiAgentTableName}.tags`,
                 integrations: this.database.raw(`
-                        COALESCE(
-                            json_agg(
-                                CASE WHEN ${AiAgentIntegrationTableName}.integration_type IS NOT NULL
-                                THEN json_build_object(
-                                    'type', ${AiAgentIntegrationTableName}.integration_type,
-                                    'channelId', ${AiAgentSlackIntegrationTableName}.slack_channel_id
-                                )
-                                ELSE NULL
-                                END
-                            ) FILTER (WHERE ${AiAgentIntegrationTableName}.integration_type IS NOT NULL),
-                            '[]'::json
-                        )
+                    COALESCE(
+                        (SELECT json_agg(
+                            json_build_object(
+                                'type', integration_type,
+                                'channelId', slack_channel_id
+                            )
+                        ) FROM integrations
+                         WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid),
+                        '[]'::json
+                    )
                 `),
                 updatedAt: `${AiAgentTableName}.updated_at`,
                 createdAt: `${AiAgentTableName}.created_at`,
                 instruction: this.database.raw(`
-                    (SELECT instruction FROM ${AiAgentInstructionVersionsTableName}
-                     WHERE ${AiAgentInstructionVersionsTableName}.ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid
-                     ORDER BY created_at DESC LIMIT 1)
-                    `),
+                    (SELECT instruction FROM latest_instruction 
+                     WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid AND rn = 1)
+                `),
                 imageUrl: `${AiAgentTableName}.image_url`,
+                groupAccess: this.database.raw(`
+                    COALESCE(
+                        (SELECT json_agg(group_uuid) 
+                         FROM group_access
+                         WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid),
+                        '[]'::json
+                    )
+                `),
             } satisfies Record<keyof AiAgentSummary, unknown>)
-            .leftJoin(
-                AiAgentIntegrationTableName,
-                `${AiAgentTableName}.ai_agent_uuid`,
-                `${AiAgentIntegrationTableName}.ai_agent_uuid`,
-            )
-            .leftJoin(
-                AiAgentSlackIntegrationTableName,
-                `${AiAgentIntegrationTableName}.ai_agent_integration_uuid`,
-                `${AiAgentSlackIntegrationTableName}.ai_agent_integration_uuid`,
-            )
             .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
             .groupBy(`${AiAgentTableName}.ai_agent_uuid`);
 
@@ -235,7 +291,12 @@ export class AiAgentModel {
     async createAgent(
         args: Pick<
             ApiCreateAiAgent,
-            'name' | 'projectUuid' | 'tags' | 'integrations' | 'instruction'
+            | 'name'
+            | 'projectUuid'
+            | 'tags'
+            | 'integrations'
+            | 'instruction'
+            | 'groupAccess'
         > & {
             organizationUuid: string;
         },
@@ -293,6 +354,12 @@ export class AiAgentModel {
                 });
             }
 
+            const groupAccess = await this.setAndGetGroupAccess(
+                agent.ai_agent_uuid,
+                args.groupAccess ?? undefined,
+                { trx },
+            );
+
             return {
                 uuid: agent.ai_agent_uuid,
                 name: agent.name,
@@ -304,6 +371,7 @@ export class AiAgentModel {
                 updatedAt: agent.updated_at,
                 instruction: args.instruction,
                 imageUrl: agent.image_url,
+                groupAccess,
             };
         });
     }
@@ -389,6 +457,12 @@ export class AiAgentModel {
                 instruction = result.instruction;
             }
 
+            const groupAccess = await this.setAndGetGroupAccess(
+                agent.ai_agent_uuid,
+                args.groupAccess ?? undefined,
+                { trx },
+            );
+
             return {
                 uuid: agent.ai_agent_uuid,
                 name: agent.name,
@@ -400,8 +474,55 @@ export class AiAgentModel {
                 updatedAt: agent.updated_at,
                 instruction,
                 imageUrl: agent.image_url,
+                groupAccess,
             };
         });
+    }
+
+    private async getGroupAccess(
+        agentUuid: AiAgent['uuid'],
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<NonNullable<AiAgent['groupAccess']>> {
+        const rows = await trx(AiAgentGroupAccessTableName)
+            .select('group_uuid')
+            .where('ai_agent_uuid', agentUuid);
+
+        return rows.map((row) => row.group_uuid);
+    }
+
+    private async setGroupAccess(
+        agentUuid: AiAgent['uuid'],
+        groupAccess: NonNullable<AiAgent['groupAccess']>,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<NonNullable<AiAgent['groupAccess']>> {
+        // Delete existing group access
+        await trx(AiAgentGroupAccessTableName)
+            .where('ai_agent_uuid', agentUuid)
+            .delete();
+
+        if (groupAccess.length === 0) {
+            return [];
+        }
+
+        await trx(AiAgentGroupAccessTableName).insert(
+            groupAccess.map((groupUuid) => ({
+                ai_agent_uuid: agentUuid,
+                group_uuid: groupUuid,
+            })),
+        );
+
+        return groupAccess;
+    }
+
+    private async setAndGetGroupAccess(
+        agentUuid: AiAgent['uuid'],
+        groupAccess: NonNullable<AiAgent['groupAccess']> | undefined,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<NonNullable<AiAgent['groupAccess']>> {
+        if (groupAccess !== undefined) {
+            await this.setGroupAccess(agentUuid, groupAccess, { trx });
+        }
+        return this.getGroupAccess(agentUuid, { trx });
     }
 
     async getAgentLastInstruction(

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -59,6 +59,7 @@ import {
 import { type SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import { GroupsModel } from '../../models/GroupsModel';
 import { UserModel } from '../../models/UserModel';
 import { AsyncQueryService } from '../../services/AsyncQueryService/AsyncQueryService';
 import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
@@ -95,6 +96,7 @@ type AiAgentServiceDependencies = {
     analytics: LightdashAnalytics;
     userModel: UserModel;
     aiAgentModel: AiAgentModel;
+    groupsModel: GroupsModel;
     featureFlagService: FeatureFlagService;
     projectService: ProjectService;
     catalogService: CommercialCatalogService;
@@ -111,6 +113,8 @@ export class AiAgentService {
 
     private readonly aiAgentModel: AiAgentModel;
 
+    private readonly groupsModel: GroupsModel;
+
     private readonly featureFlagService: FeatureFlagService;
 
     private readonly projectService: ProjectService;
@@ -126,11 +130,85 @@ export class AiAgentService {
         this.analytics = dependencies.analytics;
         this.userModel = dependencies.userModel;
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.groupsModel = dependencies.groupsModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.catalogService = dependencies.catalogService;
         this.projectService = dependencies.projectService;
         this.slackClient = dependencies.slackClient;
         this.asyncQueryService = dependencies.asyncQueryService;
+    }
+
+    /**
+     * Checks if a user has group access to an AI agent
+     * Returns true if:
+     * 1. The user can manage the AiAgent (admin access)
+     * 2. The agent has no group access defined (open access - users that can view AiAgent)
+     * 3. The user is a member of at least one of the agent's groups
+     */
+    private async checkAgentAccess(
+        user: SessionUser,
+        agent: AiAgent,
+    ): Promise<boolean> {
+        if (
+            user.ability.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: agent.organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
+            )
+        ) {
+            return true;
+        }
+
+        if (!agent.groupAccess || agent.groupAccess.length === 0) {
+            return true;
+        }
+
+        const groupUuids = agent.groupAccess;
+        const userGroups = await this.groupsModel.findUserInGroups({
+            userUuid: user.userUuid,
+            organizationUuid: agent.organizationUuid,
+            groupUuids,
+        });
+
+        return userGroups.length > 0;
+    }
+
+    /**
+     * Checks if user has access to view/interact with agent threads
+     * Returns true if:
+     * 1. The user has group access to the agent
+     * 2. The user is the thread owner
+     * 3. The user has manage permissions for the agent
+     */
+    private async checkAgentThreadAccess(
+        user: SessionUser,
+        agent: AiAgent,
+        threadUserUuid: string,
+    ): Promise<boolean> {
+        const hasAccess = await this.checkAgentAccess(user, agent);
+        if (!hasAccess) {
+            return false;
+        }
+
+        if (threadUserUuid === user.userUuid) {
+            return true;
+        }
+
+        if (
+            user.ability.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: agent.organizationUuid,
+                    projectUuid: agent.projectUuid,
+                }),
+            )
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     // from AiService getToolUtilities
@@ -253,14 +331,23 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        // TODO:
-        // permissions
-
         const agent = await this.aiAgentModel.getAgent({
             organizationUuid,
             agentUuid,
             projectUuid,
         });
+
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        // Check group access
+        const hasAccess = await this.checkAgentAccess(user, agent);
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this agent',
+            );
+        }
 
         return agent;
     }
@@ -281,7 +368,16 @@ export class AiAgentService {
             projectUuid,
         });
 
-        return agents;
+        const agentsWithAccess = (
+            await Promise.all(
+                agents.map(async (agent) => {
+                    const hasAccess = await this.checkAgentAccess(user, agent);
+                    return hasAccess ? agent : null;
+                }),
+            )
+        ).filter((agent): agent is NonNullable<typeof agent> => agent !== null);
+
+        return agentsWithAccess;
     }
 
     async listAgentThreads(
@@ -306,6 +402,14 @@ export class AiAgentService {
 
         if (!agent) {
             throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const hasAccess = await this.checkAgentAccess(user, agent);
+
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this agent',
+            );
         }
 
         // Check if user has admin permissions to view all threads
@@ -400,17 +504,15 @@ export class AiAgentService {
             throw new NotFoundError(`Thread not found: ${threadUuid}`);
         }
 
-        if (
-            user.ability.cannot(
-                'view',
-                subject('AiAgentThread', {
-                    projectUuid: agent.projectUuid,
-                    userUuid: thread.user.uuid,
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to view this thread',
+            );
         }
 
         const messages = await this.aiAgentModel.findThreadMessages({
@@ -486,16 +588,11 @@ export class AiAgentService {
             throw new NotFoundError(`Agent not found: ${agentUuid}`);
         }
 
-        if (
-            user.ability.cannot(
-                'create',
-                subject('AiAgentThread', {
-                    organizationUuid,
-                    projectUuid: agent.projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        const hasAccess = await this.checkAgentAccess(user, agent);
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to create threads for this agent',
+            );
         }
 
         const threadUuid = await this.aiAgentModel.createWebAppThread({
@@ -568,6 +665,18 @@ export class AiAgentService {
             throw new NotFoundError(`Thread not found: ${threadUuid}`);
         }
 
+        // Check if user has access to create messages for this agent's thread
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to create messages for this thread',
+            );
+        }
+
         const messageUuid = await this.aiAgentModel.createWebAppPrompt({
             threadUuid,
             createdByUserUuid: user.userUuid,
@@ -623,6 +732,7 @@ export class AiAgentService {
             tags: body.tags,
             integrations: body.integrations,
             instruction: body.instruction,
+            groupAccess: body.groupAccess,
         });
 
         this.analytics.track<AiAgentCreatedEvent>({
@@ -676,6 +786,7 @@ export class AiAgentService {
             integrations: body.integrations,
             instruction: body.instruction,
             imageUrl: body.imageUrl,
+            groupAccess: body.groupAccess,
         });
 
         this.analytics.track<AiAgentUpdatedEvent>({
@@ -757,20 +868,39 @@ export class AiAgentService {
             throw new ForbiddenError();
         }
 
-        const thread = await this.aiAgentModel.findThread(threadUuid);
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid: user.organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
         if (!thread) {
             throw new NotFoundError(`Thread not found: ${threadUuid}`);
         }
 
-        const { organizationUuid, projectUuid } = thread;
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid: user.organizationUuid,
+            agentUuid: thread.agentUuid,
+        });
 
-        if (thread.organizationUuid !== user.organizationUuid) {
-            throw new ForbiddenError();
+        if (!agent) {
+            throw new NotFoundError(`Agent not found`);
+        }
+
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to stream response for this agent',
+            );
         }
 
         const threadMessages = await this.aiAgentModel.getThreadMessages(
-            organizationUuid,
-            projectUuid,
+            user.organizationUuid,
+            agent.projectUuid,
             threadUuid,
         );
 
@@ -840,6 +970,28 @@ export class AiAgentService {
 
         if (!agent) {
             throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        // Check if user has access to this agent/thread
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this thread',
+            );
         }
 
         const { projectUuid } = agent;
@@ -934,6 +1086,28 @@ export class AiAgentService {
 
         if (!agent) {
             throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        // Check if user has access to this agent/thread
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this thread',
+            );
         }
 
         const { projectUuid } = agent;
@@ -1044,23 +1218,36 @@ export class AiAgentService {
             agentUuid,
         });
 
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
         const message = await this.aiAgentModel.findThreadMessage('assistant', {
             organizationUuid,
             threadUuid,
             messageUuid,
         });
 
-        if (
-            user.ability.cannot(
-                'update',
-                subject('AiAgentThread', {
-                    projectUuid: agent.projectUuid,
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        // Check if user has access to update this thread
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to update this thread',
+            );
         }
 
         await this.aiAgentModel.updateMessageSavedQuery({
@@ -1790,6 +1977,7 @@ export class AiAgentService {
         }
     }
 
+    // TODO: This is to get conversations for the "old" page - remove
     async getConversations(
         user: SessionUser,
         projectUuid: string,
@@ -1801,12 +1989,6 @@ export class AiAgentService {
         if (!user.organizationUuid) {
             throw new Error('Organization not found');
         }
-
-        // TODO: this is a temporary solution to check project permissions...
-        const projectSummary = await this.projectService.getProject(
-            projectUuid,
-            user,
-        );
 
         const threads = await this.aiAgentModel.getThreads(
             user.organizationUuid,
@@ -1825,6 +2007,7 @@ export class AiAgentService {
         }));
     }
 
+    // TODO: this is to get messages for the "old" page - remove
     async getConversationMessages(
         user: SessionUser,
         projectUuid: string,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4337,7 +4337,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_':
+    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4394,6 +4394,11 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    groupAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4402,7 +4407,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_',
             validators: {},
         },
     },
@@ -4423,7 +4428,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4480,6 +4485,11 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    groupAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4488,7 +4498,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_',
             validators: {},
         },
     },
@@ -4517,7 +4527,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_':
+    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4570,6 +4580,11 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    groupAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4578,12 +4593,12 @@ const models: TsoaRoute.Models = {
     ApiCreateAiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_',
+            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__':
         {
             dataType: 'refAlias',
             type: {
@@ -4653,6 +4668,16 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    groupAccess: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'array',
+                                array: { dataType: 'string' },
+                            },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -4664,7 +4689,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -27887,6 +27912,7 @@ export function RegisterRoutes(app: Router) {
                         },
                         metricQuery: { ref: 'AnyType', required: true },
                         chartConfig: { ref: 'AnyType', required: true },
+                        skipSpaceCreate: { dataType: 'boolean' },
                     },
                 },
             ],
@@ -27973,6 +27999,7 @@ export function RegisterRoutes(app: Router) {
                         },
                         tiles: { ref: 'AnyType', required: true },
                         filters: { ref: 'AnyType', required: true },
+                        skipSpaceCreate: { dataType: 'boolean' },
                     },
                 },
             ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4918,7 +4918,7 @@
             "ItemsMap": {
                 "$ref": "#/components/schemas/Record_string.Field-or-TableCalculation-or-CustomDimension-or-Metric_"
             },
-            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_": {
+            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -4971,6 +4971,12 @@
                     "imageUrl": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "groupAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -4983,13 +4989,14 @@
                     "tags",
                     "updatedAt",
                     "instruction",
-                    "imageUrl"
+                    "imageUrl",
+                    "groupAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -5008,7 +5015,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5061,6 +5068,12 @@
                     "imageUrl": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "groupAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -5073,13 +5086,14 @@
                     "tags",
                     "updatedAt",
                     "instruction",
-                    "imageUrl"
+                    "imageUrl",
+                    "groupAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -5109,7 +5123,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_": {
+            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5148,6 +5162,12 @@
                     "imageUrl": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "groupAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -5156,15 +5176,16 @@
                     "integrations",
                     "tags",
                     "instruction",
-                    "imageUrl"
+                    "imageUrl",
+                    "groupAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateAiAgent": {
-                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl_"
+                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_"
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5203,6 +5224,12 @@
                     "imageUrl": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "groupAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object",
@@ -5211,7 +5238,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__"
                     },
                     {
                         "properties": {
@@ -17652,7 +17679,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1800.1",
+        "version": "0.1807.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -23409,6 +23436,9 @@
                                             },
                                             "chartConfig": {
                                                 "$ref": "#/components/schemas/AnyType"
+                                            },
+                                            "skipSpaceCreate": {
+                                                "type": "boolean"
                                             }
                                         },
                                         "required": [
@@ -23489,6 +23519,9 @@
                                             },
                                             "filters": {
                                                 "$ref": "#/components/schemas/AnyType"
+                                            },
+                                            "skipSpaceCreate": {
+                                                "type": "boolean"
                                             }
                                         },
                                         "required": ["tiles", "filters"],

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -50,6 +50,7 @@ export const baseAgentSchema = z.object({
         .nullable(),
     provider: z.string(),
     model: z.string(),
+    groupAccess: z.array(z.string()),
 });
 
 export type BaseAiAgent = z.infer<typeof baseAgentSchema>;
@@ -66,6 +67,7 @@ export type AiAgent = Pick<
     | 'updatedAt'
     | 'instruction'
     | 'imageUrl'
+    | 'groupAccess'
 >;
 
 export type AiAgentSummary = Pick<
@@ -80,6 +82,7 @@ export type AiAgentSummary = Pick<
     | 'updatedAt'
     | 'instruction'
     | 'imageUrl'
+    | 'groupAccess'
 >;
 
 export type AiAgentUser = {
@@ -153,6 +156,7 @@ export type ApiCreateAiAgent = Pick<
     | 'name'
     | 'instruction'
     | 'imageUrl'
+    | 'groupAccess'
 >;
 
 export type ApiUpdateAiAgent = Partial<
@@ -164,6 +168,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'name'
         | 'instruction'
         | 'imageUrl'
+        | 'groupAccess'
     >
 > & {
     uuid: string;

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mantine/core';
 import { IconMessageCircleStar } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
 import { useAiAgentPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useProjectAiAgents } from '../../ee/features/aiCopilot/hooks/useProjectAiAgents';
 import { useActiveProject } from '../../hooks/useActiveProject';
 import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
 import useApp from '../../providers/App/useApp';
@@ -17,8 +18,20 @@ export const AiAgentsButton = () => {
         projectUuid: projectUuid ?? undefined,
     });
     const appQuery = useApp();
+    const canManageAiAgents = useAiAgentPermission({
+        action: 'manage',
+        projectUuid: projectUuid ?? undefined,
+    });
     const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
     const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);
+    const agents = useProjectAiAgents(projectUuid);
+
+    const canViewButton =
+        (canViewAiAgents &&
+            agents.isSuccess &&
+            agents.data?.length &&
+            agents.data.length > 0) ||
+        canManageAiAgents;
 
     if (
         !appQuery.user.isSuccess ||
@@ -32,6 +45,7 @@ export const AiAgentsButton = () => {
     const isAiAgentEnabled = aiAgentFlagQuery.data.enabled;
 
     if (
+        !canViewButton ||
         !canViewAiAgents ||
         !isAiCopilotEnabled ||
         !isAiAgentEnabled ||

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -81,15 +81,21 @@ const getAgentThreadMessageVizQuery = async (args: {
 
 export const useAiAgent = (agentUuid: string | undefined) => {
     const { showToastApiError } = useToaster();
+    const { data: activeProjectUuid } = useActiveProject();
+    const navigate = useNavigate();
 
     return useQuery<ApiAiAgentResponse['results'], ApiError>({
         queryKey: [AI_AGENTS_KEY, agentUuid],
         queryFn: () => getAgent(agentUuid!),
         onError: (error) => {
-            showToastApiError({
-                title: `Failed to fetch AI agent details`,
-                apiError: error.error,
-            });
+            if (error.error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: `Failed to fetch AI agent details`,
+                    apiError: error.error,
+                });
+            }
         },
         enabled: !!agentUuid,
     });
@@ -151,6 +157,8 @@ export const useAiAgentThreads = (
     agentUuid: string | undefined,
     allUsers?: boolean,
 ) => {
+    const { data: activeProjectUuid } = useActiveProject();
+    const navigate = useNavigate();
     const { showToastApiError } = useToaster();
 
     return useQuery<ApiAiAgentThreadSummaryListResponse['results'], ApiError>({
@@ -162,10 +170,16 @@ export const useAiAgentThreads = (
         ],
         queryFn: () => listAgentThreads(agentUuid!, allUsers),
         onError: (error) => {
-            showToastApiError({
-                title: 'Failed to fetch AI agent threads',
-                apiError: error.error,
-            });
+            if (error.error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            }
+            // Don't show error toast for permission errors - let the UI handle it gracefully
+            if (error.error?.statusCode !== 403) {
+                showToastApiError({
+                    title: 'Failed to fetch AI agent threads',
+                    apiError: error.error,
+                });
+            }
         },
         enabled: !!agentUuid,
     });
@@ -176,15 +190,21 @@ export const useAiAgentThread = (
     threadUuid: string | null | undefined,
 ) => {
     const { showToastApiError } = useToaster();
+    const { data: activeProjectUuid } = useActiveProject();
+    const navigate = useNavigate();
 
     return useQuery<ApiAiAgentThreadResponse['results'], ApiError>({
         queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
         queryFn: () => getAgentThread(agentUuid!, threadUuid!),
         onError: (error) => {
-            showToastApiError({
-                title: 'Failed to fetch AI agent thread',
-                apiError: error.error,
-            });
+            if (error.error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to fetch AI agent thread',
+                    apiError: error.error,
+                });
+            }
         },
         enabled: !!agentUuid && !!threadUuid,
     });
@@ -311,10 +331,14 @@ export const useCreateAgentThreadMutation = (
             );
         },
         onError: ({ error }) => {
-            showToastApiError({
-                title: 'Failed to create AI agent',
-                apiError: error,
-            });
+            if (error?.statusCode === 403) {
+                void navigate(`/projects/${projectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to create AI agent',
+                    apiError: error,
+                });
+            }
         },
     });
 };
@@ -335,6 +359,7 @@ export const useCreateAgentThreadMessageMutation = (
     agentUuid: string | undefined,
     threadUuid: string | undefined,
 ) => {
+    const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     const { user } = useApp();
@@ -391,10 +416,14 @@ export const useCreateAgentThreadMessageMutation = (
             });
         },
         onError: ({ error }) => {
-            showToastApiError({
-                title: 'Failed to generate AI agent thread response',
-                apiError: error,
-            });
+            if (error?.statusCode === 403) {
+                void navigate(`/projects/${projectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to generate AI agent thread response',
+                    apiError: error,
+                });
+            }
         },
     });
 };
@@ -417,6 +446,8 @@ export const useAiAgentThreadMessageVizQuery = (
         ApiError
     >,
 ) => {
+    const navigate = useNavigate();
+    const { data: activeProjectUuid } = useActiveProject();
     const health = useHealth();
     const org = useOrganization();
     const { showToastApiError } = useToaster();
@@ -440,11 +471,14 @@ export const useAiAgentThreadMessageVizQuery = (
             });
         },
         onError: (error: ApiError) => {
-            showToastApiError({
-                title: 'Failed to fetch visualization',
-                apiError: error.error,
-            });
-
+            if (error.error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to fetch visualization',
+                    apiError: error.error,
+                });
+            }
             useQueryOptions?.onError?.(error);
         },
         enabled: !!health.data && !!org.data && useQueryOptions?.enabled,
@@ -464,6 +498,8 @@ export const useUpdatePromptFeedbackMutation = (
 ) => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
+    const navigate = useNavigate();
+    const { data: activeProjectUuid } = useActiveProject();
 
     return useMutation<
         ApiSuccessEmpty,
@@ -497,10 +533,14 @@ export const useUpdatePromptFeedbackMutation = (
             );
         },
         onError: ({ error }) => {
-            showToastApiError({
-                title: 'Failed to submit feedback',
-                apiError: error,
-            });
+            if (error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to submit feedback',
+                    apiError: error,
+                });
+            }
         },
     });
 };
@@ -530,6 +570,9 @@ export const useSavePromptQuery = (
     messageUuid: string,
 ) => {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    const { showToastApiError } = useToaster();
+    const { data: activeProjectUuid } = useActiveProject();
 
     return useMutation<
         ApiSuccessEmpty,
@@ -547,6 +590,16 @@ export const useSavePromptQuery = (
             void queryClient.invalidateQueries({
                 queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
             });
+        },
+        onError: ({ error }) => {
+            if (error?.statusCode === 403) {
+                void navigate(`/projects/${activeProjectUuid}/home`);
+            } else {
+                showToastApiError({
+                    title: 'Failed to save prompt query',
+                    apiError: error,
+                });
+            }
         },
     });
 };

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -37,6 +37,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import Page from '../../../components/common/Page/Page';
 import { useGetSlack, useSlackChannels } from '../../../hooks/slack/useSlack';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
 import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
 import { ConversationsList } from '../../features/aiCopilot/components/ConversationsList';
@@ -52,7 +53,12 @@ import {
 const formSchema: z.ZodType<
     Pick<
         BaseAiAgent,
-        'name' | 'integrations' | 'tags' | 'instruction' | 'imageUrl'
+        | 'name'
+        | 'integrations'
+        | 'tags'
+        | 'instruction'
+        | 'imageUrl'
+        | 'groupAccess'
     >
 > = z.object({
     name: z.string().min(1),
@@ -65,6 +71,7 @@ const formSchema: z.ZodType<
     tags: z.array(z.string()).nullable(),
     instruction: z.string().nullable(),
     imageUrl: z.string().url().nullable(),
+    groupAccess: z.array(z.string()),
 });
 
 type Props = {
@@ -106,6 +113,10 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     const { data: agents, isSuccess: isSuccessAgents } =
         useProjectAiAgents(projectUuid);
 
+    const { data: groups, isLoading: isLoadingGroups } = useOrganizationGroups({
+        includeMembers: 5,
+    });
+
     const {
         data: slackChannels,
         refresh: refreshChannels,
@@ -134,6 +145,15 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         [slackChannels, agents],
     );
 
+    const groupOptions = useMemo(
+        () =>
+            groups?.map((group) => ({
+                value: group.uuid,
+                label: group.name,
+            })) ?? [],
+        [groups],
+    );
+
     const form = useForm<z.infer<typeof formSchema>>({
         initialValues: {
             name: '',
@@ -141,6 +161,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             tags: null,
             instruction: null,
             imageUrl: null,
+            groupAccess: [],
         },
         validate: zodResolver(formSchema),
     });
@@ -157,6 +178,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 tags: agent.tags && agent.tags.length > 0 ? agent.tags : null,
                 instruction: agent.instruction,
                 imageUrl: agent.imageUrl,
+                groupAccess: agent.groupAccess ?? [],
             };
             form.setValues(values);
             form.resetDirty(values);
@@ -399,6 +421,62 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                 );
                                             }}
                                         />
+
+                                        <Stack gap="xs">
+                                            <MultiSelect
+                                                label={
+                                                    <Group gap="xs">
+                                                        <Text fz="sm" fw={500}>
+                                                            Group Access
+                                                        </Text>
+                                                        <Tooltip
+                                                            label="Select groups that can access this agent. If no groups are selected, the agent will be visible to all users in the organization."
+                                                            withArrow
+                                                            withinPortal
+                                                            multiline
+                                                            maw="250px"
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconInfoCircle
+                                                                }
+                                                            />
+                                                        </Tooltip>
+                                                    </Group>
+                                                }
+                                                placeholder={
+                                                    isLoadingGroups
+                                                        ? 'Loading groups...'
+                                                        : groupOptions.length ===
+                                                          0
+                                                        ? 'No groups available'
+                                                        : 'Select groups or leave empty for all users'
+                                                }
+                                                data={groupOptions}
+                                                disabled={
+                                                    isLoadingGroups ||
+                                                    groupOptions.length === 0
+                                                }
+                                                clearable
+                                                {...form.getInputProps(
+                                                    'groupAccess',
+                                                )}
+                                                value={
+                                                    form.getInputProps(
+                                                        'groupAccess',
+                                                    ).value ?? []
+                                                }
+                                                onChange={(value) => {
+                                                    form.setFieldValue(
+                                                        'groupAccess',
+                                                        value.length > 0
+                                                            ? value
+                                                            : [],
+                                                    );
+                                                }}
+                                            />
+                                            {/*  Add message + link to orgfanization settings if no groups are available and if this is enabled */}
+                                        </Stack>
                                     </Stack>
                                 </Paper>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15385

### Description:
This PR adds group-based access control for AI Agents, allowing administrators to restrict agent access to specific user groups. 

Key changes:
- Added a `groupAccess` field to AI Agents that stores which groups can access an agent
- Implemented permission checks throughout the AI Agent service to verify user access
- Added UI components in the agent creation/edit form to select which groups can access an agent
- Improved error handling for permission-related errors in the frontend
- Added database schema and model methods to support group-based access control

When no groups are specified for an agent, it remains accessible to all users(non-viewers) in the organization. When groups are specified, only users in those groups (or users with admin/developer permissions) can access the agent.

<img width="1273" alt="Screenshot 2025-07-04 at 13 53 51" src="https://github.com/user-attachments/assets/1887407e-a220-4ad7-bfc1-4622641205f8" />

