### PR TITLE
style: remove backdrop if not disabled

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -7,5 +7,5 @@
 
 .input {
     background-color: rgba(255, 255, 255, 0.3) !important;
-    --input-bd-focus: var(--mantine-color-violet-5);
+    --input-bd-focus: var(--mantine-color-gray-5);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -108,7 +108,7 @@ export const AgentChatInput = ({
                             bottom: 12,
                             right: 12,
                         }}
-                        color="violet"
+                        color="dark.5"
                         disabled={disabled || isComposing}
                         loading={loading}
                         onClick={() => {
@@ -124,7 +124,7 @@ export const AgentChatInput = ({
                 }
             />
 
-            {!disabled || (disabled && disabledReason) ? (
+            {disabled && disabledReason ? (
                 <Paper
                     px="sm"
                     py={rem(4)}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated the AI Copilot chat interface styling by changing the color scheme from violet to gray/dark. The focus border color now uses gray-5 instead of violet-5, and the send button uses dark.5 instead of violet. 
- fixed the conditional rendering logic for the disabled message to only show when both disabled is true and a disabledReason exists.

![Screenshot 2025-07-04 at 16.43.35.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/ee03246f-c6dd-4082-a879-3d42f01d6b3a.png)

