### PR TITLE
fix: properly quote table names in SQL query builder

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
@@ -869,7 +869,7 @@ export class MetricQueryBuilder {
                         ...dimensionSelects,
                         ...table.primaryKey.map(
                             (pk) =>
-                                `  ${table.name}.${pk} AS ${fieldQuoteChar}pk_${pk}${fieldQuoteChar}`,
+                                `  ${fieldQuoteChar}${table.name}${fieldQuoteChar}.${pk} AS ${fieldQuoteChar}pk_${pk}${fieldQuoteChar}`,
                         ),
                     ].join(',\n'),
                     sqlFrom,
@@ -915,7 +915,7 @@ export class MetricQueryBuilder {
                     }${fieldQuoteChar} ON ${table.primaryKey
                         .map(
                             (pk) =>
-                                `${keysCteName}.${fieldQuoteChar}pk_${pk}${fieldQuoteChar} = ${table.name}.${fieldQuoteChar}${pk}${fieldQuoteChar}`,
+                                `${keysCteName}.${fieldQuoteChar}pk_${pk}${fieldQuoteChar} = ${fieldQuoteChar}${table.name}${fieldQuoteChar}.${pk}`,
                         )
                         .join(' AND ')}\n`,
                     dimensionAlias.length > 0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#15811](https://github.com/lightdash/lightdash/issues/15811)

Query working in Lightdash
<img width="1952" height="1293" alt="Screenshot 2025-07-10 at 21 23 48" src="https://github.com/user-attachments/assets/a07febe2-1f9a-4a13-a63c-762536cc17cd" />
Same query working in snowflake
<img width="1552" height="1098" alt="Screenshot 2025-07-10 at 21 24 19" src="https://github.com/user-attachments/assets/37c2c503-44d5-4fec-bb83-f8c4bc1bd6ed" />

### Description:
Fixed SQL query generation in MetricQueryBuilder by properly quoting table names in primary key references. This ensures compatibility with databases that require table names to be quoted, especially when they contain special characters or reserved keywords.