### PR TITLE
chore: add Google Cloud SDK, kubectl, and okteto to development environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,10 @@
               cloudflared
 
               git-secrets
+
+              google-cloud-sdk
+              kubectl
+              okteto
             ];
 
             # Environment setup


### PR DESCRIPTION
Added Google Cloud SDK, kubectl, and Okteto to the development environment in flake.nix.