### PR TITLE
chore: remove AsyncQueryService depencency on CsvService

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -236,7 +236,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     storageClient: clients.getResultsFileStorageClient(),
-                    csvService: repository.getCsvService(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/ee/services/ai/tools/generateOneLineResult.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateOneLineResult.ts
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
-import { CsvService } from '../../../../services/CsvService/CsvService';
+import { CsvTransformer } from '../../../../services/CsvService/CsvTransformer';
 import type {
     GetExploreFn,
     GetPromptFn,
@@ -84,7 +84,7 @@ Rules for fetching the result:
                     ? Object.keys(results.rows[0])
                     : [];
                 const rows = results.rows.map((row) =>
-                    CsvService.convertRowToCsv(
+                    CsvTransformer.convertRowToCsv(
                         row,
                         results.fields,
                         true,

--- a/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
@@ -5,7 +5,7 @@ import {
     ToolTableVizArgsTransformed,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify/sync';
-import { CsvService } from '../../../../services/CsvService/CsvService';
+import { CsvTransformer } from '../../../../services/CsvService/CsvTransformer';
 import { ProjectService } from '../../../../services/ProjectService/ProjectService';
 
 export const renderTableViz = async ({
@@ -35,7 +35,7 @@ export const renderTableViz = async ({
 
     const fields = results.rows[0] ? Object.keys(results.rows[0]) : [];
     const rows = results.rows.map((row) =>
-        CsvService.convertRowToCsv(row, results.fields, true, fields),
+        CsvTransformer.convertRowToCsv(row, results.fields, true, fields),
     );
 
     return {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -164,7 +164,6 @@ const getMockedAsyncQueryService = (lightdashConfig: LightdashConfig) =>
                 return readable;
             }),
         } as unknown as S3ResultsFileStorageClient,
-        csvService: {} as CsvService,
     });
 
 describe('AsyncQueryService', () => {

--- a/packages/backend/src/services/CsvService/CsvTransformer.test.ts
+++ b/packages/backend/src/services/CsvService/CsvTransformer.test.ts
@@ -1,0 +1,147 @@
+import moment from 'moment';
+import { itemMap } from './CsvService.mock';
+import { CsvTransformer } from './CsvTransformer';
+
+describe('CsvTransformer', () => {
+    describe('convertRowToCsv', () => {
+        it('Should convert rows to csv', async () => {
+            const row = {
+                column_number: 1,
+                column_string: `value_1`,
+                column_date: '2020-03-16T11:32:55.000Z',
+            };
+
+            const csv = CsvTransformer.convertRowToCsv(row, itemMap, false, [
+                'column_number',
+                'column_string',
+                'column_date',
+            ]);
+
+            expect(csv).toEqual(['$1.00', 'value_1', '2020-03-16']);
+        });
+
+        it('Should convert RAW rows to csv', async () => {
+            const row = {
+                column_number: 1,
+                column_string: `value_1`,
+                column_date: '2020-03-16T11:32:55.000Z',
+            };
+
+            const csv = CsvTransformer.convertRowToCsv(row, itemMap, true, [
+                'column_number',
+                'column_string',
+                'column_date',
+            ]);
+
+            expect(csv).toEqual([1, 'value_1', '2020-03-16']);
+        });
+
+        it('Should convert with row with null date', async () => {
+            const row = {
+                column_number: 1,
+                column_string: `value_1`,
+                column_date: null,
+            };
+
+            const csv = CsvTransformer.convertRowToCsv(row, itemMap, false, [
+                'column_number',
+                'column_string',
+                'column_date',
+            ]);
+
+            expect(csv).toEqual(['$1.00', 'value_1', null]);
+        });
+
+        it('Should convert with row with undefined value', async () => {
+            const row = {
+                column_number: undefined,
+                column_string: `value_1`,
+                column_date: '2020-03-16T11:32:55.000Z',
+            };
+
+            const csv = CsvTransformer.convertRowToCsv(row, itemMap, false, [
+                'column_number',
+                'column_string',
+                'column_date',
+            ]);
+
+            expect(csv).toEqual([undefined, 'value_1', '2020-03-16']);
+        });
+
+        it('Should preserve milliseconds when converting timestamp rows to csv', async () => {
+            const row = {
+                column_number: 1,
+                column_string: `value_1`,
+                column_timestamp: '2020-03-16T11:32:55.123Z',
+            };
+
+            const csv = CsvTransformer.convertRowToCsv(row, itemMap, false, [
+                'column_number',
+                'column_string',
+                'column_timestamp',
+            ]);
+
+            expect(csv).toEqual([
+                '$1.00',
+                'value_1',
+                '2020-03-16 11:32:55.123',
+            ]);
+        });
+    });
+
+    describe('escapeCsvValue', () => {
+        it('Should escape CSV values correctly', () => {
+            expect(CsvTransformer.escapeCsvValue('normal text')).toBe(
+                '"normal text"',
+            );
+            expect(CsvTransformer.escapeCsvValue('text with "quotes"')).toBe(
+                '"text with ""quotes"""',
+            );
+            expect(CsvTransformer.escapeCsvValue(null)).toBe('');
+            expect(CsvTransformer.escapeCsvValue(undefined)).toBe('');
+            expect(CsvTransformer.escapeCsvValue(123)).toBe('"123"');
+            expect(CsvTransformer.escapeCsvValue('')).toBe('""');
+        });
+    });
+
+    describe('processJsonLineToCsv', () => {
+        it('Should process valid JSON line to CSV', () => {
+            const jsonLine = JSON.stringify({
+                column_number: 1,
+                column_string: 'test',
+                column_date: '2020-03-16T11:32:55.000Z',
+            });
+
+            const result = CsvTransformer.processJsonLineToCsv(
+                jsonLine,
+                itemMap,
+                false,
+                ['column_number', 'column_string', 'column_date'],
+            );
+
+            expect(result).toBe('"$1.00","test","2020-03-16"');
+        });
+
+        it('Should return null for empty lines', () => {
+            const result = CsvTransformer.processJsonLineToCsv(
+                '',
+                itemMap,
+                false,
+                ['column_number'],
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('Should return null for invalid JSON', () => {
+            const result = CsvTransformer.processJsonLineToCsv(
+                'invalid json',
+                itemMap,
+                false,
+                ['column_number'],
+            );
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/packages/backend/src/services/CsvService/CsvTransformer.ts
+++ b/packages/backend/src/services/CsvService/CsvTransformer.ts
@@ -1,0 +1,159 @@
+import {
+    AnyType,
+    DimensionType,
+    formatItemValue,
+    getErrorMessage,
+    isField,
+    ItemsMap,
+} from '@lightdash/common';
+import moment from 'moment';
+import { Readable, Writable } from 'stream';
+import Logger from '../../logging/logger';
+
+export class CsvTransformer {
+    /**
+     * Helper method to escape CSV values
+     */
+    static escapeCsvValue(value: AnyType): string {
+        if (value === null || value === undefined) return '';
+        return `"${String(value).replace(/"/g, '""')}"`;
+    }
+
+    /**
+     * Helper method to process a single JSON line to CSV
+     */
+    static processJsonLineToCsv(
+        line: string,
+        itemMap: ItemsMap,
+        onlyRaw: boolean,
+        sortedFieldIds: string[],
+    ): string | null {
+        if (!line.trim()) return null;
+
+        try {
+            const jsonRow = JSON.parse(line.trim());
+            const csvRow = CsvTransformer.convertRowToCsv(
+                jsonRow,
+                itemMap,
+                onlyRaw,
+                sortedFieldIds,
+            );
+
+            return csvRow.map(CsvTransformer.escapeCsvValue).join(',');
+        } catch (error) {
+            Logger.debug(`Skipping invalid JSON line: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Convert a single row to CSV format
+     */
+    static convertRowToCsv(
+        row: Record<string, AnyType>,
+        itemMap: ItemsMap,
+        onlyRaw: boolean,
+        sortedFieldIds: string[],
+    ) {
+        return sortedFieldIds.map((id: string) => {
+            const data = row[id];
+            const item = itemMap[id];
+
+            if (data === null || data === undefined) {
+                return data;
+            }
+
+            const itemIsField = isField(item);
+            if (itemIsField && item.type === DimensionType.TIMESTAMP) {
+                return moment(data).format('YYYY-MM-DD HH:mm:ss.SSS');
+            }
+            if (itemIsField && item.type === DimensionType.DATE) {
+                return moment(data).format('YYYY-MM-DD');
+            }
+
+            // Return raw value and let csv-stringify handle the rest
+            if (onlyRaw) return data;
+
+            // Use standard Lightdash formatting based on the item formatting configuration
+            return formatItemValue(item, data);
+        });
+    }
+
+    /**
+     * Stream JSONL data to CSV file with proper streaming patterns
+     * Processes data row-by-row to minimize memory usage
+     */
+    static async streamJsonlRowsToFile(
+        onlyRaw: boolean,
+        itemMap: ItemsMap,
+        sortedFieldIds: string[],
+        csvHeader: string[],
+        {
+            readStream,
+            writeStream,
+        }: { readStream: Readable; writeStream: Writable },
+    ): Promise<{ truncated: boolean }> {
+        return new Promise((resolve, reject) => {
+            // Write CSV header with BOM immediately
+            const headerWithBOM = Buffer.concat([
+                Buffer.from('\uFEFF', 'utf8'),
+                Buffer.from(`${csvHeader.join(',')}\n`, 'utf8'),
+            ]);
+            writeStream.write(headerWithBOM);
+
+            let lineBuffer = '';
+            let rowCount = 0;
+
+            readStream.on('data', (chunk: Buffer) => {
+                lineBuffer += chunk.toString();
+                const lines = lineBuffer.split('\n');
+
+                // Keep last incomplete line in buffer
+                lineBuffer = lines.pop() || '';
+
+                // Process complete lines
+                for (const line of lines) {
+                    const csvString = CsvTransformer.processJsonLineToCsv(
+                        line,
+                        itemMap,
+                        onlyRaw,
+                        sortedFieldIds,
+                    );
+
+                    if (csvString) {
+                        writeStream.write(`${csvString}\n`);
+                        rowCount += 1;
+                    }
+                }
+            });
+
+            readStream.on('end', () => {
+                // Process any remaining line in buffer
+                const csvString = CsvTransformer.processJsonLineToCsv(
+                    lineBuffer,
+                    itemMap,
+                    onlyRaw,
+                    sortedFieldIds,
+                );
+
+                if (csvString) {
+                    writeStream.write(`${csvString}\n`);
+                    rowCount += 1;
+                }
+
+                Logger.debug(
+                    `streamJsonlRowsToFile: Processed ${rowCount} rows successfully`,
+                );
+                resolve({ truncated: false });
+            });
+
+            readStream.on('error', (error) => {
+                Logger.error(
+                    'streamJsonlRowsToFile: Read stream error:',
+                    error,
+                );
+                reject(error);
+            });
+        });
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -265,6 +265,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     projectService: this.getProjectService(),
+                    asyncQueryService: this.getAsyncQueryService(),
                     userModel: this.models.getUserModel(),
                     s3Client: this.clients.getS3Client(),
                     dashboardModel: this.models.getDashboardModel(),
@@ -508,7 +509,6 @@ export class ServiceRepository
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
                     storageClient: this.clients.getResultsFileStorageClient(),
-                    csvService: this.getCsvService(),
                 }),
         );
     }

--- a/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
+++ b/packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts
@@ -83,6 +83,33 @@ export function generateGenericFileId({
 }
 
 /**
+ * Generates a CSV file ID with the standard naming convention
+ */
+export function generateCsvFileId(
+    fileName: string,
+    truncated: boolean = false,
+    time: moment.Moment = moment(),
+): string {
+    return generateGenericFileId({
+        fileName,
+        fileExtension: DownloadFileType.CSV,
+        truncated,
+        time,
+    });
+}
+
+/**
+ * Validates if a file ID follows the CSV naming convention
+ */
+export function isValidCsvFileId(fileId: string): boolean {
+    // Updated regex to allow Unicode characters, spaces, mixed case, and common punctuation
+    // This matches our new sanitizeGenericFileName approach
+    return /^csv-(incomplete_results-)?[^/\\:*?"<>|]+-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.csv$/.test(
+        fileId,
+    );
+}
+
+/**
  * Processes fields for file export, handling column ordering, filtering, and header generation
  * This utility is shared between CSV and Excel export services to avoid duplication
  */


### PR DESCRIPTION
### Description:

This is a WIP to show what it could look like to not have AsyncQueryService depend on CsvService. I was trying to do something that required the dependency to go the other way: CSV service would depend on the query service. 

But I ran into a place where the `downloadAsyncPivotTableCsv` method is super tightly coupled to the CsvService in a way that will be hard to untangle. And probably make things less clear. 

I'm looking for other alternatives
