### PR TITLE
fix: split dbt installation into separate RUN commands

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -95,7 +95,7 @@ RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt\
     "dbt-bigquery~=1.9.0" \
     "dbt-databricks~=1.9.0" \
     "dbt-trino~=1.9.0" \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
+    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \ 
     && python3 -m venv /usr/local/dbt1.10 \
     && /usr/local/dbt1.10/bin/pip install \
     "dbt-core~=1.10.0" \
@@ -259,6 +259,7 @@ COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
 COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
 COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
 COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
+COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder /usr/app /usr/app
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
@@ -266,7 +267,8 @@ RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
     && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
     && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9
+    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
+    && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10
 
 
 # Run backend

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -95,7 +95,7 @@ RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt\
     "dbt-bigquery~=1.9.0" \
     "dbt-databricks~=1.9.0" \
     "dbt-trino~=1.9.0" \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
+    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \ 
     && python3 -m venv /usr/local/dbt1.10 \
     && /usr/local/dbt1.10/bin/pip install \
     "dbt-core~=1.10.0" \
@@ -259,6 +259,7 @@ COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
 COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
 COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
 COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
+COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder /usr/app /usr/app
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
@@ -266,7 +267,8 @@ RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
     && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
     && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9
+    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
+    && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10
 
 
 # Run backend


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Split the DBT installation commands in the Dockerfile to separate RUN instructions. This change improves build caching by separating the installation of DBT 1.9 and DBT 1.10 into distinct layers, which can help with more efficient rebuilds during development.