### PR TITLE
feat: use JWT token in explores for React SDK

### DIFF
--- a/packages/backend/src/auth/lightdashJwt.test.ts
+++ b/packages/backend/src/auth/lightdashJwt.test.ts
@@ -125,12 +125,12 @@ describe('JwtUtil', () => {
             }
         });
 
-        it('should throw ParameterError for invalid tokens', () => {
+        it('should throw ForbiddenError for invalid tokens', () => {
             const invalidToken = 'invalid.token.here';
 
             expect(() => {
                 decodeLightdashJwt(invalidToken, encodedSecret);
-            }).toThrow(ParameterError);
+            }).toThrow(ForbiddenError);
         });
 
         it('should handle tokens with dashboard slug content', () => {

--- a/packages/backend/src/auth/lightdashJwt.ts
+++ b/packages/backend/src/auth/lightdashJwt.ts
@@ -5,7 +5,6 @@ import {
     ForbiddenError,
     getErrorMessage,
     isDashboardUuidContent,
-    ParameterError,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -88,11 +87,11 @@ export function decodeLightdashJwt(
             throw new ForbiddenError('Your embed token has expired.');
         }
         if (e instanceof JsonWebTokenError) {
-            throw new ParameterError(`Invalid embed token: ${e.message}`);
+            throw new ForbiddenError(`Invalid embed token: ${e.message}`);
         }
         if (e instanceof z.ZodError) {
             const zodErrors = e.issues.map((issue) => issue.message).join(', ');
-            throw new ParameterError(
+            throw new ForbiddenError(
                 `Token schema validation error: ${zodErrors}`,
             );
         }

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.test.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.test.ts
@@ -3,7 +3,6 @@ import {
     ForbiddenError,
     JWT_HEADER_NAME,
     Organization,
-    ParameterError,
 } from '@lightdash/common';
 import express from 'express';
 import { jwtAuthMiddleware } from './jwtAuthMiddleware';
@@ -163,22 +162,17 @@ describe('Embed Auth Middleware', () => {
                 mockNext,
             );
 
-            expect(mockResponse.status).toHaveBeenCalledWith(403);
-            expect(mockResponse.json).toHaveBeenCalledWith({
-                status: 'error',
-                message: forbiddenError.message,
-            });
-            expect(mockNext).not.toHaveBeenCalled();
+            expect(mockResponse.status).not.toHaveBeenCalled();
+            const [error] = mockNext.mock.calls[0];
+            expect(error).toBeInstanceOf(ForbiddenError);
+            expect(error.message).toBe('Your embed token has expired.');
         });
 
-        it('should return 403 ParameterError when token is invalid', async () => {
+        it('should return 403 ForbiddenError when token is invalid', async () => {
             mockRequest.headers = { [JWT_HEADER_NAME]: mockEmbedToken };
 
-            const parameterError = new ParameterError(
-                'Invalid embed token: malformed',
-            );
             decodeLightdashJwt.mockImplementation(() => {
-                throw parameterError;
+                throw new ForbiddenError('Invalid embed token: malformed');
             });
 
             await jwtAuthMiddleware(
@@ -187,12 +181,10 @@ describe('Embed Auth Middleware', () => {
                 mockNext,
             );
 
-            expect(mockResponse.status).toHaveBeenCalledWith(403);
-            expect(mockResponse.json).toHaveBeenCalledWith({
-                status: 'error',
-                message: parameterError.message,
-            });
-            expect(mockNext).not.toHaveBeenCalled();
+            expect(mockResponse.status).not.toHaveBeenCalled();
+            const [error] = mockNext.mock.calls[0];
+            expect(error).toBeInstanceOf(ForbiddenError);
+            expect(error.message).toBe('Invalid embed token: malformed');
         });
 
         it('should pass unexpected errors to next middleware', async () => {

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -384,6 +384,7 @@ interface DashboardChartTileMainProps
     canExportImages?: boolean;
     canExportPagePdf?: boolean;
     canDateZoom?: boolean;
+    onExplore?: (options: { chart: SavedChart }) => void;
 }
 
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
@@ -1341,6 +1342,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         resultsData,
         canExportCsv,
         canExportImages,
+        onExplore,
     } = props;
 
     const {
@@ -1358,6 +1360,15 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         [resultsData, fields],
     );
 
+    const handleExploreFromHere = useCallback(() => {
+        if (onExplore) {
+            onExplore({ chart });
+        }
+    }, [onExplore, chart]);
+
+    // FIXME: This is just a stub for CASL permissions in the next PR.
+    const isEmbeddedExploreEnabled = typeof onExplore === 'function';
+
     return (
         <TileBase
             title={title || chart.name || ''}
@@ -1368,8 +1379,17 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
             extraMenuItems={
                 canExportCsv ||
                 (canExportImages &&
-                    !isTableChartConfig(chart.chartConfig.config)) ? (
+                    !isTableChartConfig(chart.chartConfig.config)) ||
+                isEmbeddedExploreEnabled ? (
                     <>
+                        {isEmbeddedExploreEnabled && (
+                            <Menu.Item
+                                icon={<MantineIcon icon={IconTelescope} />}
+                                onClick={handleExploreFromHere}
+                            >
+                                Explore from here
+                            </Menu.Item>
+                        )}
                         {canExportCsv && (
                             <DashboardMinimalDownloadCsv
                                 explore={explore}
@@ -1413,6 +1433,7 @@ type DashboardChartTileProps = Omit<
     canExportImages?: boolean;
     dashboardChartReadyQuery?: DashboardChartReadyQuery;
     resultsData?: InfiniteQueryResults;
+    onExplore?: (options: { chart: SavedChart }) => void;
 };
 
 // Abstraction needed for enterprise version
@@ -1432,6 +1453,7 @@ export const GenericDashboardChartTile: FC<
     error,
     canExportCsv = false,
     canExportImages = false,
+    onExplore,
     ...rest
 }) => {
     const { projectUuid } = useParams<{
@@ -1525,6 +1547,7 @@ export const GenericDashboardChartTile: FC<
                     dashboardChartReadyQuery={dashboardChartReadyQuery}
                     canExportCsv={canExportCsv}
                     canExportImages={canExportImages}
+                    onExplore={onExplore}
                 />
             ) : (
                 <DashboardChartTileMain
@@ -1533,6 +1556,7 @@ export const GenericDashboardChartTile: FC<
                     isEditMode={isEditMode}
                     resultsData={resultsData}
                     dashboardChartReadyQuery={dashboardChartReadyQuery}
+                    onExplore={onExplore}
                 />
             )}
             <UnderlyingDataModal />

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -15,8 +15,9 @@ import {
 } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { memo, useCallback, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import { useExplores } from '../../../hooks/useExplores';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -42,16 +43,9 @@ const LoadingSkeleton = () => (
     </Stack>
 );
 
-const BasePanel = ({
-    projectUuid: propProjectUuid,
-}: {
-    projectUuid?: string;
-}) => {
+const BasePanel = () => {
     const navigate = useNavigate();
-    const { projectUuid: urlProjectUuid } = useParams<{
-        projectUuid: string;
-    }>();
-    const projectUuid = propProjectUuid || urlProjectUuid;
+    const projectUuid = useProjectUuid();
     const [search, setSearch] = useState<string>('');
     const exploresResult = useExplores(projectUuid, true);
 
@@ -226,36 +220,27 @@ const BasePanel = ({
     );
 };
 
-const ExploreSideBar = memo(
-    ({ projectUuid: propProjectUuid }: { projectUuid?: string }) => {
-        const { projectUuid: urlProjectUuid } = useParams<{
-            projectUuid: string;
-        }>();
-        const projectUuid = propProjectUuid || urlProjectUuid;
-        const tableName = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.tableName,
-        );
+const ExploreSideBar = memo(() => {
+    const projectUuid = useProjectUuid();
+    const tableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
+    );
 
-        const clearExplore = useExplorerContext(
-            (context) => context.actions.clearExplore,
-        );
-        const navigate = useNavigate();
+    const clearExplore = useExplorerContext(
+        (context) => context.actions.clearExplore,
+    );
+    const navigate = useNavigate();
 
-        const handleBack = useCallback(() => {
-            clearExplore();
-            void navigate(`/projects/${projectUuid}/tables`);
-        }, [clearExplore, navigate, projectUuid]);
+    const handleBack = useCallback(() => {
+        clearExplore();
+        void navigate(`/projects/${projectUuid}/tables`);
+    }, [clearExplore, navigate, projectUuid]);
 
-        return (
-            <TrackSection name={SectionName.SIDEBAR}>
-                {!tableName ? (
-                    <BasePanel projectUuid={projectUuid} />
-                ) : (
-                    <ExplorePanel onBack={handleBack} />
-                )}
-            </TrackSection>
-        );
-    },
-);
+    return (
+        <TrackSection name={SectionName.SIDEBAR}>
+            {!tableName ? <BasePanel /> : <ExplorePanel onBack={handleBack} />}
+        </TrackSection>
+    );
+});
 
 export default ExploreSideBar;

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -42,9 +42,16 @@ const LoadingSkeleton = () => (
     </Stack>
 );
 
-const BasePanel = () => {
+const BasePanel = ({
+    projectUuid: propProjectUuid,
+}: {
+    projectUuid?: string;
+}) => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid: urlProjectUuid } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuid = propProjectUuid || urlProjectUuid;
     const [search, setSearch] = useState<string>('');
     const exploresResult = useExplores(projectUuid, true);
 
@@ -219,27 +226,36 @@ const BasePanel = () => {
     );
 };
 
-const ExploreSideBar = memo(() => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
-    const tableName = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableName,
-    );
+const ExploreSideBar = memo(
+    ({ projectUuid: propProjectUuid }: { projectUuid?: string }) => {
+        const { projectUuid: urlProjectUuid } = useParams<{
+            projectUuid: string;
+        }>();
+        const projectUuid = propProjectUuid || urlProjectUuid;
+        const tableName = useExplorerContext(
+            (context) => context.state.unsavedChartVersion.tableName,
+        );
 
-    const clearExplore = useExplorerContext(
-        (context) => context.actions.clearExplore,
-    );
-    const navigate = useNavigate();
+        const clearExplore = useExplorerContext(
+            (context) => context.actions.clearExplore,
+        );
+        const navigate = useNavigate();
 
-    const handleBack = useCallback(() => {
-        clearExplore();
-        void navigate(`/projects/${projectUuid}/tables`);
-    }, [clearExplore, navigate, projectUuid]);
+        const handleBack = useCallback(() => {
+            clearExplore();
+            void navigate(`/projects/${projectUuid}/tables`);
+        }, [clearExplore, navigate, projectUuid]);
 
-    return (
-        <TrackSection name={SectionName.SIDEBAR}>
-            {!tableName ? <BasePanel /> : <ExplorePanel onBack={handleBack} />}
-        </TrackSection>
-    );
-});
+        return (
+            <TrackSection name={SectionName.SIDEBAR}>
+                {!tableName ? (
+                    <BasePanel projectUuid={projectUuid} />
+                ) : (
+                    <ExplorePanel onBack={handleBack} />
+                )}
+            </TrackSection>
+        );
+    },
+);
 
 export default ExploreSideBar;

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -15,6 +15,7 @@ import {
 import { Badge, Text, Tooltip } from '@mantine/core';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
+import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -26,7 +27,11 @@ import FiltersProvider from '../../common/Filters/FiltersProvider';
 import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';
 
 const FiltersCard: FC = memo(() => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid: projectUuidFromEmbed } = useEmbed();
+    const { projectUuid: projectUuidParams } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuid = projectUuidFromEmbed || projectUuidParams;
     const project = useProject(projectUuid);
     const expandedSections = useExplorerContext(
         (context) => context.state.expandedSections,

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -14,10 +14,9 @@ import {
 } from '@lightdash/common';
 import { Badge, Text, Tooltip } from '@mantine/core';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
-import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
@@ -27,11 +26,7 @@ import FiltersProvider from '../../common/Filters/FiltersProvider';
 import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';
 
 const FiltersCard: FC = memo(() => {
-    const { projectUuid: projectUuidFromEmbed } = useEmbed();
-    const { projectUuid: projectUuidParams } = useParams<{
-        projectUuid: string;
-    }>();
-    const projectUuid = projectUuidFromEmbed || projectUuidParams;
+    const projectUuid = useProjectUuid();
     const project = useProject(projectUuid);
     const expandedSections = useExplorerContext(
         (context) => context.state.expandedSections,

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -2,9 +2,8 @@ import { subject } from '@casl/ability';
 import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
-import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -21,11 +20,7 @@ import MantineIcon from '../../common/MantineIcon';
 import { ExplorerResults } from './ExplorerResults';
 
 const ResultsCard: FC = memo(() => {
-    const { projectUuid: projectUuidFromEmbed } = useEmbed();
-    const { projectUuid: projectUuidFromParams } = useParams<{
-        projectUuid: string;
-    }>();
-    const projectUuid = projectUuidFromParams || projectUuidFromEmbed;
+    const projectUuid = useProjectUuid();
     const isEditMode = useExplorerContext(
         (context) => context.state.isEditMode,
     );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -3,6 +3,7 @@ import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
+import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -20,6 +21,11 @@ import MantineIcon from '../../common/MantineIcon';
 import { ExplorerResults } from './ExplorerResults';
 
 const ResultsCard: FC = memo(() => {
+    const { projectUuid: projectUuidFromEmbed } = useEmbed();
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuid = projectUuidFromParams || projectUuidFromEmbed;
     const isEditMode = useExplorerContext(
         (context) => context.state.isEditMode,
     );
@@ -55,8 +61,6 @@ const ResultsCard: FC = memo(() => {
     );
 
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);
-
-    const { projectUuid } = useParams<{ projectUuid: string }>();
 
     const resultsIsOpen = useMemo(
         () => expandedSections.includes(ExplorerSection.RESULTS),

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -18,65 +18,69 @@ import SqlCard from './SqlCard/SqlCard';
 import VisualizationCard from './VisualizationCard/VisualizationCard';
 import { WriteBackModal } from './WriteBackModal';
 
-const Explorer: FC<{ hideHeader?: boolean }> = memo(
-    ({ hideHeader = false }) => {
-        const unsavedChartVersionTableName = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.tableName,
-        );
-        const unsavedChartVersionMetricQuery = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.metricQuery,
-        );
-        const isEditMode = useExplorerContext(
-            (context) => context.state.isEditMode,
-        );
-        const { projectUuid } = useParams<{ projectUuid: string }>();
+const Explorer: FC<{
+    hideHeader?: boolean;
+    projectUuid?: string;
+}> = memo(({ hideHeader = false, projectUuid: propProjectUuid }) => {
+    const unsavedChartVersionTableName = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.tableName,
+    );
+    const unsavedChartVersionMetricQuery = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.metricQuery,
+    );
+    const isEditMode = useExplorerContext(
+        (context) => context.state.isEditMode,
+    );
+    const { projectUuid: urlProjectUuid } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuid = propProjectUuid || urlProjectUuid;
 
-        const queryUuid = useExplorerContext(
-            (context) => context.query?.data?.queryUuid,
-        );
+    const queryUuid = useExplorerContext(
+        (context) => context.query?.data?.queryUuid,
+    );
 
-        const { data: explore } = useExplore(unsavedChartVersionTableName);
+    const { data: explore } = useExplore(unsavedChartVersionTableName);
 
-        const { data: { parameterReferences } = {} } = useCompiledSql({
-            enabled: !!unsavedChartVersionTableName,
-        });
+    return (
+        <MetricQueryDataProvider
+            metricQuery={unsavedChartVersionMetricQuery}
+            tableName={unsavedChartVersionTableName}
+            explore={explore}
+            queryUuid={queryUuid}
+        >
+            <Stack sx={{ flexGrow: 1 }}>
+                {!hideHeader && isEditMode && <ExplorerHeader />}
 
-        return (
-            <MetricQueryDataProvider
-                metricQuery={unsavedChartVersionMetricQuery}
-                tableName={unsavedChartVersionTableName}
-                explore={explore}
-                queryUuid={queryUuid}
-            >
-                <Stack sx={{ flexGrow: 1 }}>
-                    {!hideHeader && isEditMode && <ExplorerHeader />}
+                <FiltersCard />
+                {!!unsavedChartVersionTableName &&
+                    parameterReferences &&
+                    parameterReferences?.length > 0 && (
+                        <ParametersCard
+                            parameterReferences={parameterReferences}
+                        />
+                    )}
 
-                    {!!unsavedChartVersionTableName &&
-                        parameterReferences &&
-                        parameterReferences?.length > 0 && (
-                            <ParametersCard
-                                parameterReferences={parameterReferences}
-                            />
-                        )}
+                <FiltersCard />
 
-                    <FiltersCard />
+                <VisualizationCard
+                    projectUuid={projectUuid}
+                    isProjectPreview={isProjectPreview}
+                />
 
-                    <VisualizationCard projectUuid={projectUuid} />
+                <ResultsCard />
 
-                    <ResultsCard />
+                {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
+            </Stack>
 
-                    {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
-                </Stack>
-
-                <UnderlyingDataModal />
-                <DrillDownModal />
-                <CustomMetricModal />
-                <CustomDimensionModal />
-                <FormatModal />
-                <WriteBackModal />
-            </MetricQueryDataProvider>
-        );
-    },
-);
+            <UnderlyingDataModal />
+            <DrillDownModal />
+            <CustomMetricModal />
+            <CustomDimensionModal />
+            <FormatModal />
+            <WriteBackModal />
+        </MetricQueryDataProvider>
+    );
+});
 
 export default Explorer;

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,8 +1,8 @@
 import { Stack } from '@mantine/core';
 import { memo, type FC } from 'react';
-import { useParams } from 'react-router';
 import { useCompiledSql } from '../../hooks/useCompiledSql';
 import { useExplore } from '../../hooks/useExplore';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useExplorerContext from '../../providers/Explorer/useExplorerContext';
 import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
@@ -18,69 +18,65 @@ import SqlCard from './SqlCard/SqlCard';
 import VisualizationCard from './VisualizationCard/VisualizationCard';
 import { WriteBackModal } from './WriteBackModal';
 
-const Explorer: FC<{
-    hideHeader?: boolean;
-    projectUuid?: string;
-}> = memo(({ hideHeader = false, projectUuid: propProjectUuid }) => {
-    const unsavedChartVersionTableName = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableName,
-    );
-    const unsavedChartVersionMetricQuery = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.metricQuery,
-    );
-    const isEditMode = useExplorerContext(
-        (context) => context.state.isEditMode,
-    );
-    const { projectUuid: urlProjectUuid } = useParams<{
-        projectUuid: string;
-    }>();
-    const projectUuid = propProjectUuid || urlProjectUuid;
+const Explorer: FC<{ hideHeader?: boolean }> = memo(
+    ({ hideHeader = false }) => {
+        const unsavedChartVersionTableName = useExplorerContext(
+            (context) => context.state.unsavedChartVersion.tableName,
+        );
+        const unsavedChartVersionMetricQuery = useExplorerContext(
+            (context) => context.state.unsavedChartVersion.metricQuery,
+        );
+        const isEditMode = useExplorerContext(
+            (context) => context.state.isEditMode,
+        );
+        const projectUuid = useProjectUuid();
 
-    const queryUuid = useExplorerContext(
-        (context) => context.query?.data?.queryUuid,
-    );
+        const queryUuid = useExplorerContext(
+            (context) => context.query?.data?.queryUuid,
+        );
 
-    const { data: explore } = useExplore(unsavedChartVersionTableName);
+        const { data: explore } = useExplore(unsavedChartVersionTableName);
 
-    return (
-        <MetricQueryDataProvider
-            metricQuery={unsavedChartVersionMetricQuery}
-            tableName={unsavedChartVersionTableName}
-            explore={explore}
-            queryUuid={queryUuid}
-        >
-            <Stack sx={{ flexGrow: 1 }}>
-                {!hideHeader && isEditMode && <ExplorerHeader />}
+        const { data: { parameterReferences } = {} } = useCompiledSql({
+            enabled: !!unsavedChartVersionTableName,
+        });
 
-                <FiltersCard />
-                {!!unsavedChartVersionTableName &&
-                    parameterReferences &&
-                    parameterReferences?.length > 0 && (
-                        <ParametersCard
-                            parameterReferences={parameterReferences}
-                        />
-                    )}
+        return (
+            <MetricQueryDataProvider
+                metricQuery={unsavedChartVersionMetricQuery}
+                tableName={unsavedChartVersionTableName}
+                explore={explore}
+                queryUuid={queryUuid}
+            >
+                <Stack sx={{ flexGrow: 1 }}>
+                    {!hideHeader && isEditMode && <ExplorerHeader />}
 
-                <FiltersCard />
+                    {!!unsavedChartVersionTableName &&
+                        parameterReferences &&
+                        parameterReferences?.length > 0 && (
+                            <ParametersCard
+                                parameterReferences={parameterReferences}
+                            />
+                        )}
 
-                <VisualizationCard
-                    projectUuid={projectUuid}
-                    isProjectPreview={isProjectPreview}
-                />
+                    <FiltersCard />
 
-                <ResultsCard />
+                    <VisualizationCard projectUuid={projectUuid} />
 
-                {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
-            </Stack>
+                    <ResultsCard />
 
-            <UnderlyingDataModal />
-            <DrillDownModal />
-            <CustomMetricModal />
-            <CustomDimensionModal />
-            <FormatModal />
-            <WriteBackModal />
-        </MetricQueryDataProvider>
-    );
-});
+                    {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
+                </Stack>
+
+                <UnderlyingDataModal />
+                <DrillDownModal />
+                <CustomMetricModal />
+                <CustomDimensionModal />
+                <FormatModal />
+                <WriteBackModal />
+            </MetricQueryDataProvider>
+        );
+    },
+);
 
 export default Explorer;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -34,7 +34,6 @@ const EmbedDashboardGrid: FC<{
     layouts: { lg: Layout[] };
     dashboard: any;
     projectUuid: string;
-    embedToken: string;
     hasRequiredDashboardFiltersToSet: boolean;
     isTabEmpty?: boolean;
 }> = ({
@@ -42,7 +41,6 @@ const EmbedDashboardGrid: FC<{
     layouts,
     dashboard,
     projectUuid,
-    embedToken,
     hasRequiredDashboardFiltersToSet,
     isTabEmpty,
 }) => (
@@ -73,7 +71,6 @@ const EmbedDashboardGrid: FC<{
                             <EmbedDashboardChartTile
                                 projectUuid={projectUuid}
                                 dashboardSlug={dashboard.slug}
-                                embedToken={embedToken}
                                 key={tile.uuid}
                                 minimal
                                 tile={tile}
@@ -189,10 +186,8 @@ const EmbedDashboard: FC<{
         throw new Error('Embed token is required');
     }
 
-    const { data: dashboard, error: dashboardError } = useEmbedDashboard(
-        projectUuid,
-        embedToken,
-    );
+    const { data: dashboard, error: dashboardError } =
+        useEmbedDashboard(projectUuid);
 
     const setEmbedDashboard = useDashboardContext((c) => c.setEmbedDashboard);
     useEffect(() => {
@@ -368,21 +363,16 @@ const EmbedDashboard: FC<{
                             </Tabs.Tab>
                         ))}
                     </Tabs.List>
-                    <Group pos="relative">
-                        {' '}
-                        {/* required to respect the position inside the Embed SDK */}
-                        <EmbedDashboardGrid
-                            filteredTiles={filteredTiles}
-                            layouts={layouts}
-                            dashboard={dashboard}
-                            projectUuid={projectUuid}
-                            embedToken={embedToken}
-                            hasRequiredDashboardFiltersToSet={
-                                hasRequiredDashboardFiltersToSet
-                            }
-                            isTabEmpty={isTabEmpty}
-                        />
-                    </Group>
+                    <EmbedDashboardGrid
+                        filteredTiles={filteredTiles}
+                        layouts={layouts}
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                        hasRequiredDashboardFiltersToSet={
+                            hasRequiredDashboardFiltersToSet
+                        }
+                        isTabEmpty={isTabEmpty}
+                    />
                 </Tabs>
             ) : (
                 <EmbedDashboardGrid
@@ -390,7 +380,6 @@ const EmbedDashboard: FC<{
                     layouts={layouts}
                     dashboard={dashboard}
                     projectUuid={projectUuid}
-                    embedToken={embedToken}
                     hasRequiredDashboardFiltersToSet={
                         hasRequiredDashboardFiltersToSet
                     }

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -13,7 +13,6 @@ import { useEmbedChartAndResults } from '../hooks';
 type Props = ComponentProps<typeof DashboardChartTile> & {
     projectUuid: string;
     dashboardSlug: string;
-    embedToken: string;
     locked: boolean;
     tileIndex: number;
 };
@@ -21,7 +20,6 @@ type Props = ComponentProps<typeof DashboardChartTile> & {
 const EmbedDashboardChartTile: FC<Props> = ({
     projectUuid,
     dashboardSlug,
-    embedToken,
     locked,
     canExportCsv,
     canExportImages,
@@ -35,7 +33,6 @@ const EmbedDashboardChartTile: FC<Props> = ({
 
     const { isLoading, data, error } = useEmbedChartAndResults(
         projectUuid,
-        embedToken,
         tile.uuid,
     );
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -31,7 +31,7 @@ const EmbedDashboardChartTile: FC<Props> = ({
     tileIndex,
     ...rest
 }) => {
-    const { languageMap } = useEmbed();
+    const { languageMap, onExplore } = useEmbed();
 
     const { isLoading, data, error } = useEmbedChartAndResults(
         projectUuid,
@@ -137,6 +137,7 @@ const EmbedDashboardChartTile: FC<Props> = ({
             resultsData={resultData}
             dashboardChartReadyQuery={query}
             error={error}
+            onExplore={onExplore}
         />
     );
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
@@ -10,21 +10,17 @@ import useDashboardFiltersForTile from '../../../../hooks/dashboard/useDashboard
 import useDashboardContext from '../../../../providers/Dashboard/useDashboardContext';
 import { postEmbedChartAndResults, postEmbedDashboard } from './api';
 
-export const useEmbedDashboard = (
-    projectUuid: string | undefined,
-    embedToken: string | undefined,
-) => {
+export const useEmbedDashboard = (projectUuid: string | undefined) => {
     return useQuery<Dashboard & InteractivityOptions, ApiError>({
         queryKey: ['embed-dashboard'],
         queryFn: () => postEmbedDashboard(projectUuid!),
-        enabled: !!embedToken && !!projectUuid,
+        enabled: !!projectUuid,
         retry: false,
     });
 };
 
 export const useEmbedChartAndResults = (
     projectUuid: string,
-    embedToken: string | undefined,
     tileUuid: string,
 ) => {
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
@@ -50,7 +46,7 @@ export const useEmbedChartAndResults = (
                 dateZoomGranularity,
                 dashboardSorts,
             ),
-        enabled: !!embedToken,
+        enabled: !!projectUuid,
         retry: false,
     });
 };

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -19,6 +19,62 @@ const themeOverride: MantineThemeOverride = {
     }),
 };
 
+const getInitialState = (exploreId: string, savedChart: SavedChart) => ({
+    parameters: {},
+    shouldFetchResults: true,
+    expandedSections: [
+        ExplorerSection.FILTERS,
+        ExplorerSection.VISUALIZATION,
+        ExplorerSection.RESULTS,
+    ],
+    unsavedChartVersion: {
+        tableName: exploreId,
+        metricQuery: savedChart?.metricQuery || {
+            exploreName: exploreId,
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            timezone: undefined,
+        },
+        chartConfig: savedChart?.chartConfig || {
+            type: ChartType.CARTESIAN,
+            config: {
+                layout: {
+                    xField: '',
+                    yField: [],
+                },
+                eChartsConfig: {
+                    series: [],
+                },
+            },
+        },
+        tableConfig: savedChart?.tableConfig || {
+            columnOrder: [],
+        },
+        pivotConfig: savedChart?.pivotConfig || {
+            columns: [],
+        },
+    },
+    modals: {
+        format: {
+            isOpen: false,
+        },
+        additionalMetric: {
+            isOpen: false,
+        },
+        customDimension: {
+            isOpen: false,
+        },
+        writeBack: {
+            isOpen: false,
+        },
+    },
+});
+
 type Props = {
     containerStyles?: React.CSSProperties;
     exploreId: string;
@@ -63,70 +119,17 @@ const EmbedExplore: FC<Props> = ({
                 isEditMode={true}
                 projectUuid={projectUuid}
                 savedChart={savedChart}
-                initialState={{
-                    shouldFetchResults: true,
-                    expandedSections: [
-                        ExplorerSection.FILTERS,
-                        ExplorerSection.VISUALIZATION,
-                        ExplorerSection.RESULTS,
-                    ],
-                    unsavedChartVersion: {
-                        tableName: exploreId,
-                        metricQuery: savedChart?.metricQuery || {
-                            exploreName: exploreId,
-                            dimensions: [],
-                            metrics: [],
-                            filters: {},
-                            sorts: [],
-                            limit: 500,
-                            tableCalculations: [],
-                            additionalMetrics: [],
-                            timezone: undefined,
-                        },
-                        chartConfig: savedChart?.chartConfig || {
-                            type: ChartType.CARTESIAN,
-                            config: {
-                                layout: {
-                                    xField: '',
-                                    yField: [],
-                                },
-                                eChartsConfig: {
-                                    series: [],
-                                },
-                            },
-                        },
-                        tableConfig: savedChart?.tableConfig || {
-                            columnOrder: [],
-                        },
-                        pivotConfig: savedChart?.pivotConfig || {
-                            columns: [],
-                        },
-                    },
-                    modals: {
-                        format: {
-                            isOpen: false,
-                        },
-                        additionalMetric: {
-                            isOpen: false,
-                        },
-                        customDimension: {
-                            isOpen: false,
-                        },
-                        writeBack: {
-                            isOpen: false,
-                        },
-                    },
-                }}
+                initialState={getInitialState(exploreId, savedChart)}
                 defaultLimit={500}
             >
                 <MantineProvider inherit theme={themeOverride}>
                     <Page
                         title={data ? data?.label : 'Tables'}
-                        sidebar={<ExploreSideBar projectUuid={projectUuid} />}
+                        sidebar={<ExploreSideBar />}
                         withFullHeight
                         withPaddedContent
                     >
-                        <Explorer projectUuid={projectUuid} />
+                        <Explorer />
                     </Page>
                 </MantineProvider>
             </ExplorerProvider>

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -1,0 +1,137 @@
+import { ChartType, type SavedChart } from '@lightdash/common';
+import { MantineProvider, type MantineThemeOverride } from '@mantine/core';
+import { IconUnlink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Page from '../../../../../components/common/Page/Page';
+import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import Explorer from '../../../../../components/Explorer';
+import ExploreSideBar from '../../../../../components/Explorer/ExploreSideBar';
+import { useExplore } from '../../../../../hooks/useExplore';
+import ExplorerProvider from '../../../../../providers/Explorer/ExplorerProvider';
+import { ExplorerSection } from '../../../../../providers/Explorer/types';
+import useEmbed from '../../../../providers/Embed/useEmbed';
+
+const themeOverride: MantineThemeOverride = {
+    globalStyles: () => ({
+        'html, body': {
+            backgroundColor: 'white',
+        },
+    }),
+};
+
+type Props = {
+    containerStyles?: React.CSSProperties;
+    exploreId: string;
+    savedChart: SavedChart;
+};
+
+const EmbedExplore: FC<Props> = ({
+    containerStyles,
+    exploreId,
+    savedChart,
+}) => {
+    const { projectUuid } = useEmbed();
+    const { data, error: exploreError } = useExplore(exploreId);
+
+    if (!projectUuid) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState title="Missing project UUID" />
+            </div>
+        );
+    }
+
+    if (exploreError) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState
+                    title="Error loading explore"
+                    icon={IconUnlink}
+                    description={
+                        exploreError.error.message.includes('jwt expired')
+                            ? 'This embed link has expired'
+                            : exploreError.error.message
+                    }
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div style={containerStyles ?? { height: '100vh', overflowY: 'auto' }}>
+            <ExplorerProvider
+                isEditMode={true}
+                projectUuid={projectUuid}
+                savedChart={savedChart}
+                initialState={{
+                    shouldFetchResults: true,
+                    expandedSections: [
+                        ExplorerSection.FILTERS,
+                        ExplorerSection.VISUALIZATION,
+                        ExplorerSection.RESULTS,
+                    ],
+                    unsavedChartVersion: {
+                        tableName: exploreId,
+                        metricQuery: savedChart?.metricQuery || {
+                            exploreName: exploreId,
+                            dimensions: [],
+                            metrics: [],
+                            filters: {},
+                            sorts: [],
+                            limit: 500,
+                            tableCalculations: [],
+                            additionalMetrics: [],
+                            timezone: undefined,
+                        },
+                        chartConfig: savedChart?.chartConfig || {
+                            type: ChartType.CARTESIAN,
+                            config: {
+                                layout: {
+                                    xField: '',
+                                    yField: [],
+                                },
+                                eChartsConfig: {
+                                    series: [],
+                                },
+                            },
+                        },
+                        tableConfig: savedChart?.tableConfig || {
+                            columnOrder: [],
+                        },
+                        pivotConfig: savedChart?.pivotConfig || {
+                            columns: [],
+                        },
+                    },
+                    modals: {
+                        format: {
+                            isOpen: false,
+                        },
+                        additionalMetric: {
+                            isOpen: false,
+                        },
+                        customDimension: {
+                            isOpen: false,
+                        },
+                        writeBack: {
+                            isOpen: false,
+                        },
+                    },
+                }}
+                defaultLimit={500}
+            >
+                <MantineProvider inherit theme={themeOverride}>
+                    <Page
+                        title={data ? data?.label : 'Tables'}
+                        sidebar={<ExploreSideBar projectUuid={projectUuid} />}
+                        withFullHeight
+                        withPaddedContent
+                    >
+                        <Explorer projectUuid={projectUuid} />
+                    </Page>
+                </MantineProvider>
+            </ExplorerProvider>
+        </div>
+    );
+};
+
+export default EmbedExplore;

--- a/packages/frontend/src/ee/pages/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/pages/EmbedExplore.tsx
@@ -1,0 +1,57 @@
+import { type SavedChart } from '@lightdash/common';
+import { IconUnlink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import EmbedExplore from '../features/embed/EmbedExplore/components/EmbedExplore';
+import useEmbed from '../providers/Embed/useEmbed';
+
+const EmbedExplorePage: FC<{
+    containerStyles?: React.CSSProperties;
+    exploreId?: string;
+    savedChart?: SavedChart;
+}> = ({ containerStyles, exploreId, savedChart }) => {
+    const { embedToken } = useEmbed();
+
+    if (!embedToken) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState
+                    icon={IconUnlink}
+                    title="This embed link is not valid"
+                />
+            </div>
+        );
+    }
+
+    if (!exploreId) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState
+                    title="Missing explore ID"
+                    description="No explore ID provided"
+                />
+            </div>
+        );
+    }
+
+    if (!savedChart) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState
+                    title="Missing saved chart to explore"
+                    icon={IconUnlink}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <EmbedExplore
+            containerStyles={containerStyles}
+            exploreId={exploreId}
+            savedChart={savedChart}
+        />
+    );
+};
+
+export default EmbedExplorePage;

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -1,4 +1,4 @@
-import { type LanguageMap } from '@lightdash/common';
+import { type LanguageMap, type SavedChart } from '@lightdash/common';
 import { get } from 'lodash';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useAccount } from '../../../hooks/user/useAccount';
@@ -16,6 +16,8 @@ type Props = {
     filters?: SdkFilter[];
     projectUuid?: string;
     contentOverrides?: LanguageMap;
+    embedHeaders?: Record<string, string>;
+    onExplore?: (options: { chart: SavedChart }) => void;
 };
 
 const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
@@ -24,6 +26,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     filters,
     projectUuid,
     contentOverrides,
+    onExplore,
 }) => {
     const [isInitialized, setIsInitialized] = useState(false);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
@@ -55,6 +58,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             t: (input: string) => get(contentOverrides, input),
             projectUuid: embed?.projectUuid || projectUuid,
             languageMap: contentOverrides,
+            onExplore,
         };
     }, [
         embed?.projectUuid,
@@ -63,6 +67,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         filters,
         projectUuid,
         contentOverrides,
+        onExplore,
     ]);
 
     return (

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -1,12 +1,15 @@
+import { type SavedChart } from '@lightdash/common';
 import { createContext } from 'react';
 import { type EmbedContext } from './types';
 
 const EmbedProviderContext = createContext<EmbedContext>({
     embedToken: undefined,
     filters: undefined,
+    embedHeaders: undefined,
     projectUuid: undefined,
     languageMap: undefined,
     t: (_input: string) => undefined,
+    onExplore: (_options: { chart: SavedChart }) => {},
 });
 
 export default EmbedProviderContext;

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -5,7 +5,6 @@ import { type EmbedContext } from './types';
 const EmbedProviderContext = createContext<EmbedContext>({
     embedToken: undefined,
     filters: undefined,
-    embedHeaders: undefined,
     projectUuid: undefined,
     languageMap: undefined,
     t: (_input: string) => undefined,

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -1,4 +1,4 @@
-import { type LanguageMap } from '@lightdash/common';
+import { type LanguageMap, type SavedChart } from '@lightdash/common';
 import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 
 export const EMBED_KEY = 'lightdash-embed';
@@ -13,5 +13,6 @@ export interface EmbedContext {
     filters?: SdkFilter[];
     projectUuid?: string;
     languageMap?: LanguageMap;
+    onExplore?: (options: { chart: SavedChart }) => void;
     t: (input: string) => string | undefined;
 }

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -1,16 +1,29 @@
+import { type SavedChart } from '@lightdash/common';
 import { useContext } from 'react';
+import { useParams } from 'react-router';
 import EmbedProviderContext from './context';
 import { type EmbedContext } from './types';
 
 function useEmbed(): EmbedContext {
     const context = useContext(EmbedProviderContext);
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
+
+    if (context.projectUuid && projectUuidFromParams) {
+        throw new Error(
+            'Cannot use ?projectUuid=... in the URL and embed context at the same time',
+        );
+    }
 
     if (context === undefined) {
         return {
+            embedHeaders: undefined,
             embedToken: undefined,
             filters: undefined,
             projectUuid: undefined,
             languageMap: undefined,
+            onExplore: (_options: { chart: SavedChart }) => {},
             t: (_input: string) => undefined,
         };
     }

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -10,15 +10,18 @@ function useEmbed(): EmbedContext {
         projectUuid: string;
     }>();
 
-    if (context.projectUuid && projectUuidFromParams) {
+    if (
+        context.projectUuid &&
+        projectUuidFromParams &&
+        context.projectUuid !== projectUuidFromParams
+    ) {
         throw new Error(
-            'Cannot use ?projectUuid=... in the URL and embed context at the same time',
+            'Cannot have mismatching :projectUuid in the URL route path and embed context',
         );
     }
 
     if (context === undefined) {
         return {
-            embedHeaders: undefined,
             embedToken: undefined,
             filters: undefined,
             projectUuid: undefined,

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -1,20 +1,14 @@
 import { type ApiError, type ApiExploreResults } from '@lightdash/common';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
-import useEmbed from '../ee/providers/Embed/useEmbed';
+import { useProjectUuid } from './useProjectUuid';
 import useQueryError from './useQueryError';
 
-const getExplore = async (
-    projectUuid: string,
-    exploreId: string,
-    options: { headers?: Record<string, string> } = {},
-) => {
+const getExplore = async (projectUuid: string, exploreId: string) => {
     try {
         const t = await lightdashApi<ApiExploreResults>({
             url: `/projects/${projectUuid}/explores/${exploreId}`,
             method: 'GET',
-            headers: options.headers,
         });
         console.log('t', t);
         return t;
@@ -28,21 +22,13 @@ export const useExplore = (
     activeTableName: string | undefined,
     useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
 ) => {
-    const { projectUuid: embedProjectUuid, embedHeaders } = useEmbed();
-    const { projectUuid: projectUuidFromParams } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
     const setErrorResponse = useQueryError();
-
-    const projectUuid = projectUuidFromParams || embedProjectUuid;
 
     const queryKey = ['tables', activeTableName, projectUuid];
     return useQuery<ApiExploreResults, ApiError>({
         queryKey,
-        queryFn: () =>
-            getExplore(projectUuid!, activeTableName || '', {
-                headers: embedHeaders,
-            }),
+        queryFn: () => getExplore(projectUuid!, activeTableName || ''),
         enabled: !!activeTableName && !!projectUuid,
         onError: (result) => setErrorResponse(result),
         retry: false,

--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -2,26 +2,48 @@ import { type ApiError, type ApiExploreResults } from '@lightdash/common';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import useQueryError from './useQueryError';
 
-const getExplore = async (projectUuid: string, exploreId: string) =>
-    lightdashApi<ApiExploreResults>({
-        url: `/projects/${projectUuid}/explores/${exploreId}`,
-        method: 'GET',
-        body: undefined,
-    });
+const getExplore = async (
+    projectUuid: string,
+    exploreId: string,
+    options: { headers?: Record<string, string> } = {},
+) => {
+    try {
+        const t = await lightdashApi<ApiExploreResults>({
+            url: `/projects/${projectUuid}/explores/${exploreId}`,
+            method: 'GET',
+            headers: options.headers,
+        });
+        console.log('t', t);
+        return t;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+};
 
 export const useExplore = (
     activeTableName: string | undefined,
     useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
 ) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid: embedProjectUuid, embedHeaders } = useEmbed();
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
     const setErrorResponse = useQueryError();
+
+    const projectUuid = projectUuidFromParams || embedProjectUuid;
+
     const queryKey = ['tables', activeTableName, projectUuid];
     return useQuery<ApiExploreResults, ApiError>({
         queryKey,
-        queryFn: () => getExplore(projectUuid!, activeTableName || ''),
-        enabled: !!activeTableName,
+        queryFn: () =>
+            getExplore(projectUuid!, activeTableName || '', {
+                headers: embedHeaders,
+            }),
+        enabled: !!activeTableName && !!projectUuid,
         onError: (result) => setErrorResponse(result),
         retry: false,
         ...useQueryOptions,

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -27,9 +27,6 @@ const getEmbedFilterValues = async (options: {
     return lightdashApi<FieldValueSearchResult>({
         url: `/embed/${options.projectId}/filter/${options.filterId}/search`,
         method: 'POST',
-        headers: {
-            'Lightdash-Embed-Token': options.embedToken!,
-        },
         body: JSON.stringify({
             search: options.search,
             limit: MAX_AUTOCOMPLETE_RESULTS,

--- a/packages/frontend/src/hooks/useProjectUuid.ts
+++ b/packages/frontend/src/hooks/useProjectUuid.ts
@@ -1,0 +1,19 @@
+import { useParams } from 'react-router';
+
+import useEmbed from '../ee/providers/Embed/useEmbed';
+
+/**
+ * We have a couple ways to derive the projectUuid:
+ * - From the URL when logging in via the Lightdash app UI
+ * - From the embed context when logging in via the Lightdash SDK or embed URL
+ *
+ * We prioritize the URL over the embed context to facilitate the most use-cases.
+ */
+export function useProjectUuid() {
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
+    const { projectUuid: embedProjectUuid } = useEmbed();
+
+    return projectUuidFromParams || embedProjectUuid;
+}

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -10,29 +10,21 @@ import {
     type UseQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
-import useEmbed from '../ee/providers/Embed/useEmbed';
 import { useOrganization } from './organization/useOrganization';
 import useToaster from './toaster/useToaster';
 
-const getProjectsQuery = async (options?: {
-    headers?: Record<string, string>;
-    projectUuid?: string;
-}) =>
+const getProjectsQuery = async () =>
     lightdashApi<OrganizationProject[]>({
-        url: options?.projectUuid
-            ? `/org/projects?projectUuid=${options.projectUuid}`
-            : `/org/projects`,
+        url: `/org/projects`,
         method: 'GET',
-        headers: options?.headers,
     });
 
 export const useProjects = (
     useQueryOptions?: UseQueryOptions<OrganizationProject[], ApiError>,
 ) => {
-    const { embedHeaders, projectUuid } = useEmbed();
     return useQuery<OrganizationProject[], ApiError>({
         queryKey: ['projects'],
-        queryFn: () => getProjectsQuery({ headers: embedHeaders, projectUuid }),
+        queryFn: getProjectsQuery,
         ...useQueryOptions,
     });
 };

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -10,22 +10,29 @@ import {
     type UseQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import { useOrganization } from './organization/useOrganization';
 import useToaster from './toaster/useToaster';
 
-const getProjectsQuery = async () =>
+const getProjectsQuery = async (options?: {
+    headers?: Record<string, string>;
+    projectUuid?: string;
+}) =>
     lightdashApi<OrganizationProject[]>({
-        url: `/org/projects`,
+        url: options?.projectUuid
+            ? `/org/projects?projectUuid=${options.projectUuid}`
+            : `/org/projects`,
         method: 'GET',
-        body: undefined,
+        headers: options?.headers,
     });
 
 export const useProjects = (
     useQueryOptions?: UseQueryOptions<OrganizationProject[], ApiError>,
 ) => {
+    const { embedHeaders, projectUuid } = useEmbed();
     return useQuery<OrganizationProject[], ApiError>({
         queryKey: ['projects'],
-        queryFn: getProjectsQuery,
+        queryFn: () => getProjectsQuery({ headers: embedHeaders, projectUuid }),
         ...useQueryOptions,
     });
 };

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -849,6 +849,7 @@ const ExplorerProvider: FC<
             | { chartUuid: string; context?: string }
             | { chartUuid: string; chartVersionUuid: string };
         dateZoomGranularity?: DateGranularity;
+        projectUuid?: string;
     }>
 > = ({
     minimal = false,
@@ -859,6 +860,7 @@ const ExplorerProvider: FC<
     children,
     viewModeQueryArgs,
     dateZoomGranularity,
+    projectUuid: propProjectUuid,
 }) => {
     const defaultStateWithConfig = useMemo(
         () => ({
@@ -1381,7 +1383,10 @@ const ExplorerProvider: FC<
             minimal,
         ],
     );
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid: projectUuidFromParams } = useParams<{
+        projectUuid: string;
+    }>();
+    const projectUuid = propProjectUuid || projectUuidFromParams;
     const { remove: clearQueryResults } = query;
     const resetQueryResults = useCallback(() => {
         setValidQueryArgs(null);

--- a/packages/sdk-next-test-app/next.config.ts
+++ b/packages/sdk-next-test-app/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-    /* config options here */
+    turbopack: {
+        // Configure Turbopack to handle dynamic imports and Web Workers
+        rules: {
+            '*.worker.js': {
+                loaders: ['worker-loader'],
+                as: '*.worker.js',
+            },
+        },
+    },
 };
 
 export default nextConfig;

--- a/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
+++ b/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
@@ -1,17 +1,31 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { SavedChart } from '../../../../common/src';
 
 const LightdashDashboard = dynamic(
     () => import('@lightdash/sdk').then((Lightdash) => Lightdash.Dashboard),
     {
         ssr: false,
         // you can add a your custom loading component here
-        loading: () => <div>Loading...</div>,
+        loading: () => <div>Loading Dashboard...</div>,
+    },
+);
+
+const LighdashExplore = dynamic(
+    () => import('@lightdash/sdk').then((Lightdash) => Lightdash.Explore),
+    {
+        ssr: false,
+        loading: () => <div>Loading Explore...</div>,
     },
 );
 
 export default function YourCustomDashboard() {
+    const [chart, setChart] = useState<SavedChart>();
+    const instanceUrl = '<your-instance-url>';
+    const token = '<your-token>';
+
     return (
         <>
             <h3>sub page where your dashboard will be rendered</h3>
@@ -25,10 +39,25 @@ export default function YourCustomDashboard() {
                     overflow: 'auto',
                 }}
             >
-                <LightdashDashboard
-                    instanceUrl="<your-instance-url>"
-                    token="<your-token>"
-                />
+                {chart && (
+                    <button onClick={() => setChart(undefined)}>
+                        Go back to dashboard
+                    </button>
+                )}
+                {chart ? (
+                    <LighdashExplore
+                        instanceUrl={instanceUrl}
+                        token={token}
+                        exploreId={chart?.tableName}
+                        savedChart={chart}
+                    />
+                ) : (
+                    <LightdashDashboard
+                        instanceUrl={instanceUrl}
+                        token={token}
+                        onExplore={({ chart }: any) => setChart(chart)}
+                    />
+                )}
             </div>
         </>
     );

--- a/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
+++ b/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
@@ -13,7 +13,7 @@ const LightdashDashboard = dynamic(
     },
 );
 
-const LighdashExplore = dynamic(
+const LightdashExplore = dynamic(
     () => import('@lightdash/sdk').then((Lightdash) => Lightdash.Explore),
     {
         ssr: false,
@@ -45,7 +45,7 @@ export default function YourCustomDashboard() {
                     </button>
                 )}
                 {chart ? (
-                    <LighdashExplore
+                    <LightdashExplore
                         instanceUrl={instanceUrl}
                         token={token}
                         exploreId={chart?.tableName}

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -1,6 +1,7 @@
 import Lightdash from '@lightdash/sdk';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { SavedChart } from '../../common/src';
 
 // NOTE: add an embed url here for persistence
 const EMBED_URL = '';
@@ -58,6 +59,45 @@ const EmbedUrlInput: React.FC<EmbedUrlInputProps> = ({
     );
 };
 
+const containerStyle = {
+    fontFamily: 'Arial, Helvetica, sans-serif',
+    background: 'linear-gradient(135deg, #f0f2f5 0%, #e9eff5 100%)',
+    minHeight: '100vh',
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '20px',
+};
+
+const contentStyle = {
+    backgroundColor: '#ffffff',
+    padding: '40px',
+    borderRadius: '8px',
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+    maxWidth: '1400px',
+    width: '100%',
+};
+
+// Chart container style
+const chartContainerStyle = {
+    width: '100%',
+    height: '500px',
+    border: '2px dashed #ccc',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'aliceblue',
+};
+
+// Info box style with bluish text and a light blue background
+const infoBoxStyle = {
+    backgroundColor: '#e7f3fe', // light blue background
+    borderLeft: '4px solid #2196F3', // blue accent border
+    padding: '15px',
+    margin: '20px auto',
+    color: '#0b75c9', // bluish text
+    borderRadius: '4px',
+};
+
 function App() {
     const { t, i18n } = useTranslation();
 
@@ -72,43 +112,9 @@ function App() {
 
     const [inputsOpen, setInputsOpen] = useState(false);
 
-    const containerStyle = {
-        fontFamily: 'Arial, Helvetica, sans-serif',
-        background: 'linear-gradient(135deg, #f0f2f5 0%, #e9eff5 100%)',
-        minHeight: '100vh',
-        display: 'flex',
-        justifyContent: 'center',
-        padding: '20px',
-    };
-
-    const contentStyle = {
-        backgroundColor: '#ffffff',
-        padding: '40px',
-        borderRadius: '8px',
-        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
-        maxWidth: '1400px',
-        width: '100%',
-    };
-
-    // Chart container style
-    const chartContainerStyle = {
-        width: '100%',
-        height: '500px',
-        border: '2px dashed #ccc',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: 'aliceblue',
-    };
-
-    // Info box style with bluish text and a light blue background
-    const infoBoxStyle = {
-        backgroundColor: '#e7f3fe', // light blue background
-        borderLeft: '4px solid #2196F3', // blue accent border
-        padding: '15px',
-        margin: '20px auto',
-        color: '#0b75c9', // bluish text
-        borderRadius: '4px',
+    const [savedChart, setSavedChart] = useState<SavedChart | null>();
+    const handleExploreClick = (options: { chart: SavedChart }) => {
+        setSavedChart(options.chart);
     };
 
     useEffect(() => {
@@ -205,20 +211,39 @@ function App() {
                             )}
                         </p>
 
+                        {savedChart && (
+                            <button
+                                style={{ marginBottom: 10 }}
+                                onClick={() => setSavedChart(null)}
+                            >
+                                Go back to dashboard
+                            </button>
+                        )}
+
                         <div style={chartContainerStyle}>
-                            <Lightdash.Dashboard
-                                key={i18n.language}
-                                instanceUrl={lightdashUrl}
-                                token={lightdashToken}
-                                styles={{
-                                    backgroundColor: 'transparent',
-                                    fontFamily: 'Comic Sans MS',
-                                }}
-                                contentOverrides={i18n.getResourceBundle(
-                                    i18n.language,
-                                    'analytics',
-                                )}
-                            />
+                            {savedChart ? (
+                                <Lightdash.Explore
+                                    instanceUrl={lightdashUrl}
+                                    token={lightdashToken}
+                                    exploreId={savedChart.tableName}
+                                    savedChart={savedChart}
+                                />
+                            ) : (
+                                <Lightdash.Dashboard
+                                    key={i18n.language}
+                                    instanceUrl={lightdashUrl}
+                                    token={lightdashToken}
+                                    styles={{
+                                        backgroundColor: 'transparent',
+                                        fontFamily: 'Comic Sans MS',
+                                    }}
+                                    contentOverrides={i18n.getResourceBundle(
+                                        i18n.language,
+                                        'analytics',
+                                    )}
+                                    onExplore={handleExploreClick}
+                                />
+                            )}
                         </div>
 
                         {/* Info box with bluish text */}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15540

### Description:
This PR adds the ability to explore charts from embedded dashboards. When a user clicks "Explore from here" on a chart in an embedded dashboard, they can now navigate to an embedded explore view for that chart. 

For now, this is enabled just for the React SDK, but we can easily enable this with an additional field in the JWT payload. 

### Key changes:
- Added an `Explore` component to the SDK that can be used alongside the existing `Dashboard` component
- Added an `onExplore` callback to the Dashboard component that gets triggered when a user clicks "Explore from here"
- Moved the `JWT_HEADER_NAME` constant from backend to common package for better sharing
- Updated the Explorer components to work with project UUIDs from the embed context using `useEmbed`. 
- Added example implementations in both the React and Next.js test apps

![Screen Cast 2025-07-09 at 4 39 23 PM](https://github.com/user-attachments/assets/2176d6a3-6af1-4bcd-abba-174ad7985bad)

### Caveats

1. We are showing everything right now in the UI. The next PR will handle using permissions from the JWT to hide elements like the dbt button and SQL Runner.
2. When using the Next app, the viewport is too narrow and we have to scroll. We'll need to make the sidebar responsive to the screen width for narrow views. 
3. I have plans to come back and make the SDK DX a little better. Right now we have to build the whole package to use it in the test apps, which is a bit of a pain when developing. 
4. I haven't tested user-attributes yet, but will be a part of testing before releasing. 

### Testing

Use the [example apps](https://www.notion.so/lightdash/Lightdash-React-SDK-Developer-Guide-208a63207a7a80368a82c2fe5a6dfe9f#208a63207a7a80cabc41d9ab58629fd5) to test Explores

1. Start your regular Lightdash dev server
2. From `packages/frontend` run `pnpm build-sdk` 
3. Get an embed token from the embed page of User Settings. Click `Generate and copy URL` in the UI. 

![](https://cdn.zappy.app/2290f2d5c245659bf1080d98a6251397.png) 

5. Run either example app—the vanilla React app is a little easier because you can paste the embed URL and get the parsed token from it. 
  a. Vanilla React - `packages/frontend/sdk-test-app
  b. Next App       - `packages/frontend/sdk-next-test-app`

![](https://cdn.zappy.app/fb63db8d751e1a09c660c18282c8f78f.png)