### PR TITLE
fix: remove duplicate fieldsMap props and move to correct component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -172,14 +172,6 @@ export const AiChartVisualization: FC<Props> = ({
                                             queryExecutionHandle.data.query
                                                 .fields
                                         }
-                                        fieldsMap={
-                                            queryExecutionHandle.data.query
-                                                .fields
-                                        }
-                                        fieldsMap={
-                                            queryExecutionHandle.data.query
-                                                .fields
-                                        }
                                     />
                                 )}
 
@@ -190,6 +182,9 @@ export const AiChartVisualization: FC<Props> = ({
                                     filters={
                                         queryExecutionHandle.data.query
                                             .metricQuery.filters
+                                    }
+                                    fieldsMap={
+                                        queryExecutionHandle.data.query.fields
                                     }
                                 />
                             ) : null}


### PR DESCRIPTION
### Description:
Fixed duplicate `fieldsMap` props in AiChartVisualization component by removing redundant props and placing the single `fieldsMap` prop in the correct location.