### PR TITLE
feat: add config option to show query warnings

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -621,6 +621,7 @@ export type LightdashConfig = {
         csvCellsLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
+        showQueryWarnings: boolean;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -1243,6 +1244,8 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
+            showQueryWarnings:
+                process.env.LIGHTDASH_SHOW_QUERY_WARNINGS === 'true',
         },
         chart: {
             versionHistory: {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -180,6 +180,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     contentModel: models.getContentModel(),
                     encryptionUtil: utils.getEncryptionUtil(),
                     userModel: models.getUserModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                 }),
             instanceConfigurationService: ({ models, context, repository }) =>
                 new InstanceConfigurationService({
@@ -236,6 +237,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     savedSqlModel: models.getSavedSqlModel(),
                     storageClient: clients.getResultsFileStorageClient(),
                     csvService: repository.getCsvService(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -34,6 +34,8 @@ export class FeatureFlagModel {
         this.featureFlagHandlers = {
             [FeatureFlags.UserGroupsEnabled]:
                 this.getUserGroupsEnabled.bind(this),
+            [FeatureFlags.ShowQueryWarnings]:
+                this.getShowQueryWarningsEnabled.bind(this),
         };
     }
 
@@ -84,6 +86,30 @@ export class FeatureFlagModel {
                           // nor do we want to wait too long
                           throwOnTimeout: false,
                           timeoutMilliseconds: 500,
+                      },
+                  )
+                : false);
+        return {
+            id: featureFlagId,
+            enabled,
+        };
+    }
+
+    private async getShowQueryWarningsEnabled({
+        user,
+        featureFlagId,
+    }: FeatureFlagLogicArgs) {
+        const enabled =
+            this.lightdashConfig.query.showQueryWarnings ||
+            (user
+                ? await isFeatureFlagEnabled(
+                      FeatureFlags.ShowQueryWarnings,
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      {
+                          throwOnTimeout: false,
                       },
                   )
                 : false);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -177,6 +177,7 @@ import { ContentModel } from '../../models/ContentModel/ContentModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { EmailModel } from '../../models/EmailModel';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
@@ -245,6 +246,7 @@ export type ProjectServiceArguments = {
     contentModel: ContentModel;
     encryptionUtil: EncryptionUtil;
     userModel: UserModel;
+    featureFlagModel: FeatureFlagModel;
 };
 
 export class ProjectService extends BaseService {
@@ -300,6 +302,8 @@ export class ProjectService extends BaseService {
 
     userModel: UserModel;
 
+    featureFlagModel: FeatureFlagModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -326,6 +330,7 @@ export class ProjectService extends BaseService {
         contentModel,
         encryptionUtil,
         userModel,
+        featureFlagModel,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -354,6 +359,7 @@ export class ProjectService extends BaseService {
         this.contentModel = contentModel;
         this.encryptionUtil = encryptionUtil;
         this.userModel = userModel;
+        this.featureFlagModel = featureFlagModel;
     }
 
     static getMetricQueryExecutionProperties({
@@ -1731,12 +1737,11 @@ export class ProjectService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes(user, organizationUuid);
 
-        const useExperimentalMetricCtes = await isFeatureFlagEnabled(
-            FeatureFlags.ShowQueryWarnings,
-            user,
-            { throwOnTimeout: false },
-            false, // default value
-        );
+        const { enabled: useExperimentalMetricCtes } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ShowQueryWarnings,
+            });
 
         const compiledQuery = await ProjectService._compileQuery(
             metricQuery,
@@ -5076,12 +5081,11 @@ export class ProjectService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes(user, organizationUuid);
 
-        const useExperimentalMetricCtes = await isFeatureFlagEnabled(
-            FeatureFlags.ShowQueryWarnings,
-            user,
-            { throwOnTimeout: false },
-            false, // default value
-        );
+        const { enabled: useExperimentalMetricCtes } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ShowQueryWarnings,
+            });
 
         const { query } = await this._getCalculateTotalQuery(
             userAttributes,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -469,6 +469,7 @@ export class ServiceRepository
                     contentModel: this.models.getContentModel(),
                     encryptionUtil: this.utils.getEncryptionUtil(),
                     userModel: this.models.getUserModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }
@@ -509,6 +510,7 @@ export class ServiceRepository
                     savedSqlModel: this.models.getSavedSqlModel(),
                     storageClient: this.clients.getResultsFileStorageClient(),
                     csvService: this.getCsvService(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -6,6 +6,7 @@ import { memo, useEffect, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../../../providers/App/useApp';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
@@ -95,7 +96,8 @@ const ExplorerHeader: FC = memo(() => {
         'manage',
         'CompileProject',
     );
-    const showQueryWarningsEnabled = useFeatureFlagEnabled(
+
+    const { data: showQueryWarningsEnabled } = useFeatureFlag(
         FeatureFlags.ShowQueryWarnings,
     );
 
@@ -131,7 +133,7 @@ const ExplorerHeader: FC = memo(() => {
                 )}
 
                 {userCanManageCompileProject &&
-                    showQueryWarningsEnabled &&
+                    showQueryWarningsEnabled?.enabled &&
                     queryWarnings &&
                     queryWarnings.length > 0 && (
                         <QueryWarnings queryWarnings={queryWarnings} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Adds a new configuration option `showQueryWarnings` to control the display of query warnings. This feature can now be enabled either through the environment variable `LIGHTDASH_SHOW_QUERY_WARNINGS` or via the feature flag system.

The implementation refactors how the `ShowQueryWarnings` feature flag is checked by:
1. Adding it to the FeatureFlagModel handlers
2. Injecting the FeatureFlagModel into relevant services
3. Using the model's `get` method instead of direct PostHog calls
4. Updating the frontend to use the feature flag hook