### PR TITLE
feat: add support for many-to-many join relationships

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -8,10 +8,10 @@ models:
         joins:
           - join: orders
             sql_on: ${orders.order_id} = ${payments.order_id}
-            relationship: one-to-one
+            relationship: many-to-one
           - join: customers
             sql_on: ${customers.customer_id} = ${orders.customer_id}
-            relationship: many-to-many
+            relationship: many-to-one
     columns:
       - name: payment_id
         description: This is a unique identifier for a payment

--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -8,10 +8,10 @@ models:
         joins:
           - join: orders
             sql_on: ${orders.order_id} = ${payments.order_id}
-            relationship: many-to-one
+            relationship: one-to-one
           - join: customers
             sql_on: ${customers.customer_id} = ${orders.customer_id}
-            relationship: many-to-one
+            relationship: many-to-many
     columns:
       - name: payment_id
         description: This is a unique identifier for a payment

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3401,7 +3401,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     JoinRelationship: {
         dataType: 'refEnum',
-        enums: ['one-to-many', 'many-to-one', 'one-to-one'],
+        enums: ['one-to-many', 'many-to-one', 'one-to-one', 'many-to-many'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always-or-relationship_':

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3648,7 +3648,12 @@
                 "enum": ["inner", "full", "left", "right"]
             },
             "JoinRelationship": {
-                "enum": ["one-to-many", "many-to-one", "one-to-one"],
+                "enum": [
+                    "one-to-many",
+                    "many-to-one",
+                    "one-to-one",
+                    "many-to-many"
+                ],
                 "type": "string"
             },
             "Pick_ExploreJoin.table-or-sqlOn-or-type-or-hidden-or-always-or-relationship_": {
@@ -17647,7 +17652,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1797.0",
+        "version": "0.1800.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -350,7 +350,8 @@
                                 "enum": [
                                     "one-to-many",
                                     "many-to-one",
-                                    "one-to-one"
+                                    "one-to-one",
+                                    "many-to-many"
                                 ]
                             }
                         }

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -97,7 +97,8 @@
                                             "enum": [
                                                 "one-to-many",
                                                 "many-to-one",
-                                                "one-to-one"
+                                                "one-to-one",
+                                                "many-to-many"
                                             ]
                                         }
                                     },

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -17,6 +17,7 @@ export enum JoinRelationship {
     ONE_TO_MANY = 'one-to-many',
     MANY_TO_ONE = 'many-to-one',
     ONE_TO_ONE = 'one-to-one',
+    MANY_TO_MANY = 'many-to-many',
 }
 
 export type ExploreJoin = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#15810](https://github.com/lightdash/lightdash/issues/15810)

To reproduce, modified payments joins:
```
        joins:
          - join: orders
            sql_on: ${orders.order_id} = ${payments.order_id}
            relationship: one-to-one
          - join: customers
            sql_on: ${customers.customer_id} = ${orders.customer_id}
            relationship: many-to-many
```

Example: all tables have CTEs to deduplicate rows

<img width="1425" height="1293" alt="Screenshot 2025-07-10 at 21 00 42" src="https://github.com/user-attachments/assets/4a2f5457-4469-406b-b591-a98a536b70a4" />


### Description:
Added support for many-to-many join relationships in the data model. This enhancement allows users to properly define many-to-many relationships between tables, which is particularly useful for junction tables that connect entities with many-to-many relationships.

The implementation includes:
- Added 'many-to-many' as a valid join relationship type in the schema definitions
- Updated the metric inflation detection logic to properly handle many-to-many relationships
- Added test coverage to verify that all tables in a query with many-to-many relationships receive appropriate metric inflation warnings

This change helps users model more complex data relationships and provides better warnings about potential metric inflation when many-to-many relationships are present in a query.