### PR TITLE
fix: increase PostHog feature flag timeout from 5s to 15s

### DIFF
--- a/packages/backend/src/postHog.ts
+++ b/packages/backend/src/postHog.ts
@@ -39,6 +39,7 @@ export async function isFeatureFlagEnabled(
     } = {},
     defaultValue: boolean = false,
 ): Promise<boolean> {
+    const startTime = Date.now();
     /** If we don't have a PostHog client instance, we return false for all checks */
     if (!postHogClient) {
         Logger.warn(
@@ -107,7 +108,12 @@ export async function isFeatureFlagEnabled(
         );
 
         clearTimeout(timeout);
-
+        const elapsedTime = Date.now() - startTime;
+        Logger.info(
+            `Feature flag "${flag}" check completed after ${elapsedTime}ms: ${
+                result ? 'enabled' : 'disabled'
+            } for user ${user.userUuid}`,
+        );
         return result;
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Increases the default PostHog feature flag check timeout from 5 seconds to 15 seconds and improves error logging by including the timeout duration in milliseconds in all timeout-related log messages.