### PR TITLE
fix: set snowflake timeout values for login

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -235,6 +235,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             ...(credentials.accessUrl?.length
                 ? { accessUrl: credentials.accessUrl }
                 : {}),
+            sfRetryMaxLoginRetries: 3, // Number of retries for the login request.
+            retryTimeout: 15000, // according to docs: The max login timeout value. This value is either 0 or over 300.
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Snowflake client was never throwing any errors when there was a network error.
This sets explicit retry limits so that it does.

**Steps to reproduce**
1. Deploy snowflake project
2. Disable S3 (you can unset `S3_ENDPOINT` env variable)
3. Turn of wi-fi
4. Run query (can be explore)

**Before**
Queries were hanging forever

**After**
![image](https://github.com/user-attachments/assets/150cf0f4-539a-4576-9a33-69fb18354a2f)


