### PR TITLE
feat: watch @lightdash/common module in frontend dev server

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -113,6 +113,9 @@ export default defineConfig({
             'lightdash-dev', // for local development with docker
             '.lightdash.dev', // for cloudflared tunnels
         ],
+        watch: {
+            ignored: ['!**/node_modules/@lightdash/common/**'],
+        },
         proxy: {
             '/api': {
                 target: 'http://localhost:8080',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Enable watching changes in the `@lightdash/common` module within `node_modules` during development. This allows for real-time updates when working on both the frontend and common packages simultaneously without requiring manual rebuilds.