### PR TITLE
fix: improve custom visualization resizing with useResizeObserver

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -60,7 +60,7 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 </Tooltip>
             </Group>
 
-            <Divider my="sm" />
+            <Divider />
 
             <Group>
                 <Text fw={600}>Chart type</Text>

--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -11,6 +11,7 @@ import {
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, type FC, type Ref } from 'react';
 import MantineIcon from './../MantineIcon';
+import { COLLAPSIBLE_CARD_GAP_SIZE } from './constants';
 
 interface CollapsableCardProps {
     onToggle?: (isOpen: boolean) => void;
@@ -174,7 +175,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                                     overflow: 'hidden',
                                     display: 'flex',
                                     flexDirection: 'column',
-                                    paddingTop: 8,
+                                    paddingTop: COLLAPSIBLE_CARD_GAP_SIZE,
                                 }}
                             >
                                 {children}

--- a/packages/frontend/src/components/common/CollapsableCard/constants.ts
+++ b/packages/frontend/src/components/common/CollapsableCard/constants.ts
@@ -17,6 +17,8 @@ export const COLLAPSABLE_CARD_ACTION_ICON_PROPS: Pick<
     size: 'md',
 };
 
+export const COLLAPSIBLE_CARD_GAP_SIZE = 8;
+
 export const COLLAPSABLE_CARD_POPOVER_PROPS: Omit<PopoverProps, 'children'> = {
     shadow: 'md',
     position: 'bottom',


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/8787

### Description:
Improves the CustomVisualization component by:
- Adding resize observation using Mantine's `useResizeObserver` hook
- Fixing the loading state display with proper centering
- Enhancing the visualization container with explicit width and height based on the observed dimensions
- Updating the autosize configuration from `fit` to `fit-x` for better horizontal scaling
- Adding overflow handling to prevent content from spilling outside the containe


video:

[CleanShot 2025-07-11 at 11.30.46.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/cOL6QbQzyaUdOs5psinD/2114362e-444d-4b44-bf14-ac6c98e3b7da.mp4" />](https://app.graphite.dev/media/video/cOL6QbQzyaUdOs5psinD/2114362e-444d-4b44-bf14-ac6c98e3b7da.mp4)

