### PR TITLE
chore: add development ssh tunnel and instructions for testing in docker

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -104,3 +104,5 @@ S3_FORCE_PATH_STYLE=true # needed when using MinIO since it only supports path s
 # RESULTS_S3_BUCKET=
 # RESULTS_S3_SECRET_KEY=
 # RESULTS_S3_ACCESS_KEY=
+
+DEV_SSH_PUBLIC_KEY=

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -289,6 +289,37 @@ When you want to start:
 docker compose -p lightdash-app -f docker/docker-compose.dev.yml --env-file .env.development.local start
 ```
 
+#### Testing an SSH Tunnel Locally
+
+To test an SSH tunnel with Lightdash in your local development environment:
+
+1. **Go to Project Connection Advanced Settings**
+   - In the Lightdash UI, navigate to your project connection settings.
+   - Expand the advanced settings and set `Use SSH tunnel` to **true**.
+
+2. **Add the SSH Tunnel config**
+   - SSH Remote host: `ssh-server`
+   - SSH Remote port: `2222`
+   - SSH Username: `sshuser`
+
+3. **Generate a Key Pair**
+   - Use the UI to generate a new SSH key pair for the tunnel.
+
+4. **Copy the Public Key**
+   - Copy the generated public key from the UI.
+   - Open your `.env.development.local` file and set:
+     ```
+     DEV_SSH_PUBLIC_KEY="<paste your public key here>"
+     ```
+
+5. **Restart Docker Compose**
+   - Re-run the following command to apply the new SSH key:
+     ```sh
+     docker compose -p lightdash-app -f docker/docker-compose.dev.yml --env-file .env.development.local up --detach --remove-orphans
+     ```
+
+This will update the SSH server container with your new public key, allowing you to test SSH tunnel connections from your local Lightdash instance.
+
 #### Downloading files stored in local docker container MinIO
 
 When developing using the docker compose setup there's a MinIO container already setup to serve as the S3 compatible

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -102,6 +102,26 @@ services:
         ports:
             - '5432:5432'
 
+    ssh-server:
+        image: linuxserver/openssh-server:latest
+        restart: always
+        depends_on:
+            - db-dev
+        environment:
+            - PUID=1000
+            - PGID=1000
+            - TZ=UTC
+            - PUBLIC_KEY=${DEV_SSH_PUBLIC_KEY:-}
+            - USER_NAME=sshuser
+            - SUDO_ACCESS=true
+            - PASSWORD_ACCESS=false
+            - LOG_STDOUT=true
+        ports:
+            - '2222:2222'
+        volumes:
+            - ./ssh-server-configs/sshd_config:/config/sshd/sshd_config
+
+
     headless-browser:
         image: ghcr.io/browserless/chromium:v2.24.3
         restart: always

--- a/docker/ssh-server-configs/sshd_config
+++ b/docker/ssh-server-configs/sshd_config
@@ -1,0 +1,123 @@
+#	$OpenBSD: sshd_config,v 1.105 2024/12/03 14:12:47 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# Include configuration snippets before processing this file to allow the
+# snippets to override directives set in this file.
+#Include /etc/ssh/sshd_config.d/*.conf
+
+Port 2222
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to "no" here!
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to "no" to disable keyboard-interactive authentication.  Depending on
+# the system's configuration, this may involve passwords, challenge-response,
+# one-time passwords or some combination of these and other methods.
+#KbdInteractiveAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin prohibit-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+# Feel free to re-enable these if your use case requires them.
+AllowTcpForwarding yes
+GatewayPorts no
+X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+PidFile /config/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	internal-sftp
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Add SSH tunnel testing capability to local development environment

This PR adds the ability to test SSH tunnels locally during development by:

1. Adding an OpenSSH server container to the development Docker Compose setup
2. Creating a configuration for the SSH server that allows TCP forwarding
3. Adding a `DEV_SSH_PUBLIC_KEY` environment variable to store the developer's public key
4. Providing detailed documentation on how to set up and test SSH tunnels locally

Developers can now generate SSH key pairs through the Lightdash UI and use them to test database connections through SSH tunnels in their local development environment.