### PR TITLE
chore: refactor prepareMetricQueryAsyncQueryArgs to use a warehouseSqlBuilder instead of warehouseClient

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -25,7 +25,7 @@ test('Should compile without table calculations', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_NO_CALCS,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toStrictEqual(expected);
 });
@@ -35,7 +35,7 @@ test('Should compile table calculations', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_VALID_REFERENCES,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toStrictEqual(METRIC_QUERY_VALID_REFERENCES_COMPILED);
 });
@@ -45,7 +45,7 @@ test('Should throw error when table calculation contains missing reference', () 
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_MISSING_REFERENCE,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -55,7 +55,7 @@ test('Should throw error when table calculation has invalid reference format', (
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_INVALID_REFERENCE_FORMAT,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -65,7 +65,7 @@ test('Should throw error when table calculation has duplicate name', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_DUPLICATE_NAME,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });
@@ -75,7 +75,7 @@ test('Should compile query with additional metrics', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRICS,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toStrictEqual(METRIC_QUERY_WITH_ADDITIONAL_METRICS_COMPILED);
 });
@@ -85,7 +85,7 @@ test('Should throw compile error if metric in non existent table', () => {
         compileMetricQuery({
             explore: EXPLORE,
             metricQuery: METRIC_QUERY_WITH_INVALID_ADDITIONAL_METRIC,
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         }),
     ).toThrowError(CompileError);
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -143,6 +143,7 @@ import {
     WarehouseClient,
     WarehouseConnectionError,
     WarehouseCredentials,
+    type WarehouseSqlBuilder,
     WarehouseTablesCatalog,
     WarehouseTableSchema,
     WarehouseTypes,
@@ -1594,7 +1595,7 @@ export class ProjectService extends BaseService {
     static updateExploreWithDateZoom(
         explore: Explore,
         metricQuery: MetricQuery,
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
         dateZoom?: DateZoom,
     ): Explore {
         if (dateZoom?.granularity) {
@@ -1637,7 +1638,7 @@ export class ProjectService extends BaseService {
                         dimToOverride.name,
                         baseTimeDimension,
                         explore,
-                        warehouseClient,
+                        warehouseSqlBuilder,
                         dateZoom?.granularity,
                     );
 
@@ -1653,7 +1654,7 @@ export class ProjectService extends BaseService {
     static async _compileQuery(
         metricQuery: MetricQuery,
         explore: Explore,
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
         intrinsicUserAttributes: IntrinsicUserAttributes,
         userAttributes: UserAttributeValueMap,
         timezone: string,
@@ -1663,20 +1664,20 @@ export class ProjectService extends BaseService {
         const exploreWithOverride = ProjectService.updateExploreWithDateZoom(
             explore,
             metricQuery,
-            warehouseClient,
+            warehouseSqlBuilder,
             dateZoom,
         );
 
         const compiledMetricQuery = compileMetricQuery({
             explore: exploreWithOverride,
             metricQuery,
-            warehouseClient,
+            warehouseSqlBuilder,
         });
 
         const queryBuilder = new MetricQueryBuilder({
             explore: exploreWithOverride,
             compiledMetricQuery,
-            warehouseClient,
+            warehouseSqlBuilder,
             intrinsicUserAttributes,
             userAttributes,
             timezone,

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
@@ -84,7 +84,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -98,7 +98,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_BIGQUERY,
                     compiledMetricQuery: METRIC_QUERY,
-                    warehouseClient: bigqueryClientMock,
+                    warehouseSqlBuilder: bigqueryClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -112,7 +112,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -126,7 +126,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -142,7 +142,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -156,7 +156,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_JOIN_CHAIN,
                     compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -170,7 +170,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
                     compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -186,7 +186,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -202,7 +202,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -219,7 +219,7 @@ describe('Query builder', () => {
                     explore: EXPLORE,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -238,7 +238,7 @@ describe('Query builder', () => {
                     explore: EXPLORE,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -254,7 +254,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -268,7 +268,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -283,7 +283,7 @@ describe('Query builder', () => {
                     explore: EXPLORE,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -302,7 +302,7 @@ describe('Query builder', () => {
                     explore: EXPLORE,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -318,7 +318,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -334,7 +334,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -348,7 +348,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -365,7 +365,7 @@ describe('Query builder', () => {
                     explore: EXPLORE,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -381,7 +381,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_WITH_SQL_FILTER,
                     compiledMetricQuery: METRIC_QUERY,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -395,7 +395,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_WITH_SQL_FILTER,
                     compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     userAttributes: {
                         country: ['EU'],
                     },
@@ -412,7 +412,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                    warehouseClient: bigqueryClientMock,
+                    warehouseSqlBuilder: bigqueryClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -442,7 +442,7 @@ describe('Query builder', () => {
                             },
                         ],
                     },
-                    warehouseClient: bigqueryClientMock,
+                    warehouseSqlBuilder: bigqueryClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -477,7 +477,7 @@ describe('Query builder', () => {
                         ],
                     },
 
-                    warehouseClient: bigqueryClientMock,
+                    warehouseSqlBuilder: bigqueryClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -500,7 +500,7 @@ describe('Query builder', () => {
                         sorts: [{ fieldId: 'age_range', descending: true }],
                     },
 
-                    warehouseClient: bigqueryClientMock,
+                    warehouseSqlBuilder: bigqueryClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -531,7 +531,7 @@ describe('Query builder', () => {
                             },
                         ],
                     },
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     userAttributes: {},
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -552,7 +552,7 @@ describe('Query builder', () => {
                     ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
                     dimensions: ['table1_dim1'], // without age_range
                 },
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
                 userAttributes: {},
                 intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                 timezone: QUERY_BUILDER_UTC_TIMEZONE,
@@ -565,7 +565,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE_WITH_REQUIRED_FILTERS,
                     compiledMetricQuery: METRIC_QUERY,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -581,7 +581,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -613,7 +613,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: exploreWithMonthNameDimension,
                     compiledMetricQuery: METRIC_QUERY_WITH_MONTH_NAME_SORT,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -648,7 +648,7 @@ describe('Query builder', () => {
                     explore: exploreWithDayOfWeekNameDimension,
                     compiledMetricQuery:
                         METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -664,7 +664,7 @@ describe('Query builder', () => {
                 buildQuery({
                     explore: EXPLORE,
                     compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
-                    warehouseClient: warehouseClientMock,
+                    warehouseSqlBuilder: warehouseClientMock,
                     intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
@@ -692,7 +692,7 @@ describe('Query builder', () => {
                 ],
                 metrics: ['table1_metric1', 'table2_metric3'],
             },
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
             userAttributes: {},
             intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             timezone: QUERY_BUILDER_UTC_TIMEZONE,

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -265,7 +265,7 @@ describe('with custom dimensions', () => {
     it('getCustomDimensionSql with empty custom dimension', () => {
         expect(
             getCustomBinDimensionSql({
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
                 explore: EXPLORE,
                 customDimensions: undefined,
                 userAttributes: {},
@@ -278,7 +278,7 @@ describe('with custom dimensions', () => {
     it('getCustomSqlDimensionSql with custom sql dimension', () => {
         expect(
             getCustomSqlDimensionSql({
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
                 customDimensions: [CUSTOM_SQL_DIMENSION],
             }),
         ).toStrictEqual({
@@ -290,7 +290,7 @@ describe('with custom dimensions', () => {
     it('getCustomDimensionSql with custom dimension', () => {
         expect(
             getCustomBinDimensionSql({
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
 
                 explore: EXPLORE,
                 customDimensions:
@@ -329,7 +329,7 @@ ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range
     it('getCustomDimensionSql with only 1 bin', () => {
         expect(
             getCustomBinDimensionSql({
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
 
                 explore: EXPLORE,
                 customDimensions: [
@@ -368,7 +368,7 @@ ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range
     it('getCustomDimensionSql with sorted custom dimension ', () => {
         expect(
             getCustomBinDimensionSql({
-                warehouseClient: bigqueryClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
                 explore: EXPLORE,
                 customDimensions:
                     METRIC_QUERY_WITH_CUSTOM_DIMENSION.compiledCustomDimensions?.filter(

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -21,7 +21,10 @@ import {
     type CustomSqlDimension,
 } from '../../types/field';
 import { type AdditionalMetric } from '../../types/metricQuery';
-import { type WarehouseClient } from '../../types/warehouse';
+import {
+    type WarehouseClient,
+    type WarehouseSqlBuilder,
+} from '../../types/warehouse';
 import {
     type YamlColumn,
     type YamlModel,
@@ -240,7 +243,7 @@ export default class DbtSchemaEditor {
 
     private addCustomBinDimension(
         customDimension: CustomBinDimension,
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
     ): DbtSchemaEditor {
         // Extract base dimension name from custom dimension id. Eg: `table_a_dim_a` -> `dim_a`
         const baseDimensionName = customDimension.dimensionId.replace(
@@ -270,7 +273,7 @@ export default class DbtSchemaEditor {
             convertCustomBinDimensionToDbt({
                 customDimension,
                 baseDimensionSql,
-                warehouseClient,
+                warehouseSqlBuilder,
             }),
         );
         return this;

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -10,7 +10,10 @@ import {
     isCustomBinDimension,
 } from '../types/field';
 import { type CreateWarehouseCredentials } from '../types/projects';
-import { type WarehouseClient } from '../types/warehouse';
+import {
+    type WarehouseClient,
+    type WarehouseSqlBuilder,
+} from '../types/warehouse';
 import {
     getCustomRangeSelectSql,
     getFixedWidthBinSelectSql,
@@ -27,11 +30,11 @@ export const convertCustomSqlDimensionToDbt = (
 export const convertCustomBinDimensionToDbt = ({
     customDimension,
     baseDimensionSql,
-    warehouseClient,
+    warehouseSqlBuilder,
 }: {
     customDimension: CustomBinDimension;
     baseDimensionSql: string;
-    warehouseClient: WarehouseClient;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
 }): DbtColumnLightdashAdditionalDimension => {
     switch (customDimension.binType) {
         case BinType.CUSTOM_RANGE:
@@ -41,7 +44,7 @@ export const convertCustomBinDimensionToDbt = ({
                 sql: getCustomRangeSelectSql({
                     binRanges: customDimension.customRange || [],
                     baseDimensionSql,
-                    warehouseClient,
+                    warehouseSqlBuilder,
                 }),
             };
         case BinType.FIXED_WIDTH:
@@ -51,7 +54,7 @@ export const convertCustomBinDimensionToDbt = ({
                 sql: getFixedWidthBinSelectSql({
                     binWidth: customDimension.binWidth || 1,
                     baseDimensionSql,
-                    warehouseClient,
+                    warehouseSqlBuilder,
                 }),
             };
         case BinType.FIXED_NUMBER:
@@ -128,7 +131,7 @@ export const previewConvertCustomDimensionToDbt = (
         const preview = convertCustomBinDimensionToDbt({
             customDimension: field,
             baseDimensionSql: '${reference_column}',
-            warehouseClient: warehouseClientMock,
+            warehouseSqlBuilder: warehouseClientMock,
         });
         return {
             ...preview,

--- a/packages/common/src/utils/customDimensions.ts
+++ b/packages/common/src/utils/customDimensions.ts
@@ -1,17 +1,17 @@
 import { type BinRange } from '../types/field';
-import { type WarehouseClient } from '../types/warehouse';
+import { type WarehouseSqlBuilder } from '../types/warehouse';
 
 export const getFixedWidthBinSelectSql = ({
     binWidth,
     baseDimensionSql,
-    warehouseClient,
+    warehouseSqlBuilder,
 }: {
     binWidth: number;
     baseDimensionSql: string;
-    warehouseClient: WarehouseClient;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
 }) => {
-    const quoteChar = warehouseClient.getStringQuoteChar();
-    return `${warehouseClient.concatString(
+    const quoteChar = warehouseSqlBuilder.getStringQuoteChar();
+    return `${warehouseSqlBuilder.concatString(
         `FLOOR(${baseDimensionSql} / ${binWidth}) * ${binWidth}`,
         `${quoteChar} - ${quoteChar}`,
         `(FLOOR(${baseDimensionSql} / ${binWidth}) + 1) * ${binWidth} - 1`,
@@ -21,26 +21,26 @@ export const getFixedWidthBinSelectSql = ({
 export const getCustomRangeSelectSql = ({
     binRanges,
     baseDimensionSql,
-    warehouseClient,
+    warehouseSqlBuilder,
 }: {
     binRanges: BinRange[];
     baseDimensionSql: string;
-    warehouseClient: WarehouseClient;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
 }) => {
-    const quoteChar = warehouseClient.getStringQuoteChar();
+    const quoteChar = warehouseSqlBuilder.getStringQuoteChar();
     const binRangeWhens = binRanges.map((range) => {
         if (range.from === undefined) {
             // First range
             return `WHEN ${baseDimensionSql} < ${
                 range.to
-            } THEN ${warehouseClient.concatString(
+            } THEN ${warehouseSqlBuilder.concatString(
                 `${quoteChar}<${quoteChar}`,
                 `${range.to}`,
             )}`;
         }
         if (range.to === undefined) {
             // Last range
-            return `ELSE ${warehouseClient.concatString(
+            return `ELSE ${warehouseSqlBuilder.concatString(
                 `${quoteChar}≥${quoteChar}`,
                 `${range.from}`,
             )}`;
@@ -50,7 +50,7 @@ export const getCustomRangeSelectSql = ({
             range.from
         } AND ${baseDimensionSql} < ${
             range.to
-        } THEN ${warehouseClient.concatString(
+        } THEN ${warehouseSqlBuilder.concatString(
             `${range.from}`,
             "'-'",
             `${range.to}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15794 

### Description:
Refactored the query compilation process to use a dedicated `WarehouseSqlBuilder` interface instead of the full `WarehouseClient`. This change decouples SQL generation from the warehouse connection, allowing for more efficient query building without requiring an active database connection.

This allows us to remove the need for a full `warehouseClient` in `prepareMetricQueryAsyncQueryArgs`

The main changes include:
- Replaced `warehouseClient` parameter with `warehouseSqlBuilder` in query compilation functions
- Updated all SQL generation utilities to use the builder interface
- Removed unnecessary SSH tunnel connections that were being created and immediately disconnected