### PR TITLE
chore: migrate instance initialization to new InstanceConfigurationService 

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -5,9 +5,11 @@ import {
     Account,
     AnyType,
     ApiError,
+    getErrorMessage,
     LightdashError,
     LightdashMode,
     LightdashVersionHeader,
+    MissingConfigError,
     Project,
     ServiceAccount,
     SessionUser,
@@ -70,6 +72,7 @@ import { VERSION } from './version';
 import PrometheusMetrics from './prometheus';
 import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
+import { InstanceConfigurationService } from './services/InstanceConfigurationService/InstanceConfigurationService';
 
 // We need to override this interface to have our user typing
 declare global {
@@ -279,9 +282,21 @@ export default class App {
             );
         }
 
-        await this.serviceRepository
-            .getOrganizationService()
-            .initializeInstance();
+        try {
+            const instanceConfigurationService =
+                this.serviceRepository.getInstanceConfigurationService<InstanceConfigurationService>();
+            await instanceConfigurationService.initializeInstance();
+        } catch (e) {
+            if (e instanceof MissingConfigError) {
+                Logger.debug(
+                    `No instance configuration service found: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            } else {
+                throw e;
+            }
+        }
     }
 
     private async initExpress(expressApp: Express) {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -4,6 +4,7 @@ import { AppArguments } from '../App';
 import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
@@ -181,20 +182,15 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     encryptionUtil: utils.getEncryptionUtil(),
                     userModel: models.getUserModel(),
                 }),
-            organizationService: ({ models, context, repository }) =>
-                new OrganizationService({
+            instanceConfigurationService: ({ models, context, repository }) =>
+                new InstanceConfigurationService({
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
                     organizationModel: models.getOrganizationModel(),
                     projectModel: models.getProjectModel(),
-                    onboardingModel: models.getOnboardingModel(),
-                    inviteLinkModel: models.getInviteLinkModel(),
-                    organizationMemberProfileModel:
-                        models.getOrganizationMemberProfileModel(),
                     userModel: models.getUserModel(),
                     organizationAllowedEmailDomainsModel:
                         models.getOrganizationAllowedEmailDomainsModel(),
-                    groupsModel: models.getGroupsModel(),
                     personalAccessTokenModel:
                         models.getPersonalAccessTokenModel(),
                     emailModel: models.getEmailModel(),

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -1,0 +1,289 @@
+import { subject } from '@casl/ability';
+import {
+    AllowedEmailDomains,
+    AllowedEmailDomainsRoles,
+    convertProjectRoleToOrganizationRole,
+    CreateColorPalette,
+    CreateGroup,
+    CreateOrganization,
+    CreateProject,
+    DbtVersionOptionLatest,
+    ForbiddenError,
+    getOrganizationNameSchema,
+    Group,
+    GroupWithMembers,
+    isUserWithOrg,
+    KnexPaginateArgs,
+    KnexPaginatedData,
+    LightdashMode,
+    NotExistsError,
+    OnbordingRecord,
+    OpenIdIdentityIssuerType,
+    OpenIdUser,
+    Organization,
+    OrganizationColorPalette,
+    OrganizationColorPaletteWithIsActive,
+    OrganizationMemberProfile,
+    OrganizationMemberProfileUpdate,
+    OrganizationMemberProfileWithGroups,
+    OrganizationMemberRole,
+    OrganizationProject,
+    ParameterError,
+    ProjectType,
+    RequestMethod,
+    ServiceAccountScope,
+    SessionUser,
+    UnexpectedServerError,
+    UpdateAllowedEmailDomains,
+    UpdateColorPalette,
+    UpdateOrganization,
+    validateOrganizationEmailDomains,
+    validateOrganizationNameOrThrow,
+} from '@lightdash/common';
+import { groupBy } from 'lodash';
+import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { LightdashConfig } from '../../config/parseConfig';
+import { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
+import { PersonalAccessTokenModel } from '../../models/DashboardModel/PersonalAccessTokenModel';
+import { EmailModel } from '../../models/EmailModel';
+import { GroupsModel } from '../../models/GroupsModel';
+import { InviteLinkModel } from '../../models/InviteLinkModel';
+import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { UserModel } from '../../models/UserModel';
+import { BaseService } from '../BaseService';
+import { ProjectService } from '../ProjectService/ProjectService';
+
+type InstanceConfigurationServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    analytics: LightdashAnalytics;
+    organizationModel: OrganizationModel;
+    projectModel: ProjectModel;
+    userModel: UserModel;
+
+    organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+    personalAccessTokenModel: PersonalAccessTokenModel;
+    emailModel: EmailModel;
+    projectService: ProjectService; // For compiling project on new setup
+    serviceAccountModel?: ServiceAccountModel; // For creating service account on new setup
+};
+
+export class InstanceConfigurationService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly analytics: LightdashAnalytics;
+
+    private readonly organizationModel: OrganizationModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly userModel: UserModel;
+
+    private readonly organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+
+    private readonly personalAccessTokenModel: PersonalAccessTokenModel;
+
+    private readonly emailModel: EmailModel;
+
+    private readonly projectService: ProjectService;
+
+    private readonly serviceAccountModel?: ServiceAccountModel;
+
+    constructor({
+        lightdashConfig,
+        analytics,
+        organizationModel,
+        projectModel,
+        userModel,
+        organizationAllowedEmailDomainsModel,
+        personalAccessTokenModel,
+        emailModel,
+        projectService,
+        serviceAccountModel,
+    }: InstanceConfigurationServiceArguments) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.analytics = analytics;
+        this.organizationModel = organizationModel;
+        this.projectModel = projectModel;
+        this.userModel = userModel;
+        this.organizationAllowedEmailDomainsModel =
+            organizationAllowedEmailDomainsModel;
+        this.personalAccessTokenModel = personalAccessTokenModel;
+        this.emailModel = emailModel;
+        this.projectService = projectService;
+        this.serviceAccountModel = serviceAccountModel;
+    }
+
+    async initializeInstance() {
+        // No permissions check here, there are no users yet
+        // No initial setup, we skip this step
+        if (!this.lightdashConfig.initialSetup) {
+            this.logger.debug(`No initial setup config found, skipping`);
+            return;
+        }
+        try {
+            const setup = this.lightdashConfig.initialSetup;
+            // If no project is set, we can create a new one using environment variables
+            const hasOrgs = await this.organizationModel.hasOrgs();
+
+            if (hasOrgs) {
+                this.logger.debug(
+                    `Initial setup: There is already an organization, we skip this initial setup`,
+                );
+                return;
+            }
+            const hasAnyProjects = await this.projectModel.hasAnyProjects();
+
+            if (hasAnyProjects) {
+                // This should not happen, since we can't have projects without orgs
+                throw new UnexpectedServerError(
+                    `Initial setup: cannot initialize instance, there are already defined projects. Exiting`,
+                );
+            }
+
+            // No organization and no projects, we can create a new one
+            // using the initial setup config
+            this.logger.debug(
+                `Initial setup: Creating organization "${setup.organization.name}"`,
+            );
+
+            const { organizationUuid } = await this.organizationModel.create({
+                name: setup.organization.name,
+            });
+
+            this.logger.info(
+                `Initial setup: Organization "${organizationUuid}" created`,
+            );
+
+            this.logger.debug(
+                `Initial setup: Creating admin user with email "${setup.organization.admin.email}"`,
+            );
+
+            // We need `AUTH_ENABLE_OIDC_TO_EMAIL_LINKING=true`
+            // So the user can login using SSO for the pending user
+            const { email, name: adminName } = setup.organization.admin;
+            const user = await this.userModel.createPendingUser(
+                organizationUuid,
+                {
+                    firstName: adminName.split(' ')[0],
+                    lastName: adminName.split(' ').slice(1).join(' '),
+                    email,
+                    role: OrganizationMemberRole.ADMIN,
+                    password: undefined,
+                },
+            );
+            // whatever email they use here will be trusted. And any user with an OIDC account with that email will access the admin user.
+            await this.emailModel.verifyUserEmailIfExists(user.userUuid, email);
+
+            this.logger.info(`Initial setup: User ${user.userUuid} created`);
+
+            this.logger.debug(
+                `Initial setup: Creating project "${setup.project.name}"`,
+            );
+            const project: CreateProject = {
+                name: setup.project.name,
+                type: ProjectType.DEFAULT,
+                warehouseConnection: setup.project,
+                copyWarehouseConnectionFromUpstreamProject: undefined,
+                dbtConnection: setup.dbt,
+                upstreamProjectUuid: undefined,
+                dbtVersion: setup.project.dbtVersion,
+            };
+
+            const projectUuid = await this.projectModel.create(
+                user.userUuid,
+                organizationUuid,
+                project,
+            );
+            this.logger.info(`Initial setup: Project ${projectUuid} created`);
+
+            this.logger.info(`Initial setup: Compiling project ${projectUuid}`);
+
+            const sessionUser =
+                await this.userModel.findSessionUserAndOrgByUuid(
+                    user.userUuid,
+                    organizationUuid,
+                );
+            await this.projectService.scheduleCompileProject(
+                sessionUser,
+                projectUuid,
+                RequestMethod.BACKEND,
+                true, // Skip permission check
+            );
+
+            // Optional steps are performed at the end
+            if (setup.organization.emailDomain) {
+                this.logger.debug(
+                    `Initial setup: Whitelisting domain "${setup.organization.emailDomain}"`,
+                );
+                const emailDomains = [setup.organization.emailDomain];
+                // Validates input
+                const error = validateOrganizationEmailDomains(emailDomains);
+                if (error) {
+                    throw new ParameterError(error);
+                }
+                const allowedDomains: AllowedEmailDomains = {
+                    organizationUuid,
+                    emailDomains,
+                    role: OrganizationMemberRole.VIEWER,
+                    projects: [],
+                };
+                await this.organizationAllowedEmailDomainsModel.upsertAllowedEmailDomains(
+                    allowedDomains,
+                );
+
+                this.logger.info(
+                    `Initial setup: Whitelisted domain "${setup.organization.emailDomain}"`,
+                );
+            } else {
+                this.logger.info(
+                    `Initial setup: No whitelisted domain, skipping`,
+                );
+            }
+
+            if (setup.serviceAccount && this.serviceAccountModel) {
+                this.logger.debug(`Initial setup: creating service account`);
+                await this.serviceAccountModel.save(
+                    sessionUser,
+                    {
+                        organizationUuid,
+                        expiresAt: setup.serviceAccount.expirationTime,
+                        description: 'Initial setup service account',
+                        scopes: [ServiceAccountScope.ORG_ADMIN],
+                    },
+                    setup.serviceAccount.token,
+                );
+                this.logger.info(`Initial setup: service account created`);
+            } else {
+                this.logger.info(
+                    `Initial setup: No service account token provided, skipping`,
+                );
+            }
+
+            if (setup.apiKey) {
+                this.logger.debug(`Initial setup: creating API key`);
+
+                await this.personalAccessTokenModel.save(sessionUser, {
+                    expiresAt: setup.apiKey.expirationTime,
+                    description: 'Initial setup API token',
+                    autoGenerated: false,
+                    token: setup.apiKey.token,
+                });
+                this.logger.info(`Initial setup: API key created`);
+            } else {
+                this.logger.info(
+                    `Initial setup: No API key provided, skipping`,
+                );
+            }
+        } catch (error) {
+            this.logger.error(
+                `Initial setup: Error initializing project: ${error}`,
+            );
+            throw error;
+        }
+    }
+}

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -1,18 +1,13 @@
 import { LightdashInstallType } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
-import { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
-import { PersonalAccessTokenModel } from '../../models/DashboardModel/PersonalAccessTokenModel';
-import { EmailModel } from '../../models/EmailModel';
 import { GroupsModel } from '../../models/GroupsModel';
-import { InviteLinkModel } from '../../models/InviteLinkModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
-import { ProjectService } from '../ProjectService/ProjectService';
 import { OrganizationService } from './OrganizationService';
 import { organization, user } from './OrganizationService.mock';
 
@@ -30,16 +25,11 @@ describe('organization service', () => {
         organizationModel: organizationModel as unknown as OrganizationModel,
         projectModel: projectModel as unknown as ProjectModel,
         onboardingModel: {} as OnboardingModel,
-        inviteLinkModel: {} as InviteLinkModel,
         organizationMemberProfileModel: {} as OrganizationMemberProfileModel,
         userModel: {} as UserModel,
         organizationAllowedEmailDomainsModel:
             {} as OrganizationAllowedEmailDomainsModel,
         groupsModel: {} as GroupsModel,
-        personalAccessTokenModel: {} as PersonalAccessTokenModel,
-        emailModel: {} as EmailModel,
-        projectService: {} as ProjectService,
-        serviceAccountModel: {} as ServiceAccountModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -63,16 +63,10 @@ type OrganizationServiceArguments = {
     organizationModel: OrganizationModel;
     projectModel: ProjectModel;
     onboardingModel: OnboardingModel;
-    inviteLinkModel: InviteLinkModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     userModel: UserModel;
-
     groupsModel: GroupsModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
-    personalAccessTokenModel: PersonalAccessTokenModel;
-    emailModel: EmailModel;
-    projectService: ProjectService; // For compiling project on new setup
-    serviceAccountModel?: ServiceAccountModel; // For creating service account on new setup
 };
 
 export class OrganizationService extends BaseService {
@@ -86,8 +80,6 @@ export class OrganizationService extends BaseService {
 
     private readonly onboardingModel: OnboardingModel;
 
-    private readonly inviteLinkModel: InviteLinkModel;
-
     private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
 
     private readonly userModel: UserModel;
@@ -96,29 +88,16 @@ export class OrganizationService extends BaseService {
 
     private readonly groupsModel: GroupsModel;
 
-    private readonly personalAccessTokenModel: PersonalAccessTokenModel;
-
-    private readonly emailModel: EmailModel;
-
-    private readonly projectService: ProjectService;
-
-    private readonly serviceAccountModel?: ServiceAccountModel;
-
     constructor({
         lightdashConfig,
         analytics,
         organizationModel,
         projectModel,
         onboardingModel,
-        inviteLinkModel,
         organizationMemberProfileModel,
         userModel,
         groupsModel,
         organizationAllowedEmailDomainsModel,
-        personalAccessTokenModel,
-        emailModel,
-        projectService,
-        serviceAccountModel,
     }: OrganizationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -126,16 +105,11 @@ export class OrganizationService extends BaseService {
         this.organizationModel = organizationModel;
         this.projectModel = projectModel;
         this.onboardingModel = onboardingModel;
-        this.inviteLinkModel = inviteLinkModel;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
         this.userModel = userModel;
         this.organizationAllowedEmailDomainsModel =
             organizationAllowedEmailDomainsModel;
         this.groupsModel = groupsModel;
-        this.personalAccessTokenModel = personalAccessTokenModel;
-        this.emailModel = emailModel;
-        this.projectService = projectService;
-        this.serviceAccountModel = serviceAccountModel;
     }
 
     async get(user: SessionUser): Promise<Organization> {
@@ -790,172 +764,5 @@ export class OrganizationService extends BaseService {
         );
 
         return palette;
-    }
-
-    async initializeInstance() {
-        // No permissions check here, there are no users yet
-        // No initial setup, we skip this step
-        if (!this.lightdashConfig.initialSetup) return;
-        try {
-            const setup = this.lightdashConfig.initialSetup;
-            // If no project is set, we can create a new one using environment variables
-            const hasOrgs = await this.organizationModel.hasOrgs();
-
-            if (hasOrgs) {
-                this.logger.debug(
-                    `Initial setup: There is already an organization, we skip this initial setup`,
-                );
-                // There is already an organization, we skip this step
-                return;
-            }
-            const hasAnyProjects = await this.projectModel.hasAnyProjects();
-
-            if (hasAnyProjects) {
-                // This should not happen, since we can't have projects without orgs
-                throw new UnexpectedServerError(
-                    `Initial setup: cannot initialize instance, there are already defined projects. Exiting`,
-                );
-            }
-
-            // No organization and no projects, we can create a new one
-            // using the initial setup config
-            this.logger.debug(
-                `Initial setup: Creating organization "${setup.organization.name}"`,
-            );
-
-            const organization = await this.organizationModel.create({
-                name: setup.organization.name,
-            });
-            const { organizationUuid } = organization;
-
-            this.logger.info(
-                `Initial setup: Organization "${organizationUuid}" created`,
-            );
-
-            this.logger.debug(
-                `Initial setup: Creating admin user with email "${setup.organization.admin.email}"`,
-            );
-
-            // We need `AUTH_ENABLE_OIDC_TO_EMAIL_LINKING=true`
-            // So the user can login using SSO for the pending user
-            const { email, name: adminName } = setup.organization.admin;
-            const user = await this.userModel.createPendingUser(
-                organizationUuid,
-                {
-                    firstName: adminName.split(' ')[0],
-                    lastName: adminName.split(' ').slice(1).join(' '),
-                    email,
-                    role: OrganizationMemberRole.ADMIN,
-                    password: undefined,
-                },
-            );
-            // whatever email they use here will be trusted. And any user with an OIDC account with that email will access the admin user.
-            await this.emailModel.verifyUserEmailIfExists(user.userUuid, email);
-
-            this.logger.info(`Initial setup: User ${user.userUuid} created`);
-
-            this.logger.debug(
-                `Initial setup: Creating project "${setup.project.name}"`,
-            );
-            const project: CreateProject = {
-                name: setup.project.name,
-                type: ProjectType.DEFAULT,
-                warehouseConnection: setup.project,
-                copyWarehouseConnectionFromUpstreamProject: undefined,
-                dbtConnection: setup.dbt,
-                upstreamProjectUuid: undefined,
-                dbtVersion: setup.project.dbtVersion,
-            };
-
-            const projectUuid = await this.projectModel.create(
-                user.userUuid,
-                organizationUuid,
-                project,
-            );
-            this.logger.info(`Initial setup: Project ${projectUuid} created`);
-
-            this.logger.info(`Initial setup: Compiling project ${projectUuid}`);
-
-            const sessionUser =
-                await this.userModel.findSessionUserAndOrgByUuid(
-                    user.userUuid,
-                    organizationUuid,
-                );
-            await this.projectService.scheduleCompileProject(
-                sessionUser,
-                projectUuid,
-                RequestMethod.BACKEND,
-                true, // Skip permission check
-            );
-
-            // Optional steps are performed at the end
-            if (setup.organization.emailDomain) {
-                this.logger.debug(
-                    `Initial setup: Whitelisting domain "${setup.organization.emailDomain}"`,
-                );
-                const emailDomains = [setup.organization.emailDomain];
-                // Validates input
-                const error = validateOrganizationEmailDomains(emailDomains);
-                if (error) {
-                    throw new ParameterError(error);
-                }
-                const allowedDomains: AllowedEmailDomains = {
-                    organizationUuid,
-                    emailDomains,
-                    role: OrganizationMemberRole.VIEWER,
-                    projects: [],
-                };
-                await this.organizationAllowedEmailDomainsModel.upsertAllowedEmailDomains(
-                    allowedDomains,
-                );
-
-                this.logger.info(
-                    `Initial setup: Whitelisted domain "${setup.organization.emailDomain}"`,
-                );
-            } else {
-                this.logger.info(
-                    `Initial setup: No whitelisted domain, skipping`,
-                );
-            }
-
-            if (setup.serviceAccount && this.serviceAccountModel) {
-                this.logger.debug(`Initial setup: creating service account`);
-                await this.serviceAccountModel.save(
-                    sessionUser,
-                    {
-                        organizationUuid,
-                        expiresAt: setup.serviceAccount.expirationTime,
-                        description: 'Initial setup service account',
-                        scopes: [ServiceAccountScope.ORG_ADMIN],
-                    },
-                    setup.serviceAccount.token,
-                );
-                this.logger.info(`Initial setup: service account created`);
-            } else {
-                this.logger.info(
-                    `Initial setup: No service account token provided, skipping`,
-                );
-            }
-
-            if (setup.apiKey) {
-                this.logger.debug(`Initial setup: creating API key`);
-
-                await this.personalAccessTokenModel.save(sessionUser, {
-                    expiresAt: setup.apiKey.expirationTime,
-                    description: 'Initial setup API token',
-                    autoGenerated: false,
-                    token: setup.apiKey.token,
-                });
-                this.logger.info(`Initial setup: API key created`);
-            } else {
-                this.logger.info(
-                    `Initial setup: No API key provided, skipping`,
-                );
-            }
-        } catch (error) {
-            this.logger.error(
-                `Initial setup: Error initializing project: ${error}`,
-            );
-        }
     }
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1,3 +1,4 @@
+import { MissingConfigError } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { ClientRepository } from '../clients/ClientRepository';
 import { LightdashConfig } from '../config/parseConfig';
@@ -92,6 +93,7 @@ interface ServiceManifest {
     supportService: unknown;
     cacheService: unknown;
     serviceAccountService: unknown;
+    instanceConfigurationService: unknown;
 }
 
 /**
@@ -396,17 +398,12 @@ export class ServiceRepository
                     organizationModel: this.models.getOrganizationModel(),
                     projectModel: this.models.getProjectModel(),
                     onboardingModel: this.models.getOnboardingModel(),
-                    inviteLinkModel: this.models.getInviteLinkModel(),
                     organizationMemberProfileModel:
                         this.models.getOrganizationMemberProfileModel(),
                     userModel: this.models.getUserModel(),
                     organizationAllowedEmailDomainsModel:
                         this.models.getOrganizationAllowedEmailDomainsModel(),
                     groupsModel: this.models.getGroupsModel(),
-                    personalAccessTokenModel:
-                        this.models.getPersonalAccessTokenModel(),
-                    emailModel: this.models.getEmailModel(),
-                    projectService: this.getProjectService(),
                 }),
         );
     }
@@ -869,6 +866,12 @@ export class ServiceRepository
         return this.getService('serviceAccountService');
     }
 
+    public getInstanceConfigurationService<
+        InstanceConfigurationServiceImplT,
+    >(): InstanceConfigurationServiceImplT {
+        return this.getService('instanceConfigurationService');
+    }
+
     /**
      * Handles initializing a service, and taking into account service
      * providers + memoization.
@@ -894,7 +897,7 @@ export class ServiceRepository
             } else if (factory != null) {
                 serviceInstance = factory();
             } else {
-                throw new Error(
+                throw new MissingConfigError(
                     `Unable to initialize service '${serviceName}' - no factory or provider.`,
                 );
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #

## Why ? 

Initial setup was added initially to the organization service, we had to add a few extra dependencies for this to work,  when we added ServiceModel (in ee) we had to initialize also on the EE services, which makes everything more confusing. 
This approach is cleaner.
Soon we'll be adding a new method `updateInstance`  to this service too.

Related: https://github.com/lightdash/lightdash/pull/15464

## Demo

Without license (silent error) 

![image](https://github.com/user-attachments/assets/9e33fb62-5ce6-4823-a89c-1a0b322c4eaf)

WIth license but no ENV config  (skip)

![image](https://github.com/user-attachments/assets/aeddec27-41e2-4b16-bfd0-17a76199ef57)

With license and ENV config but with existing org/users  (skip)

![image](https://github.com/user-attachments/assets/3855b2ee-41c0-4de6-a0dc-ca1e904e00ec)

WIth license and ENV config and no orgs/users (apply initial setup) 

![image](https://github.com/user-attachments/assets/7d3f3f24-81a8-4079-b0b8-8168e6bfa887)



### Description:
Created a dedicated `InstanceConfigurationService` to handle instance initialization, moving this functionality out of the `OrganizationService`. This improves separation of concerns and error handling during initialization.

The new service properly handles missing configuration errors and provides better logging during the initialization process. The implementation includes graceful error handling with appropriate debug and error messages.

diff --git packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts