### PR TITLE
poc: multipage pdf dashboard export

### DIFF
--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -176,6 +176,7 @@ dashboardRouter.post(
                     req.body.gridWidth,
                     req.user!,
                     req.body.selectedTabs,
+                    req.body.separateTabPages,
                 );
 
             res.json({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/15726

### Description:
Adds support for multi-page PDF exports of dashboards with tabs. When exporting a dashboard with multiple tabs, each tab is now captured as a separate page in the PDF with the tab name displayed as a header. This enhancement allows users to export all dashboard tabs in a single PDF document rather than just the currently visible tab.

The implementation detects when a dashboard has multiple selected tabs and captures each tab individually, combining them into a multi-page PDF. A new parameter `separateTabPages` has been added to control this behavior.

AI: I've created a pull request description that focuses on the key functionality being added - multi-page PDF exports for dashboard tabs. I've explained what the feature does and how it works without getting into implementation details or mentioning generalities about file changes.