### PR TITLE
feat: add skip-space-create option to CLI upload command

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -887,6 +887,7 @@ export class ProjectController extends BaseController {
             ChartAsCode,
             'metricQuery' | 'chartConfig' | 'description'
         > & {
+            skipSpaceCreate?: boolean;
             chartConfig: AnyType;
             metricQuery: AnyType;
             description?: string | null; // Allow both undefined and null
@@ -896,12 +897,16 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.services
-                .getCoderService()
-                .upsertChart(req.user!, projectUuid, slug, {
+            results: await this.services.getCoderService().upsertChart(
+                req.user!,
+                projectUuid,
+                slug,
+                {
                     ...chart,
                     description: chart.description ?? undefined,
-                }),
+                },
+                chart.skipSpaceCreate,
+            ),
         };
     }
 
@@ -917,6 +922,7 @@ export class ProjectController extends BaseController {
             DashboardAsCode,
             'filters' | 'tiles' | 'description'
         > & {
+            skipSpaceCreate?: boolean;
             filters: AnyType;
             tiles: AnyType;
             description?: string | null; // Allow both undefined and null
@@ -926,12 +932,16 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.services
-                .getCoderService()
-                .upsertDashboard(req.user!, projectUuid, slug, {
+            results: await this.services.getCoderService().upsertDashboard(
+                req.user!,
+                projectUuid,
+                slug,
+                {
                     ...dashboard,
                     description: dashboard.description ?? undefined,
-                }),
+                },
+                dashboard.skipSpaceCreate,
+            ),
         };
     }
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -20,6 +20,7 @@ import {
     getLtreePathFromContentAsCodePath,
     getLtreePathFromSlug,
     NotFoundError,
+    ParameterError,
     Project,
     PromotionAction,
     PromotionChanges,
@@ -677,6 +678,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         slug: string,
         chartAsCode: ChartAsCode,
+        skipSpaceCreate?: boolean,
     ) {
         const project = await this.projectModel.get(projectUuid);
 
@@ -706,6 +708,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     chartAsCode.spaceSlug,
                     user,
+                    skipSpaceCreate,
                 );
 
             console.info(
@@ -805,7 +808,9 @@ export class CoderService extends BaseService {
             projectUuid,
             chartAsCode.spaceSlug,
             user,
+            skipSpaceCreate,
         );
+
         const { promotedChart, upstreamChart } =
             await this.promoteService.getPromoteCharts(
                 user,
@@ -846,6 +851,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         spaceSlug: string,
         user: SessionUser,
+        skipSpaceCreate?: boolean,
     ): Promise<{ space: Omit<SpaceSummary, 'userAccess'>; created: boolean }> {
         const [existingSpace] = await this.spaceModel.find({
             path: getLtreePathFromContentAsCodePath(spaceSlug),
@@ -870,7 +876,11 @@ export class CoderService extends BaseService {
                 "You don't have access to a private space",
             );
         }
-
+        if (skipSpaceCreate) {
+            throw new NotFoundError(
+                `Space ${spaceSlug} does not exist, skipping creation`,
+            );
+        }
         const path = getLtreePathFromContentAsCodePath(spaceSlug);
 
         const closestAncestorSpaceUuid =
@@ -969,6 +979,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         slug: string,
         dashboardAsCode: DashboardAsCode,
+        skipSpaceCreate?: boolean,
     ): Promise<PromotionChanges> {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1004,6 +1015,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     dashboardAsCode.spaceSlug,
                     user,
+                    skipSpaceCreate,
                 );
 
             const newDashboard = await this.dashboardModel.create(
@@ -1076,6 +1088,7 @@ export class CoderService extends BaseService {
             projectUuid,
             dashboardAsCode.spaceSlug,
             user,
+            skipSpaceCreate,
         );
 
         //  we force the new space on the upstreamDashboard

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -579,6 +579,11 @@ program
         parseProjectArgument,
         undefined,
     )
+    .option(
+        '--skip-space-create',
+        'Skip space creation if it does not exist',
+        false,
+    )
     .action(uploadHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/13368


Before:

<img width="914" height="342" alt="Screenshot from 2025-07-10 12-51-29" src="https://github.com/user-attachments/assets/a841a8ab-5884-4cdd-a764-af57be60ef16" />

After:

<img width="1157" height="475" alt="Screenshot from 2025-07-10 13-21-01" src="https://github.com/user-attachments/assets/febe110f-5abb-4b4b-bf4c-161164842abd" />

### Description:
Added a new `--skip-space-create` flag to the CLI upload command that prevents automatic space creation when uploading charts and dashboards. This allows users to upload resources only to existing spaces, avoiding unintended space creation.

The implementation:
1. Added a `skipSpaceCreate` parameter to the chart and dashboard upsert endpoints
2. Modified the CoderService to check this flag before creating a space
3. Updated the CLI to pass this flag through the upload command chain
4. Added appropriate error handling to skip resources when their spaces don't exist

This feature is useful for CI/CD pipelines where you want to ensure resources are only uploaded to pre-defined spaces.