### PR TITLE
feat: allow CLI deploy without credentials

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -24,7 +24,7 @@ import {
     UUID,
     type ApiCreateProjectResults,
     type ApiSuccess,
-    type CreateProject,
+    type CreateProjectOptionalCredentials,
 } from '@lightdash/common';
 import {
     Body,
@@ -507,7 +507,7 @@ export class OrganizationController extends BaseController {
     @OperationId('CreateProject')
     async createProject(
         @Request() req: express.Request,
-        @Body() body: CreateProject,
+        @Body() body: CreateProjectOptionalCredentials,
     ): Promise<ApiSuccess<ApiCreateProjectResults>> {
         const results = await this.services
             .getProjectService()

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11523,7 +11523,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11533,7 +11533,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11543,7 +11543,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11556,7 +11556,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -12870,50 +12870,67 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    type: { ref: 'ProjectType', required: true },
-                    pinnedListUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    dbtConnection: { ref: 'DbtProjectConfig', required: true },
-                    warehouseConnection: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WarehouseCredentials' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    upstreamProjectUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    dbtVersion: { ref: 'DbtVersionOption', required: true },
-                },
-                validators: {},
-            },
-        },
+    CreateProjectTableConfiguration: {
+        dataType: 'refEnum',
+        enums: ['prod', 'all'],
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                ref: 'Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__',
-                validators: {},
+    'Pick_CreateProject.Exclude_keyofCreateProject.warehouseConnection__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                type: { ref: 'ProjectType', required: true },
+                pinnedListUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                dbtConnection: { ref: 'DbtProjectConfig', required: true },
+                upstreamProjectUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                dbtVersion: { ref: 'DbtVersionOption', required: true },
+                copyWarehouseConnectionFromUpstreamProject: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                tableConfiguration: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'CreateProjectTableConfiguration' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                copyContent: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
+            validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_CreateProject.warehouseConnection_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_CreateProject.Exclude_keyofCreateProject.warehouseConnection__',
+            validators: {},
+        },
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SshTunnelConfiguration: {
         dataType: 'refAlias',
@@ -13226,32 +13243,17 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateProjectTableConfiguration: {
-        dataType: 'refEnum',
-        enums: ['prod', 'all'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateProject: {
+    CreateProjectOptionalCredentials: {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
             subSchemas: [
-                {
-                    ref: 'Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_',
-                },
+                { ref: 'Omit_CreateProject.warehouseConnection_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        copyContent: { dataType: 'boolean' },
-                        tableConfiguration: {
-                            ref: 'CreateProjectTableConfiguration',
-                        },
-                        copyWarehouseConnectionFromUpstreamProject: {
-                            dataType: 'boolean',
-                        },
                         warehouseConnection: {
                             ref: 'CreateWarehouseCredentials',
-                            required: true,
                         },
                     },
                 },
@@ -29014,7 +29016,7 @@ export function RegisterRoutes(app: Router) {
             in: 'body',
             name: 'body',
             required: true,
-            ref: 'CreateProject',
+            ref: 'CreateProjectOptionalCredentials',
         },
     };
     app.post(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12362,22 +12362,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -13762,7 +13762,11 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__": {
+            "CreateProjectTableConfiguration": {
+                "enum": ["prod", "all"],
+                "type": "string"
+            },
+            "Pick_CreateProject.Exclude_keyofCreateProject.warehouseConnection__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -13776,22 +13780,28 @@
                     "dbtConnection": {
                         "$ref": "#/components/schemas/DbtProjectConfig"
                     },
-                    "warehouseConnection": {
-                        "$ref": "#/components/schemas/WarehouseCredentials"
-                    },
                     "upstreamProjectUuid": {
                         "type": "string"
                     },
                     "dbtVersion": {
                         "$ref": "#/components/schemas/DbtVersionOption"
+                    },
+                    "copyWarehouseConnectionFromUpstreamProject": {
+                        "type": "boolean"
+                    },
+                    "tableConfiguration": {
+                        "$ref": "#/components/schemas/CreateProjectTableConfiguration"
+                    },
+                    "copyContent": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["name", "type", "dbtConnection", "dbtVersion"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_": {
-                "$ref": "#/components/schemas/Pick_Project.Exclude_keyofProject.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid__",
+            "Omit_CreateProject.warehouseConnection_": {
+                "$ref": "#/components/schemas/Pick_CreateProject.Exclude_keyofCreateProject.warehouseConnection__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "SshTunnelConfiguration": {
@@ -14260,31 +14270,17 @@
                     }
                 ]
             },
-            "CreateProjectTableConfiguration": {
-                "enum": ["prod", "all"],
-                "type": "string"
-            },
-            "CreateProject": {
+            "CreateProjectOptionalCredentials": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Omit_Project.projectUuid-or-organizationUuid-or-schedulerTimezone-or-createdByUserUuid_"
+                        "$ref": "#/components/schemas/Omit_CreateProject.warehouseConnection_"
                     },
                     {
                         "properties": {
-                            "copyContent": {
-                                "type": "boolean"
-                            },
-                            "tableConfiguration": {
-                                "$ref": "#/components/schemas/CreateProjectTableConfiguration"
-                            },
-                            "copyWarehouseConnectionFromUpstreamProject": {
-                                "type": "boolean"
-                            },
                             "warehouseConnection": {
                                 "$ref": "#/components/schemas/CreateWarehouseCredentials"
                             }
                         },
-                        "required": ["warehouseConnection"],
                         "type": "object"
                     }
                 ]
@@ -17557,7 +17553,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1780.1",
+        "version": "0.1782.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -23688,7 +23684,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/CreateProject"
+                                "$ref": "#/components/schemas/CreateProjectOptionalCredentials"
                             }
                         }
                     }

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -34,6 +34,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     verbose: boolean;
     ignoreErrors: boolean;
     startOfWeek?: number;
