### PR TITLE
fix: handle SCIM root path requests

### DIFF
--- a/packages/backend/src/ee/controllers/scimRootController.ts
+++ b/packages/backend/src/ee/controllers/scimRootController.ts
@@ -1,0 +1,31 @@
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { BaseController } from '../../controllers/baseController';
+import { isScimAuthenticated } from '../authentication';
+
+@Route('/api/v1/scim/v2')
+@Hidden()
+@Tags('SCIM')
+export class ScimRootController extends BaseController {
+    /**
+     * Root SCIM endpoint for validating SCIM configuration
+     * @param req express request
+     */
+    @Middlewares([isScimAuthenticated])
+    @Get('/')
+    @OperationId('GetScimRoot')
+    @Response('200', 'Success')
+    async getScimRoot(@Request() req: express.Request): Promise<void> {
+        // Return empty success response as expected by identity providers
+        this.setStatus(200);
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12,6 +12,8 @@ import { ServiceAccountsController } from './../ee/controllers/serviceAccountsCo
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimUserController } from './../ee/controllers/scimUserController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ScimRootController } from './../ee/controllers/scimRootController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimOrganizationAccessTokenController } from './../ee/controllers/scimOrganizationAccessTokenController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimGroupController } from './../ee/controllers/scimGroupController';
@@ -17242,6 +17244,60 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteScimUser',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getScimRoot: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/scim/v2',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getScimRoot,
+        ),
+
+        async function ScimRootController_getScimRoot(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getScimRoot,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getScimRoot',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17558,7 +17558,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1788.1",
+        "version": "0.1788.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"


### PR DESCRIPTION
## Summary
- Adds a new SCIM root endpoint controller to handle GET requests to `/api/v1/scim/v2`
- The endpoint validates the SCIM token using the existing `isScimAuthenticated` middleware
- Returns an empty 200 response as expected by identity providers like Azure and Okta during SCIM setup

## Test plan
- [ ] Manual testing with a valid SCIM token should return 200 OK
- [ ] Manual testing with an invalid SCIM token should return 401 Unauthorized
- [ ] Manual testing without an authorization header should return 401 Unauthorized

Fixes #15753

🤖 Generated with [Claude Code](https://claude.ai/code)