### PR TITLE
chore: remove asyc query service dependency on csv service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -222,9 +222,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     storageClient: clients.getResultsFileStorageClient(),
-                    csvService: repository.getCsvService(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
+                    pivotTableService: repository.getPivotTableService(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -53,6 +53,7 @@ import { warehouseClientMock } from '../../utils/QueryBuilder/queryBuilder.mock'
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
 import type { CsvService } from '../CsvService/CsvService';
+import { PivotTableService } from '../PivotTableService/PivotTableService';
 import {
     allExplores,
     expectedColumns,
@@ -186,9 +187,13 @@ const getMockedAsyncQueryService = (
                 close: jest.fn(),
             })),
         } as unknown as S3ResultsFileStorageClient,
-        csvService: {} as CsvService,
         featureFlagModel: {} as FeatureFlagModel,
         projectParametersModel: {} as ProjectParametersModel,
+        pivotTableService: new PivotTableService({
+            lightdashConfig,
+            s3Client: {} as S3Client,
+            downloadFileModel: {} as DownloadFileModel,
+        }),
         ...overrides,
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -109,6 +109,7 @@ import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
+import { PivotTableService } from '../PivotTableService/PivotTableService';
 import {
     ProjectService,
     type ProjectServiceArguments,
@@ -142,7 +143,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     savedSqlModel: SavedSqlModel;
     featureFlagModel: FeatureFlagModel;
     storageClient: S3ResultsFileStorageClient;
-    csvService: CsvService;
+    pivotTableService: PivotTableService;
 };
 
 export class AsyncQueryService extends ProjectService {
@@ -156,7 +157,7 @@ export class AsyncQueryService extends ProjectService {
 
     storageClient: S3ResultsFileStorageClient;
 
-    csvService: CsvService;
+    pivotTableService: PivotTableService;
 
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
@@ -165,7 +166,7 @@ export class AsyncQueryService extends ProjectService {
         this.savedSqlModel = args.savedSqlModel;
         this.featureFlagModel = args.featureFlagModel;
         this.storageClient = args.storageClient;
-        this.csvService = args.csvService;
+        this.pivotTableService = args.pivotTableService;
     }
 
     // ! Duplicate of SavedSqlService.hasAccess
@@ -830,7 +831,7 @@ export class AsyncQueryService extends ProjectService {
             case DownloadFileType.CSV:
                 // Check if this is a pivot table download
                 if (pivotConfig && queryHistory.metricQuery) {
-                    return this.csvService.downloadAsyncPivotTableCsv({
+                    return this.pivotTableService.downloadAsyncPivotTableCsv({
                         resultsFileName,
                         fields,
                         metricQuery: queryHistory.metricQuery,

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -28,6 +28,7 @@ import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredent
 import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { ProjectService } from '../ProjectService/ProjectService';
 import { CsvService } from './CsvService';
 import { itemMap, metricQuery } from './CsvService.mock';
@@ -77,6 +78,11 @@ describe('Csv service', () => {
         schedulerClient: {} as SchedulerClient,
         projectModel: {} as ProjectModel,
         savedSqlModel: {} as SavedSqlModel,
+        pivotTableService: new PivotTableService({
+            lightdashConfig,
+            s3Client: {} as S3Client,
+            downloadFileModel: {} as DownloadFileModel,
+        }),
     });
 
     it('Should convert rows to CSV with format', async () => {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -86,6 +86,7 @@ import {
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { BaseService } from '../BaseService';
+import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { ProjectService } from '../ProjectService/ProjectService';
 
 type CsvServiceArguments = {
@@ -100,6 +101,7 @@ type CsvServiceArguments = {
     downloadFileModel: DownloadFileModel;
     schedulerClient: SchedulerClient;
     projectModel: ProjectModel;
+    pivotTableService: PivotTableService;
 };
 
 export const convertSqlToCsv = (
@@ -208,6 +210,8 @@ export class CsvService extends BaseService {
 
     projectModel: ProjectModel;
 
+    pivotTableService: PivotTableService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -220,6 +224,7 @@ export class CsvService extends BaseService {
         downloadFileModel,
         schedulerClient,
         projectModel,
+        pivotTableService,
     }: CsvServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -233,6 +238,7 @@ export class CsvService extends BaseService {
         this.downloadFileModel = downloadFileModel;
         this.schedulerClient = schedulerClient;
         this.projectModel = projectModel;
+        this.pivotTableService = pivotTableService;
     }
 
     static convertRowToCsv(
@@ -585,84 +591,6 @@ export class CsvService extends BaseService {
         };
     }
 
-    /*  
-This pivot method returns directly the final CSV result as a string
-This method can be memory intensive
-*/
-    async downloadPivotTableCsv({
-        name,
-        projectUuid,
-        rows,
-        itemMap,
-        metricQuery,
-        pivotConfig,
-        exploreId,
-        onlyRaw,
-        truncated,
-        customLabels,
-    }: {
-        name?: string;
-        projectUuid: string;
-        rows: Record<string, AnyType>[];
-        itemMap: ItemsMap;
-        metricQuery: MetricQuery;
-        pivotConfig: PivotConfig;
-        exploreId: string;
-        onlyRaw: boolean;
-        truncated: boolean;
-        customLabels: Record<string, string> | undefined;
-        metricsAsRows?: boolean;
-    }) {
-        return wrapSentryTransaction<AttachmentUrl>(
-            'downloadPivotTableCsv',
-            {
-                numberRows: rows.length,
-                projectUuid,
-                pivotColumns: pivotConfig.pivotDimensions,
-            },
-            async () => {
-                // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
-                // TODO: refactor pivotQueryResults to accept a Record<string, any>[] simple row type for performance
-                const formattedRows = formatRows(rows, itemMap);
-
-                const csvResults = pivotResultsAsCsv({
-                    pivotConfig,
-                    rows: formattedRows,
-                    itemMap,
-                    metricQuery,
-                    customLabels,
-                    onlyRaw,
-                    maxColumnLimit:
-                        this.lightdashConfig.pivotTable.maxColumnLimit,
-                });
-
-                const csvContent = await new Promise<string>(
-                    (resolve, reject) => {
-                        stringify(
-                            csvResults,
-                            {
-                                delimiter: ',',
-                            },
-                            (err, output) => {
-                                if (err) {
-                                    reject(new Error(getErrorMessage(err)));
-                                }
-                                resolve(output);
-                            },
-                        );
-                    },
-                );
-
-                return this.downloadCsvFile({
-                    csvContent,
-                    fileName: name || exploreId,
-                    projectUuid,
-                    truncated,
-                });
-            },
-        );
-    }
-
     async getCsvForChart({
         user,
         chartUuid,
@@ -784,7 +712,7 @@ This method can be memory intensive
             );
             const customLabels = getCustomLabelsFromTableConfig(config);
 
-            const downloadUrl = this.downloadPivotTableCsv({
+            const downloadUrl = this.pivotTableService.downloadPivotTableCsv({
                 pivotConfig,
                 name: chart.name,
                 projectUuid: chart.projectUuid,
@@ -1252,18 +1180,19 @@ This method can be memory intensive
             const truncated = this.couldBeTruncated(rows);
 
             if (pivotConfig) {
-                const downloadUrl = await this.downloadPivotTableCsv({
-                    pivotConfig,
-                    name: chartName,
-                    projectUuid,
-                    rows,
-                    itemMap: fields,
-                    metricQuery,
-                    exploreId,
-                    onlyRaw,
-                    truncated,
-                    customLabels,
-                });
+                const downloadUrl =
+                    await this.pivotTableService.downloadPivotTableCsv({
+                        pivotConfig,
+                        name: chartName,
+                        projectUuid,
+                        rows,
+                        itemMap: fields,
+                        metricQuery,
+                        exploreId,
+                        onlyRaw,
+                        truncated,
+                        customLabels,
+                    });
 
                 this.analytics.track({
                     event: 'download_results.completed',
@@ -1479,96 +1408,5 @@ This method can be memory intensive
             fs.createReadStream(zipFile),
             zipFileName,
         );
-    }
-
-    /**
-     * Downloads pivot table CSV from async query results file
-     * Handles loading data from JSONL storage file and generating pivot CSV
-     */
-    async downloadAsyncPivotTableCsv({
-        resultsFileName,
-        fields,
-        metricQuery,
-        projectUuid,
-        storageClient,
-        options,
-    }: {
-        resultsFileName: string;
-        fields: ItemsMap;
-        metricQuery: MetricQuery;
-        projectUuid: string;
-        storageClient: S3ResultsFileStorageClient;
-        options: {
-            onlyRaw: boolean;
-            showTableNames: boolean;
-            customLabels: Record<string, string>;
-            columnOrder: string[];
-            hiddenFields: string[];
-            pivotConfig: PivotConfig;
-            attachmentDownloadName?: string;
-        };
-    }): Promise<{ fileUrl: string; truncated: boolean }> {
-        const {
-            onlyRaw,
-            showTableNames,
-            customLabels,
-            columnOrder,
-            hiddenFields,
-            pivotConfig,
-        } = options;
-
-        // Load rows from the results file using shared streaming utility
-        // Use the same logic as regular CSV exports - respect csvCellsLimit with field count
-        const readStream = await storageClient.getDowloadStream(
-            resultsFileName,
-        );
-
-        const fieldCount = Object.keys(fields).length;
-        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
-
-        // Use standard csvCellsLimit calculation - same as original downloadPivotTableCsv
-        const maxRows = Math.floor(cellsLimit / fieldCount);
-
-        const { results: rows, truncated } = await streamJsonlData<
-            Record<string, unknown>
-        >({
-            readStream,
-            onRow: (parsedRow: Record<string, unknown>) => parsedRow, // Just collect all rows
-            maxLines: maxRows, // Use standard csvCellsLimit logic
-        });
-
-        if (rows.length === 0) {
-            throw new Error('No data found in results file');
-        }
-
-        // Use same truncation logic as original downloadPivotTableCsv
-        const finalTruncated = truncated || this.couldBeTruncated(rows);
-
-        if (finalTruncated) {
-            Logger.warn(
-                `Pivot CSV export truncated: loaded ${rows.length} rows (csvCellsLimit: ${cellsLimit}, fieldCount: ${fieldCount})`,
-            );
-        }
-
-        const fileName =
-            options.attachmentDownloadName || `pivot-${resultsFileName}`;
-
-        const attachmentUrl = await this.downloadPivotTableCsv({
-            name: fileName,
-            projectUuid,
-            rows,
-            itemMap: fields,
-            metricQuery,
-            pivotConfig,
-            exploreId: metricQuery.exploreName || 'explore',
-            onlyRaw,
-            truncated: finalTruncated,
-            customLabels,
-        });
-
-        return {
-            fileUrl: attachmentUrl.path,
-            truncated: finalTruncated,
-        };
     }
 }

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -1,0 +1,299 @@
+import {
+    AnyType,
+    DownloadFileType,
+    formatRows,
+    getErrorMessage,
+    ItemsMap,
+    MetricQuery,
+    MissingConfigError,
+    PivotConfig,
+    pivotResultsAsCsv,
+} from '@lightdash/common';
+import { stringify } from 'csv-stringify';
+import * as fs from 'fs';
+import * as fsPromise from 'fs/promises';
+import moment from 'moment';
+import { nanoid } from 'nanoid';
+import { Readable } from 'stream';
+import { S3Client } from '../../clients/Aws/S3Client';
+import { AttachmentUrl } from '../../clients/EmailClient/EmailClient';
+import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { DownloadFileModel } from '../../models/DownloadFileModel';
+import {
+    generateGenericFileId,
+    streamJsonlData,
+} from '../../utils/FileDownloadUtils/FileDownloadUtils';
+import { BaseService } from '../BaseService';
+
+type PivotTableServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    s3Client: S3Client;
+    downloadFileModel: DownloadFileModel;
+};
+
+export class PivotTableService extends BaseService {
+    lightdashConfig: LightdashConfig;
+
+    s3Client: S3Client;
+
+    downloadFileModel: DownloadFileModel;
+
+    constructor({
+        lightdashConfig,
+        s3Client,
+        downloadFileModel,
+    }: PivotTableServiceArguments) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.s3Client = s3Client;
+        this.downloadFileModel = downloadFileModel;
+    }
+
+    /**
+     * Generates a file ID for CSV files
+     */
+    private static generateFileId(
+        fileName: string,
+        truncated: boolean = false,
+        time: moment.Moment = moment(),
+    ): string {
+        return generateGenericFileId({
+            fileName,
+            fileExtension: DownloadFileType.CSV,
+            truncated,
+            time,
+        });
+    }
+
+    /**
+     * Checks if the rows could be truncated based on cell limit
+     */
+    private couldBeTruncated(rows: Record<string, AnyType>[]) {
+        if (rows.length === 0) return false;
+
+        const numberRows = rows.length;
+        const numberColumns = Object.keys(rows[0]).length;
+
+        // we use floor when limiting the rows, so the need to make sure we got the last row valid
+        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
+
+        return numberRows * numberColumns >= cellsLimit - numberColumns;
+    }
+
+    /**
+     * Downloads pivot table CSV from async query results file
+     * Handles loading data from JSONL storage file and generating pivot CSV
+     */
+    async downloadAsyncPivotTableCsv({
+        resultsFileName,
+        fields,
+        metricQuery,
+        projectUuid,
+        storageClient,
+        options,
+    }: {
+        resultsFileName: string;
+        fields: ItemsMap;
+        metricQuery: MetricQuery;
+        projectUuid: string;
+        storageClient: S3ResultsFileStorageClient;
+        options: {
+            onlyRaw: boolean;
+            showTableNames: boolean;
+            customLabels: Record<string, string>;
+            columnOrder: string[];
+            hiddenFields: string[];
+            pivotConfig: PivotConfig;
+            attachmentDownloadName?: string;
+        };
+    }): Promise<{ fileUrl: string; truncated: boolean }> {
+        const {
+            onlyRaw,
+            showTableNames,
+            customLabels,
+            columnOrder,
+            hiddenFields,
+            pivotConfig,
+        } = options;
+
+        // Load rows from the results file using shared streaming utility
+        // Use the same logic as regular CSV exports - respect csvCellsLimit with field count
+        const readStream = await storageClient.getDowloadStream(
+            resultsFileName,
+        );
+
+        const fieldCount = Object.keys(fields).length;
+        const cellsLimit = this.lightdashConfig.query?.csvCellsLimit || 100000;
+
+        // Use standard csvCellsLimit calculation - same as original downloadPivotTableCsv
+        const maxRows = Math.floor(cellsLimit / fieldCount);
+
+        const { results: rows, truncated } = await streamJsonlData<
+            Record<string, unknown>
+        >({
+            readStream,
+            onRow: (parsedRow: Record<string, unknown>) => parsedRow, // Just collect all rows
+            maxLines: maxRows, // Use standard csvCellsLimit logic
+        });
+
+        if (rows.length === 0) {
+            throw new Error('No data found in results file');
+        }
+
+        // Use same truncation logic as original downloadPivotTableCsv
+        const finalTruncated = truncated || this.couldBeTruncated(rows);
+
+        if (finalTruncated) {
+            Logger.warn(
+                `Pivot CSV export truncated: loaded ${rows.length} rows (csvCellsLimit: ${cellsLimit}, fieldCount: ${fieldCount})`,
+            );
+        }
+
+        const fileName =
+            options.attachmentDownloadName || `pivot-${resultsFileName}`;
+
+        const attachmentUrl = await this.downloadPivotTableCsv({
+            name: fileName,
+            projectUuid,
+            rows,
+            itemMap: fields,
+            metricQuery,
+            pivotConfig,
+            exploreId: metricQuery.exploreName || 'explore',
+            onlyRaw,
+            truncated: finalTruncated,
+            customLabels,
+        });
+
+        return {
+            fileUrl: attachmentUrl.path,
+            truncated: finalTruncated,
+        };
+    }
+
+    /**
+     * Downloads pivot table CSV and returns the final CSV result as a string
+     * This method can be memory intensive
+     */
+    async downloadPivotTableCsv({
+        name,
+        projectUuid,
+        rows,
+        itemMap,
+        metricQuery,
+        pivotConfig,
+        exploreId,
+        onlyRaw,
+        truncated,
+        customLabels,
+    }: {
+        name?: string;
+        projectUuid: string;
+        rows: Record<string, AnyType>[];
+        itemMap: ItemsMap;
+        metricQuery: MetricQuery;
+        pivotConfig: PivotConfig;
+        exploreId: string;
+        onlyRaw: boolean;
+        truncated: boolean;
+        customLabels: Record<string, string> | undefined;
+        metricsAsRows?: boolean;
+    }): Promise<AttachmentUrl> {
+        // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
+        // TODO: refactor pivotQueryResults to accept a Record<string, any>[] simple row type for performance
+        const formattedRows = formatRows(rows, itemMap);
+
+        const csvResults = pivotResultsAsCsv({
+            pivotConfig,
+            rows: formattedRows,
+            itemMap,
+            metricQuery,
+            customLabels,
+            onlyRaw,
+            maxColumnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+        });
+
+        const csvContent = await new Promise<string>((resolve, reject) => {
+            stringify(
+                csvResults,
+                {
+                    delimiter: ',',
+                },
+                (err, output) => {
+                    if (err) {
+                        reject(new Error(getErrorMessage(err)));
+                    }
+                    resolve(output);
+                },
+            );
+        });
+
+        return this.downloadCsvFile({
+            csvContent,
+            fileName: name || exploreId,
+            projectUuid,
+            truncated,
+        });
+    }
+
+    /**
+     * Downloads a CSV file to S3 or local storage
+     */
+    private async downloadCsvFile({
+        csvContent,
+        fileName,
+        projectUuid,
+        truncated = false,
+    }: {
+        csvContent: string;
+        fileName: string;
+        projectUuid: string;
+        truncated?: boolean;
+    }): Promise<AttachmentUrl> {
+        const fileId = PivotTableService.generateFileId(fileName, truncated);
+        const filePath = `/tmp/${fileId}`;
+        const csvWithBOM = Buffer.concat([
+            Buffer.from('\uFEFF', 'utf8'),
+            Buffer.from(csvContent, 'utf8'),
+        ]);
+        await fsPromise.writeFile(filePath, csvWithBOM);
+
+        if (this.s3Client.isEnabled()) {
+            const s3Url = await this.s3Client.uploadCsv(csvContent, fileId);
+
+            // Delete local file in 10 minutes, we could still read from the local file to upload to google sheets
+            setTimeout(async () => {
+                await fsPromise.unlink(filePath);
+            }, 60 * 10 * 1000);
+
+            return {
+                filename: fileName,
+                path: s3Url,
+                localPath: filePath,
+                truncated,
+            };
+        }
+
+        // storing locally
+        const downloadFileId = nanoid();
+        await this.downloadFileModel.createDownloadFile(
+            downloadFileId,
+            filePath,
+            DownloadFileType.CSV,
+        );
+
+        const localUrl = new URL(
+            `/api/v1/projects/${projectUuid}/csv/${downloadFileId}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
+
+        return {
+            filename: fileName,
+            path: localUrl,
+            localPath: filePath,
+            truncated,
+        };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -26,6 +26,7 @@ import { NotificationsService } from './NotificationsService/NotificationsServic
 import { OrganizationService } from './OrganizationService/OrganizationService';
 import { PersonalAccessTokenService } from './PersonalAccessTokenService';
 import { PinningService } from './PinningService/PinningService';
+import { PivotTableService } from './PivotTableService/PivotTableService';
 import { ProjectParametersService } from './ProjectParametersService';
 import { ProjectService } from './ProjectService/ProjectService';
 import { PromoteService } from './PromoteService/PromoteService';
@@ -63,6 +64,7 @@ interface ServiceManifest {
     organizationService: OrganizationService;
     personalAccessTokenService: PersonalAccessTokenService;
     pinningService: PinningService;
+    pivotTableService: PivotTableService;
     projectService: ProjectService;
     savedChartService: SavedChartService;
     schedulerService: SchedulerService;
@@ -275,6 +277,7 @@ export class ServiceRepository
                     downloadFileModel: this.models.getDownloadFileModel(),
                     schedulerClient: this.clients.getSchedulerClient(),
                     projectModel: this.models.getProjectModel(),
+                    pivotTableService: this.getPivotTableService(),
                 }),
         );
     }
@@ -440,6 +443,18 @@ export class ServiceRepository
         );
     }
 
+    public getPivotTableService(): PivotTableService {
+        return this.getService(
+            'pivotTableService',
+            () =>
+                new PivotTableService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    s3Client: this.clients.getS3Client(),
+                    downloadFileModel: this.models.getDownloadFileModel(),
+                }),
+        );
+    }
+
     public getProjectService(): ProjectService {
         return this.getService(
             'projectService',
@@ -514,10 +529,10 @@ export class ServiceRepository
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
                     storageClient: this.clients.getResultsFileStorageClient(),
-                    csvService: this.getCsvService(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),
+                    pivotTableService: this.getPivotTableService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Async query service had a dependency on CSV service just to download pivoted tables. This remove that dependency by moving pivot csv generation to its own service. 

This was necessary as a pre-req for having CSV service use the AsyncQuery service in the future. 
