### PR TITLE
fix: add cache invalidation option for minimal explorer

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -36,6 +36,7 @@ export type QueryResultsProps = {
     chartVersionUuid?: string;
     dateZoomGranularity?: DateGranularity;
     context?: string;
+    invalidateCache?: boolean;
 };
 
 /**
@@ -106,6 +107,7 @@ const executeAsyncQuery = (
                 chartUuid: data.chartUuid,
                 versionUuid: data.chartVersionUuid,
                 limit: data.csvLimit,
+                invalidateCache: data.invalidateCache,
             },
             { signal },
         );
@@ -116,6 +118,7 @@ const executeAsyncQuery = (
                 context: QueryExecutionContext.CHART,
                 chartUuid: data.chartUuid,
                 limit: data.csvLimit,
+                invalidateCache: data.invalidateCache,
             },
             { signal },
         );

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -93,6 +93,7 @@ const MinimalSavedExplorer: FC = () => {
 
     return (
         <ExplorerProvider
+            minimal={true}
             viewModeQueryArgs={
                 savedQueryUuid
                     ? { chartUuid: savedQueryUuid, context }

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -126,7 +126,6 @@ const DashboardProvider: React.FC<
     const [haveFiltersChanged, setHaveFiltersChanged] =
         useState<boolean>(false);
     const [resultsCacheTimes, setResultsCacheTimes] = useState<Date[]>([]);
-
     const [invalidateCache, setInvalidateCache] = useState<boolean>(
         defaultInvalidateCache === true,
     );

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -808,6 +808,7 @@ export function reducer(
 
 const ExplorerProvider: FC<
     React.PropsWithChildren<{
+        minimal?: boolean;
         isEditMode?: boolean;
         initialState?: ExplorerReduceState;
         savedChart?: SavedChart;
@@ -818,6 +819,7 @@ const ExplorerProvider: FC<
         dateZoomGranularity?: DateGranularity;
     }>
 > = ({
+    minimal = false,
     isEditMode = false,
     initialState,
     savedChart,
@@ -1306,6 +1308,7 @@ const ExplorerProvider: FC<
                     ? {
                           ...validQueryArgs,
                           csvLimit: limit,
+                          invalidateCache: minimal,
                       }
                     : null;
                 const downloadQuery = await executeQueryAndWaitForResults(
@@ -1318,7 +1321,12 @@ const ExplorerProvider: FC<
             }
             return queryUuid;
         },
-        [queryResults.queryUuid, queryResults.totalResults, validQueryArgs],
+        [
+            queryResults.queryUuid,
+            queryResults.totalResults,
+            validQueryArgs,
+            minimal,
+        ],
     );
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { remove: clearQueryResults } = query;
@@ -1344,6 +1352,7 @@ const ExplorerProvider: FC<
                 query: unsavedChartVersion.metricQuery,
                 ...(isEditMode ? {} : viewModeQueryArgs),
                 dateZoomGranularity,
+                invalidateCache: minimal,
             });
             dispatch({
                 type: ActionType.SET_PREVIOUSLY_FETCHED_STATE,
@@ -1364,6 +1373,7 @@ const ExplorerProvider: FC<
         isEditMode,
         viewModeQueryArgs,
         dateZoomGranularity,
+        minimal,
     ]);
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related issue: https://github.com/lightdash/lightdash/issues/15780

![Screenshot from 2025-07-10 11-24-14](https://github.com/user-attachments/assets/199973e4-866e-49a6-901a-78f17c352280)


### Description:
Added an `invalidateCache` option to query execution to force fresh data retrieval. This is particularly useful in minimal explorer mode, where we now set this flag to true to ensure users always see the most up-to-date results.

The implementation:
1. Added `invalidateCache` parameter to `QueryResultsProps`
2. Passed this parameter to API calls in `executeAsyncQuery`
3. Set `invalidateCache: true` for minimal explorer mode
4. Added `minimal` prop to `ExplorerProvider` to track this state