### PR TITLE
fix: prevent color picker from getting cut off in small window height #14156

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -31,7 +31,7 @@ const ColorSelector: FC<Props> = ({
     const isValidHexColor = color && isHexCodeColor(color);
 
     return (
-        <Popover shadow="md" withArrow disabled={!onColorChange}>
+        <Popover withinPortal shadow="md" withArrow disabled={!onColorChange}>
             <Popover.Target>
                 <ColorSwatch
                     size={20}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#14156](https://github.com/lightdash/lightdash/issues/14156)

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
<img width="2588" height="1644" alt="Screenshot 2025-07-11 at 10 04 59 PM" src="https://github.com/user-attachments/assets/07fec970-3eb4-436b-8d24-411581ba12fd" />

This PR explicitly sets the `withinPortal` prop on `<Popover>` to ensure the dropdown renders **within a portal**, outside the normal DOM flow. This change fixes an issue where the dropdown would flip to the top on small screens and get hidden behind fixed headers.

<!-- Even better add a screenshot / gif / loom -->