### PR TITLE
feat: add tab support to embedded dashboards

### DIFF
--- a/packages/common/src/types/filterGrammar.ts
+++ b/packages/common/src/types/filterGrammar.ts
@@ -335,6 +335,7 @@ export const parseModelRequiredFilters = ({
         const [key, value] = Object.entries(filterRule)[0];
 
         if (acc.map((a) => a.target.fieldRef).includes(key)) {
+            // eslint-disable-next-line no-console
             console.warn(`Duplicate filter key "${key}" in default filters`);
             return acc;
         }

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -2,9 +2,11 @@ import {
     assertUnreachable,
     DashboardTileTypes,
     getItemId,
+    type DashboardTab,
+    type DashboardTile,
 } from '@lightdash/common';
 import { IconUnlink } from '@tabler/icons-react';
-import { useEffect, useMemo, type FC } from 'react';
+import { useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import {
     getReactGridLayoutConfig,
@@ -20,11 +22,107 @@ import { useEmbedDashboard } from '../hooks';
 import EmbedDashboardChartTile from './EmbedDashboardChartTile';
 import EmbedDashboardHeader from './EmbedDashboardHeader';
 
+import { Group, Tabs, Title } from '@mantine/core';
 import '../../../../../styles/react-grid.css';
 import { convertSdkFilterToDashboardFilter } from '../utils';
 import { EmbedMarkdownTile } from './EmbedMarkdownTile';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const EmbedDashboardGrid: FC<{
+    filteredTiles: DashboardTile[];
+    layouts: { lg: Layout[] };
+    dashboard: any;
+    projectUuid: string;
+    embedToken: string;
+    hasRequiredDashboardFiltersToSet: boolean;
+    isTabEmpty?: boolean;
+}> = ({
+    filteredTiles,
+    layouts,
+    dashboard,
+    projectUuid,
+    embedToken,
+    hasRequiredDashboardFiltersToSet,
+    isTabEmpty,
+}) => (
+    <Group grow pt="sm" px="xs">
+        {isTabEmpty ? (
+            <div
+                style={{
+                    marginTop: '40px',
+                    textAlign: 'center',
+                }}
+            >
+                <SuboptimalState
+                    title="Tab is empty"
+                    description="This tab has no tiles"
+                />
+            </div>
+        ) : (
+            <ResponsiveGridLayout
+                {...getResponsiveGridLayoutProps({ enableAnimation: false })}
+                layouts={layouts}
+                className={`react-grid-layout-dashboard ${
+                    hasRequiredDashboardFiltersToSet ? 'locked' : ''
+                }`}
+            >
+                {filteredTiles.map((tile, index) => (
+                    <div key={tile.uuid}>
+                        {tile.type === DashboardTileTypes.SAVED_CHART ? (
+                            <EmbedDashboardChartTile
+                                projectUuid={projectUuid}
+                                dashboardSlug={dashboard.slug}
+                                embedToken={embedToken}
+                                key={tile.uuid}
+                                minimal
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                                canExportCsv={dashboard.canExportCsv}
+                                canExportImages={dashboard.canExportImages}
+                                locked={hasRequiredDashboardFiltersToSet}
+                                tileIndex={index}
+                            />
+                        ) : tile.type === DashboardTileTypes.MARKDOWN ? (
+                            <EmbedMarkdownTile
+                                key={tile.uuid}
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                                tileIndex={index}
+                                dashboardSlug={dashboard.slug}
+                            />
+                        ) : tile.type === DashboardTileTypes.LOOM ? (
+                            <LoomTile
+                                key={tile.uuid}
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                            />
+                        ) : tile.type === DashboardTileTypes.SQL_CHART ? (
+                            <SqlChartTile
+                                key={tile.uuid}
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                            />
+                        ) : (
+                            assertUnreachable(
+                                tile,
+                                `Dashboard tile type is not recognised`,
+                            )
+                        )}
+                    </div>
+                ))}
+            </ResponsiveGridLayout>
+        )}
+    </Group>
+);
 
 const EmbedDashboard: FC<{
     containerStyles?: React.CSSProperties;
@@ -117,6 +215,56 @@ const EmbedDashboard: FC<{
             [dashboard],
         ) || false;
 
+    // Tab state
+    const [activeTab, setActiveTab] = useState<DashboardTab | undefined>();
+
+    // Sort tabs by order
+    const sortedTabs = useMemo(() => {
+        if (!dashboard?.tabs || dashboard.tabs.length === 0) {
+            return [];
+        }
+        return dashboard.tabs.sort((a, b) => a.order - b.order);
+    }, [dashboard?.tabs]);
+
+    // Set active tab to first tab if no active tab is set
+    useEffect(() => {
+        if (sortedTabs.length > 0 && !activeTab) {
+            setActiveTab(sortedTabs[0]);
+        }
+    }, [sortedTabs, activeTab]);
+
+    // Filter tiles by active tab
+    const filteredTiles = useMemo(() => {
+        if (!dashboard?.tiles) {
+            return [];
+        }
+
+        // If no tabs or only one tab, show all tiles
+        if (sortedTabs.length <= 1) {
+            return dashboard.tiles;
+        }
+
+        // If there are tabs, filter tiles by active tab
+        if (activeTab) {
+            return dashboard.tiles.filter((tile) => {
+                // Show tiles that belong to the active tab
+                const tileBelongsToActiveTab = tile.tabUuid === activeTab.uuid;
+
+                // Show tiles that don't belong to any tab (legacy tiles) on the first tab
+                const tileHasNoTab = !tile.tabUuid;
+                const isFirstTab = activeTab.uuid === sortedTabs[0]?.uuid;
+
+                return tileBelongsToActiveTab || (tileHasNoTab && isFirstTab);
+            });
+        }
+
+        return [];
+    }, [dashboard?.tiles, sortedTabs, activeTab]);
+
+    // Check if tabs should be enabled (more than one tab)
+    const tabsEnabled = sortedTabs.length > 1;
+    const MAGIC_SCROLL_AREA_HEIGHT = 40;
+
     if (!projectUuid) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -160,10 +308,12 @@ const EmbedDashboard: FC<{
     }
 
     const layouts = {
-        lg: dashboard.tiles.map<Layout>((tile) =>
-            getReactGridLayoutConfig(tile),
-        ),
+        lg: filteredTiles.map<Layout>((tile) => getReactGridLayoutConfig(tile)),
     };
+
+    // Check if current tab is empty
+    const isTabEmpty = tabsEnabled && filteredTiles.length === 0;
+
     return (
         <div style={containerStyles ?? { height: '100vh', overflowY: 'auto' }}>
             <EmbedDashboardHeader
@@ -174,66 +324,74 @@ const EmbedDashboard: FC<{
             <LockedDashboardModal
                 opened={hasRequiredDashboardFiltersToSet && !!hasChartTiles}
             />
-            <ResponsiveGridLayout
-                {...getResponsiveGridLayoutProps({ enableAnimation: false })}
-                layouts={layouts}
-                className={`react-grid-layout-dashboard ${
-                    hasRequiredDashboardFiltersToSet ? 'locked' : ''
-                }`}
-            >
-                {dashboard.tiles.map((tile, index) => (
-                    <div key={tile.uuid}>
-                        {tile.type === DashboardTileTypes.SAVED_CHART ? (
-                            <EmbedDashboardChartTile
-                                projectUuid={projectUuid}
-                                dashboardSlug={dashboard.slug}
-                                embedToken={embedToken}
-                                key={tile.uuid}
-                                minimal
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                canExportCsv={dashboard.canExportCsv}
-                                canExportImages={dashboard.canExportImages}
-                                locked={hasRequiredDashboardFiltersToSet}
-                                tileIndex={index}
-                            />
-                        ) : tile.type === DashboardTileTypes.MARKDOWN ? (
-                            <EmbedMarkdownTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                                tileIndex={index}
-                                dashboardSlug={dashboard.slug}
-                            />
-                        ) : tile.type === DashboardTileTypes.LOOM ? (
-                            <LoomTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                            />
-                        ) : tile.type === DashboardTileTypes.SQL_CHART ? (
-                            <SqlChartTile
-                                key={tile.uuid}
-                                tile={tile}
-                                isEditMode={false}
-                                onDelete={() => {}}
-                                onEdit={() => {}}
-                            />
-                        ) : (
-                            assertUnreachable(
-                                tile,
-                                `Dashboard tile type is not recognised`,
-                            )
-                        )}
-                    </div>
-                ))}
-            </ResponsiveGridLayout>
+
+            {tabsEnabled ? (
+                <Tabs
+                    value={activeTab?.uuid}
+                    onTabChange={(e) => {
+                        const tab = sortedTabs.find((t) => t.uuid === e);
+                        if (tab) {
+                            setActiveTab(tab);
+                        }
+                    }}
+                    mt="md"
+                    styles={{
+                        tabsList: {
+                            flexWrap: 'nowrap',
+                            height: MAGIC_SCROLL_AREA_HEIGHT - 1,
+                        },
+                    }}
+                    variant="outline"
+                >
+                    <Tabs.List bg="gray.0" px="lg">
+                        {sortedTabs.map((tab) => (
+                            <Tabs.Tab
+                                key={tab.uuid}
+                                value={tab.uuid}
+                                bg={
+                                    activeTab?.uuid === tab.uuid
+                                        ? 'white'
+                                        : 'gray.0'
+                                }
+                            >
+                                <Title
+                                    fw={500}
+                                    order={6}
+                                    color="gray.7"
+                                    truncate
+                                    maw={`calc(${
+                                        100 / (sortedTabs?.length || 1)
+                                    }vw)`}
+                                >
+                                    {tab.name}
+                                </Title>
+                            </Tabs.Tab>
+                        ))}
+                    </Tabs.List>
+                    <EmbedDashboardGrid
+                        filteredTiles={filteredTiles}
+                        layouts={layouts}
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                        embedToken={embedToken}
+                        hasRequiredDashboardFiltersToSet={
+                            hasRequiredDashboardFiltersToSet
+                        }
+                        isTabEmpty={isTabEmpty}
+                    />
+                </Tabs>
+            ) : (
+                <EmbedDashboardGrid
+                    filteredTiles={filteredTiles}
+                    layouts={layouts}
+                    dashboard={dashboard}
+                    projectUuid={projectUuid}
+                    embedToken={embedToken}
+                    hasRequiredDashboardFiltersToSet={
+                        hasRequiredDashboardFiltersToSet
+                    }
+                />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #15779

Dashboard:

![Screenshot from 2025-07-09 12-01-16](https://github.com/user-attachments/assets/b80bdd3e-64d2-47dd-8dc3-531d187a5541)

Before

![Screenshot from 2025-07-09 12-01-51](https://github.com/user-attachments/assets/21dd80aa-df24-4678-91a3-cc78e1bf9084)

After

![Screenshot from 2025-07-09 11-11-13](https://github.com/user-attachments/assets/fca7b547-44a0-483c-9407-1d7f8b08b792)


### Description:
Added tab support to embedded dashboards, allowing users to navigate between different dashboard tabs in embedded views. The implementation includes:

- Tab navigation UI with proper styling and active tab highlighting
- Filtering dashboard tiles based on the selected tab
- Handling legacy tiles (without tab assignment) by showing them on the first tab
- Empty tab state with appropriate messaging
- Automatic selection of the first tab when loading the dashboard

This enhancement ensures embedded dashboards maintain the same tab functionality as regular dashboards, providing a consistent user experience across both interfaces.