### PR TITLE
fix: add Snowflake token refresh error handling with reauthentication UI

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -534,6 +534,20 @@ export class AiAgentNotFoundError extends LightdashError {
     }
 }
 
+/* This specific error will be used in the frontend
+to show a "reauthenticate" button in the UI
+*/
+export class SnowflakeTokenError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'SnowflakeTokenError',
+            statusCode: 401,
+            data: {},
+        });
+    }
+}
+
 export class CustomSqlQueryForbiddenError extends LightdashError {
     constructor(
         message: string = 'User cannot run queries with custom SQL dimensions',

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -24,7 +24,9 @@ const BigQueryFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
     );
 };
 
-const SnowflakeFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
+export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
+    onClose,
+}) => {
     const { mutate: openLoginPopup } = useSnowflakeLoginPopup({
         onLogin: async () => {
             onClose();

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -3,14 +3,55 @@ import {
     ActionIcon,
     CopyButton,
     Group,
+    Modal,
     Stack,
     Text,
     Tooltip,
 } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import MantineIcon from '../../components/common/MantineIcon';
+import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
 
-const ApiErrorDisplay = ({ apiError }: { apiError: ApiErrorDetail }) => {
+const ApiErrorDisplay = ({
+    apiError,
+    onClose,
+}: {
+    apiError: ApiErrorDetail;
+    onClose?: () => void;
+}) => {
+    switch (apiError.name) {
+        case 'SnowflakeTokenError':
+            return (
+                <>
+                    <Modal
+                        opened={true}
+                        onClose={() => onClose?.()}
+                        title="Snowflake Authentication Error"
+                        centered
+                        size="md"
+                    >
+                        <Stack spacing="md">
+                            <Text mb={0} color="red">
+                                {apiError.message}
+                            </Text>
+
+                            <Text mb={0}>
+                                You can try to reauthenticate with Snowflake:
+                            </Text>
+
+                            <SnowflakeFormInput
+                                onClose={() => {
+                                    onClose?.();
+                                }}
+                            />
+                        </Stack>
+                    </Modal>
+                    <Text mb={0}>{apiError.message}</Text>
+                </>
+            );
+        default:
+            break;
+    }
     return apiError.sentryEventId || apiError.sentryTraceId ? (
         <Stack spacing="xxs">
             <Text mb={0}>{apiError.message}</Text>

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -76,6 +76,7 @@ const MultipleToastBody = ({
                             {toastData.apiError ? (
                                 <ApiErrorDisplay
                                     apiError={toastData.apiError}
+                                    onClose={() => onCloseError?.(toastData)}
                                 />
                             ) : (
                                 <>

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -276,6 +276,7 @@ const useToaster = () => {
             ) : currentErrors.current[key][0].apiError ? (
                 <ApiErrorDisplay
                     apiError={currentErrors.current[key][0].apiError}
+                    onClose={() => notifications.hide(key)}
                 />
             ) : (
                 currentErrors.current[key][0].subtitle ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/15803

[Screencast from 2025-07-10 16-22-51.webm](https://github.com/user-attachments/assets/331e32f8-a537-4601-aa39-7317b37d06d3)

### Description:
Improved error handling for Snowflake SSO token refresh by adding a specific `SnowflakeTokenError` class that triggers a re-authentication UI in the frontend. When a Snowflake token refresh fails, users will now see a prompt to re-authenticate instead of a generic error message.

The implementation:
1. Adds try/catch block around Snowflake token refresh
2. Creates a new `SnowflakeTokenError` class in common error types
3. Enhances the API error display component to show a Snowflake login form when this specific error occurs
4. Exports the `SnowflakeFormInput` component for reuse in the error display