### PR TITLE
feat: add OpenRouter as AI provider option

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -56,6 +56,7 @@
         "@octokit/core": "^5.1.1",
         "@octokit/request": "^8.4.1",
         "@octokit/rest": "^20.0.2",
+        "@openrouter/ai-sdk-provider": "^0.7.2",
         "@rudderstack/rudder-sdk-node": "^2.0.6",
         "@sentry/core": "^9.31.0",
         "@sentry/node": "^9.31.0",

--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -3,11 +3,12 @@ import { z } from 'zod';
 export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-4.1';
 export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-4-sonnet-20250514';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
+export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-4.1-2025-04-14';
 
 export const aiCopilotConfigSchema = z
     .object({
         defaultProvider: z
-            .enum(['openai', 'azure', 'anthropic'])
+            .enum(['openai', 'azure', 'anthropic', 'openrouter'])
             .default('openai'),
         providers: z.object({
             openai: z
@@ -29,6 +30,22 @@ export const aiCopilotConfigSchema = z
                 .object({
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
+                })
+                .optional(),
+            openrouter: z
+                .object({
+                    apiKey: z.string(),
+                    /** @ref https://openrouter.ai/docs/features/provider-routing#provider-sorting */
+                    sortOrder: z
+                        .enum(['price', 'throughput', 'latency'])
+                        .default('latency'),
+                    /** @ref https://openrouter.ai/models */
+                    allowedProviders: z
+                        .array(z.enum(['anthropic', 'openai', 'google']))
+                        .default(['openai']),
+                    modelName: z
+                        .string()
+                        .default(DEFAULT_OPENROUTER_MODEL_NAME),
                 })
                 .optional(),
         }),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -32,6 +32,7 @@ import {
     DEFAULT_ANTHROPIC_MODEL_NAME,
     DEFAULT_DEFAULT_AI_PROVIDER,
     DEFAULT_OPENAI_MODEL_NAME,
+    DEFAULT_OPENROUTER_MODEL_NAME,
 } from './aiConfigSchema';
 
 enum TokenEnvironmentVariable {
@@ -963,6 +964,18 @@ export const parseConfig = (): LightdashConfig => {
                       modelName:
                           process.env.ANTHROPIC_MODEL_NAME ||
                           DEFAULT_ANTHROPIC_MODEL_NAME,
+                  }
+                : undefined,
+            openrouter: process.env.OPENROUTER_API_KEY
+                ? {
+                      apiKey: process.env.OPENROUTER_API_KEY,
+                      modelName:
+                          process.env.OPENROUTER_MODEL_NAME ||
+                          DEFAULT_OPENROUTER_MODEL_NAME,
+                      sortOrder: process.env.OPENROUTER_SORT_ORDER,
+                      allowedProviders: getArrayFromCommaSeparatedList(
+                          'OPENROUTER_ALLOWED_PROVIDERS',
+                      ),
                   }
                 : undefined,
         },

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -3,6 +3,7 @@ import { LightdashConfig } from '../../../../config/parseConfig';
 import { getAnthropicModel } from './anthropic-claude';
 import { getAzureGpt41Model } from './azure-openai-gpt-4.1';
 import { getOpenaiGptmodel } from './openai-gpt';
+import { getOpenRouterModel } from './openrouter';
 
 export const getModel = (config: LightdashConfig['ai']['copilot']) => {
     switch (config.defaultProvider) {
@@ -26,6 +27,15 @@ export const getModel = (config: LightdashConfig['ai']['copilot']) => {
                 throw new ParameterError('Anthropic configuration is required');
             }
             return getAnthropicModel(anthropicConfig);
+        }
+        case 'openrouter': {
+            const openrouterConfig = config.providers.openrouter;
+            if (!openrouterConfig) {
+                throw new ParameterError(
+                    'OpenRouter configuration is required',
+                );
+            }
+            return getOpenRouterModel(openrouterConfig);
         }
         default:
             return assertUnreachable(

--- a/packages/backend/src/ee/services/ai/models/openrouter.ts
+++ b/packages/backend/src/ee/services/ai/models/openrouter.ts
@@ -1,0 +1,26 @@
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { LightdashConfig } from '../../../../config/parseConfig';
+
+export const getOpenRouterModel = (
+    config: NonNullable<
+        LightdashConfig['ai']['copilot']['providers']['openrouter']
+    >,
+) => {
+    /** @ref https://openrouter.ai/docs/community/vercel-ai-sdk */
+    const openrouter = createOpenRouter({
+        apiKey: `${config.apiKey}`,
+        compatibility: 'strict',
+        extraBody: {
+            /** @ref https://openrouter.ai/docs/features/provider-routing */
+            provider: {
+                data_collection: 'deny',
+                require_parameters: true,
+                ...(config.allowedProviders.length > 0
+                    ? { only: config.allowedProviders }
+                    : {}),
+            },
+        },
+    });
+
+    return openrouter.chat(config.modelName);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@octokit/rest':
         specifier: ^20.0.2
         version: 20.1.1
+      '@openrouter/ai-sdk-provider':
+        specifier: ^0.7.2
+        version: 0.7.2(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)
       '@rudderstack/rudder-sdk-node':
         specifier: ^2.0.6
         version: 2.1.1(tslib@2.8.1)
@@ -3444,6 +3447,13 @@ packages:
   '@octokit/webhooks@12.1.0':
     resolution: {integrity: sha512-ppqZ1DyHhZklpeuxnx7WRn5S5WRxjHYt/fQlr33JNvbK+Dpaz6XFD5Zw/AFri62J4NH3jKreHeQFQkLouMqdog==}
     engines: {node: '>= 18'}
+
+  '@openrouter/ai-sdk-provider@0.7.2':
+    resolution: {integrity: sha512-Fry2mV7uGGJRmP9JntTZRc8ElESIk7AJNTacLbF6Syoeb5k8d7HPGkcK9rTXDlqBb8HgU1hOKtz23HojesTmnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^4.3.16
+      zod: ^3.25.34
 
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
@@ -16684,7 +16694,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17237,6 +17247,13 @@ snapshots:
       '@octokit/webhooks-methods': 4.0.0
       '@octokit/webhooks-types': 7.3.2
       aggregate-error: 3.1.0
+
+  '@openrouter/ai-sdk-provider@0.7.2(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.55)
+      ai: 4.3.16(react@19.0.0)(zod@3.25.55)
+      zod: 3.25.55
 
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
@@ -19937,7 +19954,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -19954,7 +19971,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -21847,7 +21864,7 @@ snapshots:
       chalk: 2.4.2
       commander: 2.20.3
       core-js: 3.38.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       fast-json-patch: 3.1.1
       get-stdin: 6.0.0
       http-proxy-agent: 5.0.0
@@ -26266,7 +26283,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -28380,7 +28397,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add OpenRouter as an AI provider option for Lightdash AI Agent

- Adds OpenRouter as a new provider option alongside OpenAI, Azure, and Anthropic
- Supports configuration via environment variables:
  - OPENROUTER_API_KEY
  - OPENROUTER_MODEL_NAME
  - OPENROUTER_SORT_ORDER
  - OPENROUTER_ALLOWED_PROVIDERS
