### PR TITLE
fix: opperator precedence in final fanout join

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
@@ -1008,7 +1008,7 @@ export class MetricQueryBuilder {
                         return `INNER JOIN ${metricCte.name} ON ${dimensionAlias
                             .map(
                                 (alias) =>
-                                    `${unaffectedMetricsCteName}.${alias} = ${metricCte.name}.${alias} OR ( ${unaffectedMetricsCteName}.${alias} IS NULL AND ${metricCte.name}.${alias} IS NULL )`,
+                                    `( ${unaffectedMetricsCteName}.${alias} = ${metricCte.name}.${alias} OR ( ${unaffectedMetricsCteName}.${alias} IS NULL AND ${metricCte.name}.${alias} IS NULL ) )`,
                             )
                             .join(' AND ')}`;
                     }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15725 

### Description:

There was an issue with fanout handling that included custom dimensions (see the linked ticket). This fixes that issue, and probably some similar issues as well. 

We were getting the wrong opperator precedence when comparing dimension aliases and joining the clauses together. This fixes it by **wrapping each condition for a single dimension in parentheses before joining them with `AND`**.

So, we had
```
ON 
    cte_unaffected."payments_payment_method" = cte_metrics_orders."payments_payment_method"
    OR (
        cte_unaffected."payments_payment_method" IS NULL 
        AND cte_metrics_orders."payments_payment_method" IS NULL
    )
    AND cte_unaffected."amount_range" = cte_metrics_orders."amount_range"
    OR (
        cte_unaffected."amount_range" IS NULL 
        AND cte_metrics_orders."amount_range" IS NULL
    )

```

And the OR was binding incorrectly and the results were very confusing. 

With this fix, the same code becomes
```
ON (
    cte_unaffected."payments_payment_method" = cte_metrics_orders."payments_payment_method"
    OR (
        cte_unaffected."payments_payment_method" IS NULL
        AND cte_metrics_orders."payments_payment_method" IS NULL
    )
)
AND (
    cte_unaffected."amount_range" = cte_metrics_orders."amount_range"
    OR (
        cte_unaffected."amount_range" IS NULL
        AND cte_metrics_orders."amount_range" IS NULL
    )
)

```

I tested this in some cases, but it probably needs more. 