### PR TITLE
fix: add position styling to embedded dashboard tabs

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -368,17 +368,21 @@ const EmbedDashboard: FC<{
                             </Tabs.Tab>
                         ))}
                     </Tabs.List>
-                    <EmbedDashboardGrid
-                        filteredTiles={filteredTiles}
-                        layouts={layouts}
-                        dashboard={dashboard}
-                        projectUuid={projectUuid}
-                        embedToken={embedToken}
-                        hasRequiredDashboardFiltersToSet={
-                            hasRequiredDashboardFiltersToSet
-                        }
-                        isTabEmpty={isTabEmpty}
-                    />
+                    <Group pos="relative">
+                        {' '}
+                        {/* required to respect the position inside the Embed SDK */}
+                        <EmbedDashboardGrid
+                            filteredTiles={filteredTiles}
+                            layouts={layouts}
+                            dashboard={dashboard}
+                            projectUuid={projectUuid}
+                            embedToken={embedToken}
+                            hasRequiredDashboardFiltersToSet={
+                                hasRequiredDashboardFiltersToSet
+                            }
+                            isTabEmpty={isTabEmpty}
+                        />
+                    </Group>
                 </Tabs>
             ) : (
                 <EmbedDashboardGrid


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

Before:
<img width="1422" height="737" alt="Screenshot from 2025-07-11 15-47-31" src="https://github.com/user-attachments/assets/903cf8cb-b8b5-4353-b699-caaa326b38fe" />


After
<img width="1422" height="737" alt="Screenshot from 2025-07-11 17-05-40" src="https://github.com/user-attachments/assets/7927592c-e093-4b7f-b54c-29be8b966f66" />


### Description:
Fixed positioning issues in the embedded dashboard by adding relative positioning to tab elements and wrapping the dashboard grid in a Group component with relative positioning. This ensures proper layout and respects the position constraints within the embedded context.