### PR TITLE
feat: add invalidateCache option to CSV downloads

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -707,12 +707,13 @@ export default class SchedulerTask {
 
                 try {
                     if (savedChartUuid) {
-                        csvUrl = await this.csvService.getCsvForChart(
+                        csvUrl = await this.csvService.getCsvForChart({
                             user,
-                            savedChartUuid,
-                            csvOptions,
+                            chartUuid: savedChartUuid,
+                            options: csvOptions,
                             jobId,
-                        );
+                            invalidateCache: true,
+                        });
                     } else if (dashboardUuid) {
                         this.analytics.track({
                             event: 'download_results.started',
@@ -732,6 +733,7 @@ export default class SchedulerTask {
                                 ? scheduler.filters
                                 : undefined,
                             selectedTabs,
+                            invalidateCache: true,
                         });
 
                         this.analytics.track({

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -663,15 +663,25 @@ This method can be memory intensive
         );
     }
 
-    async getCsvForChart(
-        user: SessionUser,
-        chartUuid: string,
-        options: SchedulerCsvOptions | undefined,
-        jobId?: string,
-        tileUuid?: string,
-        dashboardFilters?: DashboardFilters,
-        dateZoomGranularity?: DateGranularity,
-    ): Promise<AttachmentUrl> {
+    async getCsvForChart({
+        user,
+        chartUuid,
+        options,
+        jobId,
+        tileUuid,
+        dashboardFilters,
+        dateZoomGranularity,
+        invalidateCache,
+    }: {
+        user: SessionUser;
+        chartUuid: string;
+        options: SchedulerCsvOptions | undefined;
+        jobId?: string;
+        tileUuid?: string;
+        dashboardFilters?: DashboardFilters;
+        dateZoomGranularity?: DateGranularity;
+        invalidateCache?: boolean;
+    }): Promise<AttachmentUrl> {
         const chart = await this.savedChartModel.get(chartUuid);
         const {
             metricQuery,
@@ -750,6 +760,7 @@ This method can be memory intensive
             },
             chartUuid,
             queryTags,
+            invalidateCache,
         });
         const numberRows = rows.length;
 
@@ -937,6 +948,7 @@ This method can be memory intensive
         selectedTabs,
         overrideDashboardFilters,
         dateZoomGranularity,
+        invalidateCache,
     }: {
         user: SessionUser;
         dashboardUuid: string;
@@ -946,6 +958,7 @@ This method can be memory intensive
         selectedTabs?: string[] | undefined;
         overrideDashboardFilters?: DashboardFilters;
         dateZoomGranularity?: DateGranularity;
+        invalidateCache?: boolean;
     }): Promise<AttachmentUrl[]> {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
 
@@ -983,7 +996,7 @@ This method can be memory intensive
         );
         const csvForChartPromises = chartTileUuidsWithChartUuids.map(
             ({ tileUuid, chartUuid }) =>
-                this.getCsvForChart(
+                this.getCsvForChart({
                     user,
                     chartUuid,
                     options,
@@ -991,7 +1004,8 @@ This method can be memory intensive
                     tileUuid,
                     dashboardFilters,
                     dateZoomGranularity,
-                ),
+                    invalidateCache,
+                }),
         );
         this.logger.info(
             `Downloading ${sqlChartTileUuids.length} sql chart CSVs for dashboard ${dashboardUuid}`,

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -160,6 +160,7 @@ const MinimalDashboard: FC = () => {
         <DashboardProvider
             schedulerFilters={schedulerFilters}
             dateZoom={dateZoom}
+            defaultInvalidateCache={true}
         >
             {/* This is when viewing a dashboard with tabs in mobile mode - you can navigate between tabs. */}
             {canNavigateBetweenTabs && (

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -49,6 +49,7 @@ const DashboardProvider: React.FC<
         projectUuid?: string;
         embedToken?: string;
         dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
+        defaultInvalidateCache?: boolean;
     }>
 > = ({
     schedulerFilters,
@@ -56,6 +57,7 @@ const DashboardProvider: React.FC<
     projectUuid,
     embedToken,
     dashboardCommentsCheck,
+    defaultInvalidateCache,
     children,
 }) => {
     const { search, pathname } = useLocation();
@@ -125,7 +127,9 @@ const DashboardProvider: React.FC<
         useState<boolean>(false);
     const [resultsCacheTimes, setResultsCacheTimes] = useState<Date[]>([]);
 
-    const [invalidateCache, setInvalidateCache] = useState<boolean>(false);
+    const [invalidateCache, setInvalidateCache] = useState<boolean>(
+        defaultInvalidateCache === true,
+    );
 
     const [chartSort, setChartSort] = useState<Record<string, SortField[]>>({});
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Adds an `invalidateCache` flag to CSV generation for scheduled deliveries and minimal dashboard views. This ensures that scheduled deliveries and minimal dashboard views always fetch fresh data rather than using cached results.

The PR refactors the `getCsvForChart` method to use a named parameters object pattern for better readability and maintainability, and passes the `invalidateCache` flag through the relevant service calls.