### PR TITLE
fix: retain pivotDimension from ai to explore

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -42,8 +42,13 @@ export const AiChartQuickOptions = ({
     const { agentUuid } = useParams();
 
     const [opened, { open, close }] = useDisclosure(false);
-    const { visualizationConfig, columnOrder, resultsData, chartConfig } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        columnOrder,
+        resultsData,
+        chartConfig,
+        pivotDimensions,
+    } = useVisualizationContext();
     const { mutate: savePromptQuery } = useSavePromptQuery(
         agentUuid!,
         message.threadUuid,
@@ -51,9 +56,8 @@ export const AiChartQuickOptions = ({
     );
     const metricQuery = resultsData?.metricQuery;
     const type = chartConfig.type;
-    const vizConfig = visualizationConfig;
 
-    const isDisabled = !metricQuery || !type || !vizConfig;
+    const isDisabled = !metricQuery || !type || !visualizationConfig;
     const onSaveChart = (savedData: SavedChart) => {
         void savePromptQuery({ savedQueryUuid: savedData.uuid });
         if (
@@ -86,12 +90,7 @@ export const AiChartQuickOptions = ({
             projectUuid,
             columnOrder,
             chartConfig,
-            pivotColumns:
-                vizConfig &&
-                'breakdownByDimension' in vizConfig &&
-                typeof vizConfig.breakdownByDimension === 'string'
-                    ? [vizConfig.breakdownByDimension]
-                    : undefined,
+            pivotColumns: pivotDimensions,
         });
     }, [
         isDisabled,
@@ -99,7 +98,7 @@ export const AiChartQuickOptions = ({
         projectUuid,
         columnOrder,
         chartConfig,
-        vizConfig,
+        pivotDimensions,
     ]);
 
     const onClickExplore = () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15721

### Description:

Refactored `AiChartQuickOptions` component to use `pivotDimensions` directly from the visualization context instead of deriving it from `visualizationConfig`. This simplifies the code by removing the conditional logic that was previously used to extract pivot columns from the configuration.

The PR also removes an unnecessary local variable `vizConfig` and uses `visualizationConfig` directly in the `isDisabled` check.

![Screenshot 2025-07-04 at 16.19.47.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/9431b526-1e10-45cc-afdf-9b491b8a673e.png)

![Screenshot 2025-07-04 at 16.19.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/9444a36e-8378-480f-b2af-92108b83bcad.png)

