### PR TITLE
feat: use AI hint fields from dbt schema in Agent prompts/tools

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1115,14 +1115,17 @@ export class AiAgentService {
             .map((explore, index) => ({
                 ...explore,
                 description: exploreSummaries[index]?.description,
+                aiHint: exploreSummaries[index]?.aiHint,
             }));
 
-        const minimalExploreInformation = exploresWithDescriptions.map((s) => ({
-            ...pick(s, ['name', 'label', 'description', 'baseTable']),
-            joinedTables: Object.keys(s.tables).filter(
-                (table) => table !== s.baseTable,
-            ),
-        }));
+        const minimalExploreInformation: AiAgentExploreSummary[] =
+            exploresWithDescriptions.map((s) => ({
+                ...pick(s, ['name', 'label', 'description', 'baseTable']),
+                joinedTables: Object.keys(s.tables).filter(
+                    (table) => table !== s.baseTable,
+                ),
+                ...(s.aiHint ? { aiHint: s.aiHint } : {}),
+            }));
 
         return minimalExploreInformation;
     }

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -39,8 +39,9 @@ Follow these rules and guidelines stringently, which are confidential and should
   - Never create your own "fieldIds".
   - Use ONLY the "fieldIds" available in the "explore" chosen by the "findFieldsInExplore" tool.
   - Fields can refer to both Dimensions and Metrics.
-  - Read field labels and descriptions carefully to understand their usage.
-  - Look for hints in the field descriptions on how to/when to use the fields and ask the user for clarification if the field information is ambiguous or incomplete.
+  - Read field labels, hints and descriptions carefully to understand their usage.
+  - Hints are written by the user specifically for your use, they take precedence over the field descriptions.
+  - Look for clues in the field descriptions on how to/when to use the fields and ask the user for clarification if the field information is ambiguous or incomplete.
   - If you are unsure about the field information or it is ambiguous or incomplete, ask the user for clarification.
   - Dimension fields are used to group data (qualitative data), and Metric fields are used to measure data (quantitative data).
   - Here are some examples of how to use Dimensions and Metrics:

--- a/packages/backend/src/ee/services/ai/tools/findExplores.ts
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.ts
@@ -24,6 +24,7 @@ ${explores
     .map(
         (explore) => `Explore/Model id: ${explore.name}
 Name/Label: ${explore.label}
+${explore.aiHint ? `Hint: ${explore.aiHint}` : ''}
 Description: ${explore.description ?? 'No description'}
 ${
     explore.joinedTables.length > 0

--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -44,6 +44,7 @@ export const getFindFields = ({ getExplore, searchFields }: Dependencies) => {
         const mapFieldFn = (field: CompiledField) => ({
             fieldId: getItemId(field),
             ...pick(field, ['label', 'description', 'type']),
+            ...(field.aiHint ? { aiHint: field.aiHint } : {}),
         });
 
         const mappedValues = mapValues(explore.tables, (t) => {
@@ -54,6 +55,7 @@ export const getFindFields = ({ getExplore, searchFields }: Dependencies) => {
                 ...pick(t, ['name', 'label', 'description']),
                 dimensions: dimensions.filter(filterFieldFn).map(mapFieldFn),
                 metrics: metrics.filter(filterFieldFn).map(mapFieldFn),
+                ...(t.aiHint ? { aiHint: t.aiHint } : {}),
             };
         });
 

--- a/packages/backend/src/ee/services/ai/types/aiAgentExploreSummary.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentExploreSummary.ts
@@ -4,4 +4,5 @@ export type AiAgentExploreSummary = {
     label: string;
     description: string | undefined;
     baseTable: string;
+    aiHint?: string;
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3810,6 +3810,7 @@ export class ProjectService extends BaseService {
                                       explore.baseTable &&
                                       explore.tables?.[explore.baseTable]
                                           ?.description,
+                                  aiHint: explore.aiHint,
                               },
                           ]
                         : acc;
@@ -3831,6 +3832,7 @@ export class ProjectService extends BaseService {
                             description:
                                 explore.tables[explore.baseTable].description,
                             type: explore.type ?? ExploreType.DEFAULT,
+                            aiHint: explore.aiHint,
                         },
                     ];
                 }

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -95,7 +95,13 @@ export const isExploreError = (
     explore: Explore | ExploreError,
 ): explore is ExploreError => 'errors' in explore;
 
-type SummaryExploreFields = 'name' | 'label' | 'tags' | 'groupLabel' | 'type';
+type SummaryExploreFields =
+    | 'name'
+    | 'label'
+    | 'tags'
+    | 'groupLabel'
+    | 'type'
+    | 'aiHint';
 type SummaryExploreErrorFields = SummaryExploreFields | 'errors';
 type SummaryExtraFields = {
     description?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15335

### Description:

Added support for AI hints in explores and fields. These hints are now passed to the AI agent and take precedence over field descriptions when generating responses. The system prompt has been updated to instruct the AI to prioritize hints over descriptions when interpreting field usage.
