### PR TITLE
feat: add groups:history to required Slack scopes for EE

### DIFF
--- a/packages/backend/src/ee/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/ee/clients/Slack/SlackClient.ts
@@ -52,7 +52,11 @@ export class CommercialSlackClient extends SlackClient {
     }
 
     public getRequiredScopes() {
-        return [...super.getRequiredScopes(), 'channels:history'];
+        return [
+            ...super.getRequiredScopes(),
+            'channels:history',
+            'groups:history',
+        ];
     }
 
     protected addEventListeners(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added 'groups:history' to the required Slack scopes in the CommercialSlackClient class to ensure proper access to private channel history.
