### PR TITLE
feat: Display how it's calculated for one line answers

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartGenerationToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartGenerationToolCallDescription.tsx
@@ -63,6 +63,7 @@ export const AiChartGenerationToolCallDescription = ({
                     ))}
                     {breakdownByDimension && (
                         <>
+                            {' '}
                             and breakdown by{' '}
                             <Badge
                                 color="gray"

--- a/packages/frontend/src/hooks/useCompiledSql.ts
+++ b/packages/frontend/src/hooks/useCompiledSql.ts
@@ -82,14 +82,14 @@ export const useCompiledSqlFromMetricQuery = ({
     tableName,
     projectUuid,
     metricQuery,
-}: {
+}: Partial<{
     tableName: string;
     projectUuid: string;
     metricQuery: MetricQuery;
-}) => {
+}>) => {
     return useQuery<ApiCompiledQueryResults, ApiError>({
         queryKey: ['compiledQuery', tableName, metricQuery, projectUuid],
-        queryFn: () => getCompiledQuery(projectUuid!, tableName, metricQuery),
+        queryFn: () => getCompiledQuery(projectUuid!, tableName!, metricQuery!),
         enabled: !!tableName && !!projectUuid && !!metricQuery,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15705

### Description:
This PR displays the `How it's calculated` for all type of answers that have a tool call.
I've moved the section from a tab to a collapsible panel before the assistant's message.


[Screen Recording 2025-07-08 at 17.17.55.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/HorFj8gm8QUuuIDE2vgk/3c4f8104-a02d-4b76-bd06-7bd0762fc5d1.mov" />](https://app.graphite.dev/media/video/HorFj8gm8QUuuIDE2vgk/3c4f8104-a02d-4b76-bd06-7bd0762fc5d1.mov)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/a9b1808d-327d-4b27-8910-bbc6bd4ca5e2.png)



![image](https://github.com/lightdash/lightdash/assets/123456789/abcd1234-5678-9abc-def0-123456789abc)