### PR TITLE
feat: add account endpoint

### DIFF
--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -1,0 +1,117 @@
+<summary>
+Backend API controllers built with TSOA that handle HTTP requests and generate OpenAPI specs. Controllers extend BaseController for dependency injection and use decorators for routing, authentication, and documentation. The module contains v1 controllers for existing APIs and v2 controllers for newer async/streaming endpoints.
+</summary>
+
+<howToUse>
+Controllers are automatically registered by TSOA and accessible at their defined routes. All controllers extend BaseController and use dependency injection:
+
+```typescript
+export class MyController extends BaseController {
+    @Route('/api/v1/my-resource')
+    @Tags('MyResource')
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/{id}')
+    @SuccessResponse('200', 'Success')
+    @Response<ApiErrorPayload>('default', 'Error')
+    async getResource(@Path() id: string): Promise<ApiSuccessEmpty> {
+        const result = await this.services.getMyService().getById(id);
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+}
+```
+
+Key patterns:
+
+-   Use `@Middlewares([allowApiKeyAuthentication, isAuthenticated])` for protected endpoints
+-   Return `{status: 'ok', results: T}` for success responses
+-   Access services via `this.services.get{Service}Service()`
+-   Set HTTP status with `this.setStatus(201)` for non-200 responses
+    </howToUse>
+
+<codeExample>
+```typescript
+// Basic CRUD controller
+@Route('/api/v1/projects')
+@Tags('Projects')
+export class ProjectController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/{projectUuid}/charts')
+    @OperationId('listCharts')
+    async getCharts(
+        @Path() projectUuid: string,
+        @Query() includePrivate?: boolean,
+        @Request() req: express.Request,
+    ): Promise<ApiGetCharts> {
+        const charts = await this.services
+            .getSavedChartService()
+            .getAllSpaces(req.user!, projectUuid, includePrivate);
+        return {
+            status: 'ok',
+            results: charts,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/{projectUuid}/charts')
+    @SuccessResponse('201', 'Created')
+    async createChart(
+        @Path() projectUuid: string,
+        @Body() body: CreateSavedChart,
+        @Request() req: express.Request,
+    ): Promise<ApiCreateSavedChart> {
+        this.setStatus(201);
+        const chart = await this.services
+            .getSavedChartService()
+            .createSavedChart(req.user!, projectUuid, body);
+        return {
+            status: 'ok',
+            results: chart,
+        };
+    }
+
+}
+
+```
+</codeExample>
+
+<importantToKnow>
+**Authentication Middleware:**
+- `allowApiKeyAuthentication` - Enables both session and API key auth
+- `isAuthenticated` - Requires active authenticated user
+- `unauthorisedInDemo` - Blocks actions in demo mode
+
+**Controller Organization:**
+- V1 controllers: `/api/v1/` routes with existing patterns
+- V2 controllers: `/api/v2/` routes with async/streaming support
+- Authentication logic in `@authentication/` subdirectory
+
+**Key Conventions:**
+- All controllers extend `BaseController` for service injection
+- Use TSOA decorators for OpenAPI generation and routing
+- Services accessed via `this.services.get{Service}Service()`
+- Consistent response format: `{status: 'ok', results: T}`
+- User object available as `req.user!` in authenticated endpoints
+
+**V2 Differences:**
+- Focus on async operations and result streaming
+- Cleaner RESTful API design
+- Enhanced error handling patterns
+
+**Critical Business Logic:**
+- Project permissions enforced through service layer
+- Organization membership required for most operations
+- Demo mode restrictions applied via middleware
+- API keys and sessions both supported for authentication
+</importantToKnow>
+
+<links>
+@packages/backend/src/controllers/baseController.ts - Base controller implementation
+@packages/backend/src/controllers/authentication/index.ts - Authentication strategies
+@packages/backend/src/controllers/userController.ts - User management example
+@packages/backend/src/controllers/projectController.ts - Complex resource controller
+@packages/backend/src/controllers/v2/ - V2 API controllers with async patterns
+</links>
+```

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -1,6 +1,7 @@
 import {
     ApiEmailStatusResponse,
     ApiErrorPayload,
+    ApiGetAccountResponse,
     ApiGetAuthenticatedUserResponse,
     ApiGetLoginOptionsResponse,
     ApiRegisterUserResponse,
@@ -9,6 +10,7 @@ import {
     CreatePersonalAccessToken,
     getRequestMethod,
     LightdashRequestMethodHeader,
+    NotFoundError,
     ParameterError,
     PersonalAccessToken,
     PersonalAccessTokenWithToken,
@@ -442,6 +444,32 @@ export class UserController extends BaseController {
                     personalAccessTokenUuid,
                     body,
                 ),
+        };
+    }
+
+    /**
+     * Get account information
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/account')
+    @OperationId('GetAccount')
+    async getAccount(
+        @Request() req: express.Request,
+    ): Promise<ApiGetAccountResponse> {
+        if (!req.account) {
+            throw new NotFoundError('Account not found');
+        }
+
+        const { ability, ...userWithoutAbility } = req.account.user;
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: {
+                ...req.account,
+                user: userWithoutAbility,
+            },
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6229,6 +6229,158 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Partial_Pick_Organization.name-or-createdAt-or-organizationUuid__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                createdAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                organizationUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SessionAuth: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { dataType: 'string', required: true },
+                type: { dataType: 'enum', enums: ['session'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    JwtAuth: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { dataType: 'string', required: true },
+                data: { ref: 'CreateEmbedJwt', required: true },
+                type: { dataType: 'enum', enums: ['jwt'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Account.Exclude_keyofAccount.user-or-keyofAccountHelpers__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organization: {
+                    ref: 'Partial_Pick_Organization.name-or-createdAt-or-organizationUuid__',
+                    required: true,
+                },
+                authentication: {
+                    dataType: 'union',
+                    subSchemas: [{ ref: 'SessionAuth' }, { ref: 'JwtAuth' }],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_Account.user-or-keyofAccountHelpers_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_Account.Exclude_keyofAccount.user-or-keyofAccountHelpers__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Account-at-user.Exclude_keyofAccount-at-user.ability-or-abilityRules__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    id: { dataType: 'string', required: true },
+                    type: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'enum', enums: ['registered'] },
+                            { dataType: 'enum', enums: ['anonymous'] },
+                        ],
+                        required: true,
+                    },
+                    email: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    isActive: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_Account-at-user.ability-or-abilityRules_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_Account-at-user.Exclude_keyofAccount-at-user.ability-or-abilityRules__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SerializedAccount: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Omit_Account.user-or-keyofAccountHelpers_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        user: {
+                            ref: 'Omit_Account-at-user.ability-or-abilityRules_',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetAccountResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SerializedAccount', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UserAttributeValue: {
         dataType: 'refAlias',
         type: {
@@ -7927,6 +8079,11 @@ const models: TsoaRoute.Models = {
                 projectUuid: { dataType: 'string', required: true },
                 organizationUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
+                access: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
                 isPrivate: { dataType: 'boolean', required: true },
                 pinnedListUuid: {
                     dataType: 'union',
@@ -7954,11 +8111,6 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 path: { dataType: 'string', required: true },
-                access: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
                 chartCount: { dataType: 'double', required: true },
                 dashboardCount: { dataType: 'double', required: true },
             },
@@ -11667,7 +11819,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11677,7 +11829,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11687,7 +11839,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11700,7 +11852,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21646,6 +21798,60 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'rotatePersonalAccessToken',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsUserController_getAccount: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/user/account',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.getAccount,
+        ),
+
+        async function UserController_getAccount(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsUserController_getAccount,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<UserController>(
+                    UserController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAccount',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6875,6 +6875,134 @@
                     }
                 ]
             },
+            "Partial_Pick_Organization.name-or-createdAt-or-organizationUuid__": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the organization"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "organizationUuid": {
+                        "type": "string",
+                        "description": "The unique identifier of the organization",
+                        "format": "uuid"
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "SessionAuth": {
+                "properties": {
+                    "source": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["session"],
+                        "nullable": false
+                    }
+                },
+                "required": ["source", "type"],
+                "type": "object"
+            },
+            "JwtAuth": {
+                "properties": {
+                    "source": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/CreateEmbedJwt"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["jwt"],
+                        "nullable": false
+                    }
+                },
+                "required": ["source", "data", "type"],
+                "type": "object"
+            },
+            "Pick_Account.Exclude_keyofAccount.user-or-keyofAccountHelpers__": {
+                "properties": {
+                    "organization": {
+                        "$ref": "#/components/schemas/Partial_Pick_Organization.name-or-createdAt-or-organizationUuid__"
+                    },
+                    "authentication": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SessionAuth"
+                            },
+                            {
+                                "$ref": "#/components/schemas/JwtAuth"
+                            }
+                        ]
+                    }
+                },
+                "required": ["organization", "authentication"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_Account.user-or-keyofAccountHelpers_": {
+                "$ref": "#/components/schemas/Pick_Account.Exclude_keyofAccount.user-or-keyofAccountHelpers__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "Pick_Account-at-user.Exclude_keyofAccount-at-user.ability-or-abilityRules__": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["registered", "anonymous"]
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "isActive": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["id", "type", "isActive"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_Account-at-user.ability-or-abilityRules_": {
+                "$ref": "#/components/schemas/Pick_Account-at-user.Exclude_keyofAccount-at-user.ability-or-abilityRules__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "SerializedAccount": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Omit_Account.user-or-keyofAccountHelpers_"
+                    },
+                    {
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/Omit_Account-at-user.ability-or-abilityRules_"
+                            }
+                        },
+                        "required": ["user"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiGetAccountResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SerializedAccount"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "UserAttributeValue": {
                 "properties": {
                     "value": {
@@ -8589,6 +8717,12 @@
                     "uuid": {
                         "type": "string"
                     },
+                    "access": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     },
@@ -8611,12 +8745,6 @@
                     "path": {
                         "type": "string"
                     },
-                    "access": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "chartCount": {
                         "type": "number",
                         "format": "double"
@@ -8631,13 +8759,13 @@
                     "projectUuid",
                     "organizationUuid",
                     "uuid",
+                    "access",
                     "isPrivate",
                     "pinnedListUuid",
                     "pinnedListOrder",
                     "slug",
                     "parentSpaceUuid",
                     "path",
-                    "access",
                     "chartCount",
                     "dashboardCount"
                 ],
@@ -12461,22 +12589,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -18547,6 +18675,37 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/user/account": {
+            "get": {
+                "operationId": "GetAccount",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetAccountResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get account information",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v1/org/attributes": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -135,6 +135,7 @@ import type {
 import { type AnyType } from './types/any';
 import { type ApiGetProjectParametersResults } from './types/api/parameters';
 import { type ApiGetSpotlightTableConfig } from './types/api/spotlight';
+import { type Account } from './types/auth';
 import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
@@ -197,6 +198,7 @@ export * from './pivotTable/pivotQueryResults';
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';
 export { default as lightdashProjectConfigSchema } from './schemas/json/lightdash-project-config-1.0.json';
 export * from './templating/template';
+export * from './types/account';
 export * from './types/analytics';
 export * from './types/any';
 export * from './types/api';
@@ -927,7 +929,8 @@ type ApiResults =
     | ApiGetUserAgentPreferencesResponse[`results`]
     | ApiGetProjectParametersResults
     | ApiAiAgentThreadCreateResponse['results']
-    | ApiAiAgentThreadMessageCreateResponse['results'];
+    | ApiAiAgentThreadMessageCreateResponse['results']
+    | Account;
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/common/src/types/account.ts
+++ b/packages/common/src/types/account.ts
@@ -1,0 +1,12 @@
+import { type Account, type AccountHelpers } from './auth';
+
+// We omit AbilityRules because tsoa is very unforgiving. We'll still get this in the UI to apply abilities.
+// The same approach is taken for SessionUser from the UserController.
+export type SerializedAccount = Omit<Account, 'user' | keyof AccountHelpers> & {
+    user: Omit<Account['user'], 'ability' | 'abilityRules'>;
+};
+
+export type ApiGetAccountResponse = {
+    status: 'ok';
+    results: SerializedAccount;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added a new `/user/account` endpoint to fetch account information without the user's ability rules. This endpoint returns a serialized account object that excludes the ability property from the user object.

Also implemented a new `useAccount` hook in the frontend to fetch account data, and updated the `useOrganization` hook to support embed tokens and project UUIDs. The EmbedExplore component now uses the account hook to ensure proper loading state.

We'll use this hook to get user abilities for the JWT user. 