### PR TITLE
feat: add x and y axis labels to time series visualization

### DIFF
--- a/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
@@ -52,11 +52,17 @@ export const echartsConfigTimeSeriesMetric = async (
         xAxis: [
             {
                 type: 'time',
+                ...(vizTool.vizConfig.xAxisLabel
+                    ? { name: vizTool.vizConfig.xAxisLabel }
+                    : {}),
             },
         ],
         yAxis: [
             {
                 type: 'value',
+                ...(vizTool.vizConfig.yAxisLabel
+                    ? { name: vizTool.vizConfig.yAxisLabel }
+                    : {}),
             },
         ],
         series: metrics.map((metric) => ({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -27,8 +27,15 @@ export const toolTimeSeriesArgsSchema = visualizationMetadataSchema.extend({
 
 export type ToolTimeSeriesArgs = z.infer<typeof toolTimeSeriesArgsSchema>;
 
-export const toolTimeSeriesArgsSchemaTransformed =
-    toolTimeSeriesArgsSchema.transform((data) => ({
+export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
+    .extend({
+        // backwards compatibility for old viz configs
+        vizConfig: timeSeriesMetricVizConfigSchema.extend({
+            xAxisLabel: z.string().default(''),
+            yAxisLabel: z.string().default(''),
+        }),
+    })
+    .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
     }));

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -43,6 +43,14 @@ export const timeSeriesMetricVizConfigSchema = z.object({
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
         .nullable()
         .describe(`The total number of data points allowed on the chart.`),
+    xAxisLabel: z
+        .string()
+        .nullable()
+        .describe('A helpful label to explain the x-axis'),
+    yAxisLabel: z
+        .string()
+        .nullable()
+        .describe('A helpful label to explain the y-axis'),
 });
 
 export type TimeSeriesMetricVizConfigSchemaType = z.infer<

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -176,6 +176,10 @@ export const AiChartVisualization: FC<Props> = ({
                                             queryExecutionHandle.data.query
                                                 .fields
                                         }
+                                        fieldsMap={
+                                            queryExecutionHandle.data.query
+                                                .fields
+                                        }
                                     />
                                 )}
 

--- a/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
@@ -143,11 +143,17 @@ const getTimeSeriesMetricEchartsConfig = (
                 xAxis: [
                     {
                         type: 'time',
+                        ...(config.xAxisLabel
+                            ? { name: config.xAxisLabel }
+                            : {}),
                     },
                 ] as Axis[],
                 yAxis: [
                     {
                         type: 'value',
+                        ...(config.yAxisLabel
+                            ? { name: config.yAxisLabel }
+                            : {}),
                     },
                 ] as Axis[],
                 series: config.yMetrics.map((metric) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15453

### Description:

Added support for x-axis and y-axis labels in time series visualizations. The schema now includes optional `xAxisLabel` and `yAxisLabel` fields that allow users to provide helpful descriptions for each axis. These labels are properly rendered in the ECharts configuration when present.

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/9a91a6ca-a3a1-4a41-ab67-fda124f9988e.png)

After: 
![CleanShot 2025-07-07 at 17.49.21@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/81f85a24-bc1a-4d08-bbd7-4a2f032856a3.png)

