### PR TITLE
feat: add AI thread access column to Slack installations

### DIFF
--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -11,7 +11,7 @@ export type DbSlackAuthTokens = {
     created_at: Date;
     notification_channel: string | null;
     app_profile_photo_url: string | null;
-    ai_thread_access_consent: boolean | null;
+    ai_thread_access_consent: boolean;
 };
 
 export type CreateDbSlackAuthTokens = Pick<

--- a/packages/backend/src/database/migrations/20250707073534_slack_installation_ai_thread_consent.ts
+++ b/packages/backend/src/database/migrations/20250707073534_slack_installation_ai_thread_consent.ts
@@ -1,4 +1,7 @@
 import { Knex } from 'knex';
+import { lightdashConfig } from '../../config/lightdashConfig';
+
+const hasEnterpriseLicense = !!lightdashConfig.license.licenseKey;
 
 const SlackAuthTokensTableName = 'slack_auth_tokens';
 
@@ -22,6 +25,11 @@ export async function down(knex: Knex): Promise<void> {
         'ai_thread_access_consent',
     );
     if (!hasColumn) {
+        return;
+    }
+
+    // We have a duplicated migration in EE, so we don't need to remove the column here if we're running EE
+    if (hasEnterpriseLicense) {
         return;
     }
 

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -135,8 +135,7 @@ export class SlackAuthenticationModel {
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
             ...(includeAiThreadAccessConsent
                 ? {
-                      aiThreadAccessConsent:
-                          row.ai_thread_access_consent ?? false,
+                      aiThreadAccessConsent: row.ai_thread_access_consent,
                   }
                 : {}),
         };


### PR DESCRIPTION
### Description:

Added a new boolean column `ai_thread_access_consent` to the `slack_auth_tokens` table with a default value of `false`. This column will track whether users have consented to AI access for their Slack threads.

The changes include:
- Creating a new migration for the column in the open-source version
- Updating the existing EE migration to check if the column exists before creating it


Internal thread: https://lightdash.slack.com/archives/C02GQKJK84Q/p1751639371093159