+    warehouseCredentials?: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {
@@ -159,6 +160,7 @@ const createNewProject = async (
             ...options,
             name: projectName,
             type: ProjectType.DEFAULT,
+            warehouseCredentials: options.warehouseCredentials,
         });
 
         const project = results?.project;
@@ -193,8 +195,17 @@ const createNewProject = async (
     }
 };
 
-export const deployHandler = async (options: DeployHandlerOptions) => {
+export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
+    const options = {
+        ...originalOptions,
+    };
     GlobalState.setVerbose(options.verbose);
+
+    // No warehouse credentials assumes we skip dbt compile and warehouse catalog
+    if (options.warehouseCredentials === false) {
+        options.skipDbtCompile = true;
+        options.skipWarehouseCatalog = true;
+    }
     const dbtVersion = await getDbtVersion();
     await checkLightdashVersion();
     const executionId = uuidv4();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -335,6 +335,10 @@ program
         'dbt property. Do not resolve unselected nodes by deferring to the manifest within the --state directory.',
         undefined,
     )
+    .option(
+        '--no-warehouse-credentials',
+        'Compile without any warehouse credentials. Skips dbt compile + warehouse catalog',
+    )
     .action(compileHandler);
 
 program
@@ -639,6 +643,10 @@ program
         'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
         parseUseDbtListOption,
         true,
+    )
+    .option(
+        '--no-warehouse-credentials',
+        'Create project without warehouse credentials. Skips dbt compile + warehouse catalog',
     )
     .action(deployHandler);
 

--- a/packages/warehouses/src/index.ts
+++ b/packages/warehouses/src/index.ts
@@ -7,3 +7,4 @@ export * from './warehouseClients/PostgresWarehouseClient';
 export * from './warehouseClients/RedshiftWarehouseClient';
 export * from './warehouseClients/SnowflakeWarehouseClient';
 export * from './warehouseClients/TrinoWarehouseClient';
+export * from './warehouseSqlBuilderFromType';

--- a/packages/warehouses/src/warehouseSqlBuilderFromType.ts
+++ b/packages/warehouses/src/warehouseSqlBuilderFromType.ts
@@ -1,0 +1,42 @@
+import {
+    SupportedDbtAdapter,
+    isSupportedDbtAdapterType,
+} from '@lightdash/common';
+import { BigquerySqlBuilder } from './warehouseClients/BigqueryWarehouseClient';
+import { DatabricksSqlBuilder } from './warehouseClients/DatabricksWarehouseClient';
+import { PostgresSqlBuilder } from './warehouseClients/PostgresWarehouseClient';
+import { RedshiftSqlBuilder } from './warehouseClients/RedshiftWarehouseClient';
+import { SnowflakeSqlBuilder } from './warehouseClients/SnowflakeWarehouseClient';
+import { TrinoSqlBuilder } from './warehouseClients/TrinoWarehouseClient';
+import WarehouseBaseSqlBuilder from './warehouseClients/WarehouseBaseSqlBuilder';
+
+export const warehouseSqlBuilderFromType = (
+    adapterType: string | SupportedDbtAdapter,
+    ...args: ConstructorParameters<typeof WarehouseBaseSqlBuilder>
+) => {
+    if (!isSupportedDbtAdapterType(adapterType)) {
+        throw new Error(
+            `Invalid adapter type: ${adapterType}. Must be one of: ${Object.values(
+                SupportedDbtAdapter,
+            ).join(', ')}`,
+        );
+    }
+
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return new BigquerySqlBuilder(...args);
+        case SupportedDbtAdapter.DATABRICKS:
+            return new DatabricksSqlBuilder(...args);
+        case SupportedDbtAdapter.POSTGRES:
+            return new PostgresSqlBuilder(...args);
+        case SupportedDbtAdapter.REDSHIFT:
+            return new RedshiftSqlBuilder(...args);
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return new SnowflakeSqlBuilder(...args);
+        case SupportedDbtAdapter.TRINO:
+            return new TrinoSqlBuilder(...args);
+        default:
+            const never: never = adapterType;
+            throw new Error(`Unsupported adapter type: ${adapterType}`);
+    }
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15347

Allows users to compile, deploy, and create new projects without credentials.

This will operate on an existing `target/manifest.json` file, so user needs to have run `dbt compile` already.

- **compile** (used by deploy) - now only needs a `WarehouseSqlBuilder` (without credentials). The only time we create a `WarehouseClient` is if we need to fetch the warehouse schema
- **deploy** this uses compile and also doesn't need credentials, since credentials are sent on deploy
- **deploy --create** we used to required credentials to create a project, but now the project is created without credentials. user needs to finish setup in the UI


This PR does not introduce UI changes to improve onboarding, it's a quick workaround.


### Reviewing

Suggest you review in this order:

- `index.ts` - cli UX change
- `organizationController` - this is change that was missing on a previous PR to make it optional to send credentials on project creation (already supported in https://github.com/lightdash/lightdash/pull/15594)
- `compile` - how we compile without credentials
- `deploy` - no changes to logic (since it follows compile)
- `createProject` - optionally sends credentials