### PR TITLE
fix: update Slack logging level and add required channel history scope

### DIFF
--- a/packages/backend/src/ee/clients/Slack/SlackBot.ts
+++ b/packages/backend/src/ee/clients/Slack/SlackBot.ts
@@ -474,7 +474,7 @@ export class CommercialSlackBot extends SlackBot {
                 botId,
             );
         } catch (error) {
-            Logger.warn(
+            Logger.error(
                 'Failed to fetch thread history, using original message only:',
                 error,
             );

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -18,6 +18,7 @@ export const slackRequiredScopes = [
     'links:write',
     'chat:write',
     'chat:write.customize',
+    'channels:history',
     'channels:read',
     'channels:join',
     'groups:read',

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -344,7 +344,7 @@ const SlackSettingsPanel: FC = () => {
                             {organizationHasSlack &&
                                 !hasRequiredScopes(slackInstallation) && (
                                     <Alert
-                                        color="blue"
+                                        color="yellow"
                                         icon={
                                             <MantineIcon
                                                 icon={IconAlertCircle}


### PR DESCRIPTION
This PR enhances Slack AI integration by:

1. Adding the `channels:history` scope to the required Slack scopes list, which is necessary for properly fetching thread history
2. Changing the warning log to an error log when thread history fetching fails, to better highlight this issue
3. Updating the Slack permissions alert color from blue to yellow to make it more noticeable when required scopes are missing