### PR TITLE
fix: update progress message and reorder single row result handling

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -71,11 +71,16 @@ export const getGenerateTableVizConfig = ({
                     vizTool,
                     maxLimit,
                 });
+                await updateProgress('✅ Done.');
 
                 isOneRow = results.rows.length === 1;
 
+                if (isOneRow) {
+                    return `Here's the result:
+${serializeData(csv, 'csv')}`;
+                }
+
                 if (isSlackPrompt(prompt)) {
-                    await updateProgress('✅ Done.');
                     await sendFile({
                         channelId: prompt.slackChannelId,
                         threadTs: prompt.slackThreadTs,
@@ -85,11 +90,6 @@ export const getGenerateTableVizConfig = ({
                         filename: 'lightdash-query-results.csv',
                         file: Buffer.from(csv, 'utf8'),
                     });
-                }
-
-                if (isOneRow) {
-                    return `Here's the result:
-${serializeData(csv, 'csv')}`;
                 }
 
                 return `Success.`;


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/15783

### Description:
Reordered the progress update and result handling in the `generateTableVizConfig` tool:

1. Added "Done" progress update before checking if the result is a single row
2. Moved the single row result handling before the Slack-specific logic
3. This ensures proper progress updates are shown regardless of the result type and improves the flow of the